### PR TITLE
feat(test): マップ切替・方位磁針ボタンのビジュアルテスト追加

### DIFF
--- a/tests/validation.spec.ts
+++ b/tests/validation.spec.ts
@@ -98,9 +98,27 @@ for (const engine of engines) {
         });
         await mapToggle.click();
 
+        // ARIAラベルが切り替わるのを待ち、操作反映を確定
+        await expect(
+            page.getByRole("button", { name: "地図切替: 標準地図に変更" })
+        ).toBeVisible({ timeout: 10000 });
+
         // タイルテクスチャ再読み込みを待つ
         await page.waitForLoadState("networkidle", { timeout: 30000 });
-        await page.waitForTimeout(5000);
+
+        // 描画安定のため数フレーム待機
+        await page.waitForFunction(
+            () =>
+                new Promise((resolve) => {
+                    let count = 0;
+                    const tick = () => {
+                        if (++count >= 5) return resolve(true);
+                        requestAnimationFrame(tick);
+                    };
+                    requestAnimationFrame(tick);
+                }),
+            { timeout: 5000 }
+        );
 
         await expect(page).toHaveScreenshot({
             timeout: 30000,

--- a/tests/validation.spec.ts
+++ b/tests/validation.spec.ts
@@ -18,10 +18,6 @@ const engines = [
     { name: "WebGPU", param: "webgpu" },
 ];
 
-test.beforeEach(async ({ page }) => {
-    await page.goto("/", { timeout: 120000 });
-});
-
 for (const scene of scenes) {
     for (const engine of engines) {
         test(`Render ${scene.name} with ${engine.name}`, async ({

--- a/tests/validation.spec.ts
+++ b/tests/validation.spec.ts
@@ -13,7 +13,10 @@ const scenes: {
     },
 ];
 
-const engines = ["WebGL2", "WebGPU"];
+const engines = [
+    { name: "WebGL2", param: "webgl" },
+    { name: "WebGPU", param: "webgpu" },
+];
 
 test.beforeEach(async ({ page }) => {
     await page.goto("/", { timeout: 120000 });
@@ -21,11 +24,11 @@ test.beforeEach(async ({ page }) => {
 
 for (const scene of scenes) {
     for (const engine of engines) {
-        test(`Render ${scene.name} with ${engine}`, async ({
+        test(`Render ${scene.name} with ${engine.name}`, async ({
             page,
         }, testInfo) => {
             const sceneUrl = new URL(scene.url, "http://localhost");
-            sceneUrl.searchParams.set("engine", engine);
+            sceneUrl.searchParams.set("engine", engine.param);
             await page.goto(
                 `${sceneUrl.pathname}${sceneUrl.search}${sceneUrl.hash}`
             );
@@ -90,8 +93,8 @@ async function waitForScene(
 }
 
 for (const engine of engines) {
-    test(`Map toggle button with ${engine}`, async ({ page }, testInfo) => {
-        await waitForScene(page, engine);
+    test(`Map toggle button with ${engine.name}`, async ({ page }, testInfo) => {
+        await waitForScene(page, engine.param);
 
         // 地図切替ボタンをクリック（標準 → 写真）
         const mapToggle = page.getByRole("button", {
@@ -110,8 +113,8 @@ for (const engine of engines) {
         expect(testInfo.errors).toHaveLength(0);
     });
 
-    test(`Compass reset button with ${engine}`, async ({ page }, testInfo) => {
-        await waitForScene(page, engine);
+    test(`Compass reset button with ${engine.name}`, async ({ page }, testInfo) => {
+        await waitForScene(page, engine.param);
 
         // 方位磁針ボタンをクリック（北向きリセット）
         const compass = page.getByRole("button", {

--- a/tests/validation.spec.ts
+++ b/tests/validation.spec.ts
@@ -121,7 +121,10 @@ for (const engine of engines) {
         // アニメーション完了(400ms) + 描画安定待ち
         await page.waitForTimeout(2000);
 
-        await expect(page).toHaveScreenshot({ timeout: 30000 });
+        await expect(page).toHaveScreenshot({
+            timeout: 30000,
+            maxDiffPixelRatio: 0.02,
+        });
         expect(testInfo.errors).toHaveLength(0);
     });
 }

--- a/tests/validation.spec.ts
+++ b/tests/validation.spec.ts
@@ -158,8 +158,20 @@ for (const engine of engines) {
         });
         await compass.click();
 
-        // アニメーション完了(400ms) + 描画安定待ち
-        await page.waitForTimeout(2000);
+        // アニメーション完了をカメラ状態で判定（alpha→-π/2, beta→0.1）
+        await page.waitForFunction(
+            () => {
+                const cam = (window as any).scene?.activeCamera;
+                if (!cam) return false;
+                const targetAlpha = -Math.PI / 2;
+                const targetBeta = 0.1;
+                return (
+                    Math.abs(cam.alpha - targetAlpha) < 0.01 &&
+                    Math.abs(cam.beta - targetBeta) < 0.01
+                );
+            },
+            { timeout: 5000 }
+        );
 
         await expect(page).toHaveScreenshot({
             timeout: 30000,

--- a/tests/validation.spec.ts
+++ b/tests/validation.spec.ts
@@ -9,6 +9,7 @@ const scenes: {
     {
         name: "Default",
         url: "/?scene=default",
+        waitForNetworkIdle: true,
     },
 ];
 
@@ -29,7 +30,9 @@ for (const scene of scenes) {
                 `${sceneUrl.pathname}${sceneUrl.search}${sceneUrl.hash}`
             );
             if (scene.waitForNetworkIdle) {
-                await page.waitForLoadState("networkidle");
+                await page.waitForLoadState("networkidle", { timeout: 30000 });
+                // タイル読み込み後の描画安定待ち
+                await page.waitForTimeout(3000);
             }
             if (scene.renderCount) {
                 await page.evaluate(() => {
@@ -57,8 +60,69 @@ for (const scene of scenes) {
             // UI/描画結果に意図した変更が入った場合のみ実行します。
             await expect(page).toHaveScreenshot({
                 timeout: 30000,
+                maxDiffPixelRatio: 0.02,
             });
             expect(testInfo.errors).toHaveLength(0);
         });
     }
+}
+
+// ---------- UI操作テスト ----------
+
+/** シーン準備の共通ヘルパー */
+async function waitForScene(
+    page: import("@playwright/test").Page,
+    engine: string
+) {
+    const sceneUrl = new URL("/?scene=default", "http://localhost");
+    sceneUrl.searchParams.set("engine", engine);
+    await page.goto(`${sceneUrl.pathname}${sceneUrl.search}`, {
+        timeout: 120000,
+    });
+    await page.waitForFunction(
+        () => (window as any).scene && (window as any).scene.isReady(),
+        { timeout: 10000 }
+    );
+    // タイル読み込み完了を待つ
+    await page.waitForLoadState("networkidle", { timeout: 30000 });
+    // 描画安定のための追加待機
+    await page.waitForTimeout(3000);
+}
+
+for (const engine of engines) {
+    test(`Map toggle button with ${engine}`, async ({ page }, testInfo) => {
+        await waitForScene(page, engine);
+
+        // 地図切替ボタンをクリック（標準 → 写真）
+        const mapToggle = page.getByRole("button", {
+            name: "地図切替: 写真地図に変更",
+        });
+        await mapToggle.click();
+
+        // タイルテクスチャ再読み込みを待つ
+        await page.waitForLoadState("networkidle", { timeout: 30000 });
+        await page.waitForTimeout(5000);
+
+        await expect(page).toHaveScreenshot({
+            timeout: 30000,
+            maxDiffPixelRatio: 0.02,
+        });
+        expect(testInfo.errors).toHaveLength(0);
+    });
+
+    test(`Compass reset button with ${engine}`, async ({ page }, testInfo) => {
+        await waitForScene(page, engine);
+
+        // 方位磁針ボタンをクリック（北向きリセット）
+        const compass = page.getByRole("button", {
+            name: "方位磁針: クリックで北向きにリセット",
+        });
+        await compass.click();
+
+        // アニメーション完了(400ms) + 描画安定待ち
+        await page.waitForTimeout(2000);
+
+        await expect(page).toHaveScreenshot({ timeout: 30000 });
+        expect(testInfo.errors).toHaveLength(0);
+    });
 }

--- a/tests/validation.spec.ts
+++ b/tests/validation.spec.ts
@@ -30,8 +30,19 @@ for (const scene of scenes) {
             );
             if (scene.waitForNetworkIdle) {
                 await page.waitForLoadState("networkidle", { timeout: 30000 });
-                // タイル読み込み後の描画安定待ち
-                await page.waitForTimeout(3000);
+                // タイル読み込み後の描画安定待ち（数フレーム経過で確認）
+                await page.waitForFunction(
+                    () =>
+                        new Promise((resolve) => {
+                            let count = 0;
+                            const tick = () => {
+                                if (++count >= 10) return resolve(true);
+                                requestAnimationFrame(tick);
+                            };
+                            requestAnimationFrame(tick);
+                        }),
+                    { timeout: 10000 }
+                );
             }
             if (scene.renderCount) {
                 await page.evaluate(() => {
@@ -84,8 +95,19 @@ async function waitForScene(
     );
     // タイル読み込み完了を待つ
     await page.waitForLoadState("networkidle", { timeout: 30000 });
-    // 描画安定のための追加待機
-    await page.waitForTimeout(3000);
+    // 描画安定待ち（数フレーム経過で確認）
+    await page.waitForFunction(
+        () =>
+            new Promise((resolve) => {
+                let count = 0;
+                const tick = () => {
+                    if (++count >= 10) return resolve(true);
+                    requestAnimationFrame(tick);
+                };
+                requestAnimationFrame(tick);
+            }),
+        { timeout: 10000 }
+    );
 }
 
 for (const engine of engines) {


### PR DESCRIPTION
## 概要

Playwrightビジュアルテストに、マップ切替ボタン・方位磁針ボタン押下後のスクリーンショット比較テストを追加。

## 変更内容

- **マップ切替テスト**: 「写真」ボタンクリック → タイル再読み込み待ち → スクリーンショット比較（WebGL2/WebGPU）
- **方位磁針テスト**: 方位磁針クリック（北向きリセット） → アニメーション完了待ち → スクリーンショット比較（WebGL2/WebGPU）
- **既存テスト安定化**: Render Default テストに `networkidle` 待ち・`maxDiffPixelRatio: 0.02` を追加し、タイル読み込み中の描画変動によるフレーク失敗を解消

## 影響範囲

- テストコードのみ。プロダクションコードへの変更なし
- スナップショット画像は `.gitignore` 対象のため各環境で `--update-snapshots` による初回生成が必要

## 検証結果

- `npx playwright test` — 6 passed
- `npm run typecheck` — 成功
- `npm run lint` — 成功

Closes #69