### PR TITLE
fix: ホイール操作で最大/最小高度到達時にカメラの水平移動を抑止

### DIFF
--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -260,14 +260,15 @@ export class DefaultScene implements CreateSceneClass {
             worldZ: number,
             factor: number
         ): void => {
+            const upper = camera.upperRadiusLimit ?? 40000;
+            const lower = camera.lowerRadiusLimit ?? 250;
+            if (factor > 1 && camera.radius >= upper) return;
+            if (factor < 1 && camera.radius <= lower) return;
+
             camera.target.x += (worldX - camera.target.x) * (1 - factor);
             camera.target.z += (worldZ - camera.target.z) * (1 - factor);
             camera.radius *= factor;
-            camera.radius = clamp(
-                camera.radius,
-                camera.lowerRadiusLimit ?? 250,
-                camera.upperRadiusLimit ?? 40000
-            );
+            camera.radius = clamp(camera.radius, lower, upper);
             commitPanOffset();
         };
 


### PR DESCRIPTION
## 概要

`zoomTowardPoint()` にガード条件を追加し、最大/最小高度に達している場合はホイール操作によるカメラ移動を抑止する。

## 変更内容

- `factor > 1`（ズームアウト）かつ `camera.radius >= upperRadiusLimit` → 早期リターン
- `factor < 1`（ズームイン）かつ `camera.radius <= lowerRadiusLimit` → 早期リターン
- `upper` / `lower` ローカル変数で null合体演算子の重複を除去

## 影響範囲

- ホイールズーム: 上限/下限到達時にズーム操作が無効化される
- ダブルクリックズーム: `lowerRadiusLimit` 到達時にダブルクリックズームインも無効化される（意図通り）

## 検証結果

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test:unit` ✅ (94 tests passed)

Closes #50