### PR TITLE
feat: distance-based LOD with far-field sweep

### DIFF
--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -10,8 +10,10 @@ import { createControlPanel } from "../terrain/controlPanel";
 import { createTileManager } from "../terrain/tileManager";
 
 const TERRAIN_SUBDIVISIONS = 128;
-const ELEVATION_ZOOM = 14;
+const MAX_ZOOM = 18;
+const MAX_ELEVATION_ZOOM = 17;
 const HEIGHT_SCALE = 1.0;
+const MIN_ZOOM = 8;
 
 /** 1度の緯度あたりのメートル数（概算） */
 const METERS_PER_DEGREE_LAT = 111320;
@@ -35,6 +37,7 @@ export class DefaultScene implements CreateSceneClass {
         );
         camera.lowerRadiusLimit = 250;
         camera.upperRadiusLimit = 40000;
+        camera.minZ = 10;
         camera.maxZ = 100000;
 
         // チルト制限（地面から20° = beta上限 7π/18）
@@ -66,9 +69,13 @@ export class DefaultScene implements CreateSceneClass {
         const tileManager = createTileManager({
             scene,
             camera,
-            zoom: ELEVATION_ZOOM,
+            zoom: MAX_ZOOM,
             subdivisions: TERRAIN_SUBDIVISIONS,
             heightScale: HEIGHT_SCALE,
+            minZoom: MIN_ZOOM,
+            maxElevationZoom: MAX_ELEVATION_ZOOM,
+            maxTiles: 160,
+            cacheCapacity: 256,
         });
 
         let currentAltitudeOffset = 0;
@@ -121,9 +128,9 @@ export class DefaultScene implements CreateSceneClass {
                 JAPAN_BOUNDS.maxLon
             );
 
-            const oldTile = toTileXY(oldLat, oldLon, ELEVATION_ZOOM);
-            const newTile = toTileXY(newLat, newLon, ELEVATION_ZOOM);
-            const tileSize = tileEdgeMeters(newLat, ELEVATION_ZOOM);
+            const oldTile = toTileXY(oldLat, oldLon, MAX_ZOOM);
+            const newTile = toTileXY(newLat, newLon, MAX_ZOOM);
+            const tileSize = tileEdgeMeters(newLat, MAX_ZOOM);
             const gridShiftX = (newTile.x - oldTile.x) * tileSize;
             const gridShiftZ = -((newTile.y - oldTile.y) * tileSize);
 

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -11,8 +11,8 @@ import { Frustum } from "@babylonjs/core/Maths/math.frustum";
 import { Matrix } from "@babylonjs/core/Maths/math.vector";
 import { Plane } from "@babylonjs/core/Maths/math.plane";
 
-import { TileCoord, TileKey, toTileKey, tileOffsetToWorld } from "./tileTypes";
-import { computeVisibleTiles, FrustumPlane } from "./visibleTiles";
+import { TileCoord, TileKey, toTileKey, tileOffsetToWorld, convertTileZoom, computeSubTileOffset } from "./tileTypes";
+import { computeMultiLodTiles, computeBaseZoom, FrustumPlane, LodTileEntry } from "./visibleTiles";
 import { createTileCache, TileCache } from "./tileCache";
 import { createMeshPool, MeshPool } from "./meshPool";
 import {
@@ -33,6 +33,10 @@ export interface TileManagerOptions {
     maxTiles?: number;
     cacheCapacity?: number;
     debounceMs?: number;
+    /** 遠景LODの最小ズームレベル（省略時は zoom - 2） */
+    minZoom?: number;
+    /** 標高タイルの最大ズームレベル（省略時は zoom） */
+    maxElevationZoom?: number;
 }
 
 export interface TileManager {
@@ -49,11 +53,12 @@ interface ActiveTile {
     key: TileKey;
     coord: TileCoord;
     mesh: Mesh;
+    tileSize: number;
 }
 
 const DEFAULT_MAX_CONCURRENT = 4;
-const DEFAULT_MAX_TILES = 25;
-const DEFAULT_CACHE_CAPACITY = 64;
+const DEFAULT_MAX_TILES = 60;
+const DEFAULT_CACHE_CAPACITY = 96;
 const DEFAULT_DEBOUNCE_MS = 200;
 /** Frustum 判定用の基準最大標高 (m) — 富士山 3776m + マージン */
 const MAX_BASE_ELEVATION = 4000;
@@ -86,6 +91,44 @@ const applyElevation = (
     }
 };
 
+/**
+ * 親タイルの標高データから子タイルに対応する領域を切り出す。
+ * 最近傍補間で TILE_SIZE × TILE_SIZE に拡大。
+ */
+const extractSubTileElevation = (
+    parentElev: Float32Array,
+    childCoord: TileCoord,
+    parentZoom: number,
+    tileSize: number,
+): Float32Array => {
+    const diff = childCoord.zoom - parentZoom;
+    const scale = 1 << diff; // 子タイル数（片辺）
+    // 親タイル内での子タイルオフセット (0..scale-1)
+    const subX = childCoord.x - ((childCoord.x >> diff) << diff);
+    const subY = childCoord.y - ((childCoord.y >> diff) << diff);
+
+    const result = new Float32Array(tileSize * tileSize);
+    const subSize = tileSize / scale; // 親タイル内の子タイルピクセルサイズ
+    const originX = subX * subSize;
+    const originY = subY * subSize;
+
+    for (let y = 0; y < tileSize; y++) {
+        for (let x = 0; x < tileSize; x++) {
+            // 子タイルの (x,y) → 親タイルのピクセル座標
+            const srcX = Math.min(
+                tileSize - 1,
+                Math.round(originX + (x / tileSize) * subSize)
+            );
+            const srcY = Math.min(
+                tileSize - 1,
+                Math.round(originY + (y / tileSize) * subSize)
+            );
+            result[y * tileSize + x] = parentElev[srcY * tileSize + srcX];
+        }
+    }
+    return result;
+};
+
 /** Babylon.js Frustum planes を FrustumPlane[] に変換 */
 const extractFrustumPlanes = (camera: ArcRotateCamera): FrustumPlane[] => {
     const transform = Matrix.Identity();
@@ -112,7 +155,12 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         maxTiles = DEFAULT_MAX_TILES,
         cacheCapacity = DEFAULT_CACHE_CAPACITY,
         debounceMs = DEFAULT_DEBOUNCE_MS,
+        minZoom: minZoomOpt,
+        maxElevationZoom: maxElevationZoomOpt,
     } = opts;
+
+    const minZoom = minZoomOpt ?? Math.max(0, zoom - 2);
+    const maxElevationZoom = maxElevationZoomOpt ?? zoom;
 
     const cache: TileCache = createTileCache(cacheCapacity);
     const meshPool: MeshPool = createMeshPool({
@@ -132,8 +180,8 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
 
     // 現在の中心情報
     let currentCenter: TileCoord | null = null;
-    let currentTileSize = 0;
     let currentAltitudeOffset = 0;
+    let currentLat = 0;
 
     const emitStatus = (): void => {
         if (!statusCallback) return;
@@ -151,24 +199,70 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
     /** 単一タイルをロードしてメッシュに適用 */
     const loadTile = async (
         coord: TileCoord,
+        tileSize: number,
         rid: number
     ): Promise<void> => {
         const key = toTileKey(coord);
-        if (activeTiles.has(key)) return;
+        if (activeTiles.has(key) || !currentCenter) return;
 
         loadingCount++;
         emitStatus();
 
         try {
-            // キャッシュ or fetch
+            // キャッシュ or fetch（標高zoomは maxElevationZoom で制限）
+            const elevZoom = Math.min(coord.zoom, maxElevationZoom);
+
             let entry = cache.get(key);
             if (!entry) {
-                const elevation = await loadElevationTile(
-                    coord.zoom,
-                    coord.x,
-                    coord.y
-                );
-                if (rid !== requestId) return;
+                // 標高データを取得（maxElevationZoomから段階的にフォールバック）
+                let elevData: Float32Array | null = null;
+                let actualElevZoom = elevZoom;
+
+                for (let tryZoom = elevZoom; tryZoom >= minZoom; tryZoom--) {
+                    const tryCoord = convertTileZoom(coord, tryZoom);
+                    const tryKey = toTileKey(tryCoord);
+
+                    // キャッシュにあればそれを使う
+                    const cached = cache.get(tryKey);
+                    if (cached) {
+                        elevData = cached.elevation;
+                        actualElevZoom = tryZoom;
+                        break;
+                    }
+
+                    try {
+                        elevData = await loadElevationTile(
+                            tryCoord.zoom,
+                            tryCoord.x,
+                            tryCoord.y
+                        );
+                        if (rid !== requestId) return;
+                        // 成功した標高データをキャッシュ
+                        cache.set(tryKey, { coord: tryCoord, elevation: elevData });
+                        actualElevZoom = tryZoom;
+                        break;
+                    } catch {
+                        // このzoomでは利用不可 → 1段下げて再試行
+                        if (rid !== requestId) return;
+                    }
+                }
+
+                if (!elevData) {
+                    // 全zoomで失敗 → フラット標高で表示
+                    elevData = new Float32Array(TILE_SIZE * TILE_SIZE);
+                    actualElevZoom = coord.zoom;
+                }
+
+                // zoom差がある場合、親タイルの該当領域を切り出し
+                let elevation: Float32Array;
+                if (actualElevZoom < coord.zoom) {
+                    elevation = extractSubTileElevation(
+                        elevData, coord, actualElevZoom, TILE_SIZE
+                    );
+                } else {
+                    elevation = elevData;
+                }
+
                 entry = { coord, elevation };
                 cache.set(key, entry);
             }
@@ -178,17 +272,18 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
 
             // メッシュ取得・配置
             const mesh = meshPool.acquire();
-            const tileSize = currentTileSize;
 
             // スケーリング
             mesh.scaling.x = tileSize;
             mesh.scaling.z = tileSize;
             mesh.scaling.y = 1;
 
-            // 中心タイルからのオフセット
-            const dx = coord.x - currentCenter!.x;
-            const dy = coord.y - currentCenter!.y;
-            const { wx, wz } = tileOffsetToWorld(dx, dy, tileSize);
+            // 中心タイルからのオフセット（サブタイルオフセット補正込み）
+            const center = convertTileZoom(currentCenter, coord.zoom);
+            const { fracX, fracY } = computeSubTileOffset(currentCenter, coord.zoom);
+            const dx = coord.x - center.x;
+            const dy = coord.y - center.y;
+            const { wx, wz } = tileOffsetToWorld(dx - fracX, dy - fracY, tileSize);
             mesh.position.x = wx;
             mesh.position.z = wz;
 
@@ -226,7 +321,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
                 Texture.TRILINEAR_SAMPLINGMODE
             );
 
-            activeTiles.set(key, { key, coord, mesh });
+            activeTiles.set(key, { key, coord, mesh, tileSize });
         } catch (e) {
             if (rid !== requestId) return;
             statusCallback?.(
@@ -238,21 +333,23 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         }
     };
 
-    /** 既存 activeTiles の position/scaling/標高を現在の中心・タイルサイズ・高度オフセットに合わせて再配置 */
+    /** 既存 activeTiles の position/scaling/標高を現在の中心・高度オフセットに合わせて再配置 */
     const repositionActiveTiles = (): void => {
         if (!currentCenter) return;
         for (const [key, tile] of activeTiles) {
-            const { mesh, coord } = tile;
+            const { mesh, coord, tileSize } = tile;
 
             // スケーリング
-            mesh.scaling.x = currentTileSize;
-            mesh.scaling.z = currentTileSize;
+            mesh.scaling.x = tileSize;
+            mesh.scaling.z = tileSize;
             mesh.scaling.y = 1;
 
-            // 位置
-            const dx = coord.x - currentCenter.x;
-            const dy = coord.y - currentCenter.y;
-            const { wx, wz } = tileOffsetToWorld(dx, dy, currentTileSize);
+            // 位置（サブタイルオフセット補正込み）
+            const center = convertTileZoom(currentCenter, coord.zoom);
+            const { fracX, fracY } = computeSubTileOffset(currentCenter, coord.zoom);
+            const dx = coord.x - center.x;
+            const dy = coord.y - center.y;
+            const { wx, wz } = tileOffsetToWorld(dx - fracX, dy - fracY, tileSize);
             mesh.position.x = wx;
             mesh.position.z = wz;
 
@@ -284,22 +381,90 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
 
     /** 並列数制限付きのロードキュー */
     const loadTilesInQueue = async (
-        coords: TileCoord[],
+        entries: readonly LodTileEntry[],
         rid: number
     ): Promise<void> => {
         let idx = 0;
         const next = async (): Promise<void> => {
-            while (idx < coords.length && rid === requestId) {
-                const coord = coords[idx++];
-                await loadTile(coord, rid);
+            while (idx < entries.length && rid === requestId) {
+                const { coord, tileSize } = entries[idx++];
+                await loadTile(coord, tileSize, rid);
             }
         };
 
         const workers = Array.from(
-            { length: Math.min(maxConcurrent, coords.length) },
+            { length: Math.min(maxConcurrent, entries.length) },
             () => next()
         );
         await Promise.all(workers);
+    };
+
+    /** tileSizeForZoom: 指定zoomでのタイル実サイズを返す */
+    const tileSizeForZoom = (z: number): number => tileEdgeMeters(currentLat, z);
+
+    /** 可視タイルを算出する共通ヘルパー */
+    const computeVisible = (
+        frustumPlanes: FrustumPlane[],
+        maxElevation: number
+    ): LodTileEntry[] => {
+        if (!currentCenter) return [];
+
+        // カメラ→ターゲット距離（チルトに依存せず安定）
+        const cameraDistance = Math.sqrt(
+            camera.position.x ** 2 +
+            camera.position.y ** 2 +
+            camera.position.z ** 2
+        );
+
+        const baseZoom = computeBaseZoom(
+            cameraDistance,
+            tileSizeForZoom,
+            zoom,
+            minZoom
+        );
+
+        return computeMultiLodTiles({
+            baseCenter: currentCenter,
+            tileSizeForZoom,
+            frustumPlanes,
+            cameraDistance,
+            baseZoom,
+            minZoom,
+            maxTiles,
+            maxElevation,
+        });
+    };
+
+    /** 可視タイルリストから不要タイルを解放し、新規タイルをロード */
+    const applyVisibleTiles = async (
+        visibleEntries: readonly LodTileEntry[],
+        rid: number,
+        reposition: boolean
+    ): Promise<void> => {
+        const visibleKeys = new Set(visibleEntries.map((e) => toTileKey(e.coord)));
+
+        // 不要タイルを解放
+        for (const [key, tile] of activeTiles) {
+            if (!visibleKeys.has(key)) {
+                meshPool.release(tile.mesh);
+                activeTiles.delete(key);
+            }
+        }
+
+        if (reposition) {
+            repositionActiveTiles();
+        }
+
+        // 新規タイルのみロード
+        const toLoad = visibleEntries.filter(
+            (e) => !activeTiles.has(toTileKey(e.coord))
+        );
+
+        if (toLoad.length > 0) {
+            await loadTilesInQueue(toLoad, rid);
+        }
+
+        emitStatus();
     };
 
     /** 可視タイルを再計算し、不要タイルを解放・新規タイルをロード */
@@ -311,49 +476,16 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         const rid = ++requestId;
 
         const center = toTileXY(lat, lon, zoom);
-        const tileSize = tileEdgeMeters(lat, zoom);
         currentCenter = { zoom, x: center.x, y: center.y };
-        currentTileSize = tileSize;
         currentAltitudeOffset = altitudeOffset;
+        currentLat = lat;
 
-        // Frustum planes 取得
         const frustumPlanes = extractFrustumPlanes(camera);
-
-        // AABB maxY: (想定最大標高 + 高度オフセット) * heightScale
         const maxElevation =
             (MAX_BASE_ELEVATION + Math.max(0, altitudeOffset)) * heightScale;
 
-        // 可視タイル算出
-        const visibleCoords = computeVisibleTiles({
-            center: currentCenter,
-            tileSize,
-            frustumPlanes,
-            maxTiles,
-            maxElevation,
-        });
-        const visibleKeys = new Set(visibleCoords.map(toTileKey));
-
-        // 不要タイルを解放
-        for (const [key, tile] of activeTiles) {
-            if (!visibleKeys.has(key)) {
-                meshPool.release(tile.mesh);
-                activeTiles.delete(key);
-            }
-        }
-
-        // 既存タイルの position/scaling/標高を新しい中心基準で再配置
-        repositionActiveTiles();
-
-        // 新規タイルのみロード
-        const toLoad = visibleCoords.filter(
-            (c) => !activeTiles.has(toTileKey(c))
-        );
-
-        if (toLoad.length > 0) {
-            await loadTilesInQueue(toLoad, rid);
-        }
-
-        emitStatus();
+        const visibleEntries = computeVisible(frustumPlanes, maxElevation);
+        await applyVisibleTiles(visibleEntries, rid, true);
     };
 
     // カメラ変更時のリフレッシュ（中心座標を保持して使用）
@@ -365,33 +497,9 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         const maxElevation =
             (MAX_BASE_ELEVATION + Math.max(0, currentAltitudeOffset)) *
             heightScale;
-        const visibleCoords = computeVisibleTiles({
-            center: currentCenter,
-            tileSize: currentTileSize,
-            frustumPlanes,
-            maxTiles,
-            maxElevation,
-        });
-        const visibleKeys = new Set(visibleCoords.map(toTileKey));
 
-        // 不要タイルを解放
-        for (const [key, tile] of activeTiles) {
-            if (!visibleKeys.has(key)) {
-                meshPool.release(tile.mesh);
-                activeTiles.delete(key);
-            }
-        }
-
-        // 新規タイルのみロード
-        const toLoad = visibleCoords.filter(
-            (c) => !activeTiles.has(toTileKey(c))
-        );
-
-        if (toLoad.length > 0) {
-            await loadTilesInQueue(toLoad, rid);
-        }
-
-        emitStatus();
+        const visibleEntries = computeVisible(frustumPlanes, maxElevation);
+        await applyVisibleTiles(visibleEntries, rid, false);
     };
 
     return {

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -95,7 +95,7 @@ const applyElevation = (
  * 親タイルの標高データから子タイルに対応する領域を切り出す。
  * 最近傍補間で TILE_SIZE × TILE_SIZE に拡大。
  */
-const extractSubTileElevation = (
+export const extractSubTileElevation = (
     parentElev: Float32Array,
     childCoord: TileCoord,
     parentZoom: number,

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -413,12 +413,8 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
     ): LodTileEntry[] => {
         if (!currentCenter) return [];
 
-        // カメラ→ターゲット距離（チルトに依存せず安定）
-        const cameraDistance = Math.sqrt(
-            camera.position.x ** 2 +
-            camera.position.y ** 2 +
-            camera.position.z ** 2
-        );
+        // カメラ→ターゲット距離（チルトやパンに依存せず安定）
+        const cameraDistance = camera.radius;
 
         const baseZoom = computeBaseZoom(
             cameraDistance,

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -341,7 +341,11 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
     const repositionActiveTiles = (): void => {
         if (!currentCenter) return;
         for (const [key, tile] of activeTiles) {
-            const { mesh, coord, tileSize } = tile;
+            const { mesh, coord } = tile;
+
+            // tileSize を現在の緯度で再計算
+            const tileSize = tileSizeForZoom(coord.zoom);
+            tile.tileSize = tileSize;
 
             // スケーリング
             mesh.scaling.x = tileSize;

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -117,11 +117,15 @@ const extractSubTileElevation = (
             // 子タイルの (x,y) → 親タイルのピクセル座標
             const srcX = Math.min(
                 tileSize - 1,
-                Math.round(originX + (x / tileSize) * subSize)
+                tileSize > 1
+                    ? Math.round(originX + (x / (tileSize - 1)) * (subSize - 1))
+                    : Math.round(originX)
             );
             const srcY = Math.min(
                 tileSize - 1,
-                Math.round(originY + (y / tileSize) * subSize)
+                tileSize > 1
+                    ? Math.round(originY + (y / (tileSize - 1)) * (subSize - 1))
+                    : Math.round(originY)
             );
             result[y * tileSize + x] = parentElev[srcY * tileSize + srcX];
         }

--- a/src/terrain/tileTypes.ts
+++ b/src/terrain/tileTypes.ts
@@ -39,3 +39,57 @@ export const worldToTileOffset = (
     dx: Math.round(wx / tileSize),
     dy: normalizeNegZero(-(Math.round(wz / tileSize))),
 });
+
+/** タイル座標を別の zoom レベルに変換 */
+export const convertTileZoom = (
+    coord: TileCoord,
+    targetZoom: number
+): TileCoord => {
+    const diff = coord.zoom - targetZoom;
+    if (diff > 0) {
+        // 高zoom → 低zoom: ビット右シフト相当
+        return {
+            zoom: targetZoom,
+            x: coord.x >> diff,
+            y: coord.y >> diff,
+        };
+    }
+    if (diff < 0) {
+        // 低zoom → 高zoom: 左シフト（左上隅）
+        const shift = -diff;
+        return {
+            zoom: targetZoom,
+            x: coord.x << shift,
+            y: coord.y << shift,
+        };
+    }
+    return coord;
+};
+
+/** 高zoom タイルが低zoom タイルに含まれるか判定 */
+export const isChildOf = (
+    child: TileCoord,
+    parent: TileCoord
+): boolean => {
+    if (child.zoom <= parent.zoom) return false;
+    const parentOfChild = convertTileZoom(child, parent.zoom);
+    return parentOfChild.x === parent.x && parentOfChild.y === parent.y;
+};
+
+/**
+ * 基本zoom中心タイルの、対象zoom中心タイル内でのサブタイルオフセットを計算。
+ * convertTileZoom のビットシフトで失われる端数を補正するための値。
+ */
+export const computeSubTileOffset = (
+    baseCenter: TileCoord,
+    targetZoom: number
+): { fracX: number; fracY: number } => {
+    const diff = baseCenter.zoom - targetZoom;
+    if (diff <= 0) return { fracX: 0, fracY: 0 };
+    const scale = 1 << diff; // 2^diff
+    const targetCenter = convertTileZoom(baseCenter, targetZoom);
+    return {
+        fracX: (baseCenter.x + 0.5) / scale - (targetCenter.x + 0.5),
+        fracY: (baseCenter.y + 0.5) / scale - (targetCenter.y + 0.5),
+    };
+};

--- a/src/terrain/visibleTiles.ts
+++ b/src/terrain/visibleTiles.ts
@@ -116,7 +116,7 @@ export interface MultiLodTilesOptions {
     /** タイル総数の上限 */
     maxTiles?: number;
     maxElevation?: number;
-    /** 各zoomレベルの探索半径（省略時 14） */
+    /** baseZoom 格子の探索半径（省略時 14）。Far-field sweep 側の半径には影響しない。 */
     searchRadius?: number;
 }
 

--- a/src/terrain/visibleTiles.ts
+++ b/src/terrain/visibleTiles.ts
@@ -1,6 +1,6 @@
 /** カメラFrustum内の可視タイルを算出する */
 
-import { TileCoord, tileOffsetToWorld } from "./tileTypes";
+import { TileCoord, TileKey, toTileKey, tileOffsetToWorld, convertTileZoom, computeSubTileOffset } from "./tileTypes";
 
 export interface FrustumPlane {
     normal: { x: number; y: number; z: number };
@@ -17,7 +17,7 @@ export interface VisibleTilesOptions {
     maxElevation?: number;
 }
 
-const DEFAULT_MAX_TILES = 25;
+const DEFAULT_MAX_TILES = 50;
 const DEFAULT_SEARCH_RADIUS = 4;
 /** 日本の標高上限概算（富士山 3776m + マージン） */
 const DEFAULT_MAX_ELEVATION = 4000;
@@ -93,4 +93,283 @@ export const computeVisibleTiles = (opts: VisibleTilesOptions): TileCoord[] => {
 
     candidates.sort((a, b) => a.dist - b.dist);
     return candidates.slice(0, maxTiles).map((c) => c.coord);
+};
+
+/** マルチLOD可視タイルの結果 */
+export interface LodTileEntry {
+    coord: TileCoord;
+    tileSize: number;
+}
+
+export interface MultiLodTilesOptions {
+    /** 基本zoom（最高解像度）の中心タイル座標 */
+    baseCenter: TileCoord;
+    /** 各zoomでのタイル実サイズ（メートル）を返す関数 */
+    tileSizeForZoom: (zoom: number) => number;
+    frustumPlanes: readonly FrustumPlane[];
+    /** カメラからターゲットまでの距離（ArcRotateCamera.radius相当） */
+    cameraDistance: number;
+    /** カメラ高度から算出した基本ズームレベル */
+    baseZoom: number;
+    /** 使用する最小ズームレベル */
+    minZoom: number;
+    /** タイル総数の上限 */
+    maxTiles?: number;
+    maxElevation?: number;
+    /** 各zoomレベルの探索半径（省略時 14） */
+    searchRadius?: number;
+}
+
+const DEFAULT_SEARCH_RADIUS_LOD = 14;
+
+/**
+ * カメラ距離から基本ズームレベルを算出する。
+ * カメラ→ターゲット距離を基準にするため、チルト角に依存せず安定する。
+ */
+export const computeBaseZoom = (
+    cameraDistance: number,
+    tileSizeForZoom: (z: number) => number,
+    maxZoom: number,
+    minZoom: number,
+): number => {
+    // 画面中央にタイル約3枚幅が収まるレベルを選択
+    // 可視幅 ≈ cameraDistance * 1.5（典型的な FOV・アスペクト比）
+    const targetTileSize = cameraDistance * 0.8;
+    for (let z = minZoom; z < maxZoom; z++) {
+        if (tileSizeForZoom(z) <= targetTileSize) {
+            return z;
+        }
+    }
+    return maxZoom;
+};
+
+/**
+ * カメラ距離ベースのマルチLOD可視タイルを算出する。
+ * baseZoom格子を基準に探索し、距離に応じて低zoomの親タイルに集約。
+ * LOD境界では低zoom側に統一し、メッシュの重なりを防ぐ。
+ */
+export const computeMultiLodTiles = (
+    opts: MultiLodTilesOptions
+): LodTileEntry[] => {
+    const {
+        baseCenter,
+        tileSizeForZoom,
+        frustumPlanes,
+        cameraDistance: rawCameraDistance,
+        baseZoom,
+        minZoom,
+        maxTiles = DEFAULT_MAX_TILES,
+        maxElevation = DEFAULT_MAX_ELEVATION,
+        searchRadius = DEFAULT_SEARCH_RADIUS_LOD,
+    } = opts;
+
+    if (baseZoom < minZoom) return [];
+
+    const cameraDistance = Math.max(1, rawCameraDistance);
+
+    /**
+     * ターゲットからの水平距離でzoomレベルを決定。
+     * cameraDistance×1.3以遠で段階的にzoomを下げる。
+     */
+    const zoomForDist = (dist: number): number => {
+        let z = baseZoom;
+        let threshold = cameraDistance * 1.3;
+        while (z > minZoom && dist >= threshold) {
+            z--;
+            threshold *= 2;
+        }
+        return z;
+    };
+
+    // baseZoom格子で探索（baseZoomのタイルサイズに合わせた座標系）
+    const gridTileSize = tileSizeForZoom(baseZoom);
+    const gridHalf = gridTileSize / 2;
+    const gridCenter = convertTileZoom(baseCenter, baseZoom);
+
+    // 探索半径: 画面をカバーできる最小半径と設定値の大きい方
+    const minRadiusForCoverage = Math.ceil(cameraDistance * 1.5 / gridTileSize);
+    const effectiveRadius = Math.max(searchRadius, Math.min(minRadiusForCoverage, 30));
+
+    // baseCenter→gridCenter 変換で生じるサブタイルオフセット
+    const { fracX, fracY } = computeSubTileOffset(baseCenter, baseZoom);
+
+    // Step 1: baseZoom格子で可視セルを列挙、距離からzoomを決定
+    interface GridCell {
+        dx: number;
+        dy: number;
+        targetZoom: number;
+        dist: number;
+    }
+    const gridCells: GridCell[] = [];
+
+    for (let dy = -effectiveRadius; dy <= effectiveRadius; dy++) {
+        for (let dx = -effectiveRadius; dx <= effectiveRadius; dx++) {
+            const { wx, wz } = tileOffsetToWorld(dx - fracX, dy - fracY, gridTileSize);
+
+            if (
+                !isAABBInFrustum(
+                    wx - gridHalf, 0, wz - gridHalf,
+                    wx + gridHalf, maxElevation, wz + gridHalf,
+                    frustumPlanes
+                )
+            ) continue;
+
+            const dist = Math.sqrt(wx ** 2 + wz ** 2);
+            const targetZoom = zoomForDist(dist);
+            gridCells.push({ dx, dy, targetZoom, dist });
+        }
+    }
+
+    // Step 2: 低zoomタイルがカバーする全セルのzoomを統一（重なり防止）
+    const cellZoomMap = new Map<string, number>();
+    for (const cell of gridCells) {
+        cellZoomMap.set(`${cell.dx},${cell.dy}`, cell.targetZoom);
+    }
+
+    for (let z = minZoom; z < baseZoom; z++) {
+        const parentTiles = new Set<string>();
+        const diff = baseZoom - z;
+        for (const cell of gridCells) {
+            if (cellZoomMap.get(`${cell.dx},${cell.dy}`) === z) {
+                const gx = gridCenter.x + cell.dx;
+                const gy = gridCenter.y + cell.dy;
+                parentTiles.add(`${gx >> diff},${gy >> diff}`);
+            }
+        }
+        if (parentTiles.size > 0) {
+            for (const cell of gridCells) {
+                const gx = gridCenter.x + cell.dx;
+                const gy = gridCenter.y + cell.dy;
+                if (parentTiles.has(`${gx >> diff},${gy >> diff}`)) {
+                    cellZoomMap.set(`${cell.dx},${cell.dy}`, z);
+                }
+            }
+        }
+    }
+
+    // Step 3: セルを対象zoomのタイルに集約
+    const tilesByZoom = new Map<number, Map<TileKey, { coord: TileCoord; dist: number }>>();
+    for (let z = minZoom; z <= baseZoom; z++) {
+        tilesByZoom.set(z, new Map());
+    }
+
+    for (const cell of gridCells) {
+        const assignedZoom = cellZoomMap.get(`${cell.dx},${cell.dy}`)!;
+        const gridTile: TileCoord = {
+            zoom: baseZoom,
+            x: gridCenter.x + cell.dx,
+            y: gridCenter.y + cell.dy,
+        };
+        const parentCoord = convertTileZoom(gridTile, assignedZoom);
+        const key = toTileKey(parentCoord);
+
+        const zoomMap = tilesByZoom.get(assignedZoom)!;
+        const existing = zoomMap.get(key);
+        if (!existing || cell.dist < existing.dist) {
+            zoomMap.set(key, { coord: parentCoord, dist: cell.dist });
+        }
+    }
+
+    // Step 4: 低zoom → 高zoom の順に結果を収集（距離順ソート）
+    const results: LodTileEntry[] = [];
+    for (let z = minZoom; z <= baseZoom; z++) {
+        if (results.length >= maxTiles) break;
+
+        const tileSize = tileSizeForZoom(z);
+        const zoomTiles = [...tilesByZoom.get(z)!.values()];
+        zoomTiles.sort((a, b) => a.dist - b.dist);
+
+        const remaining = maxTiles - results.length;
+        for (const { coord } of zoomTiles.slice(0, remaining)) {
+            results.push({ coord, tileSize });
+        }
+    }
+
+    // Step 5: Far-field sweep — baseZoom格子のカバー範囲外を低zoom格子で補完
+    // 水平に近いチルト時、frustumはbaseZoom格子の探索範囲を大きく超える。
+    // 各低zoom層のタイルサイズで独自に探索し、遠方の欠けを埋める。
+    // baseZoom格子の既存タイルと重複する親タイルは子がカバー済みなのでスキップ。
+    const allKeys = new Set(results.map(r => toTileKey(r.coord)));
+
+    // baseZoom格子でカバー済みのセル座標を記録（重複判定用）
+    const coveredBaseZoomCells = new Set<string>();
+    for (const cell of gridCells) {
+        coveredBaseZoomCells.add(`${gridCenter.x + cell.dx},${gridCenter.y + cell.dy}`);
+    }
+
+    for (let z = baseZoom - 1; z >= minZoom && results.length < maxTiles; z--) {
+        const farTileSize = tileSizeForZoom(z);
+        const farHalf = farTileSize / 2;
+        const farCenter = convertTileZoom(baseCenter, z);
+        const { fracX: farFracX, fracY: farFracY } = computeSubTileOffset(baseCenter, z);
+
+        // zoom z の距離上限: cameraDistance × 1.3 × 2^(baseZoom − z)
+        const zoomSteps = baseZoom - z;
+        const maxDistForZoom = cameraDistance * 1.3 * Math.pow(2, zoomSteps);
+        const farSearchRadius = Math.min(
+            Math.ceil(maxDistForZoom / farTileSize) + 1,
+            30
+        );
+
+        const candidates: { coord: TileCoord; dist: number }[] = [];
+
+        for (let dy = -farSearchRadius; dy <= farSearchRadius; dy++) {
+            for (let dx = -farSearchRadius; dx <= farSearchRadius; dx++) {
+                const { wx, wz } = tileOffsetToWorld(
+                    dx - farFracX, dy - farFracY, farTileSize
+                );
+                const dist = Math.sqrt(wx ** 2 + wz ** 2);
+
+                // このzoom以下の距離帯のセルを追加（境界ギャップ防止）
+                if (zoomForDist(dist) > z) continue;
+
+                if (
+                    !isAABBInFrustum(
+                        wx - farHalf, 0, wz - farHalf,
+                        wx + farHalf, maxElevation, wz + farHalf,
+                        frustumPlanes
+                    )
+                ) continue;
+
+                const coord: TileCoord = {
+                    zoom: z,
+                    x: farCenter.x + dx,
+                    y: farCenter.y + dy,
+                };
+                const key = toTileKey(coord);
+                if (allKeys.has(key)) continue;
+
+                // この親タイルがbaseZoom格子で完全にカバー済みか確認
+                // カバー済みならスキップ（重なり防止）
+                const diff = baseZoom - z;
+                // diff > 4 は子タイル 16×16=256 以上。完全カバーは事実上ないのでスキップ
+                let fullyCovered = false;
+                if (diff <= 4) {
+                    const childCount = 1 << diff;
+                    const childBaseX = coord.x << diff;
+                    const childBaseY = coord.y << diff;
+                    fullyCovered = true;
+                    for (let cy = 0; cy < childCount && fullyCovered; cy++) {
+                        for (let cx = 0; cx < childCount && fullyCovered; cx++) {
+                            if (!coveredBaseZoomCells.has(`${childBaseX + cx},${childBaseY + cy}`)) {
+                                fullyCovered = false;
+                            }
+                        }
+                    }
+                }
+                if (fullyCovered) continue;
+
+                candidates.push({ coord, dist });
+            }
+        }
+
+        candidates.sort((a, b) => a.dist - b.dist);
+        for (const { coord } of candidates) {
+            if (results.length >= maxTiles) break;
+            results.push({ coord, tileSize: farTileSize });
+            allKeys.add(toTileKey(coord));
+        }
+    }
+
+    return results;
 };

--- a/tests/tileManager.unit.spec.ts
+++ b/tests/tileManager.unit.spec.ts
@@ -99,7 +99,8 @@ jest.unstable_mockModule("../src/terrain/gsiTile", () => ({
     stdTextureUrl: jest.fn(() => "https://example.com/tile.png"),
 }));
 
-const { createTileManager } = await import("../src/terrain/tileManager");
+const { createTileManager, extractSubTileElevation } = await import("../src/terrain/tileManager");
+const gsiTileMock = await import("../src/terrain/gsiTile");
 
 const createMockCamera = () => {
     const observers: Array<() => void> = [];
@@ -199,5 +200,338 @@ describe("createTileManager", () => {
         expect(
             (camera as any).onViewMatrixChangedObservable.remove
         ).toHaveBeenCalled();
+    });
+});
+
+/* ================================================================
+ * extractSubTileElevation 単体テスト
+ * ================================================================ */
+describe("extractSubTileElevation", () => {
+    /**
+     * tileSize=4 の親タイル（4×4）を使い、zoom+1 の子タイル切り出しを検証。
+     * 親データ配置:
+     *   [ 0,  1,| 2,  3 ]   ← row0
+     *   [ 4,  5,| 6,  7 ]   ← row1
+     *   --------------------
+     *   [ 8,  9,|10, 11 ]   ← row2
+     *   [12, 13,|14, 15 ]   ← row3
+     * 左上(0,0)={0,1,4,5}  右上(1,0)={2,3,6,7}
+     * 左下(0,1)={8,9,12,13} 右下(1,1)={10,11,14,15}
+     */
+    const tileSize = 4;
+    const parent = new Float32Array([
+        0, 1, 2, 3,
+        4, 5, 6, 7,
+        8, 9, 10, 11,
+        12, 13, 14, 15,
+    ]);
+    const parentZoom = 14;
+
+    it("zoom+1 子タイル(0,0)は親の左上領域のみ参照する", () => {
+        // parentX = 100 → child (200, 200) → subX=0, subY=0
+        const child = { zoom: 15, x: 200, y: 200 };
+        const result = extractSubTileElevation(parent, child, parentZoom, tileSize);
+
+        expect(result.length).toBe(tileSize * tileSize);
+        const values = new Set(result);
+        // 左上 2×2 の値 {0,1,4,5} のみ含むこと
+        for (const v of values) {
+            expect([0, 1, 4, 5]).toContain(v);
+        }
+        // 右半分・下半分の値を含まないこと
+        expect(values.has(2)).toBe(false);
+        expect(values.has(3)).toBe(false);
+        expect(values.has(6)).toBe(false);
+        expect(values.has(7)).toBe(false);
+        expect(values.has(10)).toBe(false);
+        expect(values.has(14)).toBe(false);
+    });
+
+    it("zoom+1 子タイル(1,1)は親の右下領域のみ参照する", () => {
+        // parentX=100, parentY=100 → child (201,201) → subX=1, subY=1
+        const child = { zoom: 15, x: 201, y: 201 };
+        const result = extractSubTileElevation(parent, child, parentZoom, tileSize);
+
+        expect(result.length).toBe(tileSize * tileSize);
+        const values = new Set(result);
+        // 右下 2×2 の値 {10,11,14,15} のみ含むこと
+        for (const v of values) {
+            expect([10, 11, 14, 15]).toContain(v);
+        }
+        // 左半分・上半分の値を含まないこと
+        expect(values.has(0)).toBe(false);
+        expect(values.has(1)).toBe(false);
+        expect(values.has(4)).toBe(false);
+        expect(values.has(5)).toBe(false);
+        expect(values.has(8)).toBe(false);
+        expect(values.has(9)).toBe(false);
+    });
+
+    it("zoom+1 子タイル(1,0)の境界ピクセルが左半分を参照しない", () => {
+        // parentX=100 → child (201, 200) → subX=1, subY=0
+        const child = { zoom: 15, x: 201, y: 200 };
+        const result = extractSubTileElevation(parent, child, parentZoom, tileSize);
+
+        const values = new Set(result);
+        // 右上 2×2 の値 {2,3,6,7} のみ含むこと
+        for (const v of values) {
+            expect([2, 3, 6, 7]).toContain(v);
+        }
+        // 左半分の値を含まないこと（境界ブリード無し）
+        expect(values.has(0)).toBe(false);
+        expect(values.has(1)).toBe(false);
+        expect(values.has(4)).toBe(false);
+        expect(values.has(5)).toBe(false);
+    });
+
+    it("zoom差2（4分の1タイル）でも正しく切り出す", () => {
+        // tileSize=4, diff=2, scale=4, subSize=1
+        // child (401, 401) → subX=1, subY=1 (parentX=100, shift=2: 401 - (401>>2)<<2 = 401-400=1)
+        const child = { zoom: 16, x: 401, y: 401 };
+        const result = extractSubTileElevation(parent, child, parentZoom, tileSize);
+
+        expect(result.length).toBe(tileSize * tileSize);
+        // subSize=1, originX=1, originY=1 → 全ピクセルが parent[1*4+1]=5 を参照
+        const values = new Set(result);
+        expect(values.size).toBe(1);
+        expect(values.has(5)).toBe(true);
+    });
+
+    it("zoom差2で右下端の子タイルが正しい値のみ参照する", () => {
+        // child (403, 403) → subX=3, subY=3 (parentX=100<<2=400, 403-400=3)
+        const child = { zoom: 16, x: 403, y: 403 };
+        const result = extractSubTileElevation(parent, child, parentZoom, tileSize);
+
+        // subSize=1, originX=3, originY=3 → 全ピクセルが parent[3*4+3]=15 を参照
+        const values = new Set(result);
+        expect(values.size).toBe(1);
+        expect(values.has(15)).toBe(true);
+    });
+
+    it("TILE_SIZE=256 相当でも境界に隣接領域の値が混入しない", () => {
+        const size = 256;
+        const big = new Float32Array(size * size);
+        // 左半分=100, 右半分=200
+        for (let y = 0; y < size; y++) {
+            for (let x = 0; x < size; x++) {
+                big[y * size + x] = x < size / 2 ? 100 : 200;
+            }
+        }
+
+        // 右上子タイル (subX=1, subY=0)
+        const child = { zoom: 15, x: 201, y: 200 };
+        const result = extractSubTileElevation(big, child, 14, size);
+
+        // 右半分（200）のみ参照すること
+        for (let i = 0; i < result.length; i++) {
+            expect(result[i]).toBe(200);
+        }
+    });
+});
+
+/* ================================================================
+ * LOD連携テスト（computeBaseZoom / computeMultiLodTiles 経由）
+ * ================================================================ */
+describe("LOD連携", () => {
+    beforeEach(() => {
+        (gsiTileMock.stdTextureUrl as jest.Mock).mockClear();
+        (gsiTileMock.loadElevationTile as jest.Mock).mockClear();
+    });
+
+    afterEach(() => {
+        // モック実装を元に戻す
+        (gsiTileMock.tileEdgeMeters as jest.Mock).mockImplementation(
+            () => 1000
+        );
+        (gsiTileMock.loadElevationTile as jest.Mock).mockImplementation(
+            () => Promise.resolve(new Float32Array(256 * 256))
+        );
+    });
+
+    it("camera.radiusが同じならtargetオフセットしてもLODは変化しない", async () => {
+        const camera1 = createMockCamera();
+        (camera1 as any).radius = 200;
+        (camera1 as any).position = { x: 0, y: 200, z: 0 };
+
+        const tm1 = createTileManager({
+            scene: {} as never,
+            camera: camera1,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 60,
+            minZoom: 12,
+        });
+        await tm1.setCenter(35.68, 139.77);
+        const count1 = tm1.activeTileCount;
+        tm1.dispose();
+
+        // 同じ radius で異なるカメラ位置
+        const camera2 = createMockCamera();
+        (camera2 as any).radius = 200;
+        (camera2 as any).position = { x: 5000, y: 200, z: 5000 };
+
+        const tm2 = createTileManager({
+            scene: {} as never,
+            camera: camera2,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 60,
+            minZoom: 12,
+        });
+        await tm2.setCenter(35.68, 139.77);
+        const count2 = tm2.activeTileCount;
+        tm2.dispose();
+
+        // camera.radius が同じなら position に依存せず同じタイル数
+        expect(count1).toBe(count2);
+    });
+
+    it("camera.radiusが変わるとロードされるタイルのzoomレベルが変化する", async () => {
+        // zoom依存の tileEdgeMeters: z14=1000, z13=2000, z12=4000
+        (gsiTileMock.tileEdgeMeters as jest.Mock<(lat: number, zoom: number) => number>).mockImplementation(
+            (_lat, zoom) => 1000 * Math.pow(2, 14 - zoom)
+        );
+
+        // 近距離: radius=2400 → baseZoom=14, 中心付近にzoom14タイルが残る
+        // (threshold=3120で近傍セルが zoom14 に収まり、zoom12親との共有が起きない)
+        const cameraNear = createMockCamera();
+        (cameraNear as any).radius = 2400;
+
+        const tmNear = createTileManager({
+            scene: {} as never,
+            camera: cameraNear,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 200,
+            minZoom: 12,
+        });
+        await tmNear.setCenter(35.68, 139.77);
+
+        const zoomsNear = (gsiTileMock.stdTextureUrl as jest.Mock).mock.calls
+            .map((c) => (c as number[])[0]);
+        tmNear.dispose();
+
+        (gsiTileMock.stdTextureUrl as jest.Mock).mockClear();
+
+        // 遠距離: radius=6000 → baseZoom=12, 全タイルzoom12
+        const cameraFar = createMockCamera();
+        (cameraFar as any).radius = 6000;
+
+        const tmFar = createTileManager({
+            scene: {} as never,
+            camera: cameraFar,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 60,
+            minZoom: 12,
+        });
+        await tmFar.setCenter(35.68, 139.77);
+
+        const zoomsFar = (gsiTileMock.stdTextureUrl as jest.Mock).mock.calls
+            .map((c) => (c as number[])[0]);
+        tmFar.dispose();
+
+        // 近距離ではzoom14が含まれる
+        expect(zoomsNear).toContain(14);
+        // 遠距離ではzoom12のみ
+        expect(zoomsFar.every((z: number) => z <= 12)).toBe(true);
+    });
+});
+
+/* ================================================================
+ * 標高ズーム段階フォールバック
+ * ================================================================ */
+describe("標高ズーム段階フォールバック", () => {
+    afterEach(() => {
+        (gsiTileMock.loadElevationTile as jest.Mock).mockImplementation(
+            () => Promise.resolve(new Float32Array(256 * 256))
+        );
+        (gsiTileMock.tileEdgeMeters as jest.Mock).mockImplementation(
+            () => 1000
+        );
+    });
+
+    it("最高zoomで失敗すると低いzoomにフォールバックする", async () => {
+        // zoom 14 は失敗、zoom 13以下は成功
+        const elevData13 = new Float32Array(256 * 256).fill(500);
+        (gsiTileMock.loadElevationTile as jest.Mock<(zoom: number, x: number, y: number) => Promise<Float32Array>>).mockImplementation(
+            (zoom) => {
+                if (zoom >= 14) return Promise.reject(new Error("not available"));
+                return Promise.resolve(elevData13);
+            }
+        );
+
+        const camera = createMockCamera();
+        const tm = createTileManager({
+            scene: {} as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 5,
+            minZoom: 12,
+            maxElevationZoom: 14,
+        });
+
+        await tm.setCenter(35.68, 139.77);
+        // フォールバックしてもタイルはロードされる
+        expect(tm.activeTileCount).toBeGreaterThan(0);
+        // zoom 13以下で loadElevationTile が呼ばれたことを確認
+        const calls = (gsiTileMock.loadElevationTile as jest.Mock).mock.calls;
+        const successZooms = calls.filter(
+            (c) => (c as number[])[0] < 14
+        );
+        expect(successZooms.length).toBeGreaterThan(0);
+    });
+
+    it("全zoomで失敗するとフラット標高（0m）でタイルが表示される", async () => {
+        (gsiTileMock.loadElevationTile as jest.Mock).mockImplementation(
+            () => Promise.reject(new Error("all fail"))
+        );
+
+        const camera = createMockCamera();
+        const tm = createTileManager({
+            scene: {} as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 5,
+            minZoom: 12,
+        });
+
+        await tm.setCenter(35.68, 139.77);
+        // フラット標高でもタイルは生成される
+        expect(tm.activeTileCount).toBeGreaterThan(0);
+    });
+
+    it("maxElevationZoomを超えるzoomでは標高フェッチを試みない", async () => {
+        const fetchedZooms: number[] = [];
+        (gsiTileMock.loadElevationTile as jest.Mock<(zoom: number, x: number, y: number) => Promise<Float32Array>>).mockImplementation(
+            (zoom) => {
+                fetchedZooms.push(zoom);
+                return Promise.resolve(new Float32Array(256 * 256));
+            }
+        );
+
+        const camera = createMockCamera();
+        const tm = createTileManager({
+            scene: {} as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 3,
+            maxElevationZoom: 12,
+            minZoom: 10,
+        });
+
+        await tm.setCenter(35.68, 139.77);
+        // zoom 13, 14 でのフェッチは発生しない
+        expect(fetchedZooms.every((z) => z <= 12)).toBe(true);
     });
 });

--- a/tests/tileManager.unit.spec.ts
+++ b/tests/tileManager.unit.spec.ts
@@ -107,6 +107,7 @@ const createMockCamera = () => {
         alpha: 0,
         beta: 0,
         radius: 4000,
+        position: { x: 0, y: 4000, z: 0 },
         getScene: jest.fn(() => ({
             getEngine: jest.fn(() => ({})),
         })),

--- a/tests/tileTypes.unit.spec.ts
+++ b/tests/tileTypes.unit.spec.ts
@@ -1,4 +1,4 @@
-import { toTileKey, tileOffsetToWorld, worldToTileOffset } from "../src/terrain/tileTypes";
+import { toTileKey, tileOffsetToWorld, worldToTileOffset, convertTileZoom, isChildOf, computeSubTileOffset } from "../src/terrain/tileTypes";
 import type { TileCoord } from "../src/terrain/tileTypes";
 
 describe("toTileKey", () => {
@@ -63,5 +63,97 @@ describe("worldToTileOffset", () => {
             expect(dx).toBe(origDx);
             expect(dy).toBe(origDy);
         }
+    });
+});
+
+describe("convertTileZoom", () => {
+    it("同じzoomなら同じ座標を返す", () => {
+        const coord: TileCoord = { zoom: 14, x: 14547, y: 6452 };
+        expect(convertTileZoom(coord, 14)).toEqual(coord);
+    });
+
+    it("高zoom → 低zoom（1段階）はビット右シフト相当", () => {
+        const coord: TileCoord = { zoom: 14, x: 14547, y: 6452 };
+        const result = convertTileZoom(coord, 13);
+        expect(result).toEqual({ zoom: 13, x: 7273, y: 3226 });
+    });
+
+    it("高zoom → 低zoom（2段階）", () => {
+        const coord: TileCoord = { zoom: 14, x: 14547, y: 6452 };
+        const result = convertTileZoom(coord, 12);
+        expect(result).toEqual({ zoom: 12, x: 3636, y: 1613 });
+    });
+
+    it("低zoom → 高zoom（1段階）は左シフト（左上隅）", () => {
+        const coord: TileCoord = { zoom: 12, x: 3636, y: 1613 };
+        const result = convertTileZoom(coord, 14);
+        expect(result).toEqual({ zoom: 14, x: 14544, y: 6452 });
+    });
+});
+
+describe("isChildOf", () => {
+    it("直接の子タイルを判定", () => {
+        const child: TileCoord = { zoom: 14, x: 14547, y: 6452 };
+        const parent: TileCoord = { zoom: 13, x: 7273, y: 3226 };
+        expect(isChildOf(child, parent)).toBe(true);
+    });
+
+    it("2段階上の親タイルを判定", () => {
+        const child: TileCoord = { zoom: 14, x: 14547, y: 6452 };
+        const parent: TileCoord = { zoom: 12, x: 3636, y: 1613 };
+        expect(isChildOf(child, parent)).toBe(true);
+    });
+
+    it("異なる親タイルにはfalse", () => {
+        const child: TileCoord = { zoom: 14, x: 14547, y: 6452 };
+        const parent: TileCoord = { zoom: 13, x: 7274, y: 3226 };
+        expect(isChildOf(child, parent)).toBe(false);
+    });
+
+    it("同じzoomまたは子のzoomが低い場合はfalse", () => {
+        const coord: TileCoord = { zoom: 14, x: 14547, y: 6452 };
+        expect(isChildOf(coord, coord)).toBe(false);
+        expect(isChildOf({ zoom: 12, x: 3636, y: 1613 }, coord)).toBe(false);
+    });
+});
+
+describe("computeSubTileOffset", () => {
+    it("同じzoomではオフセット0", () => {
+        const center: TileCoord = { zoom: 14, x: 14547, y: 6452 };
+        const { fracX, fracY } = computeSubTileOffset(center, 14);
+        expect(fracX).toBe(0);
+        expect(fracY).toBe(0);
+    });
+
+    it("zoom 14→13 のサブタイルオフセット", () => {
+        const center: TileCoord = { zoom: 14, x: 14547, y: 6452 };
+        const { fracX, fracY } = computeSubTileOffset(center, 13);
+        // (14547+0.5)/2 - (7273+0.5) = 7273.75 - 7273.5 = 0.25
+        expect(fracX).toBeCloseTo(0.25);
+        // (6452+0.5)/2 - (3226+0.5) = 3226.25 - 3226.5 = -0.25
+        expect(fracY).toBeCloseTo(-0.25);
+    });
+
+    it("zoom 14→12 のサブタイルオフセット", () => {
+        const center: TileCoord = { zoom: 14, x: 14547, y: 6452 };
+        const { fracX, fracY } = computeSubTileOffset(center, 12);
+        // (14547+0.5)/4 - (3636+0.5) = 3636.875 - 3636.5 = 0.375
+        expect(fracX).toBeCloseTo(0.375);
+        // (6452+0.5)/4 - (1613+0.5) = 1613.125 - 1613.5 = -0.375
+        expect(fracY).toBeCloseTo(-0.375);
+    });
+
+    it("偶数タイル座標ではオフセットが-0.25になる", () => {
+        const center: TileCoord = { zoom: 14, x: 14546, y: 6452 };
+        const { fracX } = computeSubTileOffset(center, 13);
+        // (14546+0.5)/2 - (7273+0.5) = 7273.25 - 7273.5 = -0.25
+        expect(fracX).toBeCloseTo(-0.25);
+    });
+
+    it("低zoom→高zoom（diff<=0）ではオフセット0", () => {
+        const center: TileCoord = { zoom: 12, x: 3636, y: 1613 };
+        const { fracX, fracY } = computeSubTileOffset(center, 14);
+        expect(fracX).toBe(0);
+        expect(fracY).toBe(0);
     });
 });

--- a/tests/visibleTiles.unit.spec.ts
+++ b/tests/visibleTiles.unit.spec.ts
@@ -1,6 +1,7 @@
-import { computeVisibleTiles } from "../src/terrain/visibleTiles";
+import { computeVisibleTiles, computeMultiLodTiles, computeBaseZoom } from "../src/terrain/visibleTiles";
 import type { FrustumPlane } from "../src/terrain/visibleTiles";
 import type { TileCoord } from "../src/terrain/tileTypes";
+import { toTileKey } from "../src/terrain/tileTypes";
 
 /**
  * 全てを包含する Frustum planes（全候補が可視）。
@@ -133,5 +134,181 @@ describe("computeVisibleTiles", () => {
             maxElevation: 1000,
         });
         expect(resultHigh.length).toBeGreaterThan(0);
+    });
+});
+
+describe("computeBaseZoom", () => {
+    // zoom14=100, zoom13=200, zoom12=400
+    const tileSizeForZoom = (z: number): number => 100 * Math.pow(2, 14 - z);
+
+    it("近距離では最高zoomを返す", () => {
+        // distance=100, targetTileSize=80 → 全zoom > 80 → return maxZoom=14
+        expect(computeBaseZoom(100, tileSizeForZoom, 14, 12)).toBe(14);
+    });
+
+    it("中距離では中間zoomを返す", () => {
+        // distance=300, targetTileSize=240 → zoom13(200) <= 240 → return 13
+        expect(computeBaseZoom(300, tileSizeForZoom, 14, 12)).toBe(13);
+    });
+
+    it("遠距離では最低zoomを返す", () => {
+        // distance=600, targetTileSize=480 → zoom12(400) <= 480 → return 12
+        expect(computeBaseZoom(600, tileSizeForZoom, 14, 12)).toBe(12);
+    });
+});
+
+describe("computeMultiLodTiles", () => {
+    const baseCenter: TileCoord = { zoom: 14, x: 14547, y: 6452 };
+
+    // zoom14=100, zoom13=200, zoom12=400
+    const tileSizeForZoom = (z: number): number => 100 * Math.pow(2, 14 - z);
+
+    it("baseZoom < minZoom で空配列を返す", () => {
+        const result = computeMultiLodTiles({
+            baseCenter,
+            tileSizeForZoom,
+            frustumPlanes: allVisiblePlanes,
+            cameraDistance: 400,
+            baseZoom: 12,
+            minZoom: 14,
+            maxTiles: 100,
+        });
+        expect(result).toHaveLength(0);
+    });
+
+    it("十分な距離では全タイルが同一zoomになる", () => {
+        // cameraDistance=4000, threshold=5200
+        // searchRadius=3, tileSize=100 → 最遠タイルdist=sqrt(300²+300²)≈424 < 5200
+        const result = computeMultiLodTiles({
+            baseCenter,
+            tileSizeForZoom,
+            frustumPlanes: allVisiblePlanes,
+            cameraDistance: 4000,
+            baseZoom: 14,
+            minZoom: 12,
+            maxTiles: 200,
+            searchRadius: 3,
+        });
+
+        expect(result.length).toBeGreaterThan(0);
+        expect(result.every((e) => e.coord.zoom === 14)).toBe(true);
+    });
+
+    it("近距離では複数zoomのタイルが含まれる", () => {
+        // cameraDistance=200, threshold=260
+        // 近いタイル: dist < 260 → zoom14
+        // 遠いタイル: dist >= 260 → zoom13 or zoom12
+        const result = computeMultiLodTiles({
+            baseCenter,
+            tileSizeForZoom,
+            frustumPlanes: allVisiblePlanes,
+            cameraDistance: 200,
+            baseZoom: 14,
+            minZoom: 12,
+            maxTiles: 500,
+            searchRadius: 6,
+        });
+
+        const zooms = new Set(result.map((e) => e.coord.zoom));
+        expect(zooms.size).toBeGreaterThanOrEqual(2);
+        expect(zooms.has(14)).toBe(true);
+    });
+
+    it("maxTilesで結果を制限する", () => {
+        const result = computeMultiLodTiles({
+            baseCenter,
+            tileSizeForZoom,
+            frustumPlanes: allVisiblePlanes,
+            cameraDistance: 400,
+            baseZoom: 14,
+            minZoom: 12,
+            maxTiles: 10,
+            searchRadius: 4,
+        });
+
+        expect(result.length).toBeLessThanOrEqual(10);
+    });
+
+    it("タイルサイズがzoomレベルに応じて異なる", () => {
+        const result = computeMultiLodTiles({
+            baseCenter,
+            tileSizeForZoom,
+            frustumPlanes: allVisiblePlanes,
+            cameraDistance: 200,
+            baseZoom: 14,
+            minZoom: 12,
+            maxTiles: 500,
+            searchRadius: 6,
+        });
+
+        const z14Entry = result.find((e) => e.coord.zoom === 14);
+        const z13Entry = result.find((e) => e.coord.zoom === 13);
+
+        expect(z14Entry?.tileSize).toBe(100);
+        if (z13Entry) {
+            expect(z13Entry.tileSize).toBe(200);
+        }
+    });
+
+    it("全不可視の場合、空配列を返す", () => {
+        const result = computeMultiLodTiles({
+            baseCenter,
+            tileSizeForZoom,
+            frustumPlanes: noneVisiblePlanes,
+            cameraDistance: 400,
+            baseZoom: 14,
+            minZoom: 12,
+            maxTiles: 60,
+            searchRadius: 4,
+        });
+
+        expect(result).toHaveLength(0);
+    });
+
+    it("TileKeyの重複がない", () => {
+        const result = computeMultiLodTiles({
+            baseCenter,
+            tileSizeForZoom,
+            frustumPlanes: allVisiblePlanes,
+            cameraDistance: 200,
+            baseZoom: 14,
+            minZoom: 12,
+            maxTiles: 500,
+            searchRadius: 6,
+        });
+
+        const keys = result.map((e) => toTileKey(e.coord));
+        expect(keys.length).toBe(new Set(keys).size);
+    });
+
+    it("ターゲットから遠いタイルほど低zoomが割り当てられる", () => {
+        // cameraDistance=200 → threshold=260
+        // 中心付近のタイルはzoom14、外周はzoom13/12
+        const result = computeMultiLodTiles({
+            baseCenter,
+            tileSizeForZoom,
+            frustumPlanes: allVisiblePlanes,
+            cameraDistance: 200,
+            baseZoom: 14,
+            minZoom: 12,
+            maxTiles: 500,
+            searchRadius: 8,
+        });
+
+        // ターゲット（原点）から遠いタイルは低zoom
+        const z14Tiles = result.filter((e) => e.coord.zoom === 14);
+        const z13Tiles = result.filter((e) => e.coord.zoom === 13);
+
+        if (z14Tiles.length > 0 && z13Tiles.length > 0) {
+            // zoom14タイルの平均距離 < zoom13タイルの平均距離
+            const avgDist = (tiles: typeof z14Tiles) =>
+                tiles.reduce((sum, t) => {
+                    const dx = t.coord.x - baseCenter.x;
+                    const dy = t.coord.y - baseCenter.y;
+                    return sum + Math.abs(dx) + Math.abs(dy);
+                }, 0) / tiles.length;
+
+            expect(avgDist(z14Tiles)).toBeLessThan(avgDist(z13Tiles));
+        }
     });
 });


### PR DESCRIPTION
## 概要

カメラからの距離に基づいてタイルのズームレベルを動的に変更し、表示を最適化する。

Closes #28

## 変更内容

### 距離ベースLOD（`visibleTiles.ts`）
- `computeBaseZoom`: カメラ距離から基本ズームレベルを算出（係数0.8）
- `computeMultiLodTiles`: baseZoom格子で探索し、距離に応じてzoomを段階的に下げる
  - Step 1: baseZoom格子で可視セル列挙＋距離→zoom決定
  - Step 2: LOD境界で低zoom側に統一（メッシュ重なり防止）
  - Step 3: セルを対象zoomの親タイルに集約
  - Step 4: 低zoom→高zoomの順に結果収集
  - Step 5: Far-field sweep — 水平チルト時の超遠方を低zoom格子で段階的に補完

### タイル座標ヘルパー（`tileTypes.ts`）
- `convertTileZoom`: zoom間のタイル座標変換
- `computeSubTileOffset`: サブタイルオフセット算出
- `isChildOf`: 親子タイル判定

### タイル管理（`tileManager.ts`）
- 動的`baseZoom`による可視タイル算出
- `extractSubTileElevation`: 親タイル標高データからの子タイル切り出し
- 段階的elevation fallback（maxElevationZoom→minZoomまで順次リトライ）

### 設定値（`default.ts`）
- `MAX_ZOOM`: 18、`MIN_ZOOM`: 8、`MAX_ELEVATION_ZOOM`: 17
- `maxTiles`: 160、`cacheCapacity`: 256

### スクリーンショット

<img width="1280" height="720" alt="Render-Default-with-WebGPU-1-chromium-darwin" src="https://github.com/user-attachments/assets/71d8717a-9c4a-468f-b965-6f965c0b9808" />

## テスト結果

- Unit test: 6 suites, 83 tests — 全パス
- Visual regression test: 2 tests — 全パス
- lint / typecheck: パス

## 影響範囲

- 画面: タイル描画が固定zoom→マルチLODに変更
- API: 新規関数/型の追加のみ。既存APIの破壊的変更なし
- パフォーマンス: タイル上限160に増加、far-field sweepで遠方カバー