### PR TITLE
fix: スナップショット更新時に既存画像が上書きされない問題を修正

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,5 +27,5 @@ Closes #<!-- issue番号 -->
 ## 確認事項
 
 - [ ] Copilot レビューを日本語で実施し、指摘を修正した
-- [ ] `npm run test:visuals -- --update-snapshots` は毎回実行していない
+- [ ] `npm run test:visuals:update` は毎回実行していない
 - [ ] 画面表示の意図した変更がある場合のみ、開発者がスナップショットを更新した

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ npm start
 | `npm run lint` | ESLint 実行 |
 | `npm run typecheck` | TypeScript 型チェック |
 | `npm run test:visuals` | Visual Regression Test 実行 |
-| `npm run test:visuals -- --update-snapshots` | Visual テスト基準画像の更新（画面表示変更時のみ） |
+| `npm run test:visuals:update` | Visual テスト基準画像の強制更新（画面表示変更時のみ） |
 | `npm run test:unit` | ユニットテスト（Jest） |
 
 ### デバッグ
@@ -71,14 +71,16 @@ npm start
 ### Visual Regression Test
 
 通常は `npm run test:visuals` のみを実行します。
-`npm run test:visuals -- --update-snapshots` は毎回実行するものではなく、UIや描画結果に意図した変更が入ったときに、開発者が基準画像を更新するために実行します。
+`npm run test:visuals:update` は毎回実行するものではなく、UIや描画結果に意図した変更が入ったときに、開発者が基準画像を更新するために実行します。
 
 
 **UIや描画結果に意図した変更が入ったときのみ実行**
 
 ```shell
-npm run test:visuals -- --update-snapshots
+npm run test:visuals:update
 ```
+
+> **Note:** Playwright 1.59+ では `--update-snapshots` のデフォルトが `missing`（不足分のみ追加）に変更されました。既存スナップショットを上書きするには `--update-snapshots=all` が必要です。`test:visuals:update` スクリプトはこのオプションを使用します。
 
 **通常の実行**
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "lint": "npx eslint . --ext .ts,.tsx",
     "typecheck": "tsc --noEmit",
     "test:visuals": "npx playwright test",
+    "test:visuals:update": "npx playwright test --update-snapshots=all",
     "test:unit": "cross-env NODE_OPTIONS=--experimental-vm-modules npx jest",
     "prepare": "husky"
   },

--- a/spec/development.md
+++ b/spec/development.md
@@ -27,11 +27,11 @@ npm run test:visuals
 
 Visual Regression Test の基準更新が必要な場合:
 
-- `npm run test:visuals -- --update-snapshots` は毎回実行しない
+- `npm run test:visuals:update` は毎回実行しない
 - 画面表示（UI/描画結果）に意図した変更がある場合にのみ、開発者が基準画像を更新する
 
 ```shell
-npm run test:visuals -- --update-snapshots
+npm run test:visuals:update
 ```
 
 ## Definition of Done

--- a/tests/validation.spec.ts
+++ b/tests/validation.spec.ts
@@ -66,10 +66,10 @@ for (const scene of scenes) {
             });
             // await page.waitForFunction(() => (window as any).renderCount === scene.renderCount || 1, { timeout: 5000 });
             // 注意:
-            // スナップショット更新（--update-snapshots=all）は定常手順ではありません。
+            // スナップショット更新（`--update-snapshots=all`）は定常手順ではありません。
             // UI/描画結果に意図した変更が入った場合のみ実行します。
-            // Playwright 1.59+ では --update-snapshots のデフォルトが missing のため、
-            // 既存画像を上書きするには npm run test:visuals:update を使用してください。
+            // Playwright 1.59+ では `--update-snapshots` のデフォルトが `missing` のため、
+            // 既存画像を上書きするには `npm run test:visuals:update` を使用してください。
             await expect(page).toHaveScreenshot({
                 timeout: 30000,
                 maxDiffPixelRatio: 0.02,

--- a/tests/validation.spec.ts
+++ b/tests/validation.spec.ts
@@ -66,8 +66,10 @@ for (const scene of scenes) {
             });
             // await page.waitForFunction(() => (window as any).renderCount === scene.renderCount || 1, { timeout: 5000 });
             // 注意:
-            // スナップショット更新（--update-snapshots）は定常手順ではありません。
+            // スナップショット更新（--update-snapshots=all）は定常手順ではありません。
             // UI/描画結果に意図した変更が入った場合のみ実行します。
+            // Playwright 1.59+ では --update-snapshots のデフォルトが missing のため、
+            // 既存画像を上書きするには npm run test:visuals:update を使用してください。
             await expect(page).toHaveScreenshot({
                 timeout: 30000,
                 maxDiffPixelRatio: 0.02,


### PR DESCRIPTION
## 概要

Playwright 1.59+ で `--update-snapshots` のデフォルトが `missing`（不足分のみ追加）に変更されたため、`npm run test:visuals -- --update-snapshots` を実行しても既存のスクリーンショットが上書きされない問題を修正しました。

## 変更内容

- `package.json`: `test:visuals:update` スクリプト（`--update-snapshots=all`）を追加
- `README.md`: 開発コマンド表とテストセクションを更新、Playwright 1.59+ の仕様変更について補足追加
- `tests/validation.spec.ts`: コメントを更新（ロジック変更なし）

## 影響範囲

- **画面/API**: 変更なし
- **ドキュメント**: README.md のコマンド表・テストセクション更新
- **既存動作**: `npm run test:visuals` は変更なし（回帰なし）

## 検証結果

- `npm run lint` → 成功
- `npm run typecheck` → 成功
- `npm run test:visuals:update` → 6 passed
- `npm run test:visuals` → 6 passed（回帰なし）

Closes #74