### PR TITLE
feat: タイル欠損・全NaN時の低zoomフォールバック補完

### DIFF
--- a/src/terrain/gsiTile.ts
+++ b/src/terrain/gsiTile.ts
@@ -41,6 +41,14 @@ export const tileEdgeMeters = (lat: number, zoom: number): number => {
     return metersPerPixel * TILE_SIZE;
 };
 
+/** 全ピクセルが NaN かどうか判定する */
+export const isAllNaN = (data: Float32Array): boolean => {
+    for (let i = 0; i < data.length; i++) {
+        if (!Number.isNaN(data[i])) return false;
+    }
+    return true;
+};
+
 /** 地理院標高タイルのRGBデコード（無効値は NaN） */
 export const decodeGsiElevation = (
     r: number,
@@ -137,6 +145,11 @@ export const loadElevationTile = async (
                     img.data[i + 1],
                     img.data[i + 2]
                 );
+            }
+            // 全NaNのタイルはこのレイヤーでは使えない → 次のレイヤーへ
+            if (isAllNaN(elev)) {
+                lastErr = new Error(`All NaN tile: ${url}`);
+                continue;
             }
             fillInvalidPixels(elev, img.width, img.height);
             return elev;

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -201,6 +201,8 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
     });
 
     const activeTiles = new Map<TileKey, ActiveTile>();
+    /** テクスチャ適用の競合を防ぐためのリクエストID（mesh単位） */
+    const textureRequestIds = new Map<Mesh, number>();
     let requestId = 0;
     let loadingCount = 0;
     let statusCallback: ((status: string) => void) | null = null;
@@ -433,6 +435,10 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         const targetZoom = fallbackZoom ?? coord.zoom;
         const targetCoord = convertTileZoom(coord, targetZoom);
 
