### PR TITLE
feat: Google Maps 3D風カメラ操作・UIコンパクト化・方位磁針追加

### DIFF
--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -328,9 +328,9 @@ export class DefaultScene implements CreateSceneClass {
         };
         camera.onViewMatrixChangedObservable.add(syncCompass);
 
-        // 方位磁針クリック: 北向き・真下にスムーズアニメーション
+        // 方位磁針: 北向き・真下にスムーズアニメーション
         ui.compass.style.cursor = "pointer";
-        ui.compass.addEventListener("click", () => {
+        const resetCompassView = (): void => {
             const targetAlpha = -Math.PI / 2; // 北向き
             const targetBeta = 0.1;           // ほぼ真下
             const duration = 400;             // ms
@@ -350,6 +350,13 @@ export class DefaultScene implements CreateSceneClass {
                 }
             };
             requestAnimationFrame(animate);
+        };
+        ui.compass.addEventListener("click", resetCompassView);
+        ui.compass.addEventListener("keydown", (e: KeyboardEvent) => {
+            if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                resetCompassView();
+            }
         });
 
         // イベント接続

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -217,7 +217,7 @@ export class DefaultScene implements CreateSceneClass {
                     camera.upperBetaLimit ?? Math.PI
                 );
             } else if (dragAnchor) {
-                // 通常ドラッグ: メッシュ座標を掴んで移動
+                // 通常ドラッグ: 逐次差分でパン（毎フレームanchor更新）
                 const rect = canvas.getBoundingClientRect();
                 const sx = e.clientX - rect.left;
                 const sy = e.clientY - rect.top;
@@ -225,6 +225,7 @@ export class DefaultScene implements CreateSceneClass {
                 if (current) {
                     camera.target.x += dragAnchor.x - current.x;
                     camera.target.z += dragAnchor.z - current.z;
+                    dragAnchor = intersectPlane(sx, sy, dragPlaneY);
                 }
             }
             lastPointerX = e.clientX;

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -1,10 +1,11 @@
 import { Scene } from "@babylonjs/core/scene";
 import { ArcRotateCamera } from "@babylonjs/core/Cameras/arcRotateCamera";
-import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { Matrix, Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight";
 import { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import "@babylonjs/core/Culling/ray";
 import { CreateSceneClass } from "../createScene";
-import { clamp } from "../terrain/gsiTile";
+import { clamp, toTileXY, tileEdgeMeters } from "../terrain/gsiTile";
 import { createControlPanel } from "../terrain/controlPanel";
 import { createTileManager } from "../terrain/tileManager";
 
@@ -13,6 +14,9 @@ const ELEVATION_ZOOM = 14;
 const HEIGHT_SCALE = 1.0;
 
 const JAPAN_BOUNDS = { minLat: 20, maxLat: 46, minLon: 122, maxLon: 154 };
+
+/** 1度の緯度あたりのメートル数（概算） */
+const METERS_PER_DEGREE_LAT = 111320;
 
 export class DefaultScene implements CreateSceneClass {
     createScene = async (
@@ -34,8 +38,15 @@ export class DefaultScene implements CreateSceneClass {
         camera.lowerRadiusLimit = 250;
         camera.upperRadiusLimit = 40000;
         camera.maxZ = 100000;
-        camera.wheelDeltaPercentage = 0.02;
-        camera.panningSensibility = 1500;
+
+        // チルト制限（地面から20° = beta上限 7π/18）
+        camera.upperBetaLimit = Math.PI / 2 - Math.PI / 9;
+        camera.lowerBetaLimit = 0.1;
+
+        // デフォルト入力をすべて無効化（カスタムハンドラで制御）
+        camera.inputs.removeByType("ArcRotateCameraPointersInput");
+        camera.inputs.removeByType("ArcRotateCameraKeyboardMoveInput");
+        camera.inputs.removeByType("ArcRotateCameraMouseWheelInput");
         camera.attachControl(canvas, true);
 
         // ライト
@@ -51,11 +62,7 @@ export class DefaultScene implements CreateSceneClass {
         const initialLon = 139.767125;
 
         // UIパネル
-        const ui = createControlPanel(initialLat, initialLon, {
-            alpha: camera.alpha,
-            beta: camera.beta,
-            radius: camera.radius,
-        });
+        const ui = createControlPanel(initialLat, initialLon);
 
         // TileManager 生成
         const tileManager = createTileManager({
@@ -66,9 +73,9 @@ export class DefaultScene implements CreateSceneClass {
             heightScale: HEIGHT_SCALE,
         });
 
-        tileManager.onStatusChange = (status: string) => {
-            ui.status.textContent = status;
-        };
+        let currentAltitudeOffset = 0;
+        let gridResidualX = 0;
+        let gridResidualZ = 0;
 
         const refreshTerrain = async (): Promise<void> => {
             const lat = clamp(
@@ -81,53 +88,269 @@ export class DefaultScene implements CreateSceneClass {
                 JAPAN_BOUNDS.minLon,
                 JAPAN_BOUNDS.maxLon
             );
-            const altOff = Number(ui.altitudeInput.value) || 0;
-
             ui.latInput.value = lat.toFixed(6);
             ui.lonInput.value = lon.toFixed(6);
-
-            await tileManager.setCenter(lat, lon, altOff);
+            await tileManager.setCenter(lat, lon, currentAltitudeOffset);
         };
 
-        // カメラ ↔ UI 同期
-        const applyCameraFromUI = (): void => {
-            camera.alpha = Number(ui.cameraAlphaInput.value);
-            camera.beta = Number(ui.cameraBetaInput.value);
-            camera.radius = Number(ui.cameraRadiusInput.value);
-        };
-        let prevAlpha = camera.alpha;
-        let prevBeta = camera.beta;
-        let prevRadius = camera.radius;
-        const syncUIFromCamera = (): void => {
-            if (
-                camera.alpha === prevAlpha &&
-                camera.beta === prevBeta &&
-                camera.radius === prevRadius
-            ) {
+        // ---------- カメラターゲットオフセット → 緯度経度変換 ----------
+        const commitPanOffset = (): void => {
+            const tx = camera.target.x;
+            const tz = camera.target.z;
+            if (tx === 0 && tz === 0) return;
+
+            // 新規オフセット = 全体 - 既知のグリッド残差
+            const newOffsetX = tx - gridResidualX;
+            const newOffsetZ = tz - gridResidualZ;
+            if (Math.abs(newOffsetX) < 0.01 && Math.abs(newOffsetZ) < 0.01) {
                 return;
             }
-            prevAlpha = camera.alpha;
-            prevBeta = camera.beta;
-            prevRadius = camera.radius;
-            ui.cameraAlphaInput.value = String(camera.alpha);
-            ui.cameraBetaInput.value = String(camera.beta);
-            ui.cameraRadiusInput.value = String(camera.radius);
+
+            const oldLat = Number(ui.latInput.value);
+            const oldLon = Number(ui.lonInput.value);
+            const metersPerDegreeLon =
+                METERS_PER_DEGREE_LAT *
+                Math.cos((oldLat * Math.PI) / 180);
+
+            const newLat = clamp(
+                oldLat + newOffsetZ / METERS_PER_DEGREE_LAT,
+                JAPAN_BOUNDS.minLat,
+                JAPAN_BOUNDS.maxLat
+            );
+            const newLon = clamp(
+                oldLon + newOffsetX / metersPerDegreeLon,
+                JAPAN_BOUNDS.minLon,
+                JAPAN_BOUNDS.maxLon
+            );
+
+            const oldTile = toTileXY(oldLat, oldLon, ELEVATION_ZOOM);
+            const newTile = toTileXY(newLat, newLon, ELEVATION_ZOOM);
+            const tileSize = tileEdgeMeters(newLat, ELEVATION_ZOOM);
+            const gridShiftX = (newTile.x - oldTile.x) * tileSize;
+            const gridShiftZ = -((newTile.y - oldTile.y) * tileSize);
+
+            // 残差更新: 旧残差 + 新規オフセット - グリッドシフト
+            gridResidualX = gridResidualX + newOffsetX - gridShiftX;
+            gridResidualZ = gridResidualZ + newOffsetZ - gridShiftZ;
+
+            camera.target.x = gridResidualX;
+            camera.target.y = 0;
+            camera.target.z = gridResidualZ;
+
+            ui.latInput.value = newLat.toFixed(6);
+            ui.lonInput.value = newLon.toFixed(6);
+            void refreshTerrain();
         };
 
-        // イベント接続
-        ui.updateButton.addEventListener("click", () => void refreshTerrain());
-        ui.latInput.addEventListener("change", () => void refreshTerrain());
-        ui.lonInput.addEventListener("change", () => void refreshTerrain());
-        ui.altitudeInput.addEventListener(
-            "change",
-            () => void refreshTerrain()
+        // ---------- レイ-平面交差ユーティリティ ----------
+        const intersectPlane = (
+            screenX: number,
+            screenY: number,
+            planeY: number
+        ): { x: number; z: number } | null => {
+            const w = canvas.clientWidth;
+            const h = canvas.clientHeight;
+            const view = camera.getViewMatrix();
+            const proj = camera.getProjectionMatrix();
+            const identity = Matrix.Identity();
+            const near = Vector3.Unproject(
+                new Vector3(screenX, screenY, 0),
+                w, h, identity, view, proj
+            );
+            const far = Vector3.Unproject(
+                new Vector3(screenX, screenY, 1),
+                w, h, identity, view, proj
+            );
+            const dirY = far.y - near.y;
+            if (Math.abs(dirY) < 1e-6) return null;
+            const t = (planeY - near.y) / dirY;
+            if (t <= 0) return null;
+            return {
+                x: near.x + (far.x - near.x) * t,
+                z: near.z + (far.z - near.z) * t,
+            };
+        };
+
+        // ---------- カスタムマウスハンドラ ----------
+        let pointerDown = false;
+        let lastPointerX = 0;
+        let lastPointerY = 0;
+        let activePointerId = -1;
+        let dragAnchor: { x: number; z: number } | null = null;
+        let dragPlaneY = 0;
+
+        canvas.addEventListener("contextmenu", (e) => e.preventDefault());
+
+        canvas.addEventListener("pointerdown", (e: PointerEvent) => {
+            if (e.button !== 0) return;
+            pointerDown = true;
+            lastPointerX = e.clientX;
+            lastPointerY = e.clientY;
+            activePointerId = e.pointerId;
+            canvas.setPointerCapture(e.pointerId);
+
+            const rect = canvas.getBoundingClientRect();
+            const sx = e.clientX - rect.left;
+            const sy = e.clientY - rect.top;
+            const pick = scene.pick(sx, sy);
+            dragPlaneY =
+                pick?.hit && pick.pickedPoint ? pick.pickedPoint.y : 0;
+            dragAnchor = intersectPlane(sx, sy, dragPlaneY);
+        });
+
+        canvas.addEventListener("pointermove", (e: PointerEvent) => {
+            if (!pointerDown || e.pointerId !== activePointerId) return;
+
+            if (e.ctrlKey || e.metaKey) {
+                // Ctrl/Cmd + ドラッグ: 水平=パン(alpha)、垂直=チルト(beta)
+                const dx = e.clientX - lastPointerX;
+                const dy = e.clientY - lastPointerY;
+                lastPointerX = e.clientX;
+                lastPointerY = e.clientY;
+                camera.alpha -= dx * 0.003;
+                camera.beta -= dy * 0.003;
+                camera.beta = clamp(
+                    camera.beta,
+                    camera.lowerBetaLimit ?? 0,
+                    camera.upperBetaLimit ?? Math.PI
+                );
+            } else if (dragAnchor) {
+                // 通常ドラッグ: メッシュ座標を掴んで移動
+                const rect = canvas.getBoundingClientRect();
+                const sx = e.clientX - rect.left;
+                const sy = e.clientY - rect.top;
+                const current = intersectPlane(sx, sy, dragPlaneY);
+                if (current) {
+                    camera.target.x += dragAnchor.x - current.x;
+                    camera.target.z += dragAnchor.z - current.z;
+                }
+            }
+            lastPointerX = e.clientX;
+            lastPointerY = e.clientY;
+        });
+
+        canvas.addEventListener("pointerup", (e: PointerEvent) => {
+            if (e.pointerId !== activePointerId) return;
+            pointerDown = false;
+            canvas.releasePointerCapture(e.pointerId);
+            commitPanOffset();
+        });
+
+        // ホイール / ダブルクリック: ポインタ方向にズーム
+        const zoomTowardPoint = (
+            worldX: number,
+            worldZ: number,
+            factor: number
+        ): void => {
+            camera.target.x += (worldX - camera.target.x) * (1 - factor);
+            camera.target.z += (worldZ - camera.target.z) * (1 - factor);
+            camera.radius *= factor;
+            camera.radius = clamp(
+                camera.radius,
+                camera.lowerRadiusLimit ?? 250,
+                camera.upperRadiusLimit ?? 40000
+            );
+            commitPanOffset();
+        };
+
+        /** メッシュまたは y=0 平面との交点を返す。空なら null */
+        const pickOrPlane = (
+            clientX: number,
+            clientY: number
+        ): { worldX: number; worldZ: number } | null => {
+            const rect = canvas.getBoundingClientRect();
+            const sx = clientX - rect.left;
+            const sy = clientY - rect.top;
+            const pick = scene.pick(sx, sy);
+            if (pick?.hit && pick.pickedPoint) {
+                return {
+                    worldX: pick.pickedPoint.x,
+                    worldZ: pick.pickedPoint.z,
+                };
+            }
+            const plane = intersectPlane(sx, sy, 0);
+            return plane ? { worldX: plane.x, worldZ: plane.z } : null;
+        };
+
+        canvas.addEventListener(
+            "wheel",
+            (e: WheelEvent) => {
+                if (e.deltaY === 0) return;
+                e.preventDefault();
+                const hit = pickOrPlane(e.clientX, e.clientY);
+                if (hit) {
+                    const factor = e.deltaY < 0 ? 0.95 : 1 / 0.95;
+                    zoomTowardPoint(hit.worldX, hit.worldZ, factor);
+                } else {
+                    const delta = e.deltaY > 0 ? -50 : 50;
+                    currentAltitudeOffset = clamp(
+                        currentAltitudeOffset + delta,
+                        -2000,
+                        8000
+                    );
+                    void refreshTerrain();
+                }
+            },
+            { passive: false }
         );
 
-        ui.cameraAlphaInput.addEventListener("input", applyCameraFromUI);
-        ui.cameraBetaInput.addEventListener("input", applyCameraFromUI);
-        ui.cameraRadiusInput.addEventListener("input", applyCameraFromUI);
+        canvas.addEventListener("dblclick", (e: MouseEvent) => {
+            const hit = pickOrPlane(e.clientX, e.clientY);
+            if (hit) {
+                zoomTowardPoint(hit.worldX, hit.worldZ, 0.7);
+            } else {
+                currentAltitudeOffset = clamp(
+                    currentAltitudeOffset + 100,
+                    -2000,
+                    8000
+                );
+                void refreshTerrain();
+            }
+        });
 
-        camera.onViewMatrixChangedObservable.add(syncUIFromCamera);
+        // 方位磁針の回転同期
+        const syncCompass = (): void => {
+            const degrees = (camera.alpha * 180) / Math.PI + 90;
+            ui.compass.style.transform = `rotate(${degrees}deg)`;
+        };
+        camera.onViewMatrixChangedObservable.add(syncCompass);
+
+        // 方位磁針クリック: 北向き・真下にスムーズアニメーション
+        ui.compass.style.cursor = "pointer";
+        ui.compass.addEventListener("click", () => {
+            const targetAlpha = -Math.PI / 2; // 北向き
+            const targetBeta = 0.1;           // ほぼ真下
+            const duration = 400;             // ms
+            const startAlpha = camera.alpha;
+            const startBeta = camera.beta;
+            const startTime = performance.now();
+
+            const animate = (now: number): void => {
+                const elapsed = now - startTime;
+                const t = Math.min(elapsed / duration, 1);
+                // ease-out cubic
+                const ease = 1 - Math.pow(1 - t, 3);
+                camera.alpha = startAlpha + (targetAlpha - startAlpha) * ease;
+                camera.beta = startBeta + (targetBeta - startBeta) * ease;
+                if (t < 1) {
+                    requestAnimationFrame(animate);
+                }
+            };
+            requestAnimationFrame(animate);
+        });
+
+        // イベント接続
+        const resetAndRefresh = (): void => {
+            camera.target.x = 0;
+            camera.target.y = 0;
+            camera.target.z = 0;
+            gridResidualX = 0;
+            gridResidualZ = 0;
+            void refreshTerrain();
+        };
+        ui.updateButton.addEventListener("click", resetAndRefresh);
+        ui.latInput.addEventListener("change", resetAndRefresh);
+        ui.lonInput.addEventListener("change", resetAndRefresh);
 
         // カメラ移動時の自動タイル更新
         tileManager.attachCamera();

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -148,18 +148,20 @@ export class DefaultScene implements CreateSceneClass {
             screenY: number,
             planeY: number
         ): { x: number; z: number } | null => {
-            const w = canvas.clientWidth;
-            const h = canvas.clientHeight;
+            const renderW = engine.getRenderWidth();
+            const renderH = engine.getRenderHeight();
+            const scaleX = renderW / canvas.clientWidth;
+            const scaleY = renderH / canvas.clientHeight;
             const view = camera.getViewMatrix();
             const proj = camera.getProjectionMatrix();
             const identity = Matrix.Identity();
             const near = Vector3.Unproject(
-                new Vector3(screenX, screenY, 0),
-                w, h, identity, view, proj
+                new Vector3(screenX * scaleX, screenY * scaleY, 0),
+                renderW, renderH, identity, view, proj
             );
             const far = Vector3.Unproject(
-                new Vector3(screenX, screenY, 1),
-                w, h, identity, view, proj
+                new Vector3(screenX * scaleX, screenY * scaleY, 1),
+                renderW, renderH, identity, view, proj
             );
             const dirY = far.y - near.y;
             if (Math.abs(dirY) < 1e-6) return null;

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -238,6 +238,16 @@ export class DefaultScene implements CreateSceneClass {
             commitPanOffset();
         });
 
+        const resetPointerState = (): void => {
+            pointerDown = false;
+            activePointerId = -1;
+            dragAnchor = null;
+            commitPanOffset();
+        };
+
+        canvas.addEventListener("pointercancel", resetPointerState);
+        canvas.addEventListener("lostpointercapture", resetPointerState);
+
         // ホイール / ダブルクリック: ポインタ方向にズーム
         const zoomTowardPoint = (
             worldX: number,

--- a/src/terrain/controlPanel.ts
+++ b/src/terrain/controlPanel.ts
@@ -103,15 +103,19 @@ export const createControlPanel = (
     // 緯度
     const latLabel = document.createElement("span");
     latLabel.textContent = "緯度";
+    css(latLabel, { gridColumn: "1", gridRow: "1" });
     panel.appendChild(latLabel);
     const latInput = numberInput(initialLat, 20, 46, "0.0001");
+    css(latInput, { gridColumn: "2", gridRow: "1" });
     panel.appendChild(latInput);
 
     // 経度
     const lonLabel = document.createElement("span");
     lonLabel.textContent = "経度";
+    css(lonLabel, { gridColumn: "1", gridRow: "2" });
     panel.appendChild(lonLabel);
     const lonInput = numberInput(initialLon, 122, 154, "0.0001");
+    css(lonInput, { gridColumn: "2", gridRow: "2" });
     panel.appendChild(lonInput);
 
     // 更新ボタン（3列目に縦並び）

--- a/src/terrain/controlPanel.ts
+++ b/src/terrain/controlPanel.ts
@@ -101,20 +101,24 @@ export const createControlPanel = (
     document.body.appendChild(panel);
 
     // 緯度
-    const latLabel = document.createElement("span");
+    const latLabel = document.createElement("label");
+    latLabel.htmlFor = "cp-lat";
     latLabel.textContent = "緯度";
     css(latLabel, { gridColumn: "1", gridRow: "1" });
     panel.appendChild(latLabel);
     const latInput = numberInput(initialLat, 20, 46, "0.0001");
+    latInput.id = "cp-lat";
     css(latInput, { gridColumn: "2", gridRow: "1" });
     panel.appendChild(latInput);
 
     // 経度
-    const lonLabel = document.createElement("span");
+    const lonLabel = document.createElement("label");
+    lonLabel.htmlFor = "cp-lon";
     lonLabel.textContent = "経度";
     css(lonLabel, { gridColumn: "1", gridRow: "2" });
     panel.appendChild(lonLabel);
     const lonInput = numberInput(initialLon, 122, 154, "0.0001");
+    lonInput.id = "cp-lon";
     css(lonInput, { gridColumn: "2", gridRow: "2" });
     panel.appendChild(lonInput);
 
@@ -122,6 +126,7 @@ export const createControlPanel = (
     const updateButton = document.createElement("button");
     updateButton.type = "button";
     updateButton.textContent = "✓";
+    updateButton.setAttribute("aria-label", "地形を更新");
     css(updateButton, {
         cursor: "pointer",
         padding: "1px 6px",

--- a/src/terrain/controlPanel.ts
+++ b/src/terrain/controlPanel.ts
@@ -1,26 +1,15 @@
-/** 操作UIパネル（緯度・経度・高度・カメラ制御） */
+/** 操作UIパネル（緯度・経度）と方位磁針 */
 
 export interface ControlPanelElements {
     panel: HTMLDivElement;
-    status: HTMLDivElement;
     latInput: HTMLInputElement;
     lonInput: HTMLInputElement;
-    altitudeInput: HTMLInputElement;
-    cameraAlphaInput: HTMLInputElement;
-    cameraBetaInput: HTMLInputElement;
-    cameraRadiusInput: HTMLInputElement;
     updateButton: HTMLButtonElement;
+    compass: HTMLDivElement;
 }
 
 const css = (el: HTMLElement, styles: Partial<CSSStyleDeclaration>): void => {
     Object.assign(el.style, styles);
-};
-
-const createLabel = (text: string): HTMLLabelElement => {
-    const label = document.createElement("label");
-    label.textContent = text;
-    css(label, { display: "grid", gap: "4px" });
-    return label;
 };
 
 const numberInput = (
@@ -35,124 +24,113 @@ const numberInput = (
     input.min = String(min);
     input.max = String(max);
     input.step = step;
-    css(input, { width: "100%" });
+    css(input, { width: "90px", fontSize: "10px" });
     return input;
 };
 
-const rangeInput = (
-    value: number,
-    min: number,
-    max: number,
-    step: string
-): HTMLInputElement => {
-    const input = document.createElement("input");
-    input.type = "range";
-    input.value = String(value);
-    input.min = String(min);
-    input.max = String(max);
-    input.step = step;
-    css(input, { width: "100%" });
-    return input;
-};
+const createCompass = (): HTMLDivElement => {
+    const container = document.createElement("div");
+    css(container, {
+        position: "absolute",
+        top: "12px",
+        right: "12px",
+        width: "40px",
+        height: "40px",
+        borderRadius: "50%",
+        background: "rgba(9,18,32,0.72)",
+        backdropFilter: "blur(6px)",
+        zIndex: "10",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        overflow: "hidden",
+    });
 
-export interface CameraDefaults {
-    alpha: number;
-    beta: number;
-    radius: number;
-}
+    // SVG コンパス矢印（北=赤、南=グレー）
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    svg.setAttribute("width", "28");
+    svg.setAttribute("height", "28");
+    svg.setAttribute("viewBox", "0 0 28 28");
+
+    // 北（赤い三角）
+    const north = document.createElementNS(
+        "http://www.w3.org/2000/svg",
+        "polygon"
+    );
+    north.setAttribute("points", "14,2 9,14 19,14");
+    north.setAttribute("fill", "#e53935");
+
+    // 南（グレーの三角）
+    const south = document.createElementNS(
+        "http://www.w3.org/2000/svg",
+        "polygon"
+    );
+    south.setAttribute("points", "14,26 9,14 19,14");
+    south.setAttribute("fill", "#9e9e9e");
+
+    svg.appendChild(north);
+    svg.appendChild(south);
+    container.appendChild(svg);
+
+    document.body.appendChild(container);
+    return container;
+};
 
 export const createControlPanel = (
     initialLat: number,
-    initialLon: number,
-    cameraDefaults: CameraDefaults
+    initialLon: number
 ): ControlPanelElements => {
     const panel = document.createElement("div");
     css(panel, {
         position: "absolute",
-        top: "12px",
-        left: "12px",
-        padding: "12px",
-        borderRadius: "8px",
+        top: "8px",
+        left: "8px",
+        padding: "4px 6px",
+        borderRadius: "6px",
         background: "rgba(9,18,32,0.72)",
         color: "#f2f7ff",
         display: "grid",
-        gap: "8px",
-        minWidth: "280px",
+        gridTemplateColumns: "auto auto auto",
+        gap: "2px 4px",
+        alignItems: "center",
         fontFamily: "'Helvetica Neue',Helvetica,Arial,sans-serif",
-        fontSize: "13px",
+        fontSize: "10px",
         backdropFilter: "blur(6px)",
         zIndex: "10",
     });
     document.body.appendChild(panel);
 
-    // ステータス
-    const status = document.createElement("div");
-    status.textContent = "タイル読込待機中…";
-    css(status, { fontSize: "12px" });
-    panel.appendChild(status);
-
     // 緯度
-    const latLabel = createLabel("緯度");
-    const latInput = numberInput(initialLat, 20, 46, "0.0001");
-    latLabel.appendChild(latInput);
+    const latLabel = document.createElement("span");
+    latLabel.textContent = "緯度";
     panel.appendChild(latLabel);
+    const latInput = numberInput(initialLat, 20, 46, "0.0001");
+    panel.appendChild(latInput);
 
     // 経度
-    const lonLabel = createLabel("経度");
-    const lonInput = numberInput(initialLon, 122, 154, "0.0001");
-    lonLabel.appendChild(lonInput);
+    const lonLabel = document.createElement("span");
+    lonLabel.textContent = "経度";
     panel.appendChild(lonLabel);
+    const lonInput = numberInput(initialLon, 122, 154, "0.0001");
+    panel.appendChild(lonInput);
 
-    // 高度オフセット
-    const altLabel = createLabel("高度オフセット [m]");
-    const altitudeInput = numberInput(0, -2000, 8000, "1");
-    altLabel.appendChild(altitudeInput);
-    panel.appendChild(altLabel);
-
-    // カメラパン
-    const alphaLabel = createLabel("カメラパン（方位）");
-    const cameraAlphaInput = rangeInput(
-        cameraDefaults.alpha,
-        -Math.PI,
-        Math.PI,
-        "0.01"
-    );
-    alphaLabel.appendChild(cameraAlphaInput);
-    panel.appendChild(alphaLabel);
-
-    // カメラチルト
-    const betaLabel = createLabel("カメラチルト");
-    const cameraBetaInput = rangeInput(cameraDefaults.beta, 0.2, 1.5, "0.01");
-    betaLabel.appendChild(cameraBetaInput);
-    panel.appendChild(betaLabel);
-
-    // カメラズーム
-    const radiusLabel = createLabel("カメラズーム");
-    const cameraRadiusInput = rangeInput(
-        cameraDefaults.radius,
-        250,
-        15000,
-        "10"
-    );
-    radiusLabel.appendChild(cameraRadiusInput);
-    panel.appendChild(radiusLabel);
-
-    // 更新ボタン
+    // 更新ボタン（3列目に縦並び）
     const updateButton = document.createElement("button");
     updateButton.type = "button";
-    updateButton.textContent = "地形を更新";
-    css(updateButton, { cursor: "pointer", padding: "8px 10px" });
+    updateButton.textContent = "✓";
+    css(updateButton, {
+        cursor: "pointer",
+        padding: "1px 6px",
+        gridRow: "1 / 3",
+        gridColumn: "3",
+        alignSelf: "stretch",
+        fontSize: "12px",
+        lineHeight: "1",
+    });
     panel.appendChild(updateButton);
 
-    return {
-        panel,
-        status,
-        latInput,
-        lonInput,
-        altitudeInput,
-        cameraAlphaInput,
-        cameraBetaInput,
-        cameraRadiusInput,
-        updateButton,
-    };
+    // 方位磁針（画面右上に独立配置）
+    const compass = createCompass();
+
+    return { panel, latInput, lonInput, updateButton, compass };
 };

--- a/src/terrain/controlPanel.ts
+++ b/src/terrain/controlPanel.ts
@@ -72,6 +72,20 @@ const createCompass = (): HTMLDivElement => {
     svg.appendChild(south);
     container.appendChild(svg);
 
+    // アクセシビリティ
+    container.setAttribute("role", "button");
+    container.tabIndex = 0;
+    container.setAttribute("aria-label", "方位磁針: クリックで北向きにリセット");
+    container.style.outline = "none";
+    container.addEventListener("focus", () => {
+        if (container.matches(":focus-visible")) {
+            container.style.boxShadow = "0 0 0 2px #90caf9";
+        }
+    });
+    container.addEventListener("blur", () => {
+        container.style.boxShadow = "";
+    });
+
     document.body.appendChild(container);
     return container;
 };


### PR DESCRIPTION
## 概要

カメラ操作をGoogle Maps 3D Map同等の操作系に変更し、コントロールパネルを簡素化、方位磁針アイコンを追加する。

Closes #25

## 変更内容

### カメラ操作 (`src/scenes/default.ts`)
- **ドラッグ**: レイ-平面交差による3Dピックで緯度・経度を移動
- **ホイール**: ポインタ方向の地面/y=0平面にズーム。上空なら高度オフセット変更
- **ダブルクリック**: ホイール同様の一定量前進
- **Ctrl/Cmd + ドラッグ**: 水平=パン(alpha回転)、垂直=チルト(beta)
- **チルト制限**: 地面から20°（`upperBetaLimit = π/2 - π/9`）
- デフォルト入力を全無効化し、カスタムポインタ/ホイールハンドラで制御

### コントロールパネル (`src/terrain/controlPanel.ts`)
- チルト・パン・ズーム・高度オフセット・ステータス表示を削除
- 3カラムグリッド（緯度/経度/✓ボタン）のコンパクトUI
- font 10px、padding 4px 6px

### 方位磁針
- SVGコンパス（北=赤、南=グレー）を画面右上に独立配置
- `camera.alpha` に連動して回転
- クリックで北向き・真下にease-out cubicアニメーション (400ms)

### スクリーンショット

<img width="1280" height="720" alt="Render-Default-with-WebGPU-1-chromium-darwin" src="https://github.com/user-attachments/assets/213ecf88-f6b7-4a80-8a02-152f97d2c861" />

## テスト結果
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run test:unit` ✅ (31テスト全通過)
- `npm run test:visuals --update-snapshots` ✅ (2テスト全通過)

## 影響範囲
- `ControlPanelElements` インターフェース変更（呼び出し元は `default.ts` のみ）
- `CameraDefaults` インターフェース削除
- `createControlPanel` シグネチャ変更（第3引数削除）