### PR TITLE
feat: 海タイル描画対応

### DIFF
--- a/src/terrain/gsiTile.ts
+++ b/src/terrain/gsiTile.ts
@@ -138,6 +138,12 @@ export const loadElevationTile = async (
                     img.data[i + 2]
                 );
             }
+            // 全ピクセルが無効値（海洋タイル等）の場合はスキップ
+            let hasValid = false;
+            for (let i = 0; i < elev.length; i++) {
+                if (!Number.isNaN(elev[i])) { hasValid = true; break; }
+            }
+            if (!hasValid) throw new Error(`All pixels invalid for ${url}`);
             fillInvalidPixels(elev, img.width, img.height);
             return elev;
         } catch (e) {

--- a/src/terrain/meshPool.ts
+++ b/src/terrain/meshPool.ts
@@ -58,11 +58,14 @@ export const createMeshPool = (opts: MeshPoolOptions): MeshPool => {
             if (!active.has(mesh)) return;
             active.delete(mesh);
             mesh.setEnabled(false);
-            // テクスチャを解放
+            // テクスチャを解放、diffuseColor をリセット
             const mat = mesh.material as StandardMaterial | null;
-            if (mat?.diffuseTexture) {
-                mat.diffuseTexture.dispose();
-                mat.diffuseTexture = null;
+            if (mat) {
+                if (mat.diffuseTexture) {
+                    mat.diffuseTexture.dispose();
+                    mat.diffuseTexture = null;
+                }
+                mat.diffuseColor = Color3.White();
             }
             pool.push(mesh);
         },

--- a/src/terrain/tileCache.ts
+++ b/src/terrain/tileCache.ts
@@ -5,6 +5,7 @@ import { TileKey, TileCoord } from "./tileTypes";
 export interface TileCacheEntry {
     coord: TileCoord;
     elevation: Float32Array;
+    isOcean?: boolean;
 }
 
 export interface TileCache {

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -7,6 +7,7 @@ import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
 import { Texture } from "@babylonjs/core/Materials/Textures/texture";
 import { VertexData } from "@babylonjs/core/Meshes/mesh.vertexData";
 import { VertexBuffer } from "@babylonjs/core/Buffers/buffer";
+import { Color3 } from "@babylonjs/core/Maths/math.color";
 import { Frustum } from "@babylonjs/core/Maths/math.frustum";
 import { Matrix } from "@babylonjs/core/Maths/math.vector";
 import { Plane } from "@babylonjs/core/Maths/math.plane";
@@ -57,6 +58,7 @@ interface ActiveTile {
     coord: TileCoord;
     mesh: Mesh;
     tileSize: number;
+    isOcean: boolean;
 }
 
 const DEFAULT_MAX_CONCURRENT = 4;
@@ -65,6 +67,9 @@ const DEFAULT_CACHE_CAPACITY = 96;
 const DEFAULT_DEBOUNCE_MS = 200;
 /** Frustum 判定用の基準最大標高 (m) — 富士山 3776m + マージン */
 const MAX_BASE_ELEVATION = 4000;
+
+/** 海タイルの表示色 (#3a6b9e) */
+const OCEAN_COLOR = new Color3(0xbe / 255, 0xd3 / 255, 0xff / 255);
 
 /** 頂点Y座標を標高値で更新 */
 const applyElevation = (
@@ -221,6 +226,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
             const elevZoom = Math.min(coord.zoom, maxElevationZoom);
 
             let entry = cache.get(key);
+            let isOcean = false;
             if (!entry) {
                 // 標高データを取得（maxElevationZoomから段階的にフォールバック）
                 let elevData: Float32Array | null = null;
@@ -235,6 +241,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
                     if (cached) {
                         elevData = cached.elevation;
                         actualElevZoom = tryZoom;
+                        if (cached.isOcean) isOcean = true;
                         break;
                     }
 
@@ -256,9 +263,10 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
                 }
 
                 if (!elevData) {
-                    // 全zoomで失敗 → フラット標高で表示
+                    // 全zoomで失敗 → 海タイル（フラット標高 0m）
                     elevData = new Float32Array(TILE_SIZE * TILE_SIZE);
                     actualElevZoom = coord.zoom;
+                    isOcean = true;
                 }
 
                 // zoom差がある場合、親タイルの該当領域を切り出し
@@ -271,8 +279,12 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
                     elevation = elevData;
                 }
 
-                entry = { coord, elevation };
+                entry = { coord, elevation, isOcean };
                 cache.set(key, entry);
+            }
+
+            if (!isOcean && entry.isOcean) {
+                isOcean = true;
             }
 
             if (rid !== requestId) return;
@@ -316,10 +328,14 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
                 mesh.updateVerticesData(VertexBuffer.NormalKind, normals);
             }
 
-            // テクスチャ
-            applyTexture(mesh, coord);
+            // テクスチャ or 海色
+            if (isOcean) {
+                applyOceanMaterial(mesh);
+            } else {
+                applyTexture(mesh, coord);
+            }
 
-            activeTiles.set(key, { key, coord, mesh, tileSize });
+            activeTiles.set(key, { key, coord, mesh, tileSize, isOcean });
         } catch (e) {
             if (rid !== requestId) return;
             statusCallback?.(
@@ -404,24 +420,48 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
     /** tileSizeForZoom: 指定zoomでのタイル実サイズを返す */
     const tileSizeForZoom = (z: number): number => tileEdgeMeters(currentLat, z);
 
+    /** 海タイル用の青色マテリアルを適用する */
+    const applyOceanMaterial = (mesh: Mesh): void => {
+        const mat = mesh.material as StandardMaterial;
+        if (mat.diffuseTexture) {
+            mat.diffuseTexture.dispose();
+            mat.diffuseTexture = null;
+        }
+        mat.diffuseColor = OCEAN_COLOR;
+    };
+
     /** メッシュにテクスチャを適用する */
     const applyTexture = (mesh: Mesh, coord: TileCoord): void => {
         const mat = mesh.material as StandardMaterial;
         if (mat.diffuseTexture) {
             mat.diffuseTexture.dispose();
+            mat.diffuseTexture = null;
         }
-        mat.diffuseTexture = new Texture(
+        const key = toTileKey(coord);
+        const tex = new Texture(
             textureUrl(currentMapType, coord.zoom, coord.x, coord.y),
             scene,
             true,
             true,
-            Texture.TRILINEAR_SAMPLINGMODE
+            Texture.TRILINEAR_SAMPLINGMODE,
+            () => {
+                // テクスチャ読込成功 → マテリアルに適用
+                mat.diffuseTexture = tex;
+            },
+            () => {
+                // テクスチャ読込失敗 → 海色にフォールバック
+                tex.dispose();
+                applyOceanMaterial(mesh);
+                const tile = activeTiles.get(key);
+                if (tile) tile.isOcean = true;
+            }
         );
     };
 
     /** 全アクティブタイルのテクスチャを現在の mapType で差し替え */
     const retextureAll = (): void => {
         for (const [, tile] of activeTiles) {
+            if (tile.isOcean) continue;
             applyTexture(tile.mesh, tile.coord);
         }
     };

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -328,14 +328,15 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
                 mesh.updateVerticesData(VertexBuffer.NormalKind, normals);
             }
 
+            // activeTiles を先に登録（applyTexture の非同期コールバックで参照するため）
+            activeTiles.set(key, { key, coord, mesh, tileSize, isOcean });
+
             // テクスチャ or 海色
             if (isOcean) {
                 applyOceanMaterial(mesh);
             } else {
                 applyTexture(mesh, coord);
             }
-
-            activeTiles.set(key, { key, coord, mesh, tileSize, isOcean });
         } catch (e) {
             if (rid !== requestId) return;
             statusCallback?.(
@@ -445,15 +446,22 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
             true,
             Texture.TRILINEAR_SAMPLINGMODE,
             () => {
+                // タイルが既に解放済み or メッシュが別タイルに再利用されている場合はスキップ
+                const tile = activeTiles.get(key);
+                if (!tile || tile.mesh !== mesh) {
+                    tex.dispose();
+                    return;
+                }
                 // テクスチャ読込成功 → マテリアルに適用
                 mat.diffuseTexture = tex;
             },
             () => {
                 // テクスチャ読込失敗 → 海色にフォールバック
                 tex.dispose();
-                applyOceanMaterial(mesh);
                 const tile = activeTiles.get(key);
-                if (tile) tile.isOcean = true;
+                if (!tile || tile.mesh !== mesh) return;
+                applyOceanMaterial(mesh);
+                tile.isOcean = true;
             }
         );
     };

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -68,7 +68,7 @@ const DEFAULT_DEBOUNCE_MS = 200;
 /** Frustum 判定用の基準最大標高 (m) — 富士山 3776m + マージン */
 const MAX_BASE_ELEVATION = 4000;
 
-/** 海タイルの表示色 (#3a6b9e) */
+/** 海タイルの表示色 (#bed3ff) */
 const OCEAN_COLOR = new Color3(0xbe / 255, 0xd3 / 255, 0xff / 255);
 
 /** 頂点Y座標を標高値で更新 */

--- a/src/terrain/visibleTiles.ts
+++ b/src/terrain/visibleTiles.ts
@@ -302,11 +302,14 @@ export const computeMultiLodTiles = (
     const allKeys = new Set(results.map(r => toTileKey(r.coord)));
 
     // 既存タイルのzoom別座標を記録（祖先/子孫の重複判定用）
-    const tilesByZoomForOverlap = new Map<number, Set<string>>();
+    // 文字列キーを避け、数値エンコードでホットパスの文字列処理を排除
+    const PACK_SHIFT = 0x1000000; // 2^24: zoom 23 まで安全
+    const packXY = (x: number, y: number): number => x * PACK_SHIFT + y;
+    const tilesByZoomForOverlap = new Map<number, Set<number>>();
     for (const r of results) {
         const { zoom, x, y } = r.coord;
         if (!tilesByZoomForOverlap.has(zoom)) tilesByZoomForOverlap.set(zoom, new Set());
-        tilesByZoomForOverlap.get(zoom)!.add(`${x},${y}`);
+        tilesByZoomForOverlap.get(zoom)!.add(packXY(x, y));
     }
 
     /** 指定タイルの領域が既存タイル（より高いzoom）によってカバーされているか判定 */
@@ -317,12 +320,13 @@ export const computeMultiLodTiles = (
             // 子孫タイルの座標範囲
             const childBaseX = coord.x << diff;
             const childBaseY = coord.y << diff;
-            for (const key of coords) {
-                const [cxStr, cyStr] = key.split(",");
-                const cx = Number(cxStr);
-                const cy = Number(cyStr);
-                if (cx >= childBaseX && cx < childBaseX + (1 << diff) &&
-                    cy >= childBaseY && cy < childBaseY + (1 << diff)) {
+            const childEndX = childBaseX + (1 << diff);
+            const childEndY = childBaseY + (1 << diff);
+            for (const packed of coords) {
+                const cx = Math.floor(packed / PACK_SHIFT);
+                const cy = packed % PACK_SHIFT;
+                if (cx >= childBaseX && cx < childEndX &&
+                    cy >= childBaseY && cy < childEndY) {
                     return true;
                 }
             }
@@ -337,15 +341,15 @@ export const computeMultiLodTiles = (
             const diff = coord.zoom - z;
             const ancestorX = coord.x >> diff;
             const ancestorY = coord.y >> diff;
-            if (coords.has(`${ancestorX},${ancestorY}`)) return true;
+            if (coords.has(packXY(ancestorX, ancestorY))) return true;
         }
         return false;
     };
 
     // baseZoom格子でカバー済みのセル座標を記録（完全カバー判定用）
-    const coveredBaseZoomCells = new Set<string>();
+    const coveredBaseZoomCells = new Set<number>();
     for (const cell of gridCells) {
-        coveredBaseZoomCells.add(`${gridCenter.x + cell.dx},${gridCenter.y + cell.dy}`);
+        coveredBaseZoomCells.add(packXY(gridCenter.x + cell.dx, gridCenter.y + cell.dy));
     }
 
     for (let z = baseZoom - 1; z >= minZoom && results.length < maxTiles; z--) {
@@ -405,7 +409,7 @@ export const computeMultiLodTiles = (
                     fullyCovered = true;
                     for (let cy = 0; cy < childCount && fullyCovered; cy++) {
                         for (let cx = 0; cx < childCount && fullyCovered; cx++) {
-                            if (!coveredBaseZoomCells.has(`${childBaseX + cx},${childBaseY + cy}`)) {
+                            if (!coveredBaseZoomCells.has(packXY(childBaseX + cx, childBaseY + cy))) {
                                 fullyCovered = false;
                             }
                         }
@@ -424,7 +428,7 @@ export const computeMultiLodTiles = (
             allKeys.add(toTileKey(coord));
             // 重複判定用のzoom別座標も更新
             if (!tilesByZoomForOverlap.has(z)) tilesByZoomForOverlap.set(z, new Set());
-            tilesByZoomForOverlap.get(z)!.add(`${coord.x},${coord.y}`);
+            tilesByZoomForOverlap.get(z)!.add(packXY(coord.x, coord.y));
         }
     }
 

--- a/src/terrain/visibleTiles.ts
+++ b/src/terrain/visibleTiles.ts
@@ -301,7 +301,48 @@ export const computeMultiLodTiles = (
     // baseZoom格子の既存タイルと重複する親タイルは子がカバー済みなのでスキップ。
     const allKeys = new Set(results.map(r => toTileKey(r.coord)));
 
-    // baseZoom格子でカバー済みのセル座標を記録（重複判定用）
+    // 既存タイルのzoom別座標を記録（祖先/子孫の重複判定用）
+    const tilesByZoomForOverlap = new Map<number, Set<string>>();
+    for (const r of results) {
+        const { zoom, x, y } = r.coord;
+        if (!tilesByZoomForOverlap.has(zoom)) tilesByZoomForOverlap.set(zoom, new Set());
+        tilesByZoomForOverlap.get(zoom)!.add(`${x},${y}`);
+    }
+
+    /** 指定タイルの領域が既存タイル（より高いzoom）によってカバーされているか判定 */
+    const hasDescendantTile = (coord: TileCoord): boolean => {
+        for (const [z, coords] of tilesByZoomForOverlap) {
+            if (z <= coord.zoom) continue;
+            const diff = z - coord.zoom;
+            // 子孫タイルの座標範囲
+            const childBaseX = coord.x << diff;
+            const childBaseY = coord.y << diff;
+            for (const key of coords) {
+                const [cxStr, cyStr] = key.split(",");
+                const cx = Number(cxStr);
+                const cy = Number(cyStr);
+                if (cx >= childBaseX && cx < childBaseX + (1 << diff) &&
+                    cy >= childBaseY && cy < childBaseY + (1 << diff)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    };
+
+    /** 指定タイルの祖先が既存タイル（より低いzoom）に含まれているか判定 */
+    const hasAncestorTile = (coord: TileCoord): boolean => {
+        for (const [z, coords] of tilesByZoomForOverlap) {
+            if (z >= coord.zoom) continue;
+            const diff = coord.zoom - z;
+            const ancestorX = coord.x >> diff;
+            const ancestorY = coord.y >> diff;
+            if (coords.has(`${ancestorX},${ancestorY}`)) return true;
+        }
+        return false;
+    };
+
+    // baseZoom格子でカバー済みのセル座標を記録（完全カバー判定用）
     const coveredBaseZoomCells = new Set<string>();
     for (const cell of gridCells) {
         coveredBaseZoomCells.add(`${gridCenter.x + cell.dx},${gridCenter.y + cell.dy}`);
@@ -349,6 +390,9 @@ export const computeMultiLodTiles = (
                 const key = toTileKey(coord);
                 if (allKeys.has(key)) continue;
 
+                // 既存タイルとの祖先/子孫関係による重複チェック
+                if (hasDescendantTile(coord) || hasAncestorTile(coord)) continue;
+
                 // この親タイルがbaseZoom格子で完全にカバー済みか確認
                 // カバー済みならスキップ（重なり防止）
                 const diff = baseZoom - z;
@@ -378,6 +422,9 @@ export const computeMultiLodTiles = (
             if (results.length >= maxTiles) break;
             results.push({ coord, tileSize: farTileSize });
             allKeys.add(toTileKey(coord));
+            // 重複判定用のzoom別座標も更新
+            if (!tilesByZoomForOverlap.has(z)) tilesByZoomForOverlap.set(z, new Set());
+            tilesByZoomForOverlap.get(z)!.add(`${coord.x},${coord.y}`);
         }
     }
 

--- a/tests/meshPool.unit.spec.ts
+++ b/tests/meshPool.unit.spec.ts
@@ -21,6 +21,7 @@ jest.unstable_mockModule("@babylonjs/core/Materials/standardMaterial", () => ({
     StandardMaterial: jest.fn().mockImplementation(() => ({
         specularColor: null,
         diffuseTexture: null,
+        diffuseColor: { r: 1, g: 1, b: 1 },
         dispose: jest.fn(),
     })),
 }));
@@ -28,6 +29,7 @@ jest.unstable_mockModule("@babylonjs/core/Materials/standardMaterial", () => ({
 jest.unstable_mockModule("@babylonjs/core/Maths/math.color", () => ({
     Color3: {
         Black: jest.fn(() => ({ r: 0, g: 0, b: 0 })),
+        White: jest.fn(() => ({ r: 1, g: 1, b: 1 })),
     },
 }));
 
@@ -108,5 +110,37 @@ describe("createMeshPool", () => {
         expect(pool.pooledCount).toBe(0);
         expect(mesh1.dispose).toHaveBeenCalled();
         expect(mesh2.dispose).toHaveBeenCalled();
+    });
+
+    it("release で diffuseColor がデフォルト（白）にリセットされる", () => {
+        const pool = createMeshPool({
+            scene: mockScene,
+            subdivisions: 128,
+            tileSize: 100,
+        });
+
+        const mesh = pool.acquire();
+        // 海タイル使用をシミュレート: diffuseColor を変更
+        (mesh.material as any).diffuseColor = { r: 0.2, g: 0.4, b: 0.6 };
+
+        pool.release(mesh);
+        // diffuseColor がリセットされていること
+        expect((mesh.material as any).diffuseColor).toEqual({ r: 1, g: 1, b: 1 });
+    });
+
+    it("release で diffuseTexture が解放される", () => {
+        const pool = createMeshPool({
+            scene: mockScene,
+            subdivisions: 128,
+            tileSize: 100,
+        });
+
+        const mesh = pool.acquire();
+        const mockDispose = jest.fn();
+        (mesh.material as any).diffuseTexture = { dispose: mockDispose };
+
+        pool.release(mesh);
+        expect(mockDispose).toHaveBeenCalled();
+        expect((mesh.material as any).diffuseTexture).toBeNull();
     });
 });

--- a/tests/tileManager.unit.spec.ts
+++ b/tests/tileManager.unit.spec.ts
@@ -110,6 +110,7 @@ jest.unstable_mockModule("../src/terrain/gsiTile", () => ({
 const { createTileManager, extractSubTileElevation } = await import("../src/terrain/tileManager");
 const gsiTileMock = await import("../src/terrain/gsiTile");
 const { Texture: TextureMock } = await import("@babylonjs/core/Materials/Textures/texture") as unknown as { Texture: jest.Mock };
+const { CreateGround: CreateGroundMock } = await import("@babylonjs/core/Meshes/Builders/groundBuilder") as unknown as { CreateGround: jest.Mock };
 
 const createMockCamera = () => {
     const observers: Array<() => void> = [];
@@ -681,6 +682,9 @@ describe("海タイル描画", () => {
             () => Promise.reject(new Error("all fail"))
         );
 
+        // このテストで生成されたメッシュだけを取得するために開始位置を記録
+        const meshCountBefore = CreateGroundMock.mock.results.length;
+
         const camera = createMockCamera();
         const tm = createTileManager({
             scene: {} as never,
@@ -695,6 +699,22 @@ describe("海タイル描画", () => {
         await tm.setCenter(35.68, 139.77);
         // 海タイルでもメッシュは生成される
         expect(tm.activeTileCount).toBeGreaterThan(0);
+
+        // updateVerticesData("position", ...) に渡された Position 配列の Y 成分がすべて 0
+        const meshes = CreateGroundMock.mock.results
+            .slice(meshCountBefore)
+            .map((r) => (r as { type: string; value: ReturnType<typeof mockMeshInstance> }).value);
+        expect(meshes.length).toBeGreaterThan(0);
+        for (const mesh of meshes) {
+            const calls = (mesh.updateVerticesData as jest.Mock).mock.calls as Array<[string, Float32Array]>;
+            const positionCalls = calls.filter((c) => c[0] === "position");
+            expect(positionCalls.length).toBeGreaterThan(0);
+            for (const [, posArray] of positionCalls) {
+                for (let i = 1; i < posArray.length; i += 3) {
+                    expect(posArray[i]).toBe(0);
+                }
+            }
+        }
 
         tm.dispose();
     });

--- a/tests/tileManager.unit.spec.ts
+++ b/tests/tileManager.unit.spec.ts
@@ -9,6 +9,7 @@ const mockMeshInstance = () => ({
     material: {
         specularColor: null,
         diffuseTexture: null,
+        diffuseColor: { r: 1, g: 1, b: 1 },
         dispose: jest.fn(),
     },
     setEnabled: jest.fn(),
@@ -28,6 +29,7 @@ jest.unstable_mockModule("@babylonjs/core/Materials/standardMaterial", () => ({
     StandardMaterial: jest.fn().mockImplementation(() => ({
         specularColor: null,
         diffuseTexture: null,
+        diffuseColor: { r: 1, g: 1, b: 1 },
         dispose: jest.fn(),
     })),
 }));
@@ -38,10 +40,14 @@ jest.unstable_mockModule("@babylonjs/core/Materials/Textures/texture", () => ({
     })),
 }));
 
+const Color3Mock = jest.fn().mockImplementation((r = 0, g = 0, b = 0) => ({ r, g, b }));
+Object.assign(Color3Mock, {
+    Black: jest.fn(() => ({ r: 0, g: 0, b: 0 })),
+    White: jest.fn(() => ({ r: 1, g: 1, b: 1 })),
+});
+
 jest.unstable_mockModule("@babylonjs/core/Maths/math.color", () => ({
-    Color3: {
-        Black: jest.fn(() => ({ r: 0, g: 0, b: 0 })),
-    },
+    Color3: Color3Mock,
 }));
 
 jest.unstable_mockModule("@babylonjs/core/Meshes/mesh.vertexData", () => ({
@@ -103,6 +109,7 @@ jest.unstable_mockModule("../src/terrain/gsiTile", () => ({
 
 const { createTileManager, extractSubTileElevation } = await import("../src/terrain/tileManager");
 const gsiTileMock = await import("../src/terrain/gsiTile");
+const { Texture: TextureMock } = await import("@babylonjs/core/Materials/Textures/texture") as unknown as { Texture: jest.Mock };
 
 const createMockCamera = () => {
     const observers: Array<() => void> = [];
@@ -597,6 +604,137 @@ describe("setMapType", () => {
         tm.setMapType("std");
 
         expect((gsiTileMock.textureUrl as jest.Mock).mock.calls.length).toBe(0);
+
+        tm.dispose();
+    });
+});
+
+/* ================================================================
+ * 海タイル描画テスト
+ * ================================================================ */
+describe("海タイル描画", () => {
+    afterEach(() => {
+        (gsiTileMock.loadElevationTile as jest.Mock).mockImplementation(
+            () => Promise.resolve(new Float32Array(256 * 256))
+        );
+        (gsiTileMock.tileEdgeMeters as jest.Mock).mockImplementation(
+            () => 1000
+        );
+    });
+
+    it("全zoomで標高取得失敗時はテクスチャURLが呼ばれない", async () => {
+        (gsiTileMock.loadElevationTile as jest.Mock).mockImplementation(
+            () => Promise.reject(new Error("all fail"))
+        );
+        (gsiTileMock.textureUrl as jest.Mock).mockClear();
+        TextureMock.mockClear();
+
+        const camera = createMockCamera();
+        const tm = createTileManager({
+            scene: {} as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 5,
+            minZoom: 12,
+        });
+
+        await tm.setCenter(35.68, 139.77);
+        expect(tm.activeTileCount).toBeGreaterThan(0);
+        // 海タイルではテクスチャURLが呼ばれない
+        expect(gsiTileMock.textureUrl).not.toHaveBeenCalled();
+        // Texture コンストラクタも呼ばれない
+        expect(TextureMock).not.toHaveBeenCalled();
+
+        tm.dispose();
+    });
+
+    it("setMapType で海タイルはテクスチャ差替えされない", async () => {
+        (gsiTileMock.loadElevationTile as jest.Mock).mockImplementation(
+            () => Promise.reject(new Error("all fail"))
+        );
+
+        const camera = createMockCamera();
+        const tm = createTileManager({
+            scene: {} as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 5,
+            minZoom: 12,
+        });
+
+        await tm.setCenter(35.68, 139.77);
+        (gsiTileMock.textureUrl as jest.Mock).mockClear();
+
+        tm.setMapType("photo");
+        // 海タイルのみの場合、retextureAll でもテクスチャURLが呼ばれない
+        expect(gsiTileMock.textureUrl).not.toHaveBeenCalled();
+
+        tm.dispose();
+    });
+
+    it("海タイルは標高0mのフラットメッシュとして表示される", async () => {
+        (gsiTileMock.loadElevationTile as jest.Mock).mockImplementation(
+            () => Promise.reject(new Error("all fail"))
+        );
+
+        const camera = createMockCamera();
+        const tm = createTileManager({
+            scene: {} as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 5,
+            minZoom: 12,
+        });
+
+        await tm.setCenter(35.68, 139.77);
+        // 海タイルでもメッシュは生成される
+        expect(tm.activeTileCount).toBeGreaterThan(0);
+
+        tm.dispose();
+    });
+
+    it("海陸混在時に setMapType は陸タイルのみテクスチャ差替えする", async () => {
+        // 最初の loadElevationTile 呼び出しのみ成功、以降は全て失敗
+        let elevCallCount = 0;
+        (gsiTileMock.loadElevationTile as jest.Mock).mockImplementation(() => {
+            elevCallCount++;
+            if (elevCallCount === 1) return Promise.resolve(new Float32Array(256 * 256));
+            return Promise.reject(new Error("ocean"));
+        });
+
+        const camera = createMockCamera();
+        const tm = createTileManager({
+            scene: {} as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 10,
+            minZoom: 12,
+            maxConcurrent: 1,
+        });
+
+        (gsiTileMock.textureUrl as jest.Mock).mockClear();
+        await tm.setCenter(35.68, 139.77);
+
+        const totalTiles = tm.activeTileCount;
+        const landTextureCount = (gsiTileMock.textureUrl as jest.Mock).mock.calls.length;
+
+        // 陸タイル（テクスチャあり）と海タイル（テクスチャなし）が混在
+        expect(totalTiles).toBeGreaterThan(landTextureCount);
+        expect(landTextureCount).toBeGreaterThan(0);
+
+        // setMapType で陸タイルのみ差替え
+        (gsiTileMock.textureUrl as jest.Mock).mockClear();
+        tm.setMapType("photo");
+        const retexturedCount = (gsiTileMock.textureUrl as jest.Mock).mock.calls.length;
+        expect(retexturedCount).toBe(landTextureCount);
 
         tm.dispose();
     });


### PR DESCRIPTION
## 概要

海の部分（標高タイル・地図タイルが存在しない領域）を青色フラットメッシュとして描画し、タイル欠損を解消する。

Closes #48

## 変更内容

### 海タイル検知・描画
- `gsiTile.ts`: `loadElevationTile` で全ピクセルが無効値（NaN）の場合はthrow（海洋タイル対応）
- `tileManager.ts`: 海タイル判定（`isOcean` フラグ）、`OCEAN_COLOR`（`#bed3ff`）による `diffuseColor` 着色
- `tileCache.ts`: `TileCacheEntry` に `isOcean?: boolean` 追加

### テクスチャ読込失敗時のフォールバック
- `applyTexture` を `onLoad`/`onError` コールバック方式に変更
- テクスチャ読込失敗時に海色マテリアルへ自動フォールバック（WebGPU null texture 警告も解消）

### メッシュプールのリセット
- `meshPool.ts`: `release` 時に `diffuseColor` を `Color3.White()` にリセット

### タイル地図切替対応
- `retextureAll` で海タイルはテクスチャ差替えをスキップ

### LODタイル重複防止
- `visibleTiles.ts`: Far-field sweep に祖先/子孫タイル重複チェック（`hasDescendantTile` / `hasAncestorTile`）を追加

### テスト
- `tileManager.unit.spec.ts`: 海タイル描画テスト4件追加（全海・setMapTypeスキップ・フラット0m・海陸混在）
- `meshPool.unit.spec.ts`: diffuseColor リセットテスト2件追加

## 検証

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:unit` (158 tests passed)
- [x] `npm run test:visuals` (スナップショット更新済み)
- [x] 目視確認（海岸沿い・沖合・チルトアップ）