### PR TITLE
docs: 10_planner.md にIssue作成ルールを追加

### DIFF
--- a/.github/agents/10_planner.md
+++ b/.github/agents/10_planner.md
@@ -8,9 +8,9 @@ version: 0.1
 
 # ルール
 - Issueを作成する。
-  - 機能実装の場合、 .github/ISSUE_TEMPLATE/future.md のテンプレートを使用する。
-  - ドキュメントの場合、 .github/ISSUE_TEMPLATE/docs.md のテンプレートを使用する。
-  - バグ修正の場合、 .github/ISSUE_TEMPLATE/bug.md のテンプレートを使用する。
+  - 機能実装の場合、 `.github/ISSUE_TEMPLATE/feature.md` のテンプレートを使用する。
+  - ドキュメントの場合、 `.github/ISSUE_TEMPLATE/docs.md` のテンプレートを使用する。
+  - バグ修正の場合、 `.github/ISSUE_TEMPLATE/bug.md` のテンプレートを使用する。
 - Parent Issueの指定がなければ、ユーザーに確認する。
 
 # 出力フォーマット

--- a/.github/agents/10_planner.md
+++ b/.github/agents/10_planner.md
@@ -6,6 +6,13 @@ version: 0.1
 # 目的
 要件をタスクに分解し、ローカルで再現可能な作業手順に落とす。
 
+# ルール
+- issueを作成する。
+  - 機能実装の場合、 .github/ISSUE_TEMPLATE/future.md のテンプレートを使用する。
+  - ドキュメントの場合、 .github/ISSUE_TEMPLATE/docs.md のテンプレートを使用する。
+  - バグ修正の場合、 .github/ISSUE_TEMPLATE/bug.md のテンプレートを使用する。
+- Parent issueの指定がなければ、ユーザーに確認する。
+
 # 出力フォーマット
 1. ゴール（1行）
 2. 前提（仮/確定）

--- a/.github/agents/10_planner.md
+++ b/.github/agents/10_planner.md
@@ -8,9 +8,9 @@ version: 0.1
 
 # ルール
 - issueを作成する。
-  - 機能実装の場合、 .github/ISSUE_TEMPLATE/future.md のテンプレートを使用する。
-  - ドキュメントの場合、 .github/ISSUE_TEMPLATE/docs.md のテンプレートを使用する。
-  - バグ修正の場合、 .github/ISSUE_TEMPLATE/bug.md のテンプレートを使用する。
+  - 機能実装の場合、`.github/ISSUE_TEMPLATE/future.md` のテンプレートを使用する。
+  - ドキュメントの場合、`.github/ISSUE_TEMPLATE/docs.md` のテンプレートを使用する。
+  - バグ修正の場合、`.github/ISSUE_TEMPLATE/bug.md` のテンプレートを使用する。
 - Parent issueの指定がなければ、ユーザーに確認する。
 
 # 出力フォーマット

--- a/.github/agents/10_planner.md
+++ b/.github/agents/10_planner.md
@@ -7,11 +7,11 @@ version: 0.1
 要件をタスクに分解し、ローカルで再現可能な作業手順に落とす。
 
 # ルール
-- issueを作成する。
-  - 機能実装の場合、`.github/ISSUE_TEMPLATE/future.md` のテンプレートを使用する。
-  - ドキュメントの場合、`.github/ISSUE_TEMPLATE/docs.md` のテンプレートを使用する。
-  - バグ修正の場合、`.github/ISSUE_TEMPLATE/bug.md` のテンプレートを使用する。
-- Parent issueの指定がなければ、ユーザーに確認する。
+- Issueを作成する。
+  - 機能実装の場合、 .github/ISSUE_TEMPLATE/future.md のテンプレートを使用する。
+  - ドキュメントの場合、 .github/ISSUE_TEMPLATE/docs.md のテンプレートを使用する。
+  - バグ修正の場合、 .github/ISSUE_TEMPLATE/bug.md のテンプレートを使用する。
+- Parent Issueの指定がなければ、ユーザーに確認する。
 
 # 出力フォーマット
 1. ゴール（1行）


### PR DESCRIPTION
## 概要

10_planner エージェントに「ルール」セクションを新設し、Issue作成時のテンプレート選択と親Issue確認のガイドラインを明確化する。

## 関連 Issue

Closes #21

## 変更内容

- `.github/agents/10_planner.md` に「ルール」セクションを追加
  - Issue作成時に使用するテンプレートの選択基準を定義
    - 機能実装: `.github/ISSUE_TEMPLATE/future.md`
    - ドキュメント: `.github/ISSUE_TEMPLATE/docs.md`
    - バグ修正: `.github/ISSUE_TEMPLATE/bug.md`
  - Parent issueの指定がない場合、ユーザーに確認するルールを追加

## 確認事項

- [ ] Copilot レビューを日本語で実施し、指摘を修正した
- [ ] `npm run test:visuals -- --update-snapshots` は毎回実行していない
- [ ] 画面表示の意図した変更がある場合のみ、開発者がスナップショットを更新した