### PR TITLE
feat: raise camera max altitude and extract constants

### DIFF
--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -18,6 +18,13 @@ const MIN_ELEVATION_ZOOM = 10;
 const HEIGHT_SCALE = 1.0;
 const MIN_ZOOM = 2;
 
+/** カメラ最小距離（メートル） */
+const CAMERA_LOWER_RADIUS = 250;
+/** カメラ最大距離（メートル） */
+const CAMERA_UPPER_RADIUS = 75000;
+/** 遠クリッピング面（メートル） */
+const CAMERA_FAR_CLIP = 400000;
+
 /** Phase 2（垂直移動）に切り替えるカメラ高度の閾値（メートル） */
 const SKY_ZOOM_ALTITUDE_THRESHOLD = 1000;
 
@@ -41,10 +48,10 @@ export class DefaultScene implements CreateSceneClass {
             Vector3.Zero(),
             scene
         );
-        camera.lowerRadiusLimit = 250;
-        camera.upperRadiusLimit = 40000;
+        camera.lowerRadiusLimit = CAMERA_LOWER_RADIUS;
+        camera.upperRadiusLimit = CAMERA_UPPER_RADIUS;
         camera.minZ = 10;
-        camera.maxZ = 200000;
+        camera.maxZ = CAMERA_FAR_CLIP;
 
         // チルト制限（地面から20° = beta上限 7π/18）
         camera.upperBetaLimit = Math.PI / 2 - Math.PI / 9;
@@ -276,8 +283,8 @@ export class DefaultScene implements CreateSceneClass {
             worldZ: number,
             factor: number
         ): void => {
-            const upper = camera.upperRadiusLimit ?? 40000;
-            const lower = camera.lowerRadiusLimit ?? 250;
+            const upper = camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS;
+            const lower = camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
             if (factor > 1 && camera.radius >= upper) return;
             if (factor < 1 && camera.radius <= lower) return;
 
@@ -327,8 +334,8 @@ export class DefaultScene implements CreateSceneClass {
                     zoomTowardPoint(hit.worldX, hit.worldZ, factor);
                 } else {
                     // 空のホイール操作: カメラ高度ベースの2段階ズーム
-                    const upper = camera.upperRadiusLimit ?? 40000;
-                    const lower = camera.lowerRadiusLimit ?? 250;
+                    const upper = camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS;
+                    const lower = camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
                     const zoomIn = e.deltaY < 0;
                     const factor = zoomIn ? 0.95 : 1 / 0.95;
                     const cameraHeight = camera.radius * Math.cos(camera.beta);
@@ -366,12 +373,12 @@ export class DefaultScene implements CreateSceneClass {
                 zoomTowardPoint(hit.worldX, hit.worldZ, 0.7);
             } else {
                 // 空のダブルクリック: ターゲットに向かってズーム
-                const lower = camera.lowerRadiusLimit ?? 250;
+                const lower = camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
                 if (camera.radius <= lower) return;
                 camera.radius = clamp(
                     camera.radius * 0.7,
                     lower,
-                    camera.upperRadiusLimit ?? 40000
+                    camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS
                 );
             }
         });


### PR DESCRIPTION
## 概要

カメラの最大高度制限を引き上げ、マジックナンバーをconst定数に抽出。

Closes #58

## 変更内容

| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| `CAMERA_UPPER_RADIUS`（`upperRadiusLimit`） | 40000 | 75000 |
| `CAMERA_FAR_CLIP`（`maxZ` 遠クリッピング面） | 200000 | 400000 |
| マジックナンバー | 直書き（fallback含む5箇所） | const定数に統一 |

## 影響範囲

- **画面**: カメラの最大引き距離が約1.9倍になり、より広域の俯瞰が可能
- **スカイボックス**: `maxZ` 連動で自動拡大（変更不要）
- **API / 型**: 変更なし

## 検証結果

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test:unit` 174テスト全パス ✅
- AIレビュー 承認・指摘なし ✅
- 実機確認: 高度マップの表現が維持されること確認済み

## 補足

当初 80000 を設定したが高度マップが 0m になる問題が発生したため、75000 に調整。