### PR TITLE
refactor: JAPAN_BOUNDS の定義を gsiTile.ts に集約

### DIFF
--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -5,15 +5,13 @@ import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight";
 import { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import "@babylonjs/core/Culling/ray";
 import { CreateSceneClass } from "../createScene";
-import { clamp, toTileXY, tileEdgeMeters } from "../terrain/gsiTile";
+import { clamp, toTileXY, tileEdgeMeters, JAPAN_BOUNDS } from "../terrain/gsiTile";
 import { createControlPanel } from "../terrain/controlPanel";
 import { createTileManager } from "../terrain/tileManager";
 
 const TERRAIN_SUBDIVISIONS = 128;
 const ELEVATION_ZOOM = 14;
 const HEIGHT_SCALE = 1.0;
-
-const JAPAN_BOUNDS = { minLat: 20, maxLat: 46, minLon: 122, maxLon: 154 };
 
 /** 1度の緯度あたりのメートル数（概算） */
 const METERS_PER_DEGREE_LAT = 111320;

--- a/src/terrain/controlPanel.ts
+++ b/src/terrain/controlPanel.ts
@@ -1,5 +1,7 @@
 /** 操作UIパネル（緯度・経度）と方位磁針 */
 
+import { JAPAN_BOUNDS } from "./gsiTile";
+
 export interface ControlPanelElements {
     panel: HTMLDivElement;
     latInput: HTMLInputElement;
@@ -120,7 +122,7 @@ export const createControlPanel = (
     latLabel.textContent = "緯度";
     css(latLabel, { gridColumn: "1", gridRow: "1" });
     panel.appendChild(latLabel);
-    const latInput = numberInput(initialLat, 20, 46, "0.0001");
+    const latInput = numberInput(initialLat, JAPAN_BOUNDS.minLat, JAPAN_BOUNDS.maxLat, "0.0001");
     latInput.id = "cp-lat";
     css(latInput, { gridColumn: "2", gridRow: "1" });
     panel.appendChild(latInput);
@@ -131,7 +133,7 @@ export const createControlPanel = (
     lonLabel.textContent = "経度";
     css(lonLabel, { gridColumn: "1", gridRow: "2" });
     panel.appendChild(lonLabel);
-    const lonInput = numberInput(initialLon, 122, 154, "0.0001");
+    const lonInput = numberInput(initialLon, JAPAN_BOUNDS.minLon, JAPAN_BOUNDS.maxLon, "0.0001");
     lonInput.id = "cp-lon";
     css(lonInput, { gridColumn: "2", gridRow: "2" });
     panel.appendChild(lonInput);

--- a/src/terrain/gsiTile.ts
+++ b/src/terrain/gsiTile.ts
@@ -2,6 +2,8 @@
 
 export const TILE_SIZE = 256;
 
+export const JAPAN_BOUNDS = { minLat: 20, maxLat: 46, minLon: 122, maxLon: 154 } as const;
+
 const DEM_LAYERS = ["dem5a_png", "dem5b_png", "dem_png"] as const;
 
 export const clamp = (value: number, min: number, max: number): number =>


### PR DESCRIPTION
## 概要

`JAPAN_BOUNDS` 定数（緯度 20〜46°N、経度 122〜154°E）を `src/terrain/gsiTile.ts` に集約し、`src/scenes/default.ts` と `src/terrain/controlPanel.ts` の重複ハードコードを解消。

## 変更内容

| ファイル | 変更 |
|---|---|
| `src/terrain/gsiTile.ts` | `JAPAN_BOUNDS` を `as const` で export 追加 |
| `src/scenes/default.ts` | ローカル `JAPAN_BOUNDS` 定数を削除、`gsiTile.ts` から import |
| `src/terrain/controlPanel.ts` | `JAPAN_BOUNDS` を import し、`numberInput` のハードコード値 `20, 46, 122, 154` を参照に置換 |

## 影響範囲

- 内部リファクタのみ。API・型・挙動の変更なし。
- 循環依存なし（`gsiTile` ← `controlPanel` / `default` の一方向参照）。

## 検証

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run test:unit` ✅ (5 suites / 31 tests)

Closes #19