### PR TITLE
fix: Step 2のズーム統一を昇格方式に変更

### DIFF
--- a/src/terrain/visibleTiles.ts
+++ b/src/terrain/visibleTiles.ts
@@ -146,7 +146,8 @@ export const computeBaseZoom = (
 /**
  * カメラ距離ベースのマルチLOD可視タイルを算出する。
  * baseZoom格子を基準に探索し、距離に応じて低zoomの親タイルに集約。
- * LOD境界では低zoom側に統一し、メッシュの重なりを防ぐ。
+ * LOD境界では昇格方式で重なりを防止：親タイル内に高zoomセルが混在する場合、
+ * 低zoomセルを z+1 に昇格して同一親タイルのメッシュ重複を排除する。
  */
 export const computeMultiLodTiles = (
     opts: MultiLodTilesOptions

--- a/src/terrain/visibleTiles.ts
+++ b/src/terrain/visibleTiles.ts
@@ -220,28 +220,37 @@ export const computeMultiLodTiles = (
         }
     }
 
-    // Step 2: 低zoomタイルがカバーする全セルのzoomを統一（重なり防止）
+    // Step 2: ズーム境界の重なり防止（昇格方式）
+    // 親タイル内に高zoomセルが混在する場合、低zoomセルを z+1 に昇格。
+    // 全セルが同一低zoomの親タイルはそのまま維持（遠方LODを保持）。
+    // 処理は baseZoom-1 → minZoom の降順。
     const cellZoomMap = new Map<string, number>();
     for (const cell of gridCells) {
         cellZoomMap.set(`${cell.dx},${cell.dy}`, cell.targetZoom);
     }
 
-    for (let z = minZoom; z < baseZoom; z++) {
-        const parentTiles = new Set<string>();
+    for (let z = baseZoom - 1; z >= minZoom; z--) {
         const diff = baseZoom - z;
+        const parentHasHigher = new Set<string>();
+
+        // 親タイル内に z より高いzoomのセルがあるか確認
         for (const cell of gridCells) {
-            if (cellZoomMap.get(`${cell.dx},${cell.dy}`) === z) {
+            const cellZoom = cellZoomMap.get(`${cell.dx},${cell.dy}`)!;
+            if (cellZoom > z) {
                 const gx = gridCenter.x + cell.dx;
                 const gy = gridCenter.y + cell.dy;
-                parentTiles.add(`${gx >> diff},${gy >> diff}`);
+                parentHasHigher.add(`${gx >> diff},${gy >> diff}`);
             }
         }
-        if (parentTiles.size > 0) {
+
+        // 高zoomセルと混在する親タイル内の低zoomセルを z+1 に昇格
+        if (parentHasHigher.size > 0) {
             for (const cell of gridCells) {
+                if (cellZoomMap.get(`${cell.dx},${cell.dy}`) !== z) continue;
                 const gx = gridCenter.x + cell.dx;
                 const gy = gridCenter.y + cell.dy;
-                if (parentTiles.has(`${gx >> diff},${gy >> diff}`)) {
-                    cellZoomMap.set(`${cell.dx},${cell.dy}`, z);
+                if (parentHasHigher.has(`${gx >> diff},${gy >> diff}`)) {
+                    cellZoomMap.set(`${cell.dx},${cell.dy}`, z + 1);
                 }
             }
         }

--- a/tests/visibleTiles.unit.spec.ts
+++ b/tests/visibleTiles.unit.spec.ts
@@ -311,4 +311,93 @@ describe("computeMultiLodTiles", () => {
             expect(avgDist(z14Tiles)).toBeLessThan(avgDist(z13Tiles));
         }
     });
+
+    it("grid center 奇数座標でも中心付近のタイルzoomがbaseZoomを維持する", () => {
+        // baseCenter.x が奇数のケース
+        const oddCenter: TileCoord = { zoom: 14, x: 14547, y: 6453 };
+        const result = computeMultiLodTiles({
+            baseCenter: oddCenter,
+            tileSizeForZoom,
+            frustumPlanes: allVisiblePlanes,
+            cameraDistance: 200,
+            baseZoom: 14,
+            minZoom: 12,
+            maxTiles: 500,
+            searchRadius: 6,
+        });
+
+        // 中心タイル自体が baseZoom で含まれること
+        const centerTile = result.find(
+            (e) => e.coord.zoom === 14 && e.coord.x === oddCenter.x && e.coord.y === oddCenter.y
+        );
+        expect(centerTile).toBeDefined();
+        expect(centerTile!.coord.zoom).toBe(14);
+    });
+
+    it("カメラ距離を段階的に変化させても中心付近のzoomがbaseZoomを下回らない", () => {
+        const distances = [500, 1000, 1500, 2000];
+        for (const dist of distances) {
+            const result = computeMultiLodTiles({
+                baseCenter,
+                tileSizeForZoom,
+                frustumPlanes: allVisiblePlanes,
+                cameraDistance: dist,
+                baseZoom: 14,
+                minZoom: 12,
+                maxTiles: 500,
+                searchRadius: 6,
+            });
+
+            // 中心タイル (dx=0, dy=0 相当) が baseZoom であること
+            const centerTile = result.find(
+                (e) => e.coord.zoom === 14 && e.coord.x === baseCenter.x && e.coord.y === baseCenter.y
+            );
+            expect(centerTile).toBeDefined();
+            expect(centerTile!.coord.zoom).toBe(14);
+        }
+    });
+
+    it("昇格後にタイル領域の重なりがない", () => {
+        const result = computeMultiLodTiles({
+            baseCenter,
+            tileSizeForZoom,
+            frustumPlanes: allVisiblePlanes,
+            cameraDistance: 200,
+            baseZoom: 14,
+            minZoom: 12,
+            maxTiles: 500,
+            searchRadius: 8,
+        });
+
+        // 主格子の内側セルのみで重なりを検証。
+        // Far-field sweep が境界で部分的に重なるのは既存動作のため、
+        // 内側（searchRadius - 2^(baseZoom-minZoom) = 4）に限定する。
+        const innerRadius = 4;
+        const coveredCells = new Set<string>();
+        let hasOverlap = false;
+
+        for (const entry of result) {
+            const { coord } = entry;
+            const diff = 14 - coord.zoom;
+            const cellCount = 1 << diff;
+            const baseX = coord.x << diff;
+            const baseY = coord.y << diff;
+
+            for (let cy = 0; cy < cellCount; cy++) {
+                for (let cx = 0; cx < cellCount; cx++) {
+                    const dx = (baseX + cx) - baseCenter.x;
+                    const dy = (baseY + cy) - baseCenter.y;
+                    if (Math.abs(dx) > innerRadius || Math.abs(dy) > innerRadius) continue;
+
+                    const cellKey = `${baseX + cx},${baseY + cy}`;
+                    if (coveredCells.has(cellKey)) {
+                        hasOverlap = true;
+                    }
+                    coveredCells.add(cellKey);
+                }
+            }
+        }
+
+        expect(hasOverlap).toBe(false);
+    });
 });


### PR DESCRIPTION
## 概要

ズームレベルを変えたとき間違ったタイルのレベルが表示されるバグを修正。

Closes #56

## 原因

`computeMultiLodTiles()` Step 2（ズーム統一処理）が、親タイル内に低zoomセルがあると全子セルを低zoomに**降格（demote）**していた。grid center のタイル座標が奇数のとき、親タイル境界がカメラ中心と隣接セルの間に落ち、カメラ近傍の高zoomセルが不正に低zoomに降格される。

## 修正内容

- **Step 2 のループ方向を反転**: `minZoom → baseZoom` から `baseZoom-1 → minZoom` に変更
- **降格→昇格**: 親タイル内に高zoomセルが存在する場合、低zoomセルを `z+1` に昇格
- 全セルが同一低zoomの親タイルはそのまま維持（遠方LODへの影響なし）

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/terrain/visibleTiles.ts` | Step 2 を昇格方式に書き換え |
| `tests/visibleTiles.unit.spec.ts` | テスト3件追加 |

## テスト

- ユニットテスト: 97 tests passed, 0 failed
- lint / typecheck: パス
- ビジュアルテスト: ズーム変更時のタイルレベル遷移がスムーズに動作することを確認

## 影響範囲

- API・型の変更なし
- 画面表示: ズーム変更時のタイルレベル遷移がスムーズになる