### PR TITLE
Expose scene only in development/test builds for debugging

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,8 +35,8 @@ export const babylonInit = async (): Promise<void> => {
     const scene = await createSceneModule.createScene(engine, canvas);
 
     // Expose scene only in development/test builds for debugging and Playwright tests.
-    // In production builds, webpack's mode:'production' sets process.env.NODE_ENV to "production",
-    // and this block is removed by dead-code elimination.
+    // This assignment is guarded by a NODE_ENV check so production-targeted builds
+    // can omit it when that condition is compiled away by the bundler/minifier.
     if (process.env.NODE_ENV !== "production") {
         (window as any).scene = scene;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,8 +34,12 @@ export const babylonInit = async (): Promise<void> => {
     // Create the scene
     const scene = await createSceneModule.createScene(engine, canvas);
 
-    // JUST FOR TESTING. Not needed for anything else
-    (window as any).scene = scene;
+    // Expose scene only in development/test builds for debugging and Playwright tests.
+    // In production builds, webpack's mode:'production' sets process.env.NODE_ENV to "production",
+    // and this block is removed by dead-code elimination.
+    if (process.env.NODE_ENV !== "production") {
+        (window as any).scene = scene;
+    }
 
     // Register a render loop to repeatedly render the scene
     engine.runRenderLoop(function () {


### PR DESCRIPTION
このプルリクエストは、デバッグおよびテスト目的で`window`に`scene`オブジェクトを公開する方法を更新します。今後は、`scene`は開発ビルドまたはテストビルドでのみ公開され、本番ビルドでは公開されないため、セキュリティが向上し、本番ビルドにおける不要なグローバル変数が削減されます。

- デバッグとテストの改善
  - `scene` オブジェクトは、非プロダクション ビルドでのみ `window` にアタッチされるようになりました。これにより、デバッグや Playwright テストで使用できますが、セキュリティとパフォーマンスの向上のため、プロダクションでは省略されます。(`src/index.ts`)