### PR TITLE
feat: タイル1枚の標高データから3D地形を表示 (#18)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="utf-8">
 
-  <title>Babylon.js webpack starter-kit</title>
-  <meta name="description" content="A sample project based on Babylon.js, written in typescript, built with webpack">
-  <meta name="author" content="Raanan Weber">
+  <title>jpmap_terrain – 3D地形ビューア</title>
+  <meta name="description" content="地理院タイルの標高データから3D地形を表示するWebアプリ">
+  <meta name="author" content="Masaru Ebata">
     <style>
       html,
       body {

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -178,7 +178,7 @@ export class DefaultScene implements CreateSceneClass {
                     stdTextureUrl(ELEVATION_ZOOM, tile.x, tile.y),
                     scene,
                     true,
-                    false,
+                    true,
                     Texture.TRILINEAR_SAMPLINGMODE
                 );
 

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -202,7 +202,20 @@ export class DefaultScene implements CreateSceneClass {
             camera.beta = Number(ui.cameraBetaInput.value);
             camera.radius = Number(ui.cameraRadiusInput.value);
         };
+        let prevAlpha = camera.alpha;
+        let prevBeta = camera.beta;
+        let prevRadius = camera.radius;
         const syncUIFromCamera = (): void => {
+            if (
+                camera.alpha === prevAlpha &&
+                camera.beta === prevBeta &&
+                camera.radius === prevRadius
+            ) {
+                return;
+            }
+            prevAlpha = camera.alpha;
+            prevBeta = camera.beta;
+            prevRadius = camera.radius;
             ui.cameraAlphaInput.value = String(camera.alpha);
             ui.cameraBetaInput.value = String(camera.beta);
             ui.cameraRadiusInput.value = String(camera.radius);
@@ -221,7 +234,7 @@ export class DefaultScene implements CreateSceneClass {
         ui.cameraBetaInput.addEventListener("input", applyCameraFromUI);
         ui.cameraRadiusInput.addEventListener("input", applyCameraFromUI);
 
-        scene.onBeforeRenderObservable.add(syncUIFromCamera);
+        camera.onViewMatrixChangedObservable.add(syncUIFromCamera);
 
         // 初回ロード
         await refreshTerrain();

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -1,96 +1,230 @@
 import { Scene } from "@babylonjs/core/scene";
 import { ArcRotateCamera } from "@babylonjs/core/Cameras/arcRotateCamera";
+import { Color3 } from "@babylonjs/core/Maths/math.color";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { CreateSphere } from "@babylonjs/core/Meshes/Builders/sphereBuilder";
 import { CreateGround } from "@babylonjs/core/Meshes/Builders/groundBuilder";
 import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
-import { CreateSceneClass } from "../createScene";
-
-// If you don't need the standard material you will still need to import it since the scene requires it.
-// import "@babylonjs/core/Materials/standardMaterial";
-
-import { DirectionalLight } from "@babylonjs/core/Lights/directionalLight";
-import { ShadowGenerator } from "@babylonjs/core/Lights/Shadows/shadowGenerator";
-
-import "@babylonjs/core/Lights/Shadows/shadowGeneratorSceneComponent";
-import "@babylonjs/core/Culling/ray";
+import { Texture } from "@babylonjs/core/Materials/Textures/texture";
+import { VertexData } from "@babylonjs/core/Meshes/mesh.vertexData";
+import { VertexBuffer } from "@babylonjs/core/Buffers/buffer";
+import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight";
 import { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import { CreateSceneClass } from "../createScene";
+import {
+    TILE_SIZE,
+    clamp,
+    toTileXY,
+    tileEdgeMeters,
+    loadElevationTile,
+    stdTextureUrl,
+} from "../terrain/gsiTile";
+import { createControlPanel } from "../terrain/controlPanel";
+
+const TERRAIN_SUBDIVISIONS = 128;
+const ELEVATION_ZOOM = 14;
+const HEIGHT_SCALE = 1.0;
+
+const JAPAN_BOUNDS = { minLat: 20, maxLat: 46, minLon: 122, maxLon: 154 };
+
+/** 頂点Y座標を標高値で更新し、中心標高を返す */
+const applyElevation = (
+    positions: Float32Array,
+    elevations: Float32Array,
+    altitudeOffset: number
+): number => {
+    let centerElev = 0;
+    const cols = TERRAIN_SUBDIVISIONS + 1;
+    for (let row = 0; row <= TERRAIN_SUBDIVISIONS; row++) {
+        for (let col = 0; col <= TERRAIN_SUBDIVISIONS; col++) {
+            const u = col / TERRAIN_SUBDIVISIONS;
+            const v = row / TERRAIN_SUBDIVISIONS;
+            const sx = Math.min(
+                TILE_SIZE - 1,
+                Math.round(u * (TILE_SIZE - 1))
+            );
+            const sy = Math.min(
+                TILE_SIZE - 1,
+                Math.round(v * (TILE_SIZE - 1))
+            );
+            const elev = elevations[sy * TILE_SIZE + sx];
+            if (
+                row === TERRAIN_SUBDIVISIONS / 2 &&
+                col === TERRAIN_SUBDIVISIONS / 2
+            ) {
+                centerElev = elev;
+            }
+            positions[(row * cols + col) * 3 + 1] =
+                (elev + altitudeOffset) * HEIGHT_SCALE;
+        }
+    }
+    return centerElev;
+};
 
 export class DefaultScene implements CreateSceneClass {
     createScene = async (
         engine: AbstractEngine,
         canvas: HTMLCanvasElement
     ): Promise<Scene> => {
-        // This creates a basic Babylon Scene object (non-mesh)
         const scene = new Scene(engine);
+        scene.clearColor.set(0.75, 0.86, 0.95, 1);
 
-        // Uncomment to load the inspector (debugging) asynchronously
-
-        // void Promise.all([
-        //     import("@babylonjs/core/Debug/debugLayer"),
-        //     import("@babylonjs/inspector"),
-        // ]).then((_values) => {
-        //     console.log(_values);
-        //     scene.debugLayer.show({
-        //         handleResize: true,
-        //         overlay: true,
-        //         globalRoot: document.getElementById("#root") || undefined,
-        //     });
-        // });
-
-        // This creates and positions a free camera (non-mesh)
+        // カメラ
         const camera = new ArcRotateCamera(
-            "my first camera",
-            0,
+            "terrain-camera",
+            -Math.PI / 2,
             Math.PI / 3,
-            10,
-            new Vector3(0, 0, 0),
+            4000,
+            Vector3.Zero(),
             scene
         );
-
-        // This targets the camera to scene origin
-        camera.setTarget(Vector3.Zero());
-
-        // This attaches the camera to the canvas
+        camera.lowerRadiusLimit = 250;
+        camera.upperRadiusLimit = 40000;
+        camera.wheelDeltaPercentage = 0.02;
+        camera.panningSensibility = 1500;
         camera.attachControl(canvas, true);
 
-        // Our built-in 'sphere' shape.
-        const sphere = CreateSphere(
-            "sphere",
-            { diameter: 2, segments: 32 },
+        // ライト
+        const light = new HemisphericLight(
+            "sky-light",
+            new Vector3(0, 1, 0),
             scene
         );
+        light.intensity = 1.0;
 
-        // Move the sphere upward 1/2 its height
-        sphere.position.y = 1;
+        // 初期位置（東京駅付近）
+        const initialLat = 35.681236;
+        const initialLon = 139.767125;
+        const initialTileSize = tileEdgeMeters(initialLat, ELEVATION_ZOOM);
 
-        // Our built-in 'ground' shape.
+        // 地形メッシュ
         const ground = CreateGround(
-            "ground",
-            { width: 6, height: 6 },
+            "terrain-ground",
+            {
+                width: initialTileSize,
+                height: initialTileSize,
+                subdivisions: TERRAIN_SUBDIVISIONS,
+                updatable: true,
+            },
             scene
         );
+        const groundMat = new StandardMaterial("terrain-mat", scene);
+        groundMat.specularColor = Color3.Black();
+        ground.material = groundMat;
 
-        // Load a texture to be used as the ground material
-        const groundMaterial = new StandardMaterial("ground material", scene);
+        // UIパネル
+        const ui = createControlPanel(initialLat, initialLon, {
+            alpha: camera.alpha,
+            beta: camera.beta,
+            radius: camera.radius,
+        });
 
-        ground.material = groundMaterial;
-        ground.receiveShadows = true;
+        // 状態
+        let requestId = 0;
 
-        const light = new DirectionalLight(
-            "light",
-            new Vector3(0, -1, 1),
-            scene
+        const refreshTerrain = async (): Promise<void> => {
+            const rid = ++requestId;
+            const lat = clamp(
+                Number(ui.latInput.value),
+                JAPAN_BOUNDS.minLat,
+                JAPAN_BOUNDS.maxLat
+            );
+            const lon = clamp(
+                Number(ui.lonInput.value),
+                JAPAN_BOUNDS.minLon,
+                JAPAN_BOUNDS.maxLon
+            );
+            const altOff = Number(ui.altitudeInput.value) || 0;
+
+            ui.latInput.value = lat.toFixed(6);
+            ui.lonInput.value = lon.toFixed(6);
+
+            const tile = toTileXY(lat, lon, ELEVATION_ZOOM);
+            ui.status.textContent = `読込中 z${ELEVATION_ZOOM}/${tile.x}/${tile.y}`;
+
+            try {
+                const elev = await loadElevationTile(
+                    ELEVATION_ZOOM,
+                    tile.x,
+                    tile.y
+                );
+                if (rid !== requestId) return; // 古いリクエスト破棄
+
+                const pos = ground.getVerticesData(VertexBuffer.PositionKind);
+                const idx = ground.getIndices();
+                if (!pos || !idx)
+                    throw new Error("Ground mesh data unavailable");
+
+                const typed =
+                    pos instanceof Float32Array
+                        ? pos
+                        : new Float32Array(pos);
+                const centerElev = applyElevation(typed, elev, altOff);
+
+                ground.updateVerticesData(VertexBuffer.PositionKind, typed);
+                const normals = new Float32Array(typed.length);
+                VertexData.ComputeNormals(typed, idx, normals);
+                ground.updateVerticesData(VertexBuffer.NormalKind, normals);
+
+                // タイルサイズ補正
+                const curSize = tileEdgeMeters(lat, ELEVATION_ZOOM);
+                ground.scaling.x = curSize / initialTileSize;
+                ground.scaling.z = curSize / initialTileSize;
+
+                // テクスチャ
+                if (groundMat.diffuseTexture) {
+                    groundMat.diffuseTexture.dispose();
+                }
+                groundMat.diffuseTexture = new Texture(
+                    stdTextureUrl(ELEVATION_ZOOM, tile.x, tile.y),
+                    scene,
+                    true,
+                    false,
+                    Texture.TRILINEAR_SAMPLINGMODE
+                );
+
+                camera.setTarget(
+                    new Vector3(
+                        0,
+                        (centerElev + altOff) * HEIGHT_SCALE,
+                        0
+                    )
+                );
+                ui.status.textContent = `表示中 z${ELEVATION_ZOOM}/${tile.x}/${tile.y}`;
+            } catch (e) {
+                if (rid !== requestId) return;
+                ui.status.textContent = `読込エラー: ${String(e)}`;
+            }
+        };
+
+        // カメラ ↔ UI 同期
+        const applyCameraFromUI = (): void => {
+            camera.alpha = Number(ui.cameraAlphaInput.value);
+            camera.beta = Number(ui.cameraBetaInput.value);
+            camera.radius = Number(ui.cameraRadiusInput.value);
+        };
+        const syncUIFromCamera = (): void => {
+            ui.cameraAlphaInput.value = String(camera.alpha);
+            ui.cameraBetaInput.value = String(camera.beta);
+            ui.cameraRadiusInput.value = String(camera.radius);
+        };
+
+        // イベント接続
+        ui.updateButton.addEventListener("click", () => void refreshTerrain());
+        ui.latInput.addEventListener("change", () => void refreshTerrain());
+        ui.lonInput.addEventListener("change", () => void refreshTerrain());
+        ui.altitudeInput.addEventListener(
+            "change",
+            () => void refreshTerrain()
         );
-        light.intensity = 0.5;
-        light.position.y = 10;
 
-        const shadowGenerator = new ShadowGenerator(512, light)
-        shadowGenerator.useBlurExponentialShadowMap = true;
-        shadowGenerator.blurScale = 2;
-        shadowGenerator.setDarkness(0.2);
+        ui.cameraAlphaInput.addEventListener("input", applyCameraFromUI);
+        ui.cameraBetaInput.addEventListener("input", applyCameraFromUI);
+        ui.cameraRadiusInput.addEventListener("input", applyCameraFromUI);
 
-        shadowGenerator.getShadowMap()!.renderList!.push(sphere);
+        scene.onBeforeRenderObservable.add(syncUIFromCamera);
+
+        // 初回ロード
+        await refreshTerrain();
 
         return scene;
     };

--- a/src/terrain/controlPanel.ts
+++ b/src/terrain/controlPanel.ts
@@ -1,0 +1,158 @@
+/** 操作UIパネル（緯度・経度・高度・カメラ制御） */
+
+export interface ControlPanelElements {
+    panel: HTMLDivElement;
+    status: HTMLDivElement;
+    latInput: HTMLInputElement;
+    lonInput: HTMLInputElement;
+    altitudeInput: HTMLInputElement;
+    cameraAlphaInput: HTMLInputElement;
+    cameraBetaInput: HTMLInputElement;
+    cameraRadiusInput: HTMLInputElement;
+    updateButton: HTMLButtonElement;
+}
+
+const css = (el: HTMLElement, styles: Partial<CSSStyleDeclaration>): void => {
+    Object.assign(el.style, styles);
+};
+
+const createLabel = (text: string): HTMLLabelElement => {
+    const label = document.createElement("label");
+    label.textContent = text;
+    css(label, { display: "grid", gap: "4px" });
+    return label;
+};
+
+const numberInput = (
+    value: number,
+    min: number,
+    max: number,
+    step: string
+): HTMLInputElement => {
+    const input = document.createElement("input");
+    input.type = "number";
+    input.value = String(value);
+    input.min = String(min);
+    input.max = String(max);
+    input.step = step;
+    css(input, { width: "100%" });
+    return input;
+};
+
+const rangeInput = (
+    value: number,
+    min: number,
+    max: number,
+    step: string
+): HTMLInputElement => {
+    const input = document.createElement("input");
+    input.type = "range";
+    input.value = String(value);
+    input.min = String(min);
+    input.max = String(max);
+    input.step = step;
+    css(input, { width: "100%" });
+    return input;
+};
+
+export interface CameraDefaults {
+    alpha: number;
+    beta: number;
+    radius: number;
+}
+
+export const createControlPanel = (
+    initialLat: number,
+    initialLon: number,
+    cameraDefaults: CameraDefaults
+): ControlPanelElements => {
+    const panel = document.createElement("div");
+    css(panel, {
+        position: "absolute",
+        top: "12px",
+        left: "12px",
+        padding: "12px",
+        borderRadius: "8px",
+        background: "rgba(9,18,32,0.72)",
+        color: "#f2f7ff",
+        display: "grid",
+        gap: "8px",
+        minWidth: "280px",
+        fontFamily: "'Helvetica Neue',Helvetica,Arial,sans-serif",
+        fontSize: "13px",
+        backdropFilter: "blur(6px)",
+        zIndex: "10",
+    });
+    document.body.appendChild(panel);
+
+    // ステータス
+    const status = document.createElement("div");
+    status.textContent = "タイル読込待機中…";
+    css(status, { fontSize: "12px" });
+    panel.appendChild(status);
+
+    // 緯度
+    const latLabel = createLabel("緯度");
+    const latInput = numberInput(initialLat, 20, 46, "0.0001");
+    latLabel.appendChild(latInput);
+    panel.appendChild(latLabel);
+
+    // 経度
+    const lonLabel = createLabel("経度");
+    const lonInput = numberInput(initialLon, 122, 154, "0.0001");
+    lonLabel.appendChild(lonInput);
+    panel.appendChild(lonLabel);
+
+    // 高度オフセット
+    const altLabel = createLabel("高度オフセット [m]");
+    const altitudeInput = numberInput(0, -2000, 8000, "1");
+    altLabel.appendChild(altitudeInput);
+    panel.appendChild(altLabel);
+
+    // カメラパン
+    const alphaLabel = createLabel("カメラパン（方位）");
+    const cameraAlphaInput = rangeInput(
+        cameraDefaults.alpha,
+        -Math.PI,
+        Math.PI,
+        "0.01"
+    );
+    alphaLabel.appendChild(cameraAlphaInput);
+    panel.appendChild(alphaLabel);
+
+    // カメラチルト
+    const betaLabel = createLabel("カメラチルト");
+    const cameraBetaInput = rangeInput(cameraDefaults.beta, 0.2, 1.5, "0.01");
+    betaLabel.appendChild(cameraBetaInput);
+    panel.appendChild(betaLabel);
+
+    // カメラズーム
+    const radiusLabel = createLabel("カメラズーム");
+    const cameraRadiusInput = rangeInput(
+        cameraDefaults.radius,
+        250,
+        15000,
+        "10"
+    );
+    radiusLabel.appendChild(cameraRadiusInput);
+    panel.appendChild(radiusLabel);
+
+    // 更新ボタン
+    const updateButton = document.createElement("button");
+    updateButton.type = "button";
+    updateButton.textContent = "地形を更新";
+    css(updateButton, { cursor: "pointer", padding: "8px 10px" });
+    panel.appendChild(updateButton);
+
+    return {
+        panel,
+        status,
+        latInput,
+        lonInput,
+        altitudeInput,
+        cameraAlphaInput,
+        cameraBetaInput,
+        cameraRadiusInput,
+        updateButton,
+    };
+};

--- a/src/terrain/gsiTile.ts
+++ b/src/terrain/gsiTile.ts
@@ -1,0 +1,145 @@
+/** 地理院タイルの座標変換・標高デコード・タイルURL生成 */
+
+export const TILE_SIZE = 256;
+
+const DEM_LAYERS = ["dem5a_png", "dem5b_png", "dem_png"] as const;
+
+export const clamp = (value: number, min: number, max: number): number =>
+    Math.min(Math.max(value, min), max);
+
+/** 緯度経度 → タイル XY */
+export const toTileXY = (
+    lat: number,
+    lon: number,
+    zoom: number
+): { x: number; y: number } => {
+    const latClamped = clamp(lat, -85.05112878, 85.05112878);
+    const n = 2 ** zoom;
+    const x = Math.floor(((lon + 180) / 360) * n);
+    const latRad = (latClamped * Math.PI) / 180;
+    const y = Math.floor(
+        ((1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) /
+            2) *
+            n
+    );
+    return { x, y };
+};
+
+/** タイル1辺の実距離[m] */
+export const tileEdgeMeters = (lat: number, zoom: number): number => {
+    const metersPerPixel =
+        (156543.03392804097 * Math.cos((lat * Math.PI) / 180)) / 2 ** zoom;
+    return metersPerPixel * TILE_SIZE;
+};
+
+/** 地理院標高タイルのRGBデコード（無効値は NaN） */
+export const decodeGsiElevation = (
+    r: number,
+    g: number,
+    b: number
+): number => {
+    if (r === 128 && g === 0 && b === 0) return NaN;
+    const raw = r * 65536 + g * 256 + b;
+    return raw < 2 ** 23 ? raw * 0.01 : (raw - 2 ** 24) * 0.01;
+};
+
+/** 無効値(NaN)を周囲の有効ピクセルから補間する */
+const fillInvalidPixels = (
+    elev: Float32Array,
+    width: number,
+    height: number
+): void => {
+    const offsets = [
+        [-1, -1], [0, -1], [1, -1],
+        [-1,  0],          [1,  0],
+        [-1,  1], [0,  1], [1,  1],
+    ];
+
+    // 距離を広げながら繰り返し補間（最大 16 パス）
+    for (let pass = 0; pass < 16; pass++) {
+        let filled = 0;
+        for (let y = 0; y < height; y++) {
+            for (let x = 0; x < width; x++) {
+                const idx = y * width + x;
+                if (!Number.isNaN(elev[idx])) continue;
+
+                let sum = 0;
+                let count = 0;
+                for (const [dx, dy] of offsets) {
+                    const nx = x + dx;
+                    const ny = y + dy;
+                    if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
+                    const v = elev[ny * width + nx];
+                    if (!Number.isNaN(v)) {
+                        sum += v;
+                        count++;
+                    }
+                }
+                if (count > 0) {
+                    elev[idx] = sum / count;
+                    filled++;
+                }
+            }
+        }
+        if (filled === 0) break;
+    }
+
+    // 全ピクセル無効等で残った NaN は 0 にフォールバック
+    for (let i = 0; i < elev.length; i++) {
+        if (Number.isNaN(elev[i])) elev[i] = 0;
+    }
+};
+
+/** ImageData を fetch して返す（Canvas経由） */
+const loadImageData = async (url: string): Promise<ImageData> => {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`Tile fetch failed: ${url}`);
+    const blob = await res.blob();
+    const bmp = await createImageBitmap(blob);
+    const cvs = document.createElement("canvas");
+    cvs.width = bmp.width;
+    cvs.height = bmp.height;
+    const ctx = cvs.getContext("2d");
+    if (!ctx) throw new Error("2D context unavailable");
+    ctx.drawImage(bmp, 0, 0);
+    const data = ctx.getImageData(0, 0, bmp.width, bmp.height);
+    bmp.close();
+    return data;
+};
+
+/** 標高タイルを読み込み Float32Array で返す（dem5a → dem5b → dem フォールバック） */
+export const loadElevationTile = async (
+    zoom: number,
+    x: number,
+    y: number
+): Promise<Float32Array> => {
+    let lastErr: unknown;
+    for (const layer of DEM_LAYERS) {
+        const url = `https://cyberjapandata.gsi.go.jp/xyz/${layer}/${zoom}/${x}/${y}.png`;
+        try {
+            const img = await loadImageData(url);
+            const elev = new Float32Array(img.width * img.height);
+            for (let i = 0; i < img.data.length; i += 4) {
+                elev[i / 4] = decodeGsiElevation(
+                    img.data[i],
+                    img.data[i + 1],
+                    img.data[i + 2]
+                );
+            }
+            fillInvalidPixels(elev, img.width, img.height);
+            return elev;
+        } catch (e) {
+            lastErr = e;
+        }
+    }
+    throw new Error(
+        `No elevation tile available for z${zoom}/${x}/${y}: ${String(lastErr)}`
+    );
+};
+
+/** 標準地図テクスチャURL */
+export const stdTextureUrl = (
+    zoom: number,
+    x: number,
+    y: number
+): string => `https://cyberjapandata.gsi.go.jp/xyz/std/${zoom}/${x}/${y}.png`;

--- a/src/terrain/gsiTile.ts
+++ b/src/terrain/gsiTile.ts
@@ -32,8 +32,10 @@ export const toTileXY = (
 
 /** タイル1辺の実距離[m] */
 export const tileEdgeMeters = (lat: number, zoom: number): number => {
+    const latClamped = clamp(lat, -85.05112878, 85.05112878);
     const metersPerPixel =
-        (156543.03392804097 * Math.cos((lat * Math.PI) / 180)) / 2 ** zoom;
+        (156543.03392804097 * Math.cos((latClamped * Math.PI) / 180)) /
+        2 ** zoom;
     return metersPerPixel * TILE_SIZE;
 };
 

--- a/src/terrain/gsiTile.ts
+++ b/src/terrain/gsiTile.ts
@@ -14,13 +14,18 @@ export const toTileXY = (
     zoom: number
 ): { x: number; y: number } => {
     const latClamped = clamp(lat, -85.05112878, 85.05112878);
+    const lonNormalized = ((((lon + 180) % 360) + 360) % 360) - 180;
     const n = 2 ** zoom;
-    const x = Math.floor(((lon + 180) / 360) * n);
+    const x = clamp(Math.floor(((lonNormalized + 180) / 360) * n), 0, n - 1);
     const latRad = (latClamped * Math.PI) / 180;
-    const y = Math.floor(
-        ((1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) /
-            2) *
-            n
+    const y = clamp(
+        Math.floor(
+            ((1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) /
+                2) *
+                n
+        ),
+        0,
+        n - 1
     );
     return { x, y };
 };


### PR DESCRIPTION
<!-- Copilot Code Review: Follow .github/copilot-instructions.md. -->
<!-- Copilot Code Review: Follow AGENTS.md. -->
<!-- Copilot Code Review: Write all review comments in Japanese. -->

## 概要

地理院タイルの標高データ（DEM5a/5b/DEM）からタイル1枚分の3D地形メッシュを生成し、
標準地図テクスチャを貼り付けて表示する機能を追加した。
緯度・経度・高度オフセット・カメラ制御が可能な操作UIパネルも実装。

## 関連 Issue

Closes #18

## 変更内容

- **src/terrain/gsiTile.ts（新規）**: 緯度経度→タイルXY変換、RGB標高デコード、無効ピクセル補間、標高タイルのフォールバック読み込み（dem5a→dem5b→dem）、標準地図テクスチャURL生成
- **src/terrain/controlPanel.ts（新規）**: 緯度・経度・高度オフセット入力、カメラ（パン/チルト/ズーム）スライダー、更新ボタンを持つ操作UIパネル
- **src/scenes/default.ts**: サンプルシーン（球体＋地面＋影）を3D地形ビューアに置き換え。ArcRotateCamera、HemisphericLight、標高適用ロジック、テクスチャマッピング、UI連携を実装
- **public/index.html**: ページタイトル・meta情報をプロジェクト固有の内容に更新

## スクリーンショット

### 修正前
<img width="1280" height="720" alt="Render-Default-with-WebGPU-1-chromium-darwin" src="https://github.com/user-attachments/assets/17a6d5ee-ebc5-4a01-b115-045f071bd7d7" />

### 修正後
<img width="1280" height="720" alt="Render-Default-with-WebGPU-1-chromium-darwin" src="https://github.com/user-attachments/assets/3fabc866-0669-4275-b490-439fcecc1de2" />


## 動作確認方法

1. `npm start` で開発サーバーを起動する
2. ブラウザで表示し、東京駅付近の3D地形が描画されることを確認する
3. 操作パネルで緯度・経度を変更し「地形を更新」ボタンを押して別の地点が表示されることを確認する
4. カメラスライダー（パン/チルト/ズーム）で視点が変わることを確認する

## 確認事項

- [ ] Copilot レビューを日本語で実施し、指摘を修正した
- [ ] `npm run test:visuals -- --update-snapshots` は毎回実行していない
- [ ] 画面表示の意図した変更がある場合のみ、開発者がスナップショットを更新した