### PR TITLE
feat: add procedural skybox using SkyMaterial (#32)

### DIFF
--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -8,6 +8,7 @@ import { CreateSceneClass } from "../createScene";
 import { clamp, toTileXY, tileEdgeMeters, JAPAN_BOUNDS } from "../terrain/gsiTile";
 import { createControlPanel } from "../terrain/controlPanel";
 import { createTileManager } from "../terrain/tileManager";
+import { createSkybox } from "../terrain/skybox";
 
 const TERRAIN_SUBDIVISIONS = 128;
 const MAX_ZOOM = 18;
@@ -60,6 +61,9 @@ export class DefaultScene implements CreateSceneClass {
             scene
         );
         light.intensity = 1.0;
+
+        // スカイボックス
+        createSkybox(scene);
 
         // 初期位置（東京駅付近）
         const initialLat = 35.681236;

--- a/src/terrain/skybox.ts
+++ b/src/terrain/skybox.ts
@@ -3,9 +3,9 @@ import { CreateBox } from "@babylonjs/core/Meshes/Builders/boxBuilder";
 import { SkyMaterial } from "@babylonjs/materials/sky/skyMaterial";
 import type { Mesh } from "@babylonjs/core/Meshes/mesh";
 
-const SKYBOX_SIZE = 1000000;
-
 export function createSkybox(scene: Scene): Mesh {
+    const skyboxSize = (scene.activeCamera?.maxZ ?? 100000) * 10;
+
     const skyMaterial = new SkyMaterial("sky-material", scene);
     skyMaterial.backFaceCulling = false;
     skyMaterial.turbidity = 10;
@@ -16,7 +16,7 @@ export function createSkybox(scene: Scene): Mesh {
     skyMaterial.inclination = 0.25;
     skyMaterial.azimuth = 0.25;
 
-    const skybox = CreateBox("skybox", { size: SKYBOX_SIZE }, scene);
+    const skybox = CreateBox("skybox", { size: skyboxSize }, scene);
     skybox.material = skyMaterial;
     skybox.isPickable = false;
     skybox.infiniteDistance = true;

--- a/src/terrain/skybox.ts
+++ b/src/terrain/skybox.ts
@@ -1,0 +1,25 @@
+import { Scene } from "@babylonjs/core/scene";
+import { CreateBox } from "@babylonjs/core/Meshes/Builders/boxBuilder";
+import { SkyMaterial } from "@babylonjs/materials/sky/skyMaterial";
+import type { Mesh } from "@babylonjs/core/Meshes/mesh";
+
+const SKYBOX_SIZE = 1000000;
+
+export function createSkybox(scene: Scene): Mesh {
+    const skyMaterial = new SkyMaterial("sky-material", scene);
+    skyMaterial.backFaceCulling = false;
+    skyMaterial.turbidity = 10;
+    skyMaterial.luminance = 1;
+    skyMaterial.rayleigh = 2;
+    skyMaterial.mieCoefficient = 0.005;
+    skyMaterial.mieDirectionalG = 0.8;
+    skyMaterial.inclination = 0.25;
+    skyMaterial.azimuth = 0.25;
+
+    const skybox = CreateBox("skybox", { size: SKYBOX_SIZE }, scene);
+    skybox.material = skyMaterial;
+    skybox.isPickable = false;
+    skybox.infiniteDistance = true;
+
+    return skybox;
+}

--- a/tests/skybox.unit.spec.ts
+++ b/tests/skybox.unit.spec.ts
@@ -3,28 +3,49 @@
  * Babylon.js の Scene/Mesh/SkyMaterial をモックして、生成ロジックを検証する。
  */
 
-import { jest, describe, it, expect } from "@jest/globals";
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
 
-const mockMesh = {
-    material: null as unknown,
-    isPickable: true,
-    infiniteDistance: false,
+let mockMesh: {
+    material: unknown;
+    isPickable: boolean;
+    infiniteDistance: boolean;
 };
+
+let mockSkyMaterialInstance: {
+    backFaceCulling: boolean;
+    turbidity: number;
+    luminance: number;
+    rayleigh: number;
+    mieCoefficient: number;
+    mieDirectionalG: number;
+    inclination: number;
+    azimuth: number;
+};
+
+function createFreshMesh() {
+    return {
+        material: null as unknown,
+        isPickable: true,
+        infiniteDistance: false,
+    };
+}
+
+function createFreshSkyMaterial() {
+    return {
+        backFaceCulling: true,
+        turbidity: 0,
+        luminance: 0,
+        rayleigh: 0,
+        mieCoefficient: 0,
+        mieDirectionalG: 0,
+        inclination: 0,
+        azimuth: 0,
+    };
+}
 
 jest.unstable_mockModule("@babylonjs/core/Meshes/Builders/boxBuilder", () => ({
     CreateBox: jest.fn(() => mockMesh),
 }));
-
-const mockSkyMaterialInstance = {
-    backFaceCulling: true,
-    turbidity: 0,
-    luminance: 0,
-    rayleigh: 0,
-    mieCoefficient: 0,
-    mieDirectionalG: 0,
-    inclination: 0,
-    azimuth: 0,
-};
 
 jest.unstable_mockModule("@babylonjs/materials/sky/skyMaterial", () => ({
     SkyMaterial: jest.fn(() => mockSkyMaterialInstance),
@@ -36,6 +57,12 @@ const { CreateBox } = await import("@babylonjs/core/Meshes/Builders/boxBuilder")
 const mockScene = {} as never;
 
 describe("createSkybox", () => {
+    beforeEach(() => {
+        mockMesh = createFreshMesh();
+        mockSkyMaterialInstance = createFreshSkyMaterial();
+        jest.clearAllMocks();
+    });
+
     it("CreateBox を呼び出して skybox メッシュを返す", () => {
         const result = createSkybox(mockScene);
         expect(CreateBox).toHaveBeenCalledWith(

--- a/tests/skybox.unit.spec.ts
+++ b/tests/skybox.unit.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * skybox のユニットテスト。
+ * Babylon.js の Scene/Mesh/SkyMaterial をモックして、生成ロジックを検証する。
+ */
+
+import { jest, describe, it, expect } from "@jest/globals";
+
+const mockMesh = {
+    material: null as unknown,
+    isPickable: true,
+    infiniteDistance: false,
+};
+
+jest.unstable_mockModule("@babylonjs/core/Meshes/Builders/boxBuilder", () => ({
+    CreateBox: jest.fn(() => mockMesh),
+}));
+
+const mockSkyMaterialInstance = {
+    backFaceCulling: true,
+    turbidity: 0,
+    luminance: 0,
+    rayleigh: 0,
+    mieCoefficient: 0,
+    mieDirectionalG: 0,
+    inclination: 0,
+    azimuth: 0,
+};
+
+jest.unstable_mockModule("@babylonjs/materials/sky/skyMaterial", () => ({
+    SkyMaterial: jest.fn(() => mockSkyMaterialInstance),
+}));
+
+const { createSkybox } = await import("../src/terrain/skybox");
+const { CreateBox } = await import("@babylonjs/core/Meshes/Builders/boxBuilder");
+
+const mockScene = {} as never;
+
+describe("createSkybox", () => {
+    it("CreateBox を呼び出して skybox メッシュを返す", () => {
+        const result = createSkybox(mockScene);
+        expect(CreateBox).toHaveBeenCalledWith(
+            "skybox",
+            expect.objectContaining({ size: expect.any(Number) }),
+            mockScene
+        );
+        expect(result).toBe(mockMesh);
+    });
+
+    it("skybox は isPickable = false に設定される", () => {
+        createSkybox(mockScene);
+        expect(mockMesh.isPickable).toBe(false);
+    });
+
+    it("skybox は infiniteDistance = true に設定される", () => {
+        createSkybox(mockScene);
+        expect(mockMesh.infiniteDistance).toBe(true);
+    });
+
+    it("SkyMaterial の backFaceCulling が false に設定される", () => {
+        createSkybox(mockScene);
+        expect(mockSkyMaterialInstance.backFaceCulling).toBe(false);
+    });
+
+    it("skybox に SkyMaterial が割り当てられる", () => {
+        createSkybox(mockScene);
+        expect(mockMesh.material).toBe(mockSkyMaterialInstance);
+    });
+});


### PR DESCRIPTION
## 概要

Babylon.js の `SkyMaterial`（`@babylonjs/materials`）を使い、プロシージャルな大気散乱スカイボックスを地形ビューアに追加する。

## 変更内容

- `src/terrain/skybox.ts` を新規作成（`SkyMaterial` + `CreateBox` で skybox メッシュ生成）
- `src/scenes/default.ts` に skybox 呼び出しを追加
- `tests/skybox.unit.spec.ts` を新規作成（5テスト）

## 主な設定

- `SkyMaterial`: 昼間の大気散乱（`inclination: 0.25`, `turbidity: 10`, `rayleigh: 2`）
- `isPickable = false` / `infiniteDistance = true` でカメラ操作・ピッキングへの影響なし

## 検証結果

- `npm run lint` ✅
- `npx tsc --noEmit` ✅
- `npm run test:unit` ✅ (7 suites / 102 tests)

Closes #32