### PR TITLE
feat: URLに緯度・経度を含める

### DIFF
--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -9,6 +9,7 @@ import { clamp, toTileXY, tileEdgeMeters, JAPAN_BOUNDS } from "../terrain/gsiTil
 import { createControlPanel } from "../terrain/controlPanel";
 import { createTileManager } from "../terrain/tileManager";
 import { createSkybox } from "../terrain/skybox";
+import { parseLatLonFromUrl, createUrlUpdater } from "../terrain/urlState";
 
 const TERRAIN_SUBDIVISIONS = 128;
 const MAX_ZOOM = 18;
@@ -65,9 +66,13 @@ export class DefaultScene implements CreateSceneClass {
         // スカイボックス
         createSkybox(scene);
 
-        // 初期位置（東京駅付近）
-        const initialLat = 35.681236;
-        const initialLon = 139.767125;
+        // 初期位置（URLパラメータ優先、なければ東京駅付近）
+        const urlLatLon = parseLatLonFromUrl(window.location.href);
+        const initialLat = urlLatLon?.lat ?? 35.681236;
+        const initialLon = urlLatLon?.lon ?? 139.767125;
+
+        // URL 自動更新
+        const updateUrl = createUrlUpdater(200);
 
         // UIパネル
         const ui = createControlPanel(initialLat, initialLon);
@@ -101,6 +106,7 @@ export class DefaultScene implements CreateSceneClass {
             );
             ui.latInput.value = lat.toFixed(6);
             ui.lonInput.value = lon.toFixed(6);
+            updateUrl(lat, lon);
             await tileManager.setCenter(lat, lon, 0);
         };
 
@@ -150,6 +156,7 @@ export class DefaultScene implements CreateSceneClass {
 
             ui.latInput.value = newLat.toFixed(6);
             ui.lonInput.value = newLon.toFixed(6);
+            updateUrl(newLat, newLon);
             void refreshTerrain();
         };
 

--- a/src/terrain/urlState.ts
+++ b/src/terrain/urlState.ts
@@ -1,0 +1,82 @@
+/** URL に緯度・経度を埋め込み / 復元するモジュール */
+
+import { clamp, JAPAN_BOUNDS } from "./gsiTile";
+
+export interface LatLon {
+    lat: number;
+    lon: number;
+}
+
+const PRECISION = 6;
+
+/** @lat,lon パターン（パス・ハッシュ両方で利用） */
+const AT_PATTERN = /@(-?\d+(?:\.\d+)?),(-?\d+(?:\.\d+)?)/;
+
+/**
+ * URL から緯度・経度を読み取る。優先順位:
+ * 1. パス内の `@lat,lon`（Google Maps 互換）
+ * 2. クエリパラメータ `?lat=&lon=`
+ * いずれも無い場合は null を返す。
+ */
+export const parseLatLonFromUrl = (url: string): LatLon | null => {
+    // パス（またはURL全体）内の @lat,lon
+    const atMatch = url.match(AT_PATTERN);
+    if (atMatch) {
+        const lat = Number(atMatch[1]);
+        const lon = Number(atMatch[2]);
+        if (isFinite(lat) && isFinite(lon)) {
+            return {
+                lat: clamp(lat, JAPAN_BOUNDS.minLat, JAPAN_BOUNDS.maxLat),
+                lon: clamp(lon, JAPAN_BOUNDS.minLon, JAPAN_BOUNDS.maxLon),
+            };
+        }
+    }
+
+    // クエリパラメータ: ?lat=&lon=
+    try {
+        const searchStr = url.includes("?") ? url.slice(url.indexOf("?")) : "";
+        const params = new URLSearchParams(searchStr);
+        const latStr = params.get("lat");
+        const lonStr = params.get("lon");
+        if (latStr !== null && lonStr !== null) {
+            const lat = Number(latStr);
+            const lon = Number(lonStr);
+            if (isFinite(lat) && isFinite(lon)) {
+                return {
+                    lat: clamp(lat, JAPAN_BOUNDS.minLat, JAPAN_BOUNDS.maxLat),
+                    lon: clamp(lon, JAPAN_BOUNDS.minLon, JAPAN_BOUNDS.maxLon),
+                };
+            }
+        }
+    } catch {
+        // URLSearchParams 解析失敗時は無視
+    }
+
+    return null;
+};
+
+/** パスセグメント文字列を生成する（例: `/@35.681236,139.767125`） */
+export const toAtPath = (lat: number, lon: number): string =>
+    `/@${lat.toFixed(PRECISION)},${lon.toFixed(PRECISION)}`;
+
+/**
+ * history.replaceState で URL のパスを `/@lat,lon` 形式に更新する。
+ * 既存のクエリパラメータは保持する。デバウンス付きファクトリを返す。
+ */
+export const createUrlUpdater = (
+    debounceMs: number = 200
+): ((lat: number, lon: number) => void) => {
+    let timerId: ReturnType<typeof setTimeout> | null = null;
+
+    return (lat: number, lon: number): void => {
+        if (timerId !== null) {
+            clearTimeout(timerId);
+        }
+        timerId = setTimeout(() => {
+            timerId = null;
+            const path = toAtPath(lat, lon);
+            const search = location.search;
+            history.replaceState(null, "", path + search);
+        }, debounceMs);
+    };
+};

