### PR TITLE
feat: 超遠方タイル表示対応

### DIFF
--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -14,6 +14,7 @@ import { parseLatLonFromUrl, createUrlUpdater } from "../terrain/urlState";
 const TERRAIN_SUBDIVISIONS = 128;
 const MAX_ZOOM = 18;
 const MAX_ELEVATION_ZOOM = 17;
+const MIN_ELEVATION_ZOOM = 10;
 const HEIGHT_SCALE = 1.0;
 const MIN_ZOOM = 2;
 
@@ -89,6 +90,7 @@ export class DefaultScene implements CreateSceneClass {
             heightScale: HEIGHT_SCALE,
             minZoom: MIN_ZOOM,
             maxElevationZoom: MAX_ELEVATION_ZOOM,
+            minElevationZoom: MIN_ELEVATION_ZOOM,
             maxTiles: 160,
             cacheCapacity: 256,
         });

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -15,7 +15,7 @@ const TERRAIN_SUBDIVISIONS = 128;
 const MAX_ZOOM = 18;
 const MAX_ELEVATION_ZOOM = 17;
 const HEIGHT_SCALE = 1.0;
-const MIN_ZOOM = 8;
+const MIN_ZOOM = 2;
 
 /** Phase 2（垂直移動）に切り替えるカメラ高度の閾値（メートル） */
 const SKY_ZOOM_ALTITUDE_THRESHOLD = 1000;