+        // このリクエストのIDを発行し、meshに紐付ける
+        const texReqId = (textureRequestIds.get(mesh) ?? 0) + 1;
+        textureRequestIds.set(mesh, texReqId);
+
         const mat = mesh.material as StandardMaterial;
         if (mat.diffuseTexture) {
             mat.diffuseTexture.dispose();
@@ -446,6 +452,8 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
             Texture.TRILINEAR_SAMPLINGMODE,
             undefined,
             () => {
+                // meshが既に別タイルへ再利用されていたらフォールバックしない
+                if (textureRequestIds.get(mesh) !== texReqId) return;
                 // テクスチャ取得失敗 → 低zoomへフォールバック
                 if (targetZoom > minZoom) {
                     applyTexture(mesh, coord, targetZoom - 1);
@@ -510,6 +518,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         // 不要タイルを解放
         for (const [key, tile] of activeTiles) {
             if (!visibleKeys.has(key)) {
+                textureRequestIds.delete(tile.mesh);
                 meshPool.release(tile.mesh);
                 activeTiles.delete(key);
             }
@@ -614,6 +623,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
                 meshPool.release(tile.mesh);
             }
             activeTiles.clear();
+            textureRequestIds.clear();
             cache.clear();
             meshPool.dispose();
         },

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -95,6 +95,30 @@ const applyElevation = (
 };
 
 /**
+ * 低zoomテクスチャ使用時のUVパラメータを算出する。
+ * tileZoom のタイルに対し textureZoom のテクスチャを適用する際の
+ * uScale/vScale/uOffset/vOffset を返す。
+ */
+export const computeTextureUvParams = (
+    tileZoom: number,
+    tileX: number,
+    tileY: number,
+    textureZoom: number,
+): { uScale: number; vScale: number; uOffset: number; vOffset: number } => {
+    const diff = tileZoom - textureZoom;
+    if (diff <= 0) return { uScale: 1, vScale: 1, uOffset: 0, vOffset: 0 };
+    const scale = 1 << diff;
+    const subX = tileX & (scale - 1);
+    const subY = tileY & (scale - 1);
+    return {
+        uScale: 1 / scale,
+        vScale: 1 / scale,
+        uOffset: subX / scale,
+        vOffset: subY / scale,
+    };
+};
+
+/**
  * 親タイルの標高データから子タイルに対応する領域を切り出す。
  * 最近傍補間で TILE_SIZE × TILE_SIZE に拡大。
  */
@@ -404,19 +428,39 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
     /** tileSizeForZoom: 指定zoomでのタイル実サイズを返す */
     const tileSizeForZoom = (z: number): number => tileEdgeMeters(currentLat, z);
 
-    /** メッシュにテクスチャを適用する */
-    const applyTexture = (mesh: Mesh, coord: TileCoord): void => {
+    /** メッシュにテクスチャを適用する（取得失敗時は低zoomへフォールバック） */
+    const applyTexture = (mesh: Mesh, coord: TileCoord, fallbackZoom?: number): void => {
+        const targetZoom = fallbackZoom ?? coord.zoom;
+        const targetCoord = convertTileZoom(coord, targetZoom);
+
         const mat = mesh.material as StandardMaterial;
         if (mat.diffuseTexture) {
             mat.diffuseTexture.dispose();
         }
-        mat.diffuseTexture = new Texture(
-            textureUrl(currentMapType, coord.zoom, coord.x, coord.y),
+
+        const tex = new Texture(
+            textureUrl(currentMapType, targetCoord.zoom, targetCoord.x, targetCoord.y),
             scene,
             true,
             true,
-            Texture.TRILINEAR_SAMPLINGMODE
+            Texture.TRILINEAR_SAMPLINGMODE,
+            undefined,
+            () => {
+                // テクスチャ取得失敗 → 低zoomへフォールバック
+                if (targetZoom > minZoom) {
+                    applyTexture(mesh, coord, targetZoom - 1);
+                }
+            }
         );
+
+        // UV補正（低zoomテクスチャ使用時）
+        const uv = computeTextureUvParams(coord.zoom, coord.x, coord.y, targetZoom);
+        tex.uScale = uv.uScale;
+        tex.vScale = uv.vScale;
+        tex.uOffset = uv.uOffset;
+        tex.vOffset = uv.vOffset;
+
+        mat.diffuseTexture = tex;
     };
 
     /** 全アクティブタイルのテクスチャを現在の mapType で差し替え */

--- a/src/terrain/visibleTiles.ts
+++ b/src/terrain/visibleTiles.ts
@@ -298,14 +298,86 @@ export const computeMultiLodTiles = (
     // Step 5: Far-field sweep — baseZoom格子のカバー範囲外を低zoom格子で補完
     // 水平に近いチルト時、frustumはbaseZoom格子の探索範囲を大きく超える。
     // 各低zoom層のタイルサイズで独自に探索し、遠方の欠けを埋める。
-    // baseZoom格子の既存タイルと重複する親タイルは子がカバー済みなのでスキップ。
+    // 部分カバー時は親タイルではなく未カバーの子セルのみを追加（重なり防止）。
     const allKeys = new Set(results.map(r => toTileKey(r.coord)));
 
-    // baseZoom格子でカバー済みのセル座標を記録（重複判定用）
+    // Step 1-4 の全結果タイルが覆う baseZoom セルを記録（重複判定用）
     const coveredBaseZoomCells = new Set<string>();
-    for (const cell of gridCells) {
-        coveredBaseZoomCells.add(`${gridCenter.x + cell.dx},${gridCenter.y + cell.dy}`);
+    for (const r of results) {
+        const rDiff = baseZoom - r.coord.zoom;
+        if (rDiff > 0) {
+            const rCount = 1 << rDiff;
+            const rBaseX = r.coord.x << rDiff;
+            const rBaseY = r.coord.y << rDiff;
+            for (let ry = 0; ry < rCount; ry++) {
+                for (let rx = 0; rx < rCount; rx++) {
+                    coveredBaseZoomCells.add(`${rBaseX + rx},${rBaseY + ry}`);
+                }
+            }
+        } else {
+            coveredBaseZoomCells.add(`${r.coord.x},${r.coord.y}`);
+        }
     }
+
+    /**
+     * 低zoomタイルのうち、baseZoom格子で未カバーの子セルを
+     * 再帰的に zoom+1 へ分割し、重なりのないタイル群を返す。
+     * 完全カバー → 空配列、カバーなし → null（親タイルをそのまま使う）
+     */
+    const findUncoveredChildren = (
+        parentCoord: TileCoord,
+        parentDist: number,
+    ): { coord: TileCoord; dist: number; tileSize: number }[] | null => {
+        const diff = baseZoom - parentCoord.zoom;
+        // diff > 4 は子タイル数が多すぎるため親タイルをそのまま使う
+        if (diff <= 0 || diff > 4) return null;
+
+        const childCount = 1 << diff;
+        const childBaseX = parentCoord.x << diff;
+        const childBaseY = parentCoord.y << diff;
+
+        let coveredCount = 0;
+        for (let cy = 0; cy < childCount; cy++) {
+            for (let cx = 0; cx < childCount; cx++) {
+                if (coveredBaseZoomCells.has(`${childBaseX + cx},${childBaseY + cy}`)) {
+                    coveredCount++;
+                }
+            }
+        }
+
+        // カバーなし → 親タイルをそのまま追加
+        if (coveredCount === 0) return null;
+        // 完全カバー → スキップ
+        if (coveredCount === childCount * childCount) return [];
+
+        // 部分カバー → zoom+1 の子タイルに分割し再帰判定
+        const nextZoom = parentCoord.zoom + 1;
+        const nextTileSize = tileSizeForZoom(nextZoom);
+        const uncovered: { coord: TileCoord; dist: number; tileSize: number }[] = [];
+
+        for (let sy = 0; sy < 2; sy++) {
+            for (let sx = 0; sx < 2; sx++) {
+                const childCoord: TileCoord = {
+                    zoom: nextZoom,
+                    x: parentCoord.x * 2 + sx,
+                    y: parentCoord.y * 2 + sy,
+                };
+                const childKey = toTileKey(childCoord);
+                if (allKeys.has(childKey)) continue;
+
+                // 再帰: この子タイルも部分カバーなら更に分割
+                const childResult = findUncoveredChildren(childCoord, parentDist);
+                if (childResult === null) {
+                    // カバーなし → この子タイルをそのまま追加
+                    uncovered.push({ coord: childCoord, dist: parentDist, tileSize: nextTileSize });
+                } else {
+                    // 部分/完全カバー → 再帰結果をそのまま追加
+                    uncovered.push(...childResult);
+                }
+            }
+        }
+        return uncovered;
+    };
 
     for (let z = baseZoom - 1; z >= minZoom && results.length < maxTiles; z--) {
         const farTileSize = tileSizeForZoom(z);
@@ -321,7 +393,7 @@ export const computeMultiLodTiles = (
             30
         );
 
-        const candidates: { coord: TileCoord; dist: number }[] = [];
+        const candidates: { coord: TileCoord; dist: number; tileSize: number }[] = [];
 
         for (let dy = -farSearchRadius; dy <= farSearchRadius; dy++) {
             for (let dx = -farSearchRadius; dx <= farSearchRadius; dx++) {
@@ -349,35 +421,45 @@ export const computeMultiLodTiles = (
                 const key = toTileKey(coord);
                 if (allKeys.has(key)) continue;
 
-                // この親タイルがbaseZoom格子で完全にカバー済みか確認
-                // カバー済みならスキップ（重なり防止）
-                const diff = baseZoom - z;
-                // diff > 4 は子タイル 16×16=256 以上。完全カバーは事実上ないのでスキップ
-                let fullyCovered = false;
-                if (diff <= 4) {
-                    const childCount = 1 << diff;
-                    const childBaseX = coord.x << diff;
-                    const childBaseY = coord.y << diff;
-                    fullyCovered = true;
-                    for (let cy = 0; cy < childCount && fullyCovered; cy++) {
-                        for (let cx = 0; cx < childCount && fullyCovered; cx++) {
-                            if (!coveredBaseZoomCells.has(`${childBaseX + cx},${childBaseY + cy}`)) {
-                                fullyCovered = false;
-                            }
+                // 部分カバー判定
+                const uncovered = findUncoveredChildren(coord, dist);
+                if (uncovered === null) {
+                    // カバーなし → 親タイルをそのまま候補に追加
+                    candidates.push({ coord, dist, tileSize: farTileSize });
+                } else if (uncovered.length > 0) {
+                    // 部分カバー → 未カバーの子タイルのみ追加
+                    for (const child of uncovered) {
+                        if (!allKeys.has(toTileKey(child.coord))) {
+                            candidates.push(child);
                         }
                     }
                 }
-                if (fullyCovered) continue;
-
-                candidates.push({ coord, dist });
+                // uncovered.length === 0 → 完全カバー → スキップ
             }
         }
 
         candidates.sort((a, b) => a.dist - b.dist);
-        for (const { coord } of candidates) {
+        for (const entry of candidates) {
             if (results.length >= maxTiles) break;
-            results.push({ coord, tileSize: farTileSize });
-            allKeys.add(toTileKey(coord));
+            const key = toTileKey(entry.coord);
+            if (allKeys.has(key)) continue;
+            results.push({ coord: entry.coord, tileSize: entry.tileSize });
+            allKeys.add(key);
+
+            // coveredBaseZoomCells を更新（後続zoom反復での重複防止）
+            const addedDiff = baseZoom - entry.coord.zoom;
+            if (addedDiff > 0 && addedDiff <= 4) {
+                const addedCount = 1 << addedDiff;
+                const addedBaseX = entry.coord.x << addedDiff;
+                const addedBaseY = entry.coord.y << addedDiff;
+                for (let ay = 0; ay < addedCount; ay++) {
+                    for (let ax = 0; ax < addedCount; ax++) {
+                        coveredBaseZoomCells.add(`${addedBaseX + ax},${addedBaseY + ay}`);
+                    }
+                }
+            } else if (addedDiff === 0) {
+                coveredBaseZoomCells.add(`${entry.coord.x},${entry.coord.y}`);
+            }
         }
     }
 

--- a/tests/gsiTile.unit.spec.ts
+++ b/tests/gsiTile.unit.spec.ts
@@ -5,6 +5,7 @@ import {
     toTileXY,
     tileEdgeMeters,
     decodeGsiElevation,
+    isAllNaN,
     stdTextureUrl,
     photoTextureUrl,
     textureUrl,
@@ -164,6 +165,38 @@ describe("decodeGsiElevation", () => {
         expect(decodeGsiElevation(128, 0, 0)).toBeNaN(); // これは無効値
         // raw = 128*65536 + 0*256 + 1 = 8388609 → (8388609 - 16777216) * 0.01 = -83886.07
         expect(decodeGsiElevation(128, 0, 1)).toBeCloseTo(-83886.07, 2);
+    });
+});
+
+describe("isAllNaN", () => {
+    it("全要素が NaN なら true を返す", () => {
+        const data = new Float32Array([NaN, NaN, NaN, NaN]);
+        expect(isAllNaN(data)).toBe(true);
+    });
+
+    it("有効値が1つでもあれば false を返す", () => {
+        const data = new Float32Array([NaN, NaN, 0, NaN]);
+        expect(isAllNaN(data)).toBe(false);
+    });
+
+    it("全要素が有効値なら false を返す", () => {
+        const data = new Float32Array([1, 2, 3, 4]);
+        expect(isAllNaN(data)).toBe(false);
+    });
+
+    it("空配列は true を返す", () => {
+        const data = new Float32Array(0);
+        expect(isAllNaN(data)).toBe(true);
+    });
+
+    it("先頭のみ有効値の場合 false を返す", () => {
+        const data = new Float32Array([0, NaN, NaN, NaN]);
+        expect(isAllNaN(data)).toBe(false);
+    });
+
+    it("末尾のみ有効値の場合 false を返す", () => {
+        const data = new Float32Array([NaN, NaN, NaN, 100]);
+        expect(isAllNaN(data)).toBe(false);
     });
 });
 

--- a/tests/tileManager.unit.spec.ts
+++ b/tests/tileManager.unit.spec.ts
@@ -25,18 +25,26 @@ jest.unstable_mockModule("@babylonjs/core/Meshes/Builders/groundBuilder", () => 
 }));
 
 jest.unstable_mockModule("@babylonjs/core/Materials/standardMaterial", () => ({
-    StandardMaterial: jest.fn().mockImplementation(() => ({
+    StandardMaterial: jest.fn<(...args: unknown[]) => unknown>().mockImplementation(() => ({
         specularColor: null,
         diffuseTexture: null,
         dispose: jest.fn(),
     })),
 }));
 
-jest.unstable_mockModule("@babylonjs/core/Materials/Textures/texture", () => ({
-    Texture: jest.fn().mockImplementation(() => ({
-        dispose: jest.fn(),
-    })),
-}));
+jest.unstable_mockModule("@babylonjs/core/Materials/Textures/texture", () => {
+    const TextureMock = jest.fn<(...args: unknown[]) => unknown>().mockImplementation(
+        () => ({
+            dispose: jest.fn(),
+            uScale: 1,
+            vScale: 1,
+            uOffset: 0,
+            vOffset: 0,
+        })
+    ) as jest.Mock & { TRILINEAR_SAMPLINGMODE: number };
+    TextureMock.TRILINEAR_SAMPLINGMODE = 3;
+    return { Texture: TextureMock };
+});
 
 jest.unstable_mockModule("@babylonjs/core/Maths/math.color", () => ({
     Color3: {
@@ -80,7 +88,7 @@ jest.unstable_mockModule("@babylonjs/core/Maths/math.vector", () => ({
 }));
 
 jest.unstable_mockModule("@babylonjs/core/Maths/math.plane", () => ({
-    Plane: jest.fn().mockImplementation(() => ({
+    Plane: jest.fn<(...args: unknown[]) => unknown>().mockImplementation(() => ({
         normal: { x: 0, y: 0, z: 0 },
         d: 0,
     })),
@@ -96,12 +104,18 @@ jest.unstable_mockModule("../src/terrain/gsiTile", () => ({
     loadElevationTile: jest.fn(
         () => Promise.resolve(new Float32Array(256 * 256))
     ),
+    isAllNaN: jest.fn((data: Float32Array) => {
+        for (let i = 0; i < data.length; i++) {
+            if (!Number.isNaN(data[i])) return false;
+        }
+        return true;
+    }),
     stdTextureUrl: jest.fn(() => "https://example.com/tile.png"),
     photoTextureUrl: jest.fn(() => "https://example.com/photo.jpg"),
     textureUrl: jest.fn(() => "https://example.com/tile.png"),
 }));
 
-const { createTileManager, extractSubTileElevation } = await import("../src/terrain/tileManager");
+const { createTileManager, extractSubTileElevation, computeTextureUvParams } = await import("../src/terrain/tileManager");
 const gsiTileMock = await import("../src/terrain/gsiTile");
 
 const createMockCamera = () => {
@@ -597,6 +611,98 @@ describe("setMapType", () => {
         tm.setMapType("std");
 
         expect((gsiTileMock.textureUrl as jest.Mock).mock.calls.length).toBe(0);
+
+        tm.dispose();
+    });
+});
+
+/* ================================================================
+ * computeTextureUvParams 単体テスト
+ * ================================================================ */
+describe("computeTextureUvParams", () => {
+    it("zoom差がない場合はデフォルト値を返す", () => {
+        const uv = computeTextureUvParams(14, 100, 200, 14);
+        expect(uv).toEqual({ uScale: 1, vScale: 1, uOffset: 0, vOffset: 0 });
+    });
+
+    it("textureZoomがtileZoomより大きい場合はデフォルト値を返す", () => {
+        const uv = computeTextureUvParams(12, 50, 100, 14);
+        expect(uv).toEqual({ uScale: 1, vScale: 1, uOffset: 0, vOffset: 0 });
+    });
+
+    it("zoom差1で左上子タイル(0,0)のUV値が正しい", () => {
+        // tile zoom=15, x=200(even), y=200(even) → subX=0, subY=0
+        const uv = computeTextureUvParams(15, 200, 200, 14);
+        expect(uv.uScale).toBeCloseTo(0.5);
+        expect(uv.vScale).toBeCloseTo(0.5);
+        expect(uv.uOffset).toBeCloseTo(0);
+        expect(uv.vOffset).toBeCloseTo(0);
+    });
+
+    it("zoom差1で右下子タイル(1,1)のUV値が正しい", () => {
+        // tile zoom=15, x=201(odd), y=201(odd) → subX=1, subY=1
+        const uv = computeTextureUvParams(15, 201, 201, 14);
+        expect(uv.uScale).toBeCloseTo(0.5);
+        expect(uv.vScale).toBeCloseTo(0.5);
+        expect(uv.uOffset).toBeCloseTo(0.5);
+        expect(uv.vOffset).toBeCloseTo(0.5);
+    });
+
+    it("zoom差2で4分の1領域のUV値が正しい", () => {
+        // tile zoom=16, x=401, y=402 → subX=1, subY=2
+        // scale=4, uScale=vScale=0.25
+        const uv = computeTextureUvParams(16, 401, 402, 14);
+        expect(uv.uScale).toBeCloseTo(0.25);
+        expect(uv.vScale).toBeCloseTo(0.25);
+        expect(uv.uOffset).toBeCloseTo(0.25);  // 1/4
+        expect(uv.vOffset).toBeCloseTo(0.5);   // 2/4
+    });
+});
+
+/* ================================================================
+ * 標高データ全NaN時のフォールバック
+ * ================================================================ */
+describe("標高データ全NaNフォールバック", () => {
+    afterEach(() => {
+        (gsiTileMock.loadElevationTile as jest.Mock).mockImplementation(
+            () => Promise.resolve(new Float32Array(256 * 256))
+        );
+        (gsiTileMock.tileEdgeMeters as jest.Mock).mockImplementation(
+            () => 1000
+        );
+    });
+
+    it("全NaN標高データを返すzoomから低zoomにフォールバックする", async () => {
+        // zoom 14: 全NaN（throwされる想定）, zoom 13以下: 有効データ
+        const validElev = new Float32Array(256 * 256).fill(300);
+        (gsiTileMock.loadElevationTile as jest.Mock<(zoom: number, x: number, y: number) => Promise<Float32Array>>).mockImplementation(
+            (zoom) => {
+                if (zoom >= 14) {
+                    return Promise.reject(new Error("All NaN tile"));
+                }
+                return Promise.resolve(validElev);
+            }
+        );
+
+        const camera = createMockCamera();
+        const tm = createTileManager({
+            scene: {} as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 5,
+            minZoom: 12,
+            maxElevationZoom: 14,
+        });
+
+        await tm.setCenter(35.68, 139.77);
+        expect(tm.activeTileCount).toBeGreaterThan(0);
+
+        // zoom 13以下で成功していることを確認
+        const calls = (gsiTileMock.loadElevationTile as jest.Mock).mock.calls;
+        const lowZoomCalls = calls.filter((c) => (c as number[])[0] < 14);
+        expect(lowZoomCalls.length).toBeGreaterThan(0);
 
         tm.dispose();
     });

--- a/tests/visibleTiles.unit.spec.ts
+++ b/tests/visibleTiles.unit.spec.ts
@@ -400,4 +400,68 @@ describe("computeMultiLodTiles", () => {
 
         expect(hasOverlap).toBe(false);
     });
+
+    it("Far-field sweepで部分カバーの親タイルが高zoomタイルと重ならない", () => {
+        // 狭いsearchRadiusで内側は高zoom、外側はFar-field sweepが補完
+        // 部分カバー境界でのメッシュ重なりがないことを確認
+        const result = computeMultiLodTiles({
+            baseCenter,
+            tileSizeForZoom,
+            frustumPlanes: allVisiblePlanes,
+            cameraDistance: 200,
+            baseZoom: 14,
+            minZoom: 12,
+            maxTiles: 500,
+            searchRadius: 4,
+        });
+
+        // baseZoom（zoom14）セルに展開して重なりチェック（全域）
+        const coveredCells = new Set<string>();
+        let hasOverlap = false;
+
+        for (const entry of result) {
+            const { coord } = entry;
+            const diff = 14 - coord.zoom;
+            const cellCount = 1 << diff;
+            const baseX = coord.x << diff;
+            const baseY = coord.y << diff;
+
+            for (let cy = 0; cy < cellCount; cy++) {
+                for (let cx = 0; cx < cellCount; cx++) {
+                    const cellKey = `${baseX + cx},${baseY + cy}`;
+                    if (coveredCells.has(cellKey)) {
+                        hasOverlap = true;
+                    }
+                    coveredCells.add(cellKey);
+                }
+            }
+        }
+
+        expect(hasOverlap).toBe(false);
+    });
+
+    it("Far-field sweepで部分カバー時に穴が開かない", () => {
+        // 狭い searchRadius で Far-field sweep が動作する構成
+        const result = computeMultiLodTiles({
+            baseCenter,
+            tileSizeForZoom,
+            frustumPlanes: allVisiblePlanes,
+            cameraDistance: 200,
+            baseZoom: 14,
+            minZoom: 12,
+            maxTiles: 500,
+            searchRadius: 4,
+        });
+
+        // 結果が空でないこと
+        expect(result.length).toBeGreaterThan(0);
+
+        // Far-field sweep 由来の低zoomタイルが含まれること
+        const lowZoomTiles = result.filter((e) => e.coord.zoom < 14);
+        expect(lowZoomTiles.length).toBeGreaterThan(0);
+
+        // 重複キーがないこと
+        const keys = result.map((e) => toTileKey(e.coord));
+        expect(keys.length).toBe(new Set(keys).size);
+    });
 });


### PR DESCRIPTION
## 概要

標高タイル・地図タイルが取得不可、または標高データが全NaNの場合にタイルレベルを段階的に下げて補完表示する。加えて、Far-field sweep での LOD 境界におけるメッシュ重なりを修正。

Closes #78

## 変更内容

### 標高タイル全NaN検出（gsiTile.ts）
- `isAllNaN` 関数を追加
- `loadElevationTile` で全NaNレイヤーをスキップし、全レイヤー全NaNなら throw → tileManager の既存 zoom フォールバックが動作

### テクスチャフォールバック（tileManager.ts）
- `computeTextureUvParams` 関数を追加（低zoom テクスチャ使用時の UV パラメータ算出）
- `applyTexture` に Babylon.js Texture の `onError` コールバックで低 zoom へ再帰フォールバック
- フォールバック時に UV オフセット/スケールを補正

### Far-field sweep 重なり防止（visibleTiles.ts）
- `coveredBaseZoomCells` の初期化を Step 1-4 の全結果タイルが覆う baseZoom セルに拡張
- `findUncoveredChildren` を再帰化（部分カバー時に baseZoom まで再帰分割）
- タイル追加時に `coveredBaseZoomCells` を更新し後続反復での重複を防止

### テスト
- `isAllNaN` テスト 6 件追加
- `computeTextureUvParams` テスト 5 件追加
- 標高全NaN フォールバックテスト 1 件追加
- Far-field sweep 全域重なりなしテスト + 穴なしテスト 2 件追加
- 計 166 件全パス

## 影響範囲

| ファイル | 影響 |
|---------|------|
| `src/terrain/gsiTile.ts` | `isAllNaN` 追加、`loadElevationTile` 内フロー変更 |
| `src/terrain/tileManager.ts` | `computeTextureUvParams` 追加、`applyTexture` シグネチャ変更（内部のみ） |
| `src/terrain/visibleTiles.ts` | Far-field sweep の重複排除ロジック改修 |

## 検証

```
npm run typecheck  ✅
npm run lint       ✅
npm run test:unit  ✅ 166件パス
```