--- a/src/terrain/urlState.ts
+++ b/src/terrain/urlState.ts
@@ -19,25 +19,26 @@ const AT_PATTERN = /@(-?\d+(?:\.\d+)?),(-?\d+(?:\.\d+)?)/;
  * いずれも無い場合は null を返す。
  */
 export const parseLatLonFromUrl = (url: string): LatLon | null => {
-    // パス（またはURL全体）内の @lat,lon
-    const atMatch = url.match(AT_PATTERN);
-    if (atMatch) {
-        const lat = Number(atMatch[1]);
-        const lon = Number(atMatch[2]);
-        if (isFinite(lat) && isFinite(lon)) {
-            return {
-                lat: clamp(lat, JAPAN_BOUNDS.minLat, JAPAN_BOUNDS.maxLat),
-                lon: clamp(lon, JAPAN_BOUNDS.minLon, JAPAN_BOUNDS.maxLon),
-            };
-        }
-    }
-
-    // クエリパラメータ: ?lat=&lon=
     try {
-        const searchStr = url.includes("?") ? url.slice(url.indexOf("?")) : "";
-        const params = new URLSearchParams(searchStr);
-        const latStr = params.get("lat");
-        const lonStr = params.get("lon");
+        const parsed = new URL(url, "http://localhost");
+
+        // pathname + hash のみに @lat,lon を適用（userinfo やクエリ値の @ を誤検出しない）
+        const target = parsed.pathname + parsed.hash;
+        const atMatch = target.match(AT_PATTERN);
+        if (atMatch) {
+            const lat = Number(atMatch[1]);
+            const lon = Number(atMatch[2]);
+            if (isFinite(lat) && isFinite(lon)) {
+                return {
+                    lat: clamp(lat, JAPAN_BOUNDS.minLat, JAPAN_BOUNDS.maxLat),
+                    lon: clamp(lon, JAPAN_BOUNDS.minLon, JAPAN_BOUNDS.maxLon),
+                };
+            }
+        }
+
+        // クエリパラメータ: ?lat=&lon=
+        const latStr = parsed.searchParams.get("lat");
+        const lonStr = parsed.searchParams.get("lon");
         if (latStr !== null && lonStr !== null) {
             const lat = Number(latStr);
             const lon = Number(lonStr);
@@ -49,7 +50,7 @@ export const parseLatLonFromUrl = (url: string): LatLon | null => {
             }
         }
     } catch {
-        // URLSearchParams 解析失敗時は無視
+        // URL 解析失敗時は無視
     }
 
     return null;

--- a/tests/urlState.unit.spec.ts
+++ b/tests/urlState.unit.spec.ts
@@ -60,6 +60,19 @@ describe("urlState", () => {
         it("lon のみ指定の場合は null を返す", () => {
             expect(parseLatLonFromUrl("http://localhost/?lon=139.0")).toBeNull();
         });
+
+        it("userinfo 内の @ を座標として誤検出しない", () => {
+            expect(parseLatLonFromUrl("http://user@host/path")).toBeNull();
+        });
+
+        it("クエリ値内の @lat,lon を座標として誤検出しない", () => {
+            expect(parseLatLonFromUrl("http://localhost/?ref=@35.0,139.0")).toBeNull();
+        });
+
+        it("ハッシュ内の @lat,lon をパースできる", () => {
+            const result = parseLatLonFromUrl("http://localhost/#/@35.681236,139.767125");
+            expect(result).toEqual({ lat: 35.681236, lon: 139.767125 });
+        });
     });
 
     describe("toAtPath", () => {

--- a/tests/urlState.unit.spec.ts
+++ b/tests/urlState.unit.spec.ts
@@ -1,0 +1,157 @@
+import { jest } from "@jest/globals";
+import { parseLatLonFromUrl, toAtPath, createUrlUpdater } from "../src/terrain/urlState";
+
+describe("urlState", () => {
+    describe("parseLatLonFromUrl", () => {
+        it("パス内の @lat,lon をパースできる", () => {
+            const result = parseLatLonFromUrl("http://localhost/@35.681236,139.767125");
+            expect(result).toEqual({ lat: 35.681236, lon: 139.767125 });
+        });
+
+        it("クエリパラメータ付きのパスをパースできる", () => {
+            const result = parseLatLonFromUrl(
+                "http://localhost/@35.681236,139.767125?engine=webgl"
+            );
+            expect(result).toEqual({ lat: 35.681236, lon: 139.767125 });
+        });
+
+        it("負の経度を含むパスをパースできる", () => {
+            const result = parseLatLonFromUrl("http://localhost/@35.0,-139.0");
+            expect(result).toEqual({ lat: 35.0, lon: expect.closeTo(122, 0) });
+        });
+
+        it("クエリパラメータ ?lat=&lon= をフォールバックでパースできる", () => {
+            const result = parseLatLonFromUrl("http://localhost/?lat=35.681236&lon=139.767125");
+            expect(result).toEqual({ lat: 35.681236, lon: 139.767125 });
+        });
+
+        it("@lat,lon がクエリより優先される", () => {
+            const result = parseLatLonFromUrl(
+                "http://localhost/@35.0,139.0?lat=36.0&lon=140.0"
+            );
+            expect(result).toEqual({ lat: 35.0, lon: 139.0 });
+        });
+
+        it("パラメータが無い場合は null を返す", () => {
+            expect(parseLatLonFromUrl("http://localhost/")).toBeNull();
+        });
+
+        it("不正な数値の場合は null を返す", () => {
+            expect(parseLatLonFromUrl("http://localhost/@abc,def")).toBeNull();
+        });
+
+        it("JAPAN_BOUNDS を超える緯度はクランプされる", () => {
+            const result = parseLatLonFromUrl("http://localhost/@50.0,139.0");
+            expect(result).not.toBeNull();
+            expect(result!.lat).toBe(46);
+            expect(result!.lon).toBe(139.0);
+        });
+
+        it("JAPAN_BOUNDS を下回る経度はクランプされる", () => {
+            const result = parseLatLonFromUrl("http://localhost/@35.0,100.0");
+            expect(result).not.toBeNull();
+            expect(result!.lon).toBe(122);
+        });
+
+        it("lat のみ指定の場合は null を返す", () => {
+            expect(parseLatLonFromUrl("http://localhost/?lat=35.0")).toBeNull();
+        });
+
+        it("lon のみ指定の場合は null を返す", () => {
+            expect(parseLatLonFromUrl("http://localhost/?lon=139.0")).toBeNull();
+        });
+    });
+
+    describe("toAtPath", () => {
+        it("パスセグメント文字列を生成する", () => {
+            const result = toAtPath(35.681236, 139.767125);
+            expect(result).toBe("/@35.681236,139.767125");
+        });
+
+        it("小数6桁に丸められる", () => {
+            const result = toAtPath(35.6812361234, 139.7671259999);
+            expect(result).toBe("/@35.681236,139.767126");
+        });
+    });
+
+    describe("toAtPath → parseLatLonFromUrl ラウンドトリップ", () => {
+        it("生成したパスをパースすると元の座標が復元される", () => {
+            const lat = 35.681236;
+            const lon = 139.767125;
+            const path = toAtPath(lat, lon);
+            const parsed = parseLatLonFromUrl(`http://localhost${path}`);
+            expect(parsed).toEqual({ lat, lon });
+        });
+
+        it("クエリ付きでもラウンドトリップできる", () => {
+            const lat = 35.681236;
+            const lon = 139.767125;
+            const path = toAtPath(lat, lon);
+            const parsed = parseLatLonFromUrl(`http://localhost${path}?engine=webgl`);
+            expect(parsed).toEqual({ lat, lon });
+        });
+    });
+
+    describe("createUrlUpdater", () => {
+        const originalHistory = globalThis.history;
+        const originalLocation = globalThis.location;
+
+        beforeEach(() => {
+            jest.useFakeTimers();
+            globalThis.history = { replaceState: jest.fn() } as unknown as History;
+            globalThis.location = { search: "" } as unknown as Location;
+        });
+
+        afterEach(() => {
+            jest.useRealTimers();
+            globalThis.history = originalHistory;
+            globalThis.location = originalLocation;
+        });
+
+        it("デバウンス後に history.replaceState が呼ばれる", () => {
+            const updater = createUrlUpdater(200);
+            updater(35.681236, 139.767125);
+
+            expect(history.replaceState).not.toHaveBeenCalled();
+
+            jest.advanceTimersByTime(200);
+
+            expect(history.replaceState).toHaveBeenCalledTimes(1);
+            expect(history.replaceState).toHaveBeenCalledWith(
+                null,
+                "",
+                "/@35.681236,139.767125"
+            );
+        });
+
+        it("既存のクエリパラメータが保持される", () => {
+            globalThis.location = { search: "?engine=webgl" } as unknown as Location;
+            const updater = createUrlUpdater(200);
+            updater(35.681236, 139.767125);
+
+            jest.advanceTimersByTime(200);
+
+            expect(history.replaceState).toHaveBeenCalledWith(
+                null,
+                "",
+                "/@35.681236,139.767125?engine=webgl"
+            );
+        });
+
+        it("連続呼び出しは最後の値のみ反映される", () => {
+            const updater = createUrlUpdater(200);
+            updater(35.0, 139.0);
+            updater(36.0, 140.0);
+            updater(37.0, 141.0);
+
+            jest.advanceTimersByTime(200);
+
+            expect(history.replaceState).toHaveBeenCalledTimes(1);
+            expect(history.replaceState).toHaveBeenCalledWith(
+                null,
+                "",
+                "/@37.000000,141.000000"
+            );
+        });
+    });
+});

--- a/tests/urlState.unit.spec.ts
+++ b/tests/urlState.unit.spec.ts
@@ -1,4 +1,4 @@
-import { jest } from "@jest/globals";
+import { describe, expect, it, jest } from "@jest/globals";
 import { parseLatLonFromUrl, toAtPath, createUrlUpdater } from "../src/terrain/urlState";
 
 describe("urlState", () => {

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -13,6 +13,9 @@ module.exports = merge(common, {
         static: path.resolve(appDirectory, "public"),
         compress: true,
         hot: true,
+        historyApiFallback: {
+            disableDotRule: true,
+        },
         // publicPath: '/',
         open: false,
         // host: '0.0.0.0', // enable to access from other devices on the network


### PR DESCRIPTION
## 概要

URLに緯度・経度を含め、マップの表示位置が移動するたびにブラウザのアドレスバーを自動更新する。
Google Maps のように `@lat,lon` 形式を採用し、URLを共有するだけで同じ位置を表示できるようにする。

Closes #29

## 変更内容

### 新規ファイル
- `src/terrain/urlState.ts`: URL パース / シリアライズ / デバウンス付き更新
- `tests/urlState.unit.spec.ts`: 16テストケース

### 修正ファイル
- `src/scenes/default.ts`: 初期位置のURL読み取り + 移動時のURL自動更新
- `webpack.dev.js`: `historyApiFallback` + `disableDotRule` 追加

## 実装方針

- パスベース `/@lat,lon` 形式（Google Maps 互換: `@` が `?` より前）
- クエリパラメータ `?lat=&lon=` をフォールバック対応
- `history.replaceState` + 200ms デバウンスでURL自動更新
- 既存クエリパラメータ（`?engine=webgl` 等）は保持
- JAPAN_BOUNDS 内にクランプ

## 影響範囲

- **画面**: URLバーの表示が変更される（URLパラメータ無しの場合は従来通り）
- **API**: なし
- **ドキュメント**: Issue #29 に実装方針を記載済み

## テスト結果

| 項目 | 結果 |
|------|------|
| lint | pass |
| typecheck | pass |
| unit test | 8 suites / 126 tests pass |
| visual regression | 2 tests pass |