### PR TITLE
feat: 緯度・経度入力パネルを削除

### DIFF
--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -75,7 +75,10 @@ export class DefaultScene implements CreateSceneClass {
         const updateUrl = createUrlUpdater(200);
 
         // UIパネル
-        const ui = createControlPanel(initialLat, initialLon);
+        const ui = createControlPanel();
+
+        let currentLat = initialLat;
+        let currentLon = initialLon;
 
         // TileManager 生成
         const tileManager = createTileManager({
@@ -94,20 +97,18 @@ export class DefaultScene implements CreateSceneClass {
         let gridResidualZ = 0;
 
         const refreshTerrain = async (): Promise<void> => {
-            const lat = clamp(
-                Number(ui.latInput.value),
+            currentLat = clamp(
+                currentLat,
                 JAPAN_BOUNDS.minLat,
                 JAPAN_BOUNDS.maxLat
             );
-            const lon = clamp(
-                Number(ui.lonInput.value),
+            currentLon = clamp(
+                currentLon,
                 JAPAN_BOUNDS.minLon,
                 JAPAN_BOUNDS.maxLon
             );
-            ui.latInput.value = lat.toFixed(6);
-            ui.lonInput.value = lon.toFixed(6);
-            updateUrl(lat, lon);
-            await tileManager.setCenter(lat, lon, 0);
+            updateUrl(currentLat, currentLon);
+            await tileManager.setCenter(currentLat, currentLon, 0);
         };
 
         // ---------- カメラターゲットオフセット → 緯度経度変換 ----------
@@ -123,8 +124,8 @@ export class DefaultScene implements CreateSceneClass {
                 return;
             }
 
-            const oldLat = Number(ui.latInput.value);
-            const oldLon = Number(ui.lonInput.value);
+            const oldLat = currentLat;
+            const oldLon = currentLon;
             const metersPerDegreeLon =
                 METERS_PER_DEGREE_LAT *
                 Math.cos((oldLat * Math.PI) / 180);
@@ -154,8 +155,8 @@ export class DefaultScene implements CreateSceneClass {
             camera.target.y = 0;
             camera.target.z = gridResidualZ;
 
-            ui.latInput.value = newLat.toFixed(6);
-            ui.lonInput.value = newLon.toFixed(6);
+            currentLat = newLat;
+            currentLon = newLon;
             updateUrl(newLat, newLon);
             void refreshTerrain();
         };
@@ -422,19 +423,6 @@ export class DefaultScene implements CreateSceneClass {
         };
         ui.zoomIn.addEventListener("click", () => zoomFromCenter(0.7));
         ui.zoomOut.addEventListener("click", () => zoomFromCenter(1 / 0.7));
-
-        // イベント接続
-        const resetAndRefresh = (): void => {
-            camera.target.x = 0;
-            camera.target.y = 0;
-            camera.target.z = 0;
-            gridResidualX = 0;
-            gridResidualZ = 0;
-            void refreshTerrain();
-        };
-        ui.updateButton.addEventListener("click", resetAndRefresh);
-        ui.latInput.addEventListener("change", resetAndRefresh);
-        ui.lonInput.addEventListener("change", resetAndRefresh);
 
         // 地図切替ボタン
         ui.mapToggle.addEventListener("click", () => {

--- a/src/terrain/controlPanel.ts
+++ b/src/terrain/controlPanel.ts
@@ -1,12 +1,6 @@
-/** 操作UIパネル（緯度・経度）と方位磁針 */
-
-import { JAPAN_BOUNDS } from "./gsiTile";
+/** 操作UI（方位磁針・ズーム・地図切替） */
 
 export interface ControlPanelElements {
-    panel: HTMLDivElement;
-    latInput: HTMLInputElement;
-    lonInput: HTMLInputElement;
-    updateButton: HTMLButtonElement;
     compass: HTMLDivElement;
     zoomIn: HTMLButtonElement;
     zoomOut: HTMLButtonElement;
@@ -15,22 +9,6 @@ export interface ControlPanelElements {
 
 const css = (el: HTMLElement, styles: Partial<CSSStyleDeclaration>): void => {
     Object.assign(el.style, styles);
-};
-
-const numberInput = (
-    value: number,
-    min: number,
-    max: number,
-    step: string
-): HTMLInputElement => {
-    const input = document.createElement("input");
-    input.type = "number";
-    input.value = String(value);
-    input.min = String(min);
-    input.max = String(max);
-    input.step = step;
-    css(input, { width: "90px", fontSize: "10px" });
-    return input;
 };
 
 const createCompass = (): HTMLDivElement => {
@@ -196,68 +174,7 @@ const createMapToggleButton = (): HTMLButtonElement => {
     return btn;
 };
 
-export const createControlPanel = (
-    initialLat: number,
-    initialLon: number
-): ControlPanelElements => {
-    const panel = document.createElement("div");
-    css(panel, {
-        position: "absolute",
-        top: "8px",
-        left: "8px",
-        padding: "4px 6px",
-        borderRadius: "6px",
-        background: "rgba(9,18,32,0.72)",
-        color: "#f2f7ff",
-        display: "grid",
-        gridTemplateColumns: "auto auto auto",
-        gap: "2px 4px",
-        alignItems: "center",
-        fontFamily: "'Helvetica Neue',Helvetica,Arial,sans-serif",
-        fontSize: "10px",
-        backdropFilter: "blur(6px)",
-        zIndex: "10",
-    });
-    document.body.appendChild(panel);
-
-    // 緯度
-    const latLabel = document.createElement("label");
-    latLabel.htmlFor = "cp-lat";
-    latLabel.textContent = "緯度";
-    css(latLabel, { gridColumn: "1", gridRow: "1" });
-    panel.appendChild(latLabel);
-    const latInput = numberInput(initialLat, JAPAN_BOUNDS.minLat, JAPAN_BOUNDS.maxLat, "0.0001");
-    latInput.id = "cp-lat";
-    css(latInput, { gridColumn: "2", gridRow: "1" });
-    panel.appendChild(latInput);
-
-    // 経度
-    const lonLabel = document.createElement("label");
-    lonLabel.htmlFor = "cp-lon";
-    lonLabel.textContent = "経度";
-    css(lonLabel, { gridColumn: "1", gridRow: "2" });
-    panel.appendChild(lonLabel);
-    const lonInput = numberInput(initialLon, JAPAN_BOUNDS.minLon, JAPAN_BOUNDS.maxLon, "0.0001");
-    lonInput.id = "cp-lon";
-    css(lonInput, { gridColumn: "2", gridRow: "2" });
-    panel.appendChild(lonInput);
-
-    // 更新ボタン（3列目に縦並び）
-    const updateButton = document.createElement("button");
-    updateButton.type = "button";
-    updateButton.textContent = "✓";
-    updateButton.setAttribute("aria-label", "地形を更新");
-    css(updateButton, {
-        cursor: "pointer",
-        padding: "1px 6px",
-        gridRow: "1 / 3",
-        gridColumn: "3",
-        alignSelf: "stretch",
-        fontSize: "12px",
-        lineHeight: "1",
-    });
-    panel.appendChild(updateButton);
-
+export const createControlPanel = (): ControlPanelElements => {
     // 方位磁針（画面右上に独立配置）
     const compass = createCompass();
 
@@ -267,5 +184,5 @@ export const createControlPanel = (
     // 地図切替ボタン（画面左下に配置）
     const mapToggle = createMapToggleButton();
 
-    return { panel, latInput, lonInput, updateButton, compass, zoomIn, zoomOut, mapToggle };
+    return { compass, zoomIn, zoomOut, mapToggle };
 };


### PR DESCRIPTION
## 概要

左上に表示されていた緯度・経度入力パネル（latInput, lonInput, updateButton）を削除し、UIをシンプル化。

Closes #66

## 変更内容

### `src/terrain/controlPanel.ts`
- `ControlPanelElements` から `panel`, `latInput`, `lonInput`, `updateButton` を削除
- `numberInput` ヘルパー関数を削除
- `createControlPanel` の引数（initialLat, initialLon）を削除
- パネル・ラベル・入力・ボタンの DOM 生成コードを削除

### `src/scenes/default.ts`
- lat/lon の状態管理を DOM 要素（`ui.latInput.value`）から内部変数（`currentLat`, `currentLon`）に移行
- `resetAndRefresh` 関数と関連イベントリスナーを削除

### スクリーンショット

<img width="1280" height="720" alt="Render-Default-with-WebGPU-1-chromium-darwin" src="https://github.com/user-attachments/assets/18767d30-328a-4a8f-ba66-0567db102dcd" />

## 残存UI（変更なし）
- 方位磁針（右上）
- ズームボタン（右下）
- 地図切替ボタン（左下）

## 検証
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test:unit` ✅ (129 tests)
- `npm run test:visuals` ✅ (snapshot更新済み)