### PR TITLE
feat: カメラビュー内の複数タイル表示

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -114,6 +114,7 @@ module.exports = {
             "ts-jest",
             {
                 useESM: true,
+                tsconfig: "tsconfig.jest.json",
             },
         ],
     },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,6 +5,7 @@ import { defineConfig, devices } from '@playwright/test';
  */
 export default defineConfig({
   testDir: './tests',
+  testMatch: 'validation.spec.ts',
   /* Maximum time one test can run for. */
   timeout: 120 * 1000,
   expect: {

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -1,64 +1,18 @@
 import { Scene } from "@babylonjs/core/scene";
 import { ArcRotateCamera } from "@babylonjs/core/Cameras/arcRotateCamera";
-import { Color3 } from "@babylonjs/core/Maths/math.color";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { CreateGround } from "@babylonjs/core/Meshes/Builders/groundBuilder";
-import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
-import { Texture } from "@babylonjs/core/Materials/Textures/texture";
-import { VertexData } from "@babylonjs/core/Meshes/mesh.vertexData";
-import { VertexBuffer } from "@babylonjs/core/Buffers/buffer";
 import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight";
 import { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { CreateSceneClass } from "../createScene";
-import {
-    TILE_SIZE,
-    clamp,
-    toTileXY,
-    tileEdgeMeters,
-    loadElevationTile,
-    stdTextureUrl,
-} from "../terrain/gsiTile";
+import { clamp } from "../terrain/gsiTile";
 import { createControlPanel } from "../terrain/controlPanel";
+import { createTileManager } from "../terrain/tileManager";
 
 const TERRAIN_SUBDIVISIONS = 128;
 const ELEVATION_ZOOM = 14;
 const HEIGHT_SCALE = 1.0;
 
 const JAPAN_BOUNDS = { minLat: 20, maxLat: 46, minLon: 122, maxLon: 154 };
-
-/** 頂点Y座標を標高値で更新し、中心標高を返す */
-const applyElevation = (
-    positions: Float32Array,
-    elevations: Float32Array,
-    altitudeOffset: number
-): number => {
-    let centerElev = 0;
-    const cols = TERRAIN_SUBDIVISIONS + 1;
-    for (let row = 0; row <= TERRAIN_SUBDIVISIONS; row++) {
-        for (let col = 0; col <= TERRAIN_SUBDIVISIONS; col++) {
-            const u = col / TERRAIN_SUBDIVISIONS;
-            const v = row / TERRAIN_SUBDIVISIONS;
-            const sx = Math.min(
-                TILE_SIZE - 1,
-                Math.round(u * (TILE_SIZE - 1))
-            );
-            const sy = Math.min(
-                TILE_SIZE - 1,
-                Math.round(v * (TILE_SIZE - 1))
-            );
-            const elev = elevations[sy * TILE_SIZE + sx];
-            if (
-                row === TERRAIN_SUBDIVISIONS / 2 &&
-                col === TERRAIN_SUBDIVISIONS / 2
-            ) {
-                centerElev = elev;
-            }
-            positions[(row * cols + col) * 3 + 1] =
-                (elev + altitudeOffset) * HEIGHT_SCALE;
-        }
-    }
-    return centerElev;
-};
 
 export class DefaultScene implements CreateSceneClass {
     createScene = async (
@@ -79,6 +33,7 @@ export class DefaultScene implements CreateSceneClass {
         );
         camera.lowerRadiusLimit = 250;
         camera.upperRadiusLimit = 40000;
+        camera.maxZ = 100000;
         camera.wheelDeltaPercentage = 0.02;
         camera.panningSensibility = 1500;
         camera.attachControl(canvas, true);
@@ -94,22 +49,6 @@ export class DefaultScene implements CreateSceneClass {
         // 初期位置（東京駅付近）
         const initialLat = 35.681236;
         const initialLon = 139.767125;
-        const initialTileSize = tileEdgeMeters(initialLat, ELEVATION_ZOOM);
-
-        // 地形メッシュ
-        const ground = CreateGround(
-            "terrain-ground",
-            {
-                width: initialTileSize,
-                height: initialTileSize,
-                subdivisions: TERRAIN_SUBDIVISIONS,
-                updatable: true,
-            },
-            scene
-        );
-        const groundMat = new StandardMaterial("terrain-mat", scene);
-        groundMat.specularColor = Color3.Black();
-        ground.material = groundMat;
 
         // UIパネル
         const ui = createControlPanel(initialLat, initialLon, {
@@ -118,11 +57,20 @@ export class DefaultScene implements CreateSceneClass {
             radius: camera.radius,
         });
 
-        // 状態
-        let requestId = 0;
+        // TileManager 生成
+        const tileManager = createTileManager({
+            scene,
+            camera,
+            zoom: ELEVATION_ZOOM,
+            subdivisions: TERRAIN_SUBDIVISIONS,
+            heightScale: HEIGHT_SCALE,
+        });
+
+        tileManager.onStatusChange = (status: string) => {
+            ui.status.textContent = status;
+        };
 
         const refreshTerrain = async (): Promise<void> => {
-            const rid = ++requestId;
             const lat = clamp(
                 Number(ui.latInput.value),
                 JAPAN_BOUNDS.minLat,
@@ -138,62 +86,7 @@ export class DefaultScene implements CreateSceneClass {
             ui.latInput.value = lat.toFixed(6);
             ui.lonInput.value = lon.toFixed(6);
 
-            const tile = toTileXY(lat, lon, ELEVATION_ZOOM);
-            ui.status.textContent = `読込中 z${ELEVATION_ZOOM}/${tile.x}/${tile.y}`;
-
-            try {
-                const elev = await loadElevationTile(
-                    ELEVATION_ZOOM,
-                    tile.x,
-                    tile.y
-                );
-                if (rid !== requestId) return; // 古いリクエスト破棄
-
-                const pos = ground.getVerticesData(VertexBuffer.PositionKind);
-                const idx = ground.getIndices();
-                if (!pos || !idx)
-                    throw new Error("Ground mesh data unavailable");
-
-                const typed =
-                    pos instanceof Float32Array
-                        ? pos
-                        : new Float32Array(pos);
-                const centerElev = applyElevation(typed, elev, altOff);
-
-                ground.updateVerticesData(VertexBuffer.PositionKind, typed);
-                const normals = new Float32Array(typed.length);
-                VertexData.ComputeNormals(typed, idx, normals);
-                ground.updateVerticesData(VertexBuffer.NormalKind, normals);
-
-                // タイルサイズ補正
-                const curSize = tileEdgeMeters(lat, ELEVATION_ZOOM);
-                ground.scaling.x = curSize / initialTileSize;
-                ground.scaling.z = curSize / initialTileSize;
-
-                // テクスチャ
-                if (groundMat.diffuseTexture) {
-                    groundMat.diffuseTexture.dispose();
-                }
-                groundMat.diffuseTexture = new Texture(
-                    stdTextureUrl(ELEVATION_ZOOM, tile.x, tile.y),
-                    scene,
-                    true,
-                    true,
-                    Texture.TRILINEAR_SAMPLINGMODE
-                );
-
-                camera.setTarget(
-                    new Vector3(
-                        0,
-                        (centerElev + altOff) * HEIGHT_SCALE,
-                        0
-                    )
-                );
-                ui.status.textContent = `表示中 z${ELEVATION_ZOOM}/${tile.x}/${tile.y}`;
-            } catch (e) {
-                if (rid !== requestId) return;
-                ui.status.textContent = `読込エラー: ${String(e)}`;
-            }
+            await tileManager.setCenter(lat, lon, altOff);
         };
 
         // カメラ ↔ UI 同期
@@ -235,6 +128,9 @@ export class DefaultScene implements CreateSceneClass {
         ui.cameraRadiusInput.addEventListener("input", applyCameraFromUI);
 
         camera.onViewMatrixChangedObservable.add(syncUIFromCamera);
+
+        // カメラ移動時の自動タイル更新
+        tileManager.attachCamera();
 
         // 初回ロード
         await refreshTerrain();

--- a/src/terrain/gsiTile.ts
+++ b/src/terrain/gsiTile.ts
@@ -97,9 +97,12 @@ const fillInvalidPixels = (
     }
 };
 
+/** fetch タイムアウト [ms] */
+const FETCH_TIMEOUT_MS = 15000;
+
 /** ImageData を fetch して返す（Canvas経由） */
 const loadImageData = async (url: string): Promise<ImageData> => {
-    const res = await fetch(url);
+    const res = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
     if (!res.ok) throw new Error(`Tile fetch failed: ${url}`);
     const blob = await res.blob();
     const bmp = await createImageBitmap(blob);

--- a/src/terrain/meshPool.ts
+++ b/src/terrain/meshPool.ts
@@ -69,10 +69,10 @@ export const createMeshPool = (opts: MeshPoolOptions): MeshPool => {
 
         dispose(): void {
             for (const mesh of active) {
-                mesh.dispose();
+                mesh.dispose(false, true);
             }
             for (const mesh of pool) {
-                mesh.dispose();
+                mesh.dispose(false, true);
             }
             active.clear();
             pool.length = 0;

--- a/src/terrain/meshPool.ts
+++ b/src/terrain/meshPool.ts
@@ -1,0 +1,89 @@
+/** 地形メッシュのオブジェクトプール */
+
+import { Mesh } from "@babylonjs/core/Meshes/mesh";
+import { Scene } from "@babylonjs/core/scene";
+import { CreateGround } from "@babylonjs/core/Meshes/Builders/groundBuilder";
+import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
+import { Color3 } from "@babylonjs/core/Maths/math.color";
+
+export interface MeshPool {
+    acquire(): Mesh;
+    release(mesh: Mesh): void;
+    dispose(): void;
+    readonly activeCount: number;
+    readonly pooledCount: number;
+}
+
+export interface MeshPoolOptions {
+    scene: Scene;
+    subdivisions: number;
+    tileSize: number;
+}
+
+let meshSeq = 0;
+
+export const createMeshPool = (opts: MeshPoolOptions): MeshPool => {
+    const { scene, subdivisions, tileSize } = opts;
+    const pool: Mesh[] = [];
+    const active = new Set<Mesh>();
+
+    const createNewMesh = (): Mesh => {
+        const id = meshSeq++;
+        const mesh = CreateGround(
+            `tile-ground-${id}`,
+            {
+                width: tileSize,
+                height: tileSize,
+                subdivisions,
+                updatable: true,
+            },
+            scene
+        );
+        const mat = new StandardMaterial(`tile-mat-${id}`, scene);
+        mat.specularColor = Color3.Black();
+        mesh.material = mat;
+        mesh.setEnabled(false);
+        return mesh;
+    };
+
+    return {
+        acquire(): Mesh {
+            const mesh = pool.pop() ?? createNewMesh();
+            mesh.setEnabled(true);
+            active.add(mesh);
+            return mesh;
+        },
+
+        release(mesh: Mesh): void {
+            if (!active.has(mesh)) return;
+            active.delete(mesh);
+            mesh.setEnabled(false);
+            // テクスチャを解放
+            const mat = mesh.material as StandardMaterial | null;
+            if (mat?.diffuseTexture) {
+                mat.diffuseTexture.dispose();
+                mat.diffuseTexture = null;
+            }
+            pool.push(mesh);
+        },
+
+        dispose(): void {
+            for (const mesh of active) {
+                mesh.dispose();
+            }
+            for (const mesh of pool) {
+                mesh.dispose();
+            }
+            active.clear();
+            pool.length = 0;
+        },
+
+        get activeCount(): number {
+            return active.size;
+        },
+
+        get pooledCount(): number {
+            return pool.length;
+        },
+    };
+};

--- a/src/terrain/tileCache.ts
+++ b/src/terrain/tileCache.ts
@@ -1,0 +1,58 @@
+/** LRU キャッシュ（標高データ用） */
+
+import { TileKey, TileCoord } from "./tileTypes";
+
+export interface TileCacheEntry {
+    coord: TileCoord;
+    elevation: Float32Array;
+}
+
+export interface TileCache {
+    get(key: TileKey): TileCacheEntry | undefined;
+    set(key: TileKey, entry: TileCacheEntry): void;
+    has(key: TileKey): boolean;
+    clear(): void;
+    readonly size: number;
+}
+
+/** Map の挿入順序を利用した LRU キャッシュを生成 */
+export const createTileCache = (capacity: number): TileCache => {
+    const map = new Map<TileKey, TileCacheEntry>();
+
+    return {
+        get(key: TileKey): TileCacheEntry | undefined {
+            const entry = map.get(key);
+            if (entry === undefined) return undefined;
+            // LRU 更新: delete して re-insert
+            map.delete(key);
+            map.set(key, entry);
+            return entry;
+        },
+
+        set(key: TileKey, entry: TileCacheEntry): void {
+            if (map.has(key)) {
+                map.delete(key);
+            }
+            map.set(key, entry);
+            // capacity 超過時に最古エントリを削除
+            if (map.size > capacity) {
+                const oldest = map.keys().next().value;
+                if (oldest !== undefined) {
+                    map.delete(oldest);
+                }
+            }
+        },
+
+        has(key: TileKey): boolean {
+            return map.has(key);
+        },
+
+        clear(): void {
+            map.clear();
+        },
+
+        get size(): number {
+            return map.size;
+        },
+    };
+};

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -1,0 +1,396 @@
+/** タイルのライフサイクルを統合管理する TileManager */
+
+import { Scene } from "@babylonjs/core/scene";
+import { ArcRotateCamera } from "@babylonjs/core/Cameras/arcRotateCamera";
+import { Mesh } from "@babylonjs/core/Meshes/mesh";
+import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
+import { Texture } from "@babylonjs/core/Materials/Textures/texture";
+import { VertexData } from "@babylonjs/core/Meshes/mesh.vertexData";
+import { VertexBuffer } from "@babylonjs/core/Buffers/buffer";
+import { Frustum } from "@babylonjs/core/Maths/math.frustum";
+import { Matrix } from "@babylonjs/core/Maths/math.vector";
+import { Plane } from "@babylonjs/core/Maths/math.plane";
+
+import { TileCoord, TileKey, toTileKey, tileOffsetToWorld } from "./tileTypes";
+import { computeVisibleTiles, FrustumPlane } from "./visibleTiles";
+import { createTileCache, TileCache } from "./tileCache";
+import { createMeshPool, MeshPool } from "./meshPool";
+import {
+    TILE_SIZE,
+    toTileXY,
+    tileEdgeMeters,
+    loadElevationTile,
+    stdTextureUrl,
+} from "./gsiTile";
+
+export interface TileManagerOptions {
+    scene: Scene;
+    camera: ArcRotateCamera;
+    zoom: number;
+    subdivisions: number;
+    heightScale: number;
+    maxConcurrent?: number;
+    maxTiles?: number;
+    cacheCapacity?: number;
+    debounceMs?: number;
+}
+
+export interface TileManager {
+    setCenter(lat: number, lon: number, altitudeOffset?: number): Promise<void>;
+    attachCamera(): void;
+    detachCamera(): void;
+    dispose(): void;
+    readonly activeTileCount: number;
+    readonly loadingCount: number;
+    onStatusChange: ((status: string) => void) | null;
+}
+
+interface ActiveTile {
+    key: TileKey;
+    coord: TileCoord;
+    mesh: Mesh;
+}
+
+const DEFAULT_MAX_CONCURRENT = 4;
+const DEFAULT_MAX_TILES = 25;
+const DEFAULT_CACHE_CAPACITY = 64;
+const DEFAULT_DEBOUNCE_MS = 200;
+
+/** 頂点Y座標を標高値で更新 */
+const applyElevation = (
+    positions: Float32Array,
+    elevations: Float32Array,
+    altitudeOffset: number,
+    heightScale: number,
+    subdivisions: number
+): void => {
+    const cols = subdivisions + 1;
+    for (let row = 0; row <= subdivisions; row++) {
+        for (let col = 0; col <= subdivisions; col++) {
+            const u = col / subdivisions;
+            const v = row / subdivisions;
+            const sx = Math.min(
+                TILE_SIZE - 1,
+                Math.round(u * (TILE_SIZE - 1))
+            );
+            const sy = Math.min(
+                TILE_SIZE - 1,
+                Math.round(v * (TILE_SIZE - 1))
+            );
+            const elev = elevations[sy * TILE_SIZE + sx];
+            positions[(row * cols + col) * 3 + 1] =
+                (elev + altitudeOffset) * heightScale;
+        }
+    }
+};
+
+/** Babylon.js Frustum planes を FrustumPlane[] に変換 */
+const extractFrustumPlanes = (camera: ArcRotateCamera): FrustumPlane[] => {
+    const transform = Matrix.Identity();
+    camera
+        .getViewMatrix()
+        .multiplyToRef(camera.getProjectionMatrix(), transform);
+    const planes: Plane[] = Array.from({ length: 6 }, () => new Plane(0, 0, 0, 0));
+    Frustum.GetPlanesToRef(transform, planes);
+
+    return planes.map((p) => ({
+        normal: { x: p.normal.x, y: p.normal.y, z: p.normal.z },
+        d: p.d,
+    }));
+};
+
+export const createTileManager = (opts: TileManagerOptions): TileManager => {
+    const {
+        scene,
+        camera,
+        zoom,
+        subdivisions,
+        heightScale,
+        maxConcurrent = DEFAULT_MAX_CONCURRENT,
+        maxTiles = DEFAULT_MAX_TILES,
+        cacheCapacity = DEFAULT_CACHE_CAPACITY,
+        debounceMs = DEFAULT_DEBOUNCE_MS,
+    } = opts;
+
+    const cache: TileCache = createTileCache(cacheCapacity);
+    const meshPool: MeshPool = createMeshPool({
+        scene,
+        subdivisions,
+        tileSize: 1, // スケーリングで実サイズに合わせる
+    });
+
+    const activeTiles = new Map<TileKey, ActiveTile>();
+    let requestId = 0;
+    let loadingCount = 0;
+    let statusCallback: ((status: string) => void) | null = null;
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+    let cameraObserver: ReturnType<
+        typeof camera.onViewMatrixChangedObservable.add
+    > | null = null;
+
+    // 現在の中心情報
+    let currentCenter: TileCoord | null = null;
+    let currentTileSize = 0;
+    let currentAltitudeOffset = 0;
+
+    const emitStatus = (): void => {
+        if (!statusCallback) return;
+        const active = activeTiles.size;
+        const loading = loadingCount;
+        if (loading > 0) {
+            statusCallback(
+                `表示中 ${active}/${maxTiles} タイル (読込中: ${loading})`
+            );
+        } else {
+            statusCallback(`表示中 ${active}/${maxTiles} タイル`);
+        }
+    };
+
+    /** 単一タイルをロードしてメッシュに適用 */
+    const loadTile = async (
+        coord: TileCoord,
+        rid: number
+    ): Promise<void> => {
+        const key = toTileKey(coord);
+        if (activeTiles.has(key)) return;
+
+        loadingCount++;
+        emitStatus();
+
+        try {
+            // キャッシュ or fetch
+            let entry = cache.get(key);
+            if (!entry) {
+                const elevation = await loadElevationTile(
+                    coord.zoom,
+                    coord.x,
+                    coord.y
+                );
+                if (rid !== requestId) return;
+                entry = { coord, elevation };
+                cache.set(key, entry);
+            }
+
+            if (rid !== requestId) return;
+            if (activeTiles.has(key)) return;
+
+            // メッシュ取得・配置
+            const mesh = meshPool.acquire();
+            const tileSize = currentTileSize;
+
+            // スケーリング
+            mesh.scaling.x = tileSize;
+            mesh.scaling.z = tileSize;
+            mesh.scaling.y = 1;
+
+            // 中心タイルからのオフセット
+            const dx = coord.x - currentCenter!.x;
+            const dy = coord.y - currentCenter!.y;
+            const { wx, wz } = tileOffsetToWorld(dx, dy, tileSize);
+            mesh.position.x = wx;
+            mesh.position.z = wz;
+
+            // 標高適用
+            const pos = mesh.getVerticesData(VertexBuffer.PositionKind);
+            const idx = mesh.getIndices();
+            if (pos && idx) {
+                const typed =
+                    pos instanceof Float32Array
+                        ? pos
+                        : new Float32Array(pos);
+                applyElevation(
+                    typed,
+                    entry.elevation,
+                    currentAltitudeOffset,
+                    heightScale,
+                    subdivisions
+                );
+                mesh.updateVerticesData(VertexBuffer.PositionKind, typed);
+                const normals = new Float32Array(typed.length);
+                VertexData.ComputeNormals(typed, idx, normals);
+                mesh.updateVerticesData(VertexBuffer.NormalKind, normals);
+            }
+
+            // テクスチャ
+            const mat = mesh.material as StandardMaterial;
+            if (mat.diffuseTexture) {
+                mat.diffuseTexture.dispose();
+            }
+            mat.diffuseTexture = new Texture(
+                stdTextureUrl(coord.zoom, coord.x, coord.y),
+                scene,
+                true,
+                true,
+                Texture.TRILINEAR_SAMPLINGMODE
+            );
+
+            activeTiles.set(key, { key, coord, mesh });
+        } catch (e) {
+            if (rid !== requestId) return;
+            statusCallback?.(
+                `タイル読込失敗 ${key}: ${e instanceof Error ? e.message : String(e)}`
+            );
+        } finally {
+            loadingCount--;
+            emitStatus();
+        }
+    };
+
+    /** 並列数制限付きのロードキュー */
+    const loadTilesInQueue = async (
+        coords: TileCoord[],
+        rid: number
+    ): Promise<void> => {
+        let idx = 0;
+        const next = async (): Promise<void> => {
+            while (idx < coords.length && rid === requestId) {
+                const coord = coords[idx++];
+                await loadTile(coord, rid);
+            }
+        };
+
+        const workers = Array.from(
+            { length: Math.min(maxConcurrent, coords.length) },
+            () => next()
+        );
+        await Promise.all(workers);
+    };
+
+    /** 可視タイルを再計算し、不要タイルを解放・新規タイルをロード */
+    const refresh = async (
+        lat: number,
+        lon: number,
+        altitudeOffset: number
+    ): Promise<void> => {
+        const rid = ++requestId;
+
+        const center = toTileXY(lat, lon, zoom);
+        const tileSize = tileEdgeMeters(lat, zoom);
+        currentCenter = { zoom, x: center.x, y: center.y };
+        currentTileSize = tileSize;
+        currentAltitudeOffset = altitudeOffset;
+
+        // Frustum planes 取得
+        const frustumPlanes = extractFrustumPlanes(camera);
+
+        // 可視タイル算出
+        const visibleCoords = computeVisibleTiles({
+            center: currentCenter,
+            tileSize,
+            frustumPlanes,
+            maxTiles,
+        });
+        const visibleKeys = new Set(visibleCoords.map(toTileKey));
+
+        // 不要タイルを解放
+        for (const [key, tile] of activeTiles) {
+            if (!visibleKeys.has(key)) {
+                meshPool.release(tile.mesh);
+                activeTiles.delete(key);
+            }
+        }
+
+        // 新規タイルのみロード
+        const toLoad = visibleCoords.filter(
+            (c) => !activeTiles.has(toTileKey(c))
+        );
+
+        if (toLoad.length > 0) {
+            await loadTilesInQueue(toLoad, rid);
+        }
+
+        emitStatus();
+    };
+
+    // カメラ変更時のリフレッシュ（中心座標を保持して使用）
+    const refreshFromCamera = async (): Promise<void> => {
+        if (!currentCenter) return;
+        const rid = ++requestId;
+
+        const frustumPlanes = extractFrustumPlanes(camera);
+        const visibleCoords = computeVisibleTiles({
+            center: currentCenter,
+            tileSize: currentTileSize,
+            frustumPlanes,
+            maxTiles,
+        });
+        const visibleKeys = new Set(visibleCoords.map(toTileKey));
+
+        // 不要タイルを解放
+        for (const [key, tile] of activeTiles) {
+            if (!visibleKeys.has(key)) {
+                meshPool.release(tile.mesh);
+                activeTiles.delete(key);
+            }
+        }
+
+        // 新規タイルのみロード
+        const toLoad = visibleCoords.filter(
+            (c) => !activeTiles.has(toTileKey(c))
+        );
+
+        if (toLoad.length > 0) {
+            await loadTilesInQueue(toLoad, rid);
+        }
+
+        emitStatus();
+    };
+
+    return {
+        async setCenter(
+            lat: number,
+            lon: number,
+            altitudeOffset = 0
+        ): Promise<void> {
+            await refresh(lat, lon, altitudeOffset);
+        },
+
+        attachCamera(): void {
+            if (cameraObserver) return;
+            cameraObserver = camera.onViewMatrixChangedObservable.add(() => {
+                if (debounceTimer !== null) {
+                    clearTimeout(debounceTimer);
+                }
+                debounceTimer = setTimeout(() => {
+                    void refreshFromCamera();
+                }, debounceMs);
+            });
+        },
+
+        detachCamera(): void {
+            if (cameraObserver) {
+                camera.onViewMatrixChangedObservable.remove(cameraObserver);
+                cameraObserver = null;
+            }
+            if (debounceTimer !== null) {
+                clearTimeout(debounceTimer);
+                debounceTimer = null;
+            }
+        },
+
+        dispose(): void {
+            this.detachCamera();
+            for (const [, tile] of activeTiles) {
+                meshPool.release(tile.mesh);
+            }
+            activeTiles.clear();
+            cache.clear();
+            meshPool.dispose();
+        },
+
+        get activeTileCount(): number {
+            return activeTiles.size;
+        },
+
+        get loadingCount(): number {
+            return loadingCount;
+        },
+
+        set onStatusChange(cb: ((status: string) => void) | null) {
+            statusCallback = cb;
+        },
+        get onStatusChange(): ((status: string) => void) | null {
+            return statusCallback;
+        },
+    };
+};

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -55,6 +55,8 @@ const DEFAULT_MAX_CONCURRENT = 4;
 const DEFAULT_MAX_TILES = 25;
 const DEFAULT_CACHE_CAPACITY = 64;
 const DEFAULT_DEBOUNCE_MS = 200;
+/** Frustum 判定用の基準最大標高 (m) — 富士山 3776m + マージン */
+const MAX_BASE_ELEVATION = 4000;
 
 /** 頂点Y座標を標高値で更新 */
 const applyElevation = (
@@ -317,12 +319,17 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         // Frustum planes 取得
         const frustumPlanes = extractFrustumPlanes(camera);
 
+        // AABB maxY: (想定最大標高 + 高度オフセット) * heightScale
+        const maxElevation =
+            (MAX_BASE_ELEVATION + Math.max(0, altitudeOffset)) * heightScale;
+
         // 可視タイル算出
         const visibleCoords = computeVisibleTiles({
             center: currentCenter,
             tileSize,
             frustumPlanes,
             maxTiles,
+            maxElevation,
         });
         const visibleKeys = new Set(visibleCoords.map(toTileKey));
 
@@ -355,11 +362,15 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         const rid = ++requestId;
 
         const frustumPlanes = extractFrustumPlanes(camera);
+        const maxElevation =
+            (MAX_BASE_ELEVATION + Math.max(0, currentAltitudeOffset)) *
+            heightScale;
         const visibleCoords = computeVisibleTiles({
             center: currentCenter,
             tileSize: currentTileSize,
             frustumPlanes,
             maxTiles,
+            maxElevation,
         });
         const visibleKeys = new Set(visibleCoords.map(toTileKey));
 

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -236,6 +236,50 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         }
     };
 
+    /** 既存 activeTiles の position/scaling/標高を現在の中心・タイルサイズ・高度オフセットに合わせて再配置 */
+    const repositionActiveTiles = (): void => {
+        if (!currentCenter) return;
+        for (const [key, tile] of activeTiles) {
+            const { mesh, coord } = tile;
+
+            // スケーリング
+            mesh.scaling.x = currentTileSize;
+            mesh.scaling.z = currentTileSize;
+            mesh.scaling.y = 1;
+
+            // 位置
+            const dx = coord.x - currentCenter.x;
+            const dy = coord.y - currentCenter.y;
+            const { wx, wz } = tileOffsetToWorld(dx, dy, currentTileSize);
+            mesh.position.x = wx;
+            mesh.position.z = wz;
+
+            // キャッシュから標高データを取得し再適用
+            const entry = cache.get(key);
+            if (entry) {
+                const pos = mesh.getVerticesData(VertexBuffer.PositionKind);
+                const idx = mesh.getIndices();
+                if (pos && idx) {
+                    const typed =
+                        pos instanceof Float32Array
+                            ? pos
+                            : new Float32Array(pos);
+                    applyElevation(
+                        typed,
+                        entry.elevation,
+                        currentAltitudeOffset,
+                        heightScale,
+                        subdivisions
+                    );
+                    mesh.updateVerticesData(VertexBuffer.PositionKind, typed);
+                    const normals = new Float32Array(typed.length);
+                    VertexData.ComputeNormals(typed, idx, normals);
+                    mesh.updateVerticesData(VertexBuffer.NormalKind, normals);
+                }
+            }
+        }
+    };
+
     /** 並列数制限付きのロードキュー */
     const loadTilesInQueue = async (
         coords: TileCoord[],
@@ -289,6 +333,9 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
                 activeTiles.delete(key);
             }
         }
+
+        // 既存タイルの position/scaling/標高を新しい中心基準で再配置
+        repositionActiveTiles();
 
         // 新規タイルのみロード
         const toLoad = visibleCoords.filter(

--- a/src/terrain/tileTypes.ts
+++ b/src/terrain/tileTypes.ts
@@ -1,0 +1,37 @@
+/** タイル座標の型定義と座標変換ユーティリティ */
+
+/** タイル座標の一意キー（"z/x/y" 形式文字列） */
+export type TileKey = `${number}/${number}/${number}`;
+
+export interface TileCoord {
+    readonly zoom: number;
+    readonly x: number;
+    readonly y: number;
+}
+
+/** TileCoord → TileKey */
+export const toTileKey = (coord: TileCoord): TileKey =>
+    `${coord.zoom}/${coord.x}/${coord.y}`;
+
+/**
+ * 中心タイルからの相対オフセットをワールド座標(x, z)に変換。
+ * タイルY軸は南向き、Babylon.js Z軸は北向きのため符号を反転。
+ */
+export const tileOffsetToWorld = (
+    dx: number,
+    dy: number,
+    tileSize: number
+): { wx: number; wz: number } => ({
+    wx: dx * tileSize,
+    wz: -(dy * tileSize) || 0,
+});
+
+/** ワールド座標(x, z) → 中心タイルからの相対タイルオフセット */
+export const worldToTileOffset = (
+    wx: number,
+    wz: number,
+    tileSize: number
+): { dx: number; dy: number } => ({
+    dx: Math.round(wx / tileSize),
+    dy: -(Math.round(wz / tileSize)) || 0,
+});

--- a/src/terrain/tileTypes.ts
+++ b/src/terrain/tileTypes.ts
@@ -17,13 +17,17 @@ export const toTileKey = (coord: TileCoord): TileKey =>
  * 中心タイルからの相対オフセットをワールド座標(x, z)に変換。
  * タイルY軸は南向き、Babylon.js Z軸は北向きのため符号を反転。
  */
+/** -0 を +0 に正規化する（NaN はそのまま伝播） */
+const normalizeNegZero = (v: number): number =>
+    Object.is(v, -0) ? 0 : v;
+
 export const tileOffsetToWorld = (
     dx: number,
     dy: number,
     tileSize: number
 ): { wx: number; wz: number } => ({
     wx: dx * tileSize,
-    wz: -(dy * tileSize) || 0,
+    wz: normalizeNegZero(-(dy * tileSize)),
 });
 
 /** ワールド座標(x, z) → 中心タイルからの相対タイルオフセット */
@@ -33,5 +37,5 @@ export const worldToTileOffset = (
     tileSize: number
 ): { dx: number; dy: number } => ({
     dx: Math.round(wx / tileSize),
-    dy: -(Math.round(wz / tileSize)) || 0,
+    dy: normalizeNegZero(-(Math.round(wz / tileSize))),
 });

--- a/src/terrain/visibleTiles.ts
+++ b/src/terrain/visibleTiles.ts
@@ -13,12 +13,14 @@ export interface VisibleTilesOptions {
     frustumPlanes: readonly FrustumPlane[];
     maxTiles?: number;
     searchRadius?: number;
+    /** AABB の maxY に使う値。省略時は DEFAULT_MAX_ELEVATION (4000) */
+    maxElevation?: number;
 }
 
 const DEFAULT_MAX_TILES = 25;
 const DEFAULT_SEARCH_RADIUS = 4;
 /** 日本の標高上限概算（富士山 3776m + マージン） */
-const MAX_ELEVATION = 4000;
+const DEFAULT_MAX_ELEVATION = 4000;
 
 /** AABB が Frustum の全平面の内側または交差にあるか判定 */
 const isAABBInFrustum = (
@@ -55,6 +57,7 @@ export const computeVisibleTiles = (opts: VisibleTilesOptions): TileCoord[] => {
         frustumPlanes,
         maxTiles = DEFAULT_MAX_TILES,
         searchRadius = DEFAULT_SEARCH_RADIUS,
+        maxElevation = DEFAULT_MAX_ELEVATION,
     } = opts;
 
     const half = tileSize / 2;
@@ -71,7 +74,7 @@ export const computeVisibleTiles = (opts: VisibleTilesOptions): TileCoord[] => {
             if (
                 isAABBInFrustum(
                     minX, 0, minZ,
-                    maxX, MAX_ELEVATION, maxZ,
+                    maxX, maxElevation, maxZ,
                     frustumPlanes
                 )
             ) {

--- a/src/terrain/visibleTiles.ts
+++ b/src/terrain/visibleTiles.ts
@@ -1,0 +1,93 @@
+/** カメラFrustum内の可視タイルを算出する */
+
+import { TileCoord, tileOffsetToWorld } from "./tileTypes";
+
+export interface FrustumPlane {
+    normal: { x: number; y: number; z: number };
+    d: number;
+}
+
+export interface VisibleTilesOptions {
+    center: TileCoord;
+    tileSize: number;
+    frustumPlanes: readonly FrustumPlane[];
+    maxTiles?: number;
+    searchRadius?: number;
+}
+
+const DEFAULT_MAX_TILES = 25;
+const DEFAULT_SEARCH_RADIUS = 4;
+/** 日本の標高上限概算（富士山 3776m + マージン） */
+const MAX_ELEVATION = 4000;
+
+/** AABB が Frustum の全平面の内側または交差にあるか判定 */
+const isAABBInFrustum = (
+    minX: number,
+    minY: number,
+    minZ: number,
+    maxX: number,
+    maxY: number,
+    maxZ: number,
+    planes: readonly FrustumPlane[]
+): boolean => {
+    for (const plane of planes) {
+        const { normal, d } = plane;
+        // AABB の「平面に最も近い頂点」（P-vertex）を選択
+        const px = normal.x >= 0 ? maxX : minX;
+        const py = normal.y >= 0 ? maxY : minY;
+        const pz = normal.z >= 0 ? maxZ : minZ;
+        // P-vertex が平面の外側なら完全に外
+        if (normal.x * px + normal.y * py + normal.z * pz + d < 0) {
+            return false;
+        }
+    }
+    return true;
+};
+
+/**
+ * カメラ Frustum 内の可視タイル座標を返す。
+ * 距離が近い順にソート済み、maxTiles で打ち切り。
+ */
+export const computeVisibleTiles = (opts: VisibleTilesOptions): TileCoord[] => {
+    const {
+        center,
+        tileSize,
+        frustumPlanes,
+        maxTiles = DEFAULT_MAX_TILES,
+        searchRadius = DEFAULT_SEARCH_RADIUS,
+    } = opts;
+
+    const half = tileSize / 2;
+    const candidates: { coord: TileCoord; dist: number }[] = [];
+
+    for (let dy = -searchRadius; dy <= searchRadius; dy++) {
+        for (let dx = -searchRadius; dx <= searchRadius; dx++) {
+            const { wx, wz } = tileOffsetToWorld(dx, dy, tileSize);
+            const minX = wx - half;
+            const maxX = wx + half;
+            const minZ = wz - half;
+            const maxZ = wz + half;
+
+            if (
+                isAABBInFrustum(
+                    minX, 0, minZ,
+                    maxX, MAX_ELEVATION, maxZ,
+                    frustumPlanes
+                )
+            ) {
+                const dist = Math.abs(dx) + Math.abs(dy); // マンハッタン距離
+                candidates.push({
+                    coord: {
+                        zoom: center.zoom,
+                        x: center.x + dx,
+                        y: center.y + dy,
+                    },
+                    dist,
+                });
+            }
+        }
+    }
+
+    candidates.sort((a, b) => a.dist - b.dist);
+    return candidates.slice(0, maxTiles).map((c) => c.coord);
+};

--- a/tests/meshPool.unit.spec.ts
+++ b/tests/meshPool.unit.spec.ts
@@ -1,0 +1,112 @@
+/**
+ * meshPool のユニットテスト。
+ * Babylon.js の Scene/Mesh をモックして、acquire/release のロジックを検証する。
+ */
+
+import { jest, describe, it, expect } from "@jest/globals";
+
+const createMockMesh = () => ({
+    material: null as unknown,
+    setEnabled: jest.fn(),
+    dispose: jest.fn(),
+    scaling: { x: 1, y: 1, z: 1 },
+    position: { x: 0, y: 0, z: 0 },
+});
+
+jest.unstable_mockModule("@babylonjs/core/Meshes/Builders/groundBuilder", () => ({
+    CreateGround: jest.fn(() => createMockMesh()),
+}));
+
+jest.unstable_mockModule("@babylonjs/core/Materials/standardMaterial", () => ({
+    StandardMaterial: jest.fn().mockImplementation(() => ({
+        specularColor: null,
+        diffuseTexture: null,
+        dispose: jest.fn(),
+    })),
+}));
+
+jest.unstable_mockModule("@babylonjs/core/Maths/math.color", () => ({
+    Color3: {
+        Black: jest.fn(() => ({ r: 0, g: 0, b: 0 })),
+    },
+}));
+
+const { createMeshPool } = await import("../src/terrain/meshPool");
+
+const mockScene = {} as never;
+
+describe("createMeshPool", () => {
+    it("acquire でメッシュを取得し activeCount が増加する", () => {
+        const pool = createMeshPool({
+            scene: mockScene,
+            subdivisions: 128,
+            tileSize: 100,
+        });
+
+        expect(pool.activeCount).toBe(0);
+        const mesh = pool.acquire();
+        expect(mesh).toBeDefined();
+        expect(pool.activeCount).toBe(1);
+    });
+
+    it("release でメッシュがプールに戻り pooledCount が増加する", () => {
+        const pool = createMeshPool({
+            scene: mockScene,
+            subdivisions: 128,
+            tileSize: 100,
+        });
+
+        const mesh = pool.acquire();
+        expect(pool.activeCount).toBe(1);
+        expect(pool.pooledCount).toBe(0);
+
+        pool.release(mesh);
+        expect(pool.activeCount).toBe(0);
+        expect(pool.pooledCount).toBe(1);
+    });
+
+    it("release 後の acquire でプールからメッシュを再利用する", () => {
+        const pool = createMeshPool({
+            scene: mockScene,
+            subdivisions: 128,
+            tileSize: 100,
+        });
+
+        const mesh1 = pool.acquire();
+        pool.release(mesh1);
+
+        const mesh2 = pool.acquire();
+        expect(mesh2).toBe(mesh1); // 同一オブジェクト
+    });
+
+    it("active でないメッシュの release は無視される", () => {
+        const pool = createMeshPool({
+            scene: mockScene,
+            subdivisions: 128,
+            tileSize: 100,
+        });
+
+        const mesh = pool.acquire();
+        pool.release(mesh);
+        pool.release(mesh); // 二重 release
+        expect(pool.pooledCount).toBe(1); // 1つのまま
+    });
+
+    it("dispose で全メッシュが破棄される", () => {
+        const pool = createMeshPool({
+            scene: mockScene,
+            subdivisions: 128,
+            tileSize: 100,
+        });
+
+        const mesh1 = pool.acquire();
+        const mesh2 = pool.acquire();
+        pool.release(mesh2);
+
+        pool.dispose();
+        expect(pool.activeCount).toBe(0);
+        expect(pool.pooledCount).toBe(0);
+        expect(mesh1.dispose).toHaveBeenCalled();
+        expect(mesh2.dispose).toHaveBeenCalled();
+    });
+});

--- a/tests/tileCache.unit.spec.ts
+++ b/tests/tileCache.unit.spec.ts
@@ -1,0 +1,80 @@
+import { createTileCache } from "../src/terrain/tileCache";
+import type { TileKey, TileCoord } from "../src/terrain/tileTypes";
+
+const makeEntry = (zoom: number, x: number, y: number) => ({
+    coord: { zoom, x, y } as TileCoord,
+    elevation: new Float32Array(4),
+});
+
+describe("createTileCache", () => {
+    it("set/get の基本動作", () => {
+        const cache = createTileCache(10);
+        const key: TileKey = "14/100/200";
+        const entry = makeEntry(14, 100, 200);
+
+        cache.set(key, entry);
+        expect(cache.has(key)).toBe(true);
+        expect(cache.get(key)).toBe(entry);
+        expect(cache.size).toBe(1);
+    });
+
+    it("存在しないキーの get は undefined を返す", () => {
+        const cache = createTileCache(10);
+        expect(cache.get("14/0/0")).toBeUndefined();
+    });
+
+    it("capacity 超過時に最古エントリが削除される", () => {
+        const cache = createTileCache(3);
+
+        cache.set("14/1/1", makeEntry(14, 1, 1));
+        cache.set("14/2/2", makeEntry(14, 2, 2));
+        cache.set("14/3/3", makeEntry(14, 3, 3));
+        expect(cache.size).toBe(3);
+
+        // 4つ目を追加 → 最古の 14/1/1 が消える
+        cache.set("14/4/4", makeEntry(14, 4, 4));
+        expect(cache.size).toBe(3);
+        expect(cache.has("14/1/1")).toBe(false);
+        expect(cache.has("14/2/2")).toBe(true);
+        expect(cache.has("14/3/3")).toBe(true);
+        expect(cache.has("14/4/4")).toBe(true);
+    });
+
+    it("get で LRU が更新される", () => {
+        const cache = createTileCache(3);
+
+        cache.set("14/1/1", makeEntry(14, 1, 1));
+        cache.set("14/2/2", makeEntry(14, 2, 2));
+        cache.set("14/3/3", makeEntry(14, 3, 3));
+
+        // 14/1/1 を get して LRU を更新
+        cache.get("14/1/1");
+
+        // 4つ目を追加 → 最古は 14/2/2 になっているはず
+        cache.set("14/4/4", makeEntry(14, 4, 4));
+        expect(cache.has("14/1/1")).toBe(true);
+        expect(cache.has("14/2/2")).toBe(false);
+    });
+
+    it("clear で全エントリが削除される", () => {
+        const cache = createTileCache(10);
+        cache.set("14/1/1", makeEntry(14, 1, 1));
+        cache.set("14/2/2", makeEntry(14, 2, 2));
+
+        cache.clear();
+        expect(cache.size).toBe(0);
+        expect(cache.has("14/1/1")).toBe(false);
+    });
+
+    it("同じキーで set するとエントリが上書きされる", () => {
+        const cache = createTileCache(3);
+        const entry1 = makeEntry(14, 1, 1);
+        const entry2 = makeEntry(14, 1, 1);
+
+        cache.set("14/1/1", entry1);
+        cache.set("14/1/1", entry2);
+
+        expect(cache.size).toBe(1);
+        expect(cache.get("14/1/1")).toBe(entry2);
+    });
+});

--- a/tests/tileManager.unit.spec.ts
+++ b/tests/tileManager.unit.spec.ts
@@ -1,0 +1,202 @@
+/**
+ * tileManager のユニットテスト。
+ * Babylon.js 依存をモックし、TileManager のロジックを検証する。
+ */
+
+import { jest, describe, it, expect } from "@jest/globals";
+
+const mockMeshInstance = () => ({
+    material: {
+        specularColor: null,
+        diffuseTexture: null,
+        dispose: jest.fn(),
+    },
+    setEnabled: jest.fn(),
+    dispose: jest.fn(),
+    scaling: { x: 1, y: 1, z: 1 },
+    position: { x: 0, y: 0, z: 0 },
+    getVerticesData: jest.fn(() => new Float32Array(3 * 129 * 129)),
+    getIndices: jest.fn(() => new Uint32Array(6 * 128 * 128)),
+    updateVerticesData: jest.fn(),
+});
+
+jest.unstable_mockModule("@babylonjs/core/Meshes/Builders/groundBuilder", () => ({
+    CreateGround: jest.fn(() => mockMeshInstance()),
+}));
+
+jest.unstable_mockModule("@babylonjs/core/Materials/standardMaterial", () => ({
+    StandardMaterial: jest.fn().mockImplementation(() => ({
+        specularColor: null,
+        diffuseTexture: null,
+        dispose: jest.fn(),
+    })),
+}));
+
+jest.unstable_mockModule("@babylonjs/core/Materials/Textures/texture", () => ({
+    Texture: jest.fn().mockImplementation(() => ({
+        dispose: jest.fn(),
+    })),
+}));
+
+jest.unstable_mockModule("@babylonjs/core/Maths/math.color", () => ({
+    Color3: {
+        Black: jest.fn(() => ({ r: 0, g: 0, b: 0 })),
+    },
+}));
+
+jest.unstable_mockModule("@babylonjs/core/Meshes/mesh.vertexData", () => ({
+    VertexData: {
+        ComputeNormals: jest.fn(),
+    },
+}));
+
+jest.unstable_mockModule("@babylonjs/core/Buffers/buffer", () => ({
+    VertexBuffer: {
+        PositionKind: "position",
+        NormalKind: "normal",
+    },
+}));
+
+jest.unstable_mockModule("@babylonjs/core/Maths/math.frustum", () => ({
+    Frustum: {
+        GetPlanesToRef: jest.fn((_transform: unknown, planes: Array<{ normal: { x: number; y: number; z: number }; d: number }>) => {
+            // 事前に Plane インスタンスが入っている前提で上書き
+            for (let i = 0; i < 6; i++) {
+                planes[i].normal.x = 0;
+                planes[i].normal.y = 0;
+                planes[i].normal.z = 0;
+                planes[i].d = 1e9;
+            }
+        }),
+    },
+}));
+
+jest.unstable_mockModule("@babylonjs/core/Maths/math.vector", () => ({
+    Matrix: {
+        Identity: jest.fn(() => ({
+            m: new Float32Array(16),
+        })),
+    },
+}));
+
+jest.unstable_mockModule("@babylonjs/core/Maths/math.plane", () => ({
+    Plane: jest.fn().mockImplementation(() => ({
+        normal: { x: 0, y: 0, z: 0 },
+        d: 0,
+    })),
+}));
+
+jest.unstable_mockModule("../src/terrain/gsiTile", () => ({
+    TILE_SIZE: 256,
+    clamp: jest.fn((v: number, min: number, max: number) =>
+        Math.min(Math.max(v, min), max)
+    ),
+    toTileXY: jest.fn(() => ({ x: 14547, y: 6452 })),
+    tileEdgeMeters: jest.fn(() => 1000),
+    loadElevationTile: jest.fn(
+        () => Promise.resolve(new Float32Array(256 * 256))
+    ),
+    stdTextureUrl: jest.fn(() => "https://example.com/tile.png"),
+}));
+
+const { createTileManager } = await import("../src/terrain/tileManager");
+
+const createMockCamera = () => {
+    const observers: Array<() => void> = [];
+    return {
+        alpha: 0,
+        beta: 0,
+        radius: 4000,
+        getScene: jest.fn(() => ({
+            getEngine: jest.fn(() => ({})),
+        })),
+        getViewMatrix: jest.fn(() => ({
+            multiplyToRef: jest.fn(),
+        })),
+        getProjectionMatrix: jest.fn(() => ({})),
+        onViewMatrixChangedObservable: {
+            add: jest.fn((cb: () => void) => {
+                observers.push(cb);
+                return cb;
+            }),
+            remove: jest.fn(),
+        },
+        _observers: observers,
+    } as never;
+};
+
+describe("createTileManager", () => {
+    it("setCenter でタイルがロードされる", async () => {
+        const camera = createMockCamera();
+        const tm = createTileManager({
+            scene: {} as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 5,
+        });
+
+        await tm.setCenter(35.68, 139.77);
+        expect(tm.activeTileCount).toBeGreaterThan(0);
+    });
+
+    it("onStatusChange コールバックが呼ばれる", async () => {
+        const camera = createMockCamera();
+        const tm = createTileManager({
+            scene: {} as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 3,
+        });
+
+        const statuses: string[] = [];
+        tm.onStatusChange = (s) => statuses.push(s);
+
+        await tm.setCenter(35.68, 139.77);
+        expect(statuses.length).toBeGreaterThan(0);
+    });
+
+    it("dispose 後に activeTileCount が 0 になる", async () => {
+        const camera = createMockCamera();
+        const tm = createTileManager({
+            scene: {} as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 5,
+        });
+
+        await tm.setCenter(35.68, 139.77);
+        expect(tm.activeTileCount).toBeGreaterThan(0);
+
+        tm.dispose();
+        expect(tm.activeTileCount).toBe(0);
+    });
+
+    it("attachCamera/detachCamera が正常に動作する", () => {
+        const camera = createMockCamera();
+        const tm = createTileManager({
+            scene: {} as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+        });
+
+        // attachCamera でオブザーバが追加される
+        tm.attachCamera();
+        expect(
+            (camera as any).onViewMatrixChangedObservable.add
+        ).toHaveBeenCalled();
+
+        // detachCamera でオブザーバが削除される
+        tm.detachCamera();
+        expect(
+            (camera as any).onViewMatrixChangedObservable.remove
+        ).toHaveBeenCalled();
+    });
+});

--- a/tests/tileTypes.unit.spec.ts
+++ b/tests/tileTypes.unit.spec.ts
@@ -1,0 +1,57 @@
+import { toTileKey, tileOffsetToWorld, worldToTileOffset } from "../src/terrain/tileTypes";
+import type { TileCoord } from "../src/terrain/tileTypes";
+
+describe("toTileKey", () => {
+    it("TileCoord を 'z/x/y' 形式の文字列に変換する", () => {
+        const coord: TileCoord = { zoom: 14, x: 14547, y: 6452 };
+        expect(toTileKey(coord)).toBe("14/14547/6452");
+    });
+
+    it("zoom=0 の場合", () => {
+        expect(toTileKey({ zoom: 0, x: 0, y: 0 })).toBe("0/0/0");
+    });
+});
+
+describe("tileOffsetToWorld", () => {
+    it("dx=0, dy=0 のときワールド原点を返す", () => {
+        const { wx, wz } = tileOffsetToWorld(0, 0, 100);
+        expect(wx).toBe(0);
+        expect(wz).toBe(0);
+    });
+
+    it("dx=1 で正のX方向にオフセット", () => {
+        const { wx, wz } = tileOffsetToWorld(1, 0, 200);
+        expect(wx).toBe(200);
+        expect(wz).toBe(0);
+    });
+
+    it("dy=1 で負のZ方向にオフセット（タイルY軸反転）", () => {
+        const { wx, wz } = tileOffsetToWorld(0, 1, 200);
+        expect(wx).toBe(0);
+        expect(wz).toBe(-200);
+    });
+
+    it("dx=-1, dy=-1 の場合", () => {
+        const { wx, wz } = tileOffsetToWorld(-1, -1, 150);
+        expect(wx).toBe(-150);
+        expect(wz).toBe(150);
+    });
+});
+
+describe("worldToTileOffset", () => {
+    it("ワールド原点から dx=0, dy=0 を返す", () => {
+        const { dx, dy } = worldToTileOffset(0, 0, 100);
+        expect(dx).toBe(0);
+        expect(dy).toBe(0);
+    });
+
+    it("tileOffsetToWorld の逆変換が一致する", () => {
+        const tileSize = 234.5;
+        for (const [origDx, origDy] of [[1, 2], [-3, 4], [0, -1], [5, 5]]) {
+            const { wx, wz } = tileOffsetToWorld(origDx, origDy, tileSize);
+            const { dx, dy } = worldToTileOffset(wx, wz, tileSize);
+            expect(dx).toBe(origDx);
+            expect(dy).toBe(origDy);
+        }
+    });
+});

--- a/tests/tileTypes.unit.spec.ts
+++ b/tests/tileTypes.unit.spec.ts
@@ -36,6 +36,11 @@ describe("tileOffsetToWorld", () => {
         expect(wx).toBe(-150);
         expect(wz).toBe(150);
     });
+
+    it("NaN 入力はそのまま伝播する", () => {
+        const { wz } = tileOffsetToWorld(0, NaN, 100);
+        expect(wz).toBeNaN();
+    });
 });
 
 describe("worldToTileOffset", () => {
@@ -43,6 +48,11 @@ describe("worldToTileOffset", () => {
         const { dx, dy } = worldToTileOffset(0, 0, 100);
         expect(dx).toBe(0);
         expect(dy).toBe(0);
+    });
+
+    it("NaN 入力はそのまま伝播する", () => {
+        const { dy } = worldToTileOffset(0, NaN, 100);
+        expect(dy).toBeNaN();
     });
 
     it("tileOffsetToWorld の逆変換が一致する", () => {

--- a/tests/visibleTiles.unit.spec.ts
+++ b/tests/visibleTiles.unit.spec.ts
@@ -1,0 +1,107 @@
+import { computeVisibleTiles } from "../src/terrain/visibleTiles";
+import type { FrustumPlane } from "../src/terrain/visibleTiles";
+import type { TileCoord } from "../src/terrain/tileTypes";
+
+/**
+ * 全てを包含する Frustum planes（全候補が可視）。
+ * 6平面すべてが十分に遠い位置に設定。
+ */
+const allVisiblePlanes: FrustumPlane[] = [
+    { normal: { x: 1, y: 0, z: 0 }, d: 1e9 },
+    { normal: { x: -1, y: 0, z: 0 }, d: 1e9 },
+    { normal: { x: 0, y: 1, z: 0 }, d: 1e9 },
+    { normal: { x: 0, y: -1, z: 0 }, d: 1e9 },
+    { normal: { x: 0, y: 0, z: 1 }, d: 1e9 },
+    { normal: { x: 0, y: 0, z: -1 }, d: 1e9 },
+];
+
+/**
+ * 全てを除外する Frustum planes（全候補が不可視）。
+ * 互いに矛盾する平面で、どの点も内側にならない。
+ */
+const noneVisiblePlanes: FrustumPlane[] = [
+    { normal: { x: 1, y: 0, z: 0 }, d: -1e9 },
+    { normal: { x: -1, y: 0, z: 0 }, d: -1e9 },
+    { normal: { x: 0, y: 1, z: 0 }, d: -1e9 },
+    { normal: { x: 0, y: -1, z: 0 }, d: -1e9 },
+    { normal: { x: 0, y: 0, z: 1 }, d: -1e9 },
+    { normal: { x: 0, y: 0, z: -1 }, d: -1e9 },
+];
+
+const center: TileCoord = { zoom: 14, x: 14547, y: 6452 };
+
+describe("computeVisibleTiles", () => {
+    it("全可視の場合、中心タイルを含む結果を返す", () => {
+        const result = computeVisibleTiles({
+            center,
+            tileSize: 100,
+            frustumPlanes: allVisiblePlanes,
+            maxTiles: 25,
+        });
+
+        expect(result.length).toBeGreaterThan(0);
+        expect(result).toContainEqual(center);
+    });
+
+    it("全不可視の場合、空配列を返す", () => {
+        const result = computeVisibleTiles({
+            center,
+            tileSize: 100,
+            frustumPlanes: noneVisiblePlanes,
+            maxTiles: 25,
+        });
+
+        expect(result).toHaveLength(0);
+    });
+
+    it("maxTiles で結果を制限する", () => {
+        const result = computeVisibleTiles({
+            center,
+            tileSize: 100,
+            frustumPlanes: allVisiblePlanes,
+            maxTiles: 5,
+        });
+
+        expect(result.length).toBeLessThanOrEqual(5);
+    });
+
+    it("結果はマンハッタン距離の昇順でソートされる", () => {
+        const result = computeVisibleTiles({
+            center,
+            tileSize: 100,
+            frustumPlanes: allVisiblePlanes,
+            maxTiles: 50,
+            searchRadius: 3,
+        });
+
+        // 中心（距離0）が先頭付近にあること
+        const centerIdx = result.findIndex(
+            (c) => c.x === center.x && c.y === center.y
+        );
+        expect(centerIdx).toBe(0);
+
+        // 距離が単調非減少であること
+        for (let i = 1; i < result.length; i++) {
+            const distPrev =
+                Math.abs(result[i - 1].x - center.x) +
+                Math.abs(result[i - 1].y - center.y);
+            const distCurr =
+                Math.abs(result[i].x - center.x) +
+                Math.abs(result[i].y - center.y);
+            expect(distCurr).toBeGreaterThanOrEqual(distPrev);
+        }
+    });
+
+    it("searchRadius=0 のとき中心タイルのみ返す", () => {
+        const result = computeVisibleTiles({
+            center,
+            tileSize: 100,
+            frustumPlanes: allVisiblePlanes,
+            maxTiles: 25,
+            searchRadius: 0,
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0]).toEqual(center);
+    });
+});

--- a/tests/visibleTiles.unit.spec.ts
+++ b/tests/visibleTiles.unit.spec.ts
@@ -104,4 +104,34 @@ describe("computeVisibleTiles", () => {
         expect(result).toHaveLength(1);
         expect(result[0]).toEqual(center);
     });
+
+    it("maxElevation を指定すると AABB の maxY に反映される", () => {
+        // y >= 500 のみ許容する Frustum で maxElevation の差を検証する
+        const highFloorPlanes: FrustumPlane[] = [
+            { normal: { x: 1, y: 0, z: 0 }, d: 1e9 },
+            { normal: { x: -1, y: 0, z: 0 }, d: 1e9 },
+            { normal: { x: 0, y: 1, z: 0 }, d: -500 },    // y >= 500
+            { normal: { x: 0, y: -1, z: 0 }, d: 1e9 },
+            { normal: { x: 0, y: 0, z: 1 }, d: 1e9 },
+            { normal: { x: 0, y: 0, z: -1 }, d: 1e9 },
+        ];
+
+        // maxElevation=100 → AABB maxY=100, P-vertex y=100, 100-500 = -400 < 0 → 不可視
+        const resultLow = computeVisibleTiles({
+            center,
+            tileSize: 100,
+            frustumPlanes: highFloorPlanes,
+            maxElevation: 100,
+        });
+        expect(resultLow).toHaveLength(0);
+
+        // maxElevation=1000 → AABB maxY=1000, P-vertex y=1000, 1000-500 = 500 >= 0 → 可視
+        const resultHigh = computeVisibleTiles({
+            center,
+            tileSize: 100,
+            frustumPlanes: highFloorPlanes,
+            maxElevation: 1000,
+        });
+        expect(resultHigh.length).toBeGreaterThan(0);
+    });
 });

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,6 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"ignoreDeprecations": "6.0"
+	}
+}


### PR DESCRIPTION
## 概要

カメラに映っている範囲の地理院タイル（zoom=14）をすべて非同期にロード・表示する。
単一タイル表示から、TileManager による複数タイルの動的管理に移行。

## 関連 Issue

Closes #23

## 変更内容

### 新規ファイル
- `src/terrain/tileTypes.ts` — TileKey 型、タイル座標 ↔ ワールド座標変換ユーティリティ
- `src/terrain/visibleTiles.ts` — Frustum + タイル数上限ハイブリッドの可視タイル算出
- `src/terrain/tileCache.ts` — LRU キャッシュ（Map ベース、capacity 64）
- `src/terrain/meshPool.ts` — メッシュ acquire/release プール
- `src/terrain/tileManager.ts` — 統合ライフサイクル管理（並列 fetch 制限 4、デバウンス 200ms）
- `tsconfig.jest.json` — Jest 用 tsconfig（TypeScript 6 deprecation 回避）
- `tests/tileTypes.unit.spec.ts` — 7 テスト
- `tests/visibleTiles.unit.spec.ts` — 5 テスト
- `tests/tileCache.unit.spec.ts` — 6 テスト
- `tests/meshPool.unit.spec.ts` — 5 テスト
- `tests/tileManager.unit.spec.ts` — 5 テスト

### 変更ファイル
- `src/scenes/default.ts` — 単一タイル → TileManager 統合、カメラ far clip 拡張
- `src/terrain/gsiTile.ts` — fetch タイムアウト追加（15 秒）
- `jest.config.js` — tsconfig.jest.json 参照追加
- `playwright.config.ts` — testMatch 追加（Jest ユニットテスト除外）

### 設計方針
1. **中心タイル原点方式** — UI 指定の緯度経度のタイルをワールド原点に配置
2. **Frustum + 距離上限ハイブリッド** — Frustum Culling 後、マンハッタン距離ソートで MAX_TILES=25 に打ち切り
3. **プール＆キャッシュ分離** — メッシュプール（GPU 資源）と LRU キャッシュ（CPU/ネットワーク資源）を独立管理

## 動作確認方法

```shell
npm start
# ブラウザで http://localhost:8080 を開き、複数タイルが表示されることを確認
# カメラをズーム/パンして、タイルが動的に追加・削除されることを確認
```

```shell
npm run typecheck && npm run lint && npm run test:unit && npm run test:visuals
```

## スクリーンショット

<img width="1280" height="720" alt="Render-Default-with-WebGPU-1-chromium-darwin" src="https://github.com/user-attachments/assets/39ae0e79-fcd9-40fe-8415-682de23d6f7b" />


## 確認事項

- [x] Copilot レビューを日本語で実施し、指摘を修正した
- [x] `npm run test:visuals -- --update-snapshots` は毎回実行していない
- [x] 画面表示の意図した変更がある場合のみ、開発者がスナップショットを更新した