### PR TITLE
feat: スケールバー表示

### DIFF
--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -6,7 +6,7 @@ import { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import "@babylonjs/core/Culling/ray";
 import { CreateSceneClass } from "../createScene";
 import { clamp, toTileXY, tileEdgeMeters, JAPAN_BOUNDS } from "../terrain/gsiTile";
-import { createControlPanel } from "../terrain/controlPanel";
+import { createControlPanel, snapScale, formatScale } from "../terrain/controlPanel";
 import { createTileManager } from "../terrain/tileManager";
 import { createSkybox } from "../terrain/skybox";
 import { parseLatLonFromUrl, createUrlUpdater } from "../terrain/urlState";
@@ -380,6 +380,29 @@ export class DefaultScene implements CreateSceneClass {
             ui.compass.style.transform = `rotate(${degrees}deg)`;
         };
         camera.onViewMatrixChangedObservable.add(syncCompass);
+
+        // スケールバー更新
+        const SCALE_BAR_BASE_PX = 100;
+        let prevScaleText = "";
+        const updateScaleBar = (): void => {
+            const altitude = camera.radius * Math.cos(camera.beta);
+            const fov = camera.fov; // 垂直FOV
+            const aspect = engine.getRenderWidth() / engine.getRenderHeight();
+            const visibleWidthM = 2 * altitude * Math.tan(fov / 2) * aspect;
+            const canvasWidth = engine.getRenderWidth();
+            const metersPerPx = visibleWidthM / canvasWidth;
+            const rawMeters = metersPerPx * SCALE_BAR_BASE_PX;
+            const snapped = snapScale(rawMeters);
+            const barPx = Math.round(snapped / metersPerPx);
+            const text = formatScale(snapped);
+            if (text !== prevScaleText) {
+                ui.scaleBar.label.textContent = text;
+                prevScaleText = text;
+            }
+            ui.scaleBar.bar.style.width = `${barPx}px`;
+        };
+        camera.onViewMatrixChangedObservable.add(updateScaleBar);
+        engine.onResizeObservable.add(updateScaleBar);
 
         // 方位磁針: 北向き・真下にスムーズアニメーション
         ui.compass.style.cursor = "pointer";

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -405,6 +405,7 @@ export class DefaultScene implements CreateSceneClass {
         };
         camera.onViewMatrixChangedObservable.add(updateScaleBar);
         engine.onResizeObservable.add(updateScaleBar);
+        updateScaleBar();
 
         // 方位磁針: 北向き・真下にスムーズアニメーション
         ui.compass.style.cursor = "pointer";

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -385,13 +385,15 @@ export class DefaultScene implements CreateSceneClass {
         const SCALE_BAR_BASE_PX = 100;
         let prevScaleText = "";
         const updateScaleBar = (): void => {
-            const altitude = camera.radius * Math.cos(camera.beta);
-            const fov = camera.fov; // 垂直FOV
-            const aspect = engine.getRenderWidth() / engine.getRenderHeight();
-            const visibleWidthM = 2 * altitude * Math.tan(fov / 2) * aspect;
-            const canvasWidth = engine.getRenderWidth();
-            const metersPerPx = visibleWidthM / canvasWidth;
-            const rawMeters = metersPerPx * SCALE_BAR_BASE_PX;
+            const cx = canvas.clientWidth / 2;
+            const cy = canvas.clientHeight / 2;
+            const center = intersectPlane(cx, cy, 0);
+            const offset = intersectPlane(cx + SCALE_BAR_BASE_PX, cy, 0);
+            if (!center || !offset) return;
+            const dx = offset.x - center.x;
+            const dz = offset.z - center.z;
+            const rawMeters = Math.sqrt(dx * dx + dz * dz);
+            const metersPerPx = rawMeters / SCALE_BAR_BASE_PX;
             const snapped = snapScale(rawMeters);
             const barPx = Math.round(snapped / metersPerPx);
             const text = formatScale(snapped);

--- a/src/terrain/controlPanel.ts
+++ b/src/terrain/controlPanel.ts
@@ -1,10 +1,17 @@
 /** 操作UI（方位磁針・ズーム・地図切替） */
 
+export interface ScaleBarElement {
+    container: HTMLDivElement;
+    bar: HTMLDivElement;
+    label: HTMLSpanElement;
+}
+
 export interface ControlPanelElements {
     compass: HTMLDivElement;
     zoomIn: HTMLButtonElement;
     zoomOut: HTMLButtonElement;
     mapToggle: HTMLButtonElement;
+    scaleBar: ScaleBarElement;
 }
 
 const css = (el: HTMLElement, styles: Partial<CSSStyleDeclaration>): void => {
@@ -80,6 +87,7 @@ const createCompass = (): HTMLDivElement => {
 const createZoomButtons = (): {
     zoomIn: HTMLButtonElement;
     zoomOut: HTMLButtonElement;
+    scaleBar: ScaleBarElement;
 } => {
     const container = document.createElement("div");
     css(container, {
@@ -89,6 +97,7 @@ const createZoomButtons = (): {
         display: "flex",
         flexDirection: "column",
         gap: "2px",
+        alignItems: "flex-end",
         zIndex: "10",
     });
 
@@ -128,11 +137,54 @@ const createZoomButtons = (): {
 
     const zoomIn = makeBtn("+", "ズームイン");
     const zoomOut = makeBtn("−", "ズームアウト");
+
+    // スケールバー（マイナスボタンの下、横一列）
+    const scaleContainer = document.createElement("div");
+    css(scaleContainer, {
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        gap: "4px",
+        marginTop: "4px",
+        pointerEvents: "none",
+    });
+
+    const scaleLabel = document.createElement("span");
+    css(scaleLabel, {
+        color: "#222",
+        fontSize: "10px",
+        fontWeight: "bold",
+        lineHeight: "1",
+        whiteSpace: "nowrap",
+        textShadow:
+            "-1px -1px 0 #fff, 1px -1px 0 #fff, -1px 1px 0 #fff, 1px 1px 0 #fff",
+    });
+    scaleLabel.textContent = "";
+
+    const scaleBar = document.createElement("div");
+    css(scaleBar, {
+        height: "4px",
+        background: "#222",
+        borderRadius: "1px",
+        boxShadow:
+            "-1px -1px 0 #fff, 1px -1px 0 #fff, -1px 1px 0 #fff, 1px 1px 0 #fff",
+        minWidth: "20px",
+        width: "60px",
+    });
+
+    scaleContainer.appendChild(scaleLabel);
+    scaleContainer.appendChild(scaleBar);
+
     container.appendChild(zoomIn);
     container.appendChild(zoomOut);
+    container.appendChild(scaleContainer);
     document.body.appendChild(container);
 
-    return { zoomIn, zoomOut };
+    return {
+        zoomIn,
+        zoomOut,
+        scaleBar: { container: scaleContainer, bar: scaleBar, label: scaleLabel },
+    };
 };
 
 const createMapToggleButton = (): HTMLButtonElement => {
@@ -174,15 +226,35 @@ const createMapToggleButton = (): HTMLButtonElement => {
     return btn;
 };
 
+/** きれいな数値にスナップ */
+export const SCALE_STEPS = [
+    1, 2, 5, 10, 20, 50, 100, 200, 500,
+    1000, 2000, 5000, 10_000, 20_000, 50_000, 100_000,
+];
+
+export const snapScale = (meters: number): number => {
+    for (const step of SCALE_STEPS) {
+        if (step >= meters) return step;
+    }
+    return SCALE_STEPS[SCALE_STEPS.length - 1];
+};
+
+export const formatScale = (meters: number): string => {
+    if (meters >= 1000) return `${meters / 1000} km`;
+    return `${meters} m`;
+};
+
 export const createControlPanel = (): ControlPanelElements => {
     // 方位磁針（画面右上に独立配置）
     const compass = createCompass();
 
-    // ズームボタン（画面右下に独立配置）
-    const { zoomIn, zoomOut } = createZoomButtons();
+    // ズームボタン＋スケールバー（画面右下に独立配置）
+    const { zoomIn, zoomOut, scaleBar } = createZoomButtons();
 
     // 地図切替ボタン（画面左下に配置）
     const mapToggle = createMapToggleButton();
 
-    return { compass, zoomIn, zoomOut, mapToggle };
+    // スケールバー（ズームボタンコンテナ内に統合済み）
+
+    return { compass, zoomIn, zoomOut, mapToggle, scaleBar };
 };

--- a/tests/controlPanel.unit.spec.ts
+++ b/tests/controlPanel.unit.spec.ts
@@ -1,0 +1,51 @@
+import { snapScale, formatScale, SCALE_STEPS } from "../src/terrain/controlPanel";
+
+describe("snapScale", () => {
+    it("小さい値は最小ステップ (1) にスナップされる", () => {
+        expect(snapScale(0.5)).toBe(1);
+    });
+
+    it("ちょうどステップ値の場合はその値を返す", () => {
+        expect(snapScale(100)).toBe(100);
+        expect(snapScale(1000)).toBe(1000);
+    });
+
+    it("ステップ間の値は次のステップにスナップされる", () => {
+        expect(snapScale(3)).toBe(5);
+        expect(snapScale(7)).toBe(10);
+        expect(snapScale(15)).toBe(20);
+        expect(snapScale(30)).toBe(50);
+        expect(snapScale(150)).toBe(200);
+        expect(snapScale(600)).toBe(1000);
+        expect(snapScale(3000)).toBe(5000);
+    });
+
+    it("最大ステップを超える値は最大ステップを返す", () => {
+        expect(snapScale(200_000)).toBe(SCALE_STEPS[SCALE_STEPS.length - 1]);
+    });
+
+    it("全ステップが昇順である", () => {
+        for (let i = 1; i < SCALE_STEPS.length; i++) {
+            expect(SCALE_STEPS[i]).toBeGreaterThan(SCALE_STEPS[i - 1]);
+        }
+    });
+});
+
+describe("formatScale", () => {
+    it("1000m 未満は m 表記", () => {
+        expect(formatScale(1)).toBe("1 m");
+        expect(formatScale(500)).toBe("500 m");
+        expect(formatScale(999)).toBe("999 m");
+    });
+
+    it("1000m 以上は km 表記", () => {
+        expect(formatScale(1000)).toBe("1 km");
+        expect(formatScale(5000)).toBe("5 km");
+        expect(formatScale(10_000)).toBe("10 km");
+        expect(formatScale(100_000)).toBe("100 km");
+    });
+
+    it("2000m は 2 km と表示", () => {
+        expect(formatScale(2000)).toBe("2 km");
+    });
+});


### PR DESCRIPTION
## 概要

地図のスケールバーをズームボタン（−）の下に表示する。ターゲットポイント（マップ中央）を基準とした距離スケールをリアルタイム更新。

Closes #36

## 変更内容

### `src/terrain/controlPanel.ts`
- `ScaleBarElement` インターフェース追加
- `ControlPanelElements` に `scaleBar` フィールド追加
- ズームボタンコンテナ内にスケールバーDOM（距離ラベル＋バー、横一列）を生成
- `SCALE_STEPS` / `snapScale()` / `formatScale()` をexport

### `src/scenes/default.ts`
- カメラ変更時（`onViewMatrixChangedObservable`）およびリサイズ時にスケールバーを更新
- カメラ高度と画面幅から1pxあたりのメートル数を算出し、きれいな数値にスナップ

### `tests/controlPanel.unit.spec.ts`（新規）
- `snapScale` / `formatScale` のユニットテスト 8件

### スナップショット

<img width="1280" height="720" alt="Render-Default-with-WebGPU-1-chromium-darwin" src="https://github.com/user-attachments/assets/3a1b9f84-d20f-4555-8259-de311b93aa16" />
<img width="1280" height="720" alt="Map-toggle-button-with-WebGPU-1-chromium-darwin" src="https://github.com/user-attachments/assets/8eb196af-4818-487b-8588-46cdbcfd9425" />


## スタイル
- 黒色テキスト・バー、白の縁取り
- 距離数字とバーの横一列レイアウト
- 1000m以下は m 表記、超えたら km 表記