@@ -43,7 +43,7 @@ export class DefaultScene implements CreateSceneClass {
         camera.lowerRadiusLimit = 250;
         camera.upperRadiusLimit = 40000;
         camera.minZ = 10;
-        camera.maxZ = 100000;
+        camera.maxZ = 200000;
 
         // チルト制限（地面から20° = beta上限 7π/18）
         camera.upperBetaLimit = Math.PI / 2 - Math.PI / 9;

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -38,6 +38,8 @@ export interface TileManagerOptions {
     minZoom?: number;
     /** 標高タイルの最大ズームレベル（省略時は zoom） */
     maxElevationZoom?: number;
+    /** 標高フォールバックの最小ズームレベル（省略時は max(minZoom, maxElevationZoom - 4)） */
+    minElevationZoom?: number;
 }
 
 export interface TileManager {
@@ -188,10 +190,12 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         debounceMs = DEFAULT_DEBOUNCE_MS,
         minZoom: minZoomOpt,
         maxElevationZoom: maxElevationZoomOpt,
+        minElevationZoom: minElevationZoomOpt,
     } = opts;
 
     const minZoom = minZoomOpt ?? Math.max(0, zoom - 2);
     const maxElevationZoom = maxElevationZoomOpt ?? zoom;
+    const minElevationZoom = minElevationZoomOpt ?? Math.max(minZoom, maxElevationZoom - 4);
 
     const cache: TileCache = createTileCache(cacheCapacity);
     const meshPool: MeshPool = createMeshPool({
@@ -252,7 +256,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
                 let elevData: Float32Array | null = null;
                 let actualElevZoom = elevZoom;
 
-                for (let tryZoom = elevZoom; tryZoom >= minZoom; tryZoom--) {
+                for (let tryZoom = elevZoom; tryZoom >= minElevationZoom; tryZoom--) {
                     const tryCoord = convertTileZoom(coord, tryZoom);
                     const tryKey = toTileKey(tryCoord);
 

--- a/src/terrain/visibleTiles.ts
+++ b/src/terrain/visibleTiles.ts
@@ -19,7 +19,7 @@ export interface VisibleTilesOptions {
 
 const DEFAULT_MAX_TILES = 50;
 /** coveredBaseZoomCells / findUncoveredChildren で許容するzoom差の上限 */
-const MAX_COVERAGE_DIFF = 6;
+const MAX_COVERAGE_DIFF = 7;
 const DEFAULT_SEARCH_RADIUS = 4;
 /** 日本の標高上限概算（富士山 3776m + マージン） */
 const DEFAULT_MAX_ELEVATION = 4000;
@@ -226,25 +226,28 @@ export const computeMultiLodTiles = (
     // Step 2: ズーム境界の重なり防止（昇格方式）
     // 親タイル内に高zoomセルが混在する場合、低zoomセルを z+1 に昇格。
     // 全セルが同一低zoomの親タイルはそのまま維持（遠方LODを保持）。
-    // 処理は baseZoom-1 → minZoom の降順。
+    // 降順パスで昇格 → カスケード昇格が発生しうるため収束まで反復。
     const cellZoomMap = new Map<string, number>();
     for (const cell of gridCells) {
         cellZoomMap.set(`${cell.dx},${cell.dy}`, cell.targetZoom);
     }
 
-    for (let z = baseZoom - 1; z >= minZoom; z--) {
-        const diff = baseZoom - z;
-        const parentHasHigher = new Set<string>();
+    let promotionsOccurred = true;
+    while (promotionsOccurred) {
+        promotionsOccurred = false;
+        for (let z = baseZoom - 1; z >= minZoom; z--) {
+            const diff = baseZoom - z;
+            const parentHasHigher = new Set<string>();
 
-        // 親タイル内に z より高いzoomのセルがあるか確認
-        for (const cell of gridCells) {
-            const cellZoom = cellZoomMap.get(`${cell.dx},${cell.dy}`)!;
-            if (cellZoom > z) {
-                const gx = gridCenter.x + cell.dx;
-                const gy = gridCenter.y + cell.dy;
-                parentHasHigher.add(`${gx >> diff},${gy >> diff}`);
+            // 親タイル内に z より高いzoomのセルがあるか確認
+            for (const cell of gridCells) {
+                const cellZoom = cellZoomMap.get(`${cell.dx},${cell.dy}`)!;
+                if (cellZoom > z) {
+                    const gx = gridCenter.x + cell.dx;
+                    const gy = gridCenter.y + cell.dy;
+                    parentHasHigher.add(`${gx >> diff},${gy >> diff}`);
+                }
             }
-        }
 
         // 高zoomセルと混在する親タイル内の低zoomセルを z+1 に昇格
         if (parentHasHigher.size > 0) {
@@ -254,8 +257,10 @@ export const computeMultiLodTiles = (
                 const gy = gridCenter.y + cell.dy;
                 if (parentHasHigher.has(`${gx >> diff},${gy >> diff}`)) {
                     cellZoomMap.set(`${cell.dx},${cell.dy}`, z + 1);
+                    promotionsOccurred = true;
                 }
             }
+        }
         }
     }
 

--- a/src/terrain/visibleTiles.ts
+++ b/src/terrain/visibleTiles.ts
@@ -18,6 +18,8 @@ export interface VisibleTilesOptions {
 }
 
 const DEFAULT_MAX_TILES = 50;
+/** coveredBaseZoomCells / findUncoveredChildren で許容するzoom差の上限 */
+const MAX_COVERAGE_DIFF = 6;
 const DEFAULT_SEARCH_RADIUS = 4;
 /** 日本の標高上限概算（富士山 3776m + マージン） */
 const DEFAULT_MAX_ELEVATION = 4000;
@@ -305,7 +307,7 @@ export const computeMultiLodTiles = (
     const coveredBaseZoomCells = new Set<string>();
     for (const r of results) {
         const rDiff = baseZoom - r.coord.zoom;
-        if (rDiff > 0) {
+        if (rDiff > 0 && rDiff <= MAX_COVERAGE_DIFF) {
             const rCount = 1 << rDiff;
             const rBaseX = r.coord.x << rDiff;
             const rBaseY = r.coord.y << rDiff;
@@ -329,8 +331,8 @@ export const computeMultiLodTiles = (
         parentDist: number,
     ): { coord: TileCoord; dist: number; tileSize: number }[] | null => {
         const diff = baseZoom - parentCoord.zoom;
-        // diff > 4 は子タイル数が多すぎるため親タイルをそのまま使う
-        if (diff <= 0 || diff > 4) return null;
+        // diff が大きい場合は子タイル数が多すぎるため親タイルをそのまま使う
+        if (diff <= 0 || diff > MAX_COVERAGE_DIFF) return null;
 
         const childCount = 1 << diff;
         const childBaseX = parentCoord.x << diff;
@@ -448,7 +450,7 @@ export const computeMultiLodTiles = (
 
             // coveredBaseZoomCells を更新（後続zoom反復での重複防止）
             const addedDiff = baseZoom - entry.coord.zoom;
-            if (addedDiff > 0 && addedDiff <= 4) {
+            if (addedDiff > 0 && addedDiff <= MAX_COVERAGE_DIFF) {
                 const addedCount = 1 << addedDiff;
                 const addedBaseX = entry.coord.x << addedDiff;
                 const addedBaseY = entry.coord.y << addedDiff;

--- a/src/terrain/visibleTiles.ts
+++ b/src/terrain/visibleTiles.ts
@@ -331,8 +331,10 @@ export const computeMultiLodTiles = (
         parentDist: number,
     ): { coord: TileCoord; dist: number; tileSize: number }[] | null => {
         const diff = baseZoom - parentCoord.zoom;
-        // diff が大きい場合は子タイル数が多すぎるため親タイルをそのまま使う
-        if (diff <= 0 || diff > MAX_COVERAGE_DIFF) return null;
+        if (diff <= 0) return null;
+        // diff が大きすぎて部分カバー判定を諦める場合は、
+        // 親タイルを追加すると高zoom側と重なり得るため、このzoomの親タイル追加をスキップする
+        if (diff > MAX_COVERAGE_DIFF) return [];
 
         const childCount = 1 << diff;
         const childBaseX = parentCoord.x << diff;

--- a/tests/tileManager.unit.spec.ts
+++ b/tests/tileManager.unit.spec.ts
@@ -550,6 +550,66 @@ describe("標高ズーム段階フォールバック", () => {
         // zoom 13, 14 でのフェッチは発生しない
         expect(fetchedZooms.every((z) => z <= 12)).toBe(true);
     });
+
+    it("minElevationZoomを下回るzoomでは標高フェッチを試みない", async () => {
+        const fetchedZooms: number[] = [];
+        (gsiTileMock.loadElevationTile as jest.Mock<(zoom: number, x: number, y: number) => Promise<Float32Array>>).mockImplementation(
+            (zoom) => {
+                fetchedZooms.push(zoom);
+                // 全zoomで失敗させてフォールバックを最大まで試行させる
+                return Promise.reject(new Error("not available"));
+            }
+        );
+
+        const camera = createMockCamera();
+        const tm = createTileManager({
+            scene: {} as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 3,
+            maxElevationZoom: 14,
+            minZoom: 2,
+            minElevationZoom: 10,
+        });
+
+        await tm.setCenter(35.68, 139.77);
+        // zoom 9以下でのフェッチは発生しない（minElevationZoom=10が下限）
+        expect(fetchedZooms.every((z) => z >= 10)).toBe(true);
+        // フォールバック幅は 14→10 の5段以内
+        const uniqueZooms = new Set(fetchedZooms);
+        expect(uniqueZooms.size).toBeLessThanOrEqual(5);
+        tm.dispose();
+    });
+
+    it("minElevationZoom省略時はデフォルト値 max(minZoom, maxElevationZoom-4) が適用される", async () => {
+        const fetchedZooms: number[] = [];
+        (gsiTileMock.loadElevationTile as jest.Mock<(zoom: number, x: number, y: number) => Promise<Float32Array>>).mockImplementation(
+            (zoom) => {
+                fetchedZooms.push(zoom);
+                return Promise.reject(new Error("not available"));
+            }
+        );
+
+        const camera = createMockCamera();
+        // maxElevationZoom=14, minZoom=2 → デフォルト minElevationZoom = max(2, 14-4) = 10
+        const tm = createTileManager({
+            scene: {} as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 3,
+            maxElevationZoom: 14,
+            minZoom: 2,
+        });
+
+        await tm.setCenter(35.68, 139.77);
+        // zoom 9以下でのフェッチは発生しない
+        expect(fetchedZooms.every((z) => z >= 10)).toBe(true);
+        tm.dispose();
+    });
 });
 
 /* ================================================================

--- a/tests/visibleTiles.unit.spec.ts
+++ b/tests/visibleTiles.unit.spec.ts
@@ -464,4 +464,74 @@ describe("computeMultiLodTiles", () => {
         const keys = result.map((e) => toTileKey(e.coord));
         expect(keys.length).toBe(new Set(keys).size);
     });
+
+    describe("超遠方タイル（低zoom）", () => {
+        // zoom18基準: zoom18=64m, zoom9≈32km, zoom2≈4160km
+        const farCenter: TileCoord = { zoom: 18, x: 232757, y: 103240 };
+        const farTileSizeForZoom = (z: number): number => 64 * Math.pow(2, 18 - z);
+
+        it("minZoom=2 で zoom 7 以下のタイルが結果に含まれる", () => {
+            const result = computeMultiLodTiles({
+                baseCenter: farCenter,
+                tileSizeForZoom: farTileSizeForZoom,
+                frustumPlanes: allVisiblePlanes,
+                cameraDistance: 40000,
+                baseZoom: 9,
+                minZoom: 2,
+                maxTiles: 160,
+                searchRadius: 14,
+            });
+
+            expect(result.length).toBeGreaterThan(0);
+            const lowZoomTiles = result.filter((e) => e.coord.zoom <= 7);
+            expect(lowZoomTiles.length).toBeGreaterThan(0);
+        });
+
+        it("低zoom タイルでも TileKey の重複がない", () => {
+            const result = computeMultiLodTiles({
+                baseCenter: farCenter,
+                tileSizeForZoom: farTileSizeForZoom,
+                frustumPlanes: allVisiblePlanes,
+                cameraDistance: 40000,
+                baseZoom: 9,
+                minZoom: 2,
+                maxTiles: 160,
+                searchRadius: 14,
+            });
+
+            const keys = result.map((e) => toTileKey(e.coord));
+            expect(keys.length).toBe(new Set(keys).size);
+        });
+
+        it("低zoom タイル追加後も maxTiles を超えない", () => {
+            const result = computeMultiLodTiles({
+                baseCenter: farCenter,
+                tileSizeForZoom: farTileSizeForZoom,
+                frustumPlanes: allVisiblePlanes,
+                cameraDistance: 40000,
+                baseZoom: 9,
+                minZoom: 2,
+                maxTiles: 160,
+                searchRadius: 14,
+            });
+
+            expect(result.length).toBeLessThanOrEqual(160);
+        });
+
+        it("近景タイル（baseZoom付近）が低zoom導入後も存在する", () => {
+            const result = computeMultiLodTiles({
+                baseCenter: farCenter,
+                tileSizeForZoom: farTileSizeForZoom,
+                frustumPlanes: allVisiblePlanes,
+                cameraDistance: 40000,
+                baseZoom: 9,
+                minZoom: 2,
+                maxTiles: 160,
+                searchRadius: 14,
+            });
+
+            const highZoomTiles = result.filter((e) => e.coord.zoom >= 8);
+            expect(highZoomTiles.length).toBeGreaterThan(0);
+        });
+    });
 });

--- a/tests/visibleTiles.unit.spec.ts
+++ b/tests/visibleTiles.unit.spec.ts
@@ -533,5 +533,85 @@ describe("computeMultiLodTiles", () => {
             const highZoomTiles = result.filter((e) => e.coord.zoom >= 8);
             expect(highZoomTiles.length).toBeGreaterThan(0);
         });
+
+        it("超遠方条件でもbaseZoomセル展開でタイル領域の重なりがない（Z-fighting防止）", () => {
+            const result = computeMultiLodTiles({
+                baseCenter: farCenter,
+                tileSizeForZoom: farTileSizeForZoom,
+                frustumPlanes: allVisiblePlanes,
+                cameraDistance: 40000,
+                baseZoom: 9,
+                minZoom: 2,
+                maxTiles: 160,
+                searchRadius: 14,
+            });
+
+            expect(result.length).toBeGreaterThan(0);
+
+            // baseZoom（zoom9）セルに展開して重なりチェック（全域）
+            const coveredCells = new Set<string>();
+            let hasOverlap = false;
+
+            for (const entry of result) {
+                const { coord } = entry;
+                const diff = 9 - coord.zoom;
+                if (diff < 0) continue;
+                const cellCount = 1 << diff;
+                const baseX = coord.x << diff;
+                const baseY = coord.y << diff;
+
+                for (let cy = 0; cy < cellCount; cy++) {
+                    for (let cx = 0; cx < cellCount; cx++) {
+                        const cellKey = `${baseX + cx},${baseY + cy}`;
+                        if (coveredCells.has(cellKey)) {
+                            hasOverlap = true;
+                        }
+                        coveredCells.add(cellKey);
+                    }
+                }
+            }
+
+            expect(hasOverlap).toBe(false);
+        });
+
+        it("カメラ距離を変えてもタイル領域の重なりがない", () => {
+            const distances = [20000, 40000, 80000];
+            for (const dist of distances) {
+                const result = computeMultiLodTiles({
+                    baseCenter: farCenter,
+                    tileSizeForZoom: farTileSizeForZoom,
+                    frustumPlanes: allVisiblePlanes,
+                    cameraDistance: dist,
+                    baseZoom: 9,
+                    minZoom: 2,
+                    maxTiles: 160,
+                    searchRadius: 14,
+                });
+
+                const coveredCells = new Set<string>();
+                let hasOverlap = false;
+
+                for (const entry of result) {
+                    const { coord } = entry;
+                    const diff = 9 - coord.zoom;
+                    if (diff < 0) continue;
+                    const cellCount = 1 << diff;
+                    const baseX = coord.x << diff;
+                    const baseY = coord.y << diff;
+
+                    for (let cy = 0; cy < cellCount; cy++) {
+                        for (let cx = 0; cx < cellCount; cx++) {
+                            const cellKey = `${baseX + cx},${baseY + cy}`;
+                            if (coveredCells.has(cellKey)) {
+                                hasOverlap = true;
+                            }
+                            coveredCells.add(cellKey);
+                        }
+                    }
+                }
+
+                expect(hasOverlap).toBe(false);
+            }
+        });
     });
 });


### PR DESCRIPTION
## 概要

水平に近いカメラチルト角で、低ズームレベルのタイルを使って超遠方（水平線付近）のマップを表示する。

Closes #61

## 変更内容

| ファイル | 変更 |
|----------|------|
| `src/scenes/default.ts` | `MIN_ZOOM` を 8 → 2 に変更、`camera.maxZ` を 100000 → 200000 に拡大 |
| `src/terrain/visibleTiles.ts` | `MAX_COVERAGE_DIFF=6` 定数を追加し、`coveredBaseZoomCells` の diff 上限を 4 → 6 に緩和（3箇所） |
| `tests/visibleTiles.unit.spec.ts` | 低zoom テストケース 4件追加 |

## 背景

- `MIN_ZOOM = 8`（タイルサイズ ~65km/枚 @lat35°）が制約で、最大ズームアウト時に `baseZoom ≈ 9` から1段しかLODが下がらず、遠方が空白になっていた
- 既存の Far-field sweep ロジックは `minZoom` まで自動探索するため、`MIN_ZOOM` を下げるだけで基本的に機能する
- `coveredBaseZoomCells` の diff 上限を 4 → 6 に緩和し、低zoom/中zoomタイルの重なり（Z-fighting）を防止

## テスト結果

- `npm run lint`: パス
- `npm run test:unit`: 170/170 パス
- `npm run build`: 成功（typecheck含む）