### PR TITLE
feat: 地図切替ボタンを追加（標準⇔写真）

### DIFF
--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -429,6 +429,19 @@ export class DefaultScene implements CreateSceneClass {
         ui.latInput.addEventListener("change", resetAndRefresh);
         ui.lonInput.addEventListener("change", resetAndRefresh);
 
+        // 地図切替ボタン
+        ui.mapToggle.addEventListener("click", () => {
+            const next = tileManager.mapType === "std" ? "photo" : "std";
+            tileManager.setMapType(next);
+            ui.mapToggle.textContent = next === "std" ? "写真" : "標準";
+            ui.mapToggle.setAttribute(
+                "aria-label",
+                next === "std"
+                    ? "地図切替: 写真地図に変更"
+                    : "地図切替: 標準地図に変更"
+            );
+        });
+
         // カメラ移動時の自動タイル更新
         tileManager.attachCamera();
 

--- a/src/terrain/controlPanel.ts
+++ b/src/terrain/controlPanel.ts
@@ -10,6 +10,7 @@ export interface ControlPanelElements {
     compass: HTMLDivElement;
     zoomIn: HTMLButtonElement;
     zoomOut: HTMLButtonElement;
+    mapToggle: HTMLButtonElement;
 }
 
 const css = (el: HTMLElement, styles: Partial<CSSStyleDeclaration>): void => {
@@ -156,6 +157,45 @@ const createZoomButtons = (): {
     return { zoomIn, zoomOut };
 };
 
+const createMapToggleButton = (): HTMLButtonElement => {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.textContent = "写真";
+    btn.tabIndex = 0;
+    btn.setAttribute("aria-label", "地図切替: 写真地図に変更");
+    css(btn, {
+        position: "absolute",
+        bottom: "12px",
+        left: "12px",
+        width: "48px",
+        height: "32px",
+        border: "none",
+        borderRadius: "4px",
+        background: "rgba(9,18,32,0.72)",
+        backdropFilter: "blur(6px)",
+        color: "#f2f7ff",
+        fontSize: "11px",
+        lineHeight: "1",
+        cursor: "pointer",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        outline: "none",
+        padding: "0",
+        zIndex: "10",
+    });
+    btn.addEventListener("focus", () => {
+        if (btn.matches(":focus-visible")) {
+            btn.style.boxShadow = "0 0 0 2px #90caf9";
+        }
+    });
+    btn.addEventListener("blur", () => {
+        btn.style.boxShadow = "";
+    });
+    document.body.appendChild(btn);
+    return btn;
+};
+
 export const createControlPanel = (
     initialLat: number,
     initialLon: number
@@ -224,5 +264,8 @@ export const createControlPanel = (
     // ズームボタン（画面右下に独立配置）
     const { zoomIn, zoomOut } = createZoomButtons();
 
-    return { panel, latInput, lonInput, updateButton, compass, zoomIn, zoomOut };
+    // 地図切替ボタン（画面左下に配置）
+    const mapToggle = createMapToggleButton();
+
+    return { panel, latInput, lonInput, updateButton, compass, zoomIn, zoomOut, mapToggle };
 };

--- a/src/terrain/gsiTile.ts
+++ b/src/terrain/gsiTile.ts
@@ -149,9 +149,29 @@ export const loadElevationTile = async (
     );
 };
 
+/** 地図タイプ */
+export type MapType = "std" | "photo";
+
 /** 標準地図テクスチャURL */
 export const stdTextureUrl = (
     zoom: number,
     x: number,
     y: number
 ): string => `https://cyberjapandata.gsi.go.jp/xyz/std/${zoom}/${x}/${y}.png`;
+
+/** 写真地図テクスチャURL */
+export const photoTextureUrl = (
+    zoom: number,
+    x: number,
+    y: number
+): string => `https://cyberjapandata.gsi.go.jp/xyz/seamlessphoto/${zoom}/${x}/${y}.jpg`;
+
+/** 地図タイプに応じたテクスチャURLを返す */
+export const textureUrl = (
+    mapType: MapType,
+    zoom: number,
+    x: number,
+    y: number
+): string => mapType === "photo"
+    ? photoTextureUrl(zoom, x, y)
+    : stdTextureUrl(zoom, x, y);

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -20,7 +20,8 @@ import {
     toTileXY,
     tileEdgeMeters,
     loadElevationTile,
-    stdTextureUrl,
+    textureUrl,
+    MapType,
 } from "./gsiTile";
 
 export interface TileManagerOptions {
@@ -41,6 +42,8 @@ export interface TileManagerOptions {
 
 export interface TileManager {
     setCenter(lat: number, lon: number, altitudeOffset?: number): Promise<void>;
+    setMapType(mapType: MapType): void;
+    readonly mapType: MapType;
     attachCamera(): void;
     detachCamera(): void;
     dispose(): void;
@@ -186,6 +189,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
     let currentCenter: TileCoord | null = null;
     let currentAltitudeOffset = 0;
     let currentLat = 0;
+    let currentMapType: MapType = "std";
 
     const emitStatus = (): void => {
         if (!statusCallback) return;
@@ -313,17 +317,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
             }
 
             // テクスチャ
-            const mat = mesh.material as StandardMaterial;
-            if (mat.diffuseTexture) {
-                mat.diffuseTexture.dispose();
-            }
-            mat.diffuseTexture = new Texture(
-                stdTextureUrl(coord.zoom, coord.x, coord.y),
-                scene,
-                true,
-                true,
-                Texture.TRILINEAR_SAMPLINGMODE
-            );
+            applyTexture(mesh, coord);
 
             activeTiles.set(key, { key, coord, mesh, tileSize });
         } catch (e) {
@@ -409,6 +403,28 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
 
     /** tileSizeForZoom: 指定zoomでのタイル実サイズを返す */
     const tileSizeForZoom = (z: number): number => tileEdgeMeters(currentLat, z);
+
+    /** メッシュにテクスチャを適用する */
+    const applyTexture = (mesh: Mesh, coord: TileCoord): void => {
+        const mat = mesh.material as StandardMaterial;
+        if (mat.diffuseTexture) {
+            mat.diffuseTexture.dispose();
+        }
+        mat.diffuseTexture = new Texture(
+            textureUrl(currentMapType, coord.zoom, coord.x, coord.y),
+            scene,
+            true,
+            true,
+            Texture.TRILINEAR_SAMPLINGMODE
+        );
+    };
+
+    /** 全アクティブタイルのテクスチャを現在の mapType で差し替え */
+    const retextureAll = (): void => {
+        for (const [, tile] of activeTiles) {
+            applyTexture(tile.mesh, tile.coord);
+        }
+    };
 
     /** 可視タイルを算出する共通ヘルパー */
     const computeVisible = (
@@ -513,6 +529,16 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
             altitudeOffset = 0
         ): Promise<void> {
             await refresh(lat, lon, altitudeOffset);
+        },
+
+        setMapType(mapType: MapType): void {
+            if (mapType === currentMapType) return;
+            currentMapType = mapType;
+            retextureAll();
+        },
+
+        get mapType(): MapType {
+            return currentMapType;
         },
 
         attachCamera(): void {

--- a/tests/gsiTile.unit.spec.ts
+++ b/tests/gsiTile.unit.spec.ts
@@ -6,6 +6,8 @@ import {
     tileEdgeMeters,
     decodeGsiElevation,
     stdTextureUrl,
+    photoTextureUrl,
+    textureUrl,
 } from "../src/terrain/gsiTile";
 
 describe("TILE_SIZE", () => {
@@ -175,6 +177,34 @@ describe("stdTextureUrl", () => {
     it("zoom=0 でもURLを生成できる", () => {
         expect(stdTextureUrl(0, 0, 0)).toBe(
             "https://cyberjapandata.gsi.go.jp/xyz/std/0/0/0.png"
+        );
+    });
+});
+
+describe("photoTextureUrl", () => {
+    it("地理院写真地図タイルURLを返す", () => {
+        expect(photoTextureUrl(14, 14547, 6452)).toBe(
+            "https://cyberjapandata.gsi.go.jp/xyz/seamlessphoto/14/14547/6452.jpg"
+        );
+    });
+
+    it("zoom=0 でもURLを生成できる", () => {
+        expect(photoTextureUrl(0, 0, 0)).toBe(
+            "https://cyberjapandata.gsi.go.jp/xyz/seamlessphoto/0/0/0.jpg"
+        );
+    });
+});
+
+describe("textureUrl", () => {
+    it("std タイプで標準地図URLを返す", () => {
+        expect(textureUrl("std", 14, 14547, 6452)).toBe(
+            "https://cyberjapandata.gsi.go.jp/xyz/std/14/14547/6452.png"
+        );
+    });
+
+    it("photo タイプで写真地図URLを返す", () => {
+        expect(textureUrl("photo", 14, 14547, 6452)).toBe(
+            "https://cyberjapandata.gsi.go.jp/xyz/seamlessphoto/14/14547/6452.jpg"
         );
     });
 });

--- a/tests/tileManager.unit.spec.ts
+++ b/tests/tileManager.unit.spec.ts
@@ -97,6 +97,8 @@ jest.unstable_mockModule("../src/terrain/gsiTile", () => ({
         () => Promise.resolve(new Float32Array(256 * 256))
     ),
     stdTextureUrl: jest.fn(() => "https://example.com/tile.png"),
+    photoTextureUrl: jest.fn(() => "https://example.com/photo.jpg"),
+    textureUrl: jest.fn(() => "https://example.com/tile.png"),
 }));
 
 const { createTileManager, extractSubTileElevation } = await import("../src/terrain/tileManager");
@@ -334,7 +336,7 @@ describe("extractSubTileElevation", () => {
  * ================================================================ */
 describe("LOD連携", () => {
     beforeEach(() => {
-        (gsiTileMock.stdTextureUrl as jest.Mock).mockClear();
+        (gsiTileMock.textureUrl as jest.Mock).mockClear();
         (gsiTileMock.loadElevationTile as jest.Mock).mockClear();
     });
 
@@ -410,11 +412,11 @@ describe("LOD連携", () => {
         });
         await tmNear.setCenter(35.68, 139.77);
 
-        const zoomsNear = (gsiTileMock.stdTextureUrl as jest.Mock).mock.calls
-            .map((c) => (c as number[])[0]);
+        const zoomsNear = (gsiTileMock.textureUrl as jest.Mock).mock.calls
+            .map((c) => (c as number[])[1]);
         tmNear.dispose();
 
-        (gsiTileMock.stdTextureUrl as jest.Mock).mockClear();
+        (gsiTileMock.textureUrl as jest.Mock).mockClear();
 
         // 遠距離: radius=6000 → baseZoom=12, 全タイルzoom12
         const cameraFar = createMockCamera();
@@ -431,8 +433,8 @@ describe("LOD連携", () => {
         });
         await tmFar.setCenter(35.68, 139.77);
 
-        const zoomsFar = (gsiTileMock.stdTextureUrl as jest.Mock).mock.calls
-            .map((c) => (c as number[])[0]);
+        const zoomsFar = (gsiTileMock.textureUrl as jest.Mock).mock.calls
+            .map((c) => (c as number[])[1]);
         tmFar.dispose();
 
         // 近距離ではzoom14が含まれる
@@ -533,5 +535,69 @@ describe("標高ズーム段階フォールバック", () => {
         await tm.setCenter(35.68, 139.77);
         // zoom 13, 14 でのフェッチは発生しない
         expect(fetchedZooms.every((z) => z <= 12)).toBe(true);
+    });
+});
+
+/* ================================================================
+ * setMapType テスト
+ * ================================================================ */
+describe("setMapType", () => {
+    beforeEach(() => {
+        (gsiTileMock.textureUrl as jest.Mock).mockClear();
+    });
+
+    it("setMapType で地図タイプを切り替えると textureUrl が新しいタイプで呼ばれる", async () => {
+        const camera = createMockCamera();
+        const tm = createTileManager({
+            scene: {} as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 5,
+            minZoom: 12,
+        });
+
+        await tm.setCenter(35.68, 139.77);
+
+        // 初期状態では std で呼ばれている
+        const initialCalls = (gsiTileMock.textureUrl as jest.Mock).mock.calls;
+        expect(initialCalls.length).toBeGreaterThan(0);
+        expect(initialCalls[0][0]).toBe("std");
+
+        (gsiTileMock.textureUrl as jest.Mock).mockClear();
+
+        // photo に切り替え
+        tm.setMapType("photo");
+
+        // retextureAll が呼ばれ、photo タイプで textureUrl が呼ばれる
+        const photoCalls = (gsiTileMock.textureUrl as jest.Mock).mock.calls;
+        expect(photoCalls.length).toBeGreaterThan(0);
+        expect(photoCalls.every((c: unknown[]) => c[0] === "photo")).toBe(true);
+
+        tm.dispose();
+    });
+
+    it("同じ地図タイプを設定しても textureUrl は呼ばれない", async () => {
+        const camera = createMockCamera();
+        const tm = createTileManager({
+            scene: {} as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 5,
+            minZoom: 12,
+        });
+
+        await tm.setCenter(35.68, 139.77);
+        (gsiTileMock.textureUrl as jest.Mock).mockClear();
+
+        // 同じタイプを再設定
+        tm.setMapType("std");
+
+        expect((gsiTileMock.textureUrl as jest.Mock).mock.calls.length).toBe(0);
+
+        tm.dispose();
     });
 });


### PR DESCRIPTION
## 概要

画面左下に地図切替ボタンを設置し、標準地図⇔写真地図（航空写真）をワンクリックで切り替えられるようにする。

Closes #34

## 変更内容

### 新規追加
- `MapType` 型（`"std" | "photo"`）と `photoTextureUrl()` / `textureUrl()` 関数（`gsiTile.ts`）
- 左下配置の地図切替ボタン（`controlPanel.ts`）
- `TileManager.setMapType()` メソッドと `mapType` ゲッター（`tileManager.ts`）

### 変更
- テクスチャURL生成を `stdTextureUrl` → `textureUrl(mapType, ...)` に動的化（`tileManager.ts`）
- ボタンクリック時に `tileManager.setMapType()` を呼び出し、ラベル・aria-labelを更新（`default.ts`）

### スクリーンショット

<img width="944" height="738" alt="ss" src="https://github.com/user-attachments/assets/6abb2860-1c2d-4bf1-9546-6d3bd5a36258" />

### テスト
- `gsiTile.unit.spec.ts`: `photoTextureUrl` / `textureUrl` のテスト追加
- `tileManager.unit.spec.ts`: `setMapType` テスト2件追加、mockを `textureUrl` に移行

## 影響範囲
- `stdTextureUrl` は引き続き export（Breaking change なし）
- 標高データ（DEM）は地図タイプによらず共通のため再取得不要

## 検証
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test:unit` ✅ (108 tests)
- `npm run test:visuals` ✅ (スナップショット更新済み)