### PR TITLE
tsconfig に Playwright 設定と tests を含める

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,10 @@
         "skipLibCheck": true,         // node_modules内の型エラーで止まらないために必須
         "isolatedModules": true       // 他のトランスパイラとの互換性を確保
     },
-    "include": ["src/**/*"],
+    "include": [
+        "src/**/*",
+        "playwright.config.ts",
+        "tests/**/*.ts"
+    ],
     "exclude": ["node_modules/**", "dist/**", "webpack.*"]
 }


### PR DESCRIPTION
## 概要

playwright.config.ts と tests 配下の TypeScript ファイルを tsconfig の include 対象に追加し、ESLint 実行時に対象外ファイルとして扱われていたことによる Lint エラーを解消します。

## 関連 Issue

Closes #14

## 変更内容

- tsconfig.json の include に playwright.config.ts を追加
- tsconfig.json の include に tests/**/*.ts を追加
- ESLint が Playwright 設定ファイルとテストファイルを TypeScript プロジェクトとして解析できる状態に修正

## 動作確認方法

- npm run lint
- npm run typecheck
- npm run test:visuals
- npm run test:unit
  - 現状は対象テストが存在せず `No tests found, exiting with code 1` になることを確認

## 確認事項

- [x] Copilot レビューを日本語で実施し、指摘を修正した