### PR TITLE
chore: npm run typecheckを追加、そのための設定を実施

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ npm run test:unit
    - 定義済みのテストがある場合は実行し、成功すること。
 
 2. lint / typecheck
-   - 最低限、対象領域で lint または typecheck を実行し成功すること。
+   - 最低限、対象領域で lint および typecheck を実行し成功すること。
    - 変更時は `npm run lint` および `npm run typecheck` を実行すること。
 
 3. Coding Rules 観点でのAIレビュー実施

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ npm run test:unit
 ### 規約参照先
 
 - 実装規約: [AGENTS.md](AGENTS.md)
-- lint/format/typecheck 設定: [package.json](package.json)
+- lint/typecheck 設定: [package.json](package.json)
 
 ### AIレビュー出力言語
 
@@ -74,7 +74,7 @@ npm run test:unit
 
 2. lint / typecheck
    - 最低限、対象領域で lint または typecheck を実行し成功すること。
-   - Frontend 変更時は `npm run lint` を実行すること。
+   - 変更時は `npm run lint` および `npm run typecheck` を実行すること。
 
 3. Coding Rules 観点でのAIレビュー実施
    - 本ファイルの Coding Rules に記載したチェック観点でAIレビューを実施し、指摘の要否を記録すること。

--- a/package.json
+++ b/package.json
@@ -42,9 +42,10 @@
   "scripts": {
     "start": "npx webpack serve --config webpack.dev.js",
     "start:test": "npx webpack serve --config webpack.tests.js",
-    "build:dev": "npx webpack --config webpack.dev.js",
-    "build": "npx webpack --config webpack.prod.js",
+    "build:dev": "npm run typecheck && npx webpack --config webpack.dev.js",
+    "build": "npm run typecheck && npx webpack --config webpack.prod.js",
     "lint": "npx eslint . --ext .ts,.tsx",
+    "typecheck": "tsc --noEmit",
     "test:visuals": "npx playwright test",
     "test:unit": "cross-env NODE_OPTIONS=--experimental-vm-modules npx jest",
     "prepare": "husky"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,9 @@
         "rootDir": "./",
         "esModuleInterop": true,
         "types": ["node", "jest"],
-	}
+        "skipLibCheck": true,         // node_modules内の型エラーで止まらないために必須
+        "isolatedModules": true       // 他のトランスパイラとの互換性を確保
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules/**", "dist/**", "webpack.*"]
 }


### PR DESCRIPTION
<!-- Copilot Code Review: Follow .github/copilot-instructions.md. -->
<!-- Copilot Code Review: Follow AGENTS.md. -->
<!-- Copilot Code Review: Write all review comments in Japanese. -->

## 概要

このプルリクエストは、プロジェクトのビルドおよび開発ワークフローを更新し、TypeScriptの型チェックがビルド前に必ず実行されるようにするとともに、関連ドキュメントを明確化します。主な変更点は、ビルドスクリプトでの型チェックの強制、専用の型チェックスクリプトの追加、およびこれらの要件を反映するためのドキュメントの更新です。

## 関連 Issue

Closes #8 

## 変更内容

- ビルドプロセスの改善
  - `package.json`に新しい`typecheck`スクリプトを追加しました。このスクリプトはTypeScriptの型チェックのために`tsc --noEmit`を実行します。
  - `package.json` 内の `build` および `build:dev` スクリプトを更新し、webpack を呼び出す前に `npm run typecheck` を実行するようにしました。これにより、ビルド前に型エラーが確実に検出されます。

- ドキュメントの更新
  - `AGENTS.md` を更新し、lint/typecheck セクションの書式設定に関する記述を削除し、lint と typecheck のみが必要であることを明確にしました。
  - `AGENTS.md` の手順を改訂し、フロントエンドの変更だけでなく、すべての変更に対して `npm run lint` と `npm run typecheck` の両方を実行する必要があるようにしました。

## 確認事項

- [ ] Copilot レビューを日本語で実施し、指摘を修正した
