### PR TITLE
feat: カメラと地形の衝突回避処理を追加

### DIFF
--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -320,6 +320,13 @@ export class DefaultScene implements CreateSceneClass {
             const newRadius = clamp(camera.radius * factor, effectiveLower, upper);
             if (Math.abs(newRadius - camera.radius) < 0.01) return;
 
+            // ズームイン操作なのに半径が増える場合はターゲット移動せず半径だけ補正
+            if (factor < 1 && newRadius > camera.radius) {
+                camera.radius = newRadius;
+                commitPanOffset();
+                return;
+            }
+
             const actualFactor = newRadius / camera.radius;
             camera.target.x += (worldX - camera.target.x) * (1 - actualFactor);
             camera.target.z += (worldZ - camera.target.z) * (1 - actualFactor);

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -246,12 +246,22 @@ export class DefaultScene implements CreateSceneClass {
                 Math.max(camY + 1000, CAMERA_LOWER_RADIUS + 1000)
             );
             const pick = scene.pickWithRay(ray, (m) => m.name.startsWith("tile-ground-"));
-            if (!pick?.hit || !pick.pickedPoint) {
+
+            // レイキャストによる地形高さ
+            let terrainY: number | null =
+                pick?.hit && pick.pickedPoint ? pick.pickedPoint.y : null;
+
+            // キャッシュ済み標高データから高精度な値を補完
+            const cacheElev = tileManager.queryElevationAtWorld(camX, camZ);
+            if (cacheElev !== null) {
+                terrainY = terrainY !== null ? Math.max(terrainY, cacheElev) : cacheElev;
+            }
+
+            if (terrainY === null) {
                 cachedMinRadius = camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
                 return cachedMinRadius;
             }
 
-            const terrainY = pick.pickedPoint.y;
             const minCamY = terrainY + CAMERA_LOWER_RADIUS;
             cachedMinRadius = (minCamY - ty) / cosB;
             return cachedMinRadius;
@@ -587,6 +597,11 @@ export class DefaultScene implements CreateSceneClass {
             camera.radius = minR;
         };
         scene.onBeforeRenderObservable.add(clampCameraAboveTerrain);
+
+        // メッシュ標高更新時にキャッシュを無効化して即座に再チェック
+        tileManager.onTerrainUpdated = () => {
+            prevAlpha = NaN; // terrainMinRadius のキャッシュを無効化
+        };
 
         // カメラ移動時の自動タイル更新
         tileManager.attachCamera();

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -202,13 +202,43 @@ export class DefaultScene implements CreateSceneClass {
         };
 
         /** 現在のカメラ位置直下の地形高さから、衝突回避に必要な最小 radius を返す */
+        let cachedMinRadius = CAMERA_LOWER_RADIUS;
+        let prevAlpha = NaN;
+        let prevBeta = NaN;
+        let prevRadius = NaN;
+        let prevTargetX = NaN;
+        let prevTargetY = NaN;
+        let prevTargetZ = NaN;
+
         const terrainMinRadius = (): number => {
-            const cosB = Math.cos(camera.beta);
-            if (Math.abs(cosB) < 1e-6) return camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
-            const sinB = Math.sin(camera.beta);
-            const camX = camera.target.x + camera.radius * sinB * Math.cos(camera.alpha);
-            const camY = camera.target.y + camera.radius * cosB;
-            const camZ = camera.target.z + camera.radius * sinB * Math.sin(camera.alpha);
+            const { alpha, beta, radius } = camera;
+            const { x: tx, y: ty, z: tz } = camera.target;
+            if (
+                alpha === prevAlpha &&
+                beta === prevBeta &&
+                radius === prevRadius &&
+                tx === prevTargetX &&
+                ty === prevTargetY &&
+                tz === prevTargetZ
+            ) {
+                return cachedMinRadius;
+            }
+            prevAlpha = alpha;
+            prevBeta = beta;
+            prevRadius = radius;
+            prevTargetX = tx;
+            prevTargetY = ty;
+            prevTargetZ = tz;
+
+            const cosB = Math.cos(beta);
+            if (Math.abs(cosB) < 1e-6) {
+                cachedMinRadius = camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
+                return cachedMinRadius;
+            }
+            const sinB = Math.sin(beta);
+            const camX = tx + radius * sinB * Math.cos(alpha);
+            const camY = ty + radius * cosB;
+            const camZ = tz + radius * sinB * Math.sin(alpha);
 
             const ray = new Ray(
                 new Vector3(camX, camY, camZ),
@@ -216,11 +246,15 @@ export class DefaultScene implements CreateSceneClass {
                 Math.max(camY + 1000, CAMERA_LOWER_RADIUS + 1000)
             );
             const pick = scene.pickWithRay(ray, (m) => m.name.startsWith("tile-ground-"));
-            if (!pick?.hit || !pick.pickedPoint) return camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
+            if (!pick?.hit || !pick.pickedPoint) {
+                cachedMinRadius = camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
+                return cachedMinRadius;
+            }
 
             const terrainY = pick.pickedPoint.y;
             const minCamY = terrainY + CAMERA_LOWER_RADIUS;
-            return (minCamY - camera.target.y) / cosB;
+            cachedMinRadius = (minCamY - ty) / cosB;
+            return cachedMinRadius;
         };
 
         // ---------- カスタムマウスハンドラ ----------

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -3,7 +3,7 @@ import { ArcRotateCamera } from "@babylonjs/core/Cameras/arcRotateCamera";
 import { Matrix, Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight";
 import { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
-import "@babylonjs/core/Culling/ray";
+import { Ray } from "@babylonjs/core/Culling/ray";
 import { CreateSceneClass } from "../createScene";
 import { clamp, toTileXY, tileEdgeMeters, JAPAN_BOUNDS } from "../terrain/gsiTile";
 import { createControlPanel, snapScale, formatScale, showToast } from "../terrain/controlPanel";
@@ -201,6 +201,28 @@ export class DefaultScene implements CreateSceneClass {
             };
         };
 
+        /** 現在のカメラ位置直下の地形高さから、衝突回避に必要な最小 radius を返す */
+        const terrainMinRadius = (): number => {
+            const cosB = Math.cos(camera.beta);
+            if (Math.abs(cosB) < 1e-6) return camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
+            const sinB = Math.sin(camera.beta);
+            const camX = camera.target.x + camera.radius * sinB * Math.cos(camera.alpha);
+            const camY = camera.target.y + camera.radius * cosB;
+            const camZ = camera.target.z + camera.radius * sinB * Math.sin(camera.alpha);
+
+            const ray = new Ray(
+                new Vector3(camX, camY, camZ),
+                Vector3.Down(),
+                Math.max(camY + 1000, CAMERA_LOWER_RADIUS + 1000)
+            );
+            const pick = scene.pickWithRay(ray, (m) => m.name.startsWith("tile-ground-"));
+            if (!pick?.hit || !pick.pickedPoint) return camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
+
+            const terrainY = pick.pickedPoint.y;
+            const minCamY = terrainY + CAMERA_LOWER_RADIUS;
+            return (minCamY - camera.target.y) / cosB;
+        };
+
         // ---------- カスタムマウスハンドラ ----------
         let pointerDown = false;
         let lastPointerX = 0;
@@ -238,12 +260,17 @@ export class DefaultScene implements CreateSceneClass {
                 lastPointerX = e.clientX;
                 lastPointerY = e.clientY;
                 camera.alpha -= dx * 0.003;
+                const prevBeta = camera.beta;
                 camera.beta -= dy * 0.003;
                 camera.beta = clamp(
                     camera.beta,
                     camera.lowerBetaLimit ?? 0,
                     camera.upperBetaLimit ?? Math.PI
                 );
+                // チルト変更で地形に衝突するなら beta を復元
+                if (camera.radius < terrainMinRadius()) {
+                    camera.beta = prevBeta;
+                }
             } else if (dragAnchor) {
                 // 通常ドラッグ: 逐次差分でパン（毎フレームanchor更新）
                 const rect = canvas.getBoundingClientRect();
@@ -288,10 +315,15 @@ export class DefaultScene implements CreateSceneClass {
             if (factor > 1 && camera.radius >= upper) return;
             if (factor < 1 && camera.radius <= lower) return;
 
-            camera.target.x += (worldX - camera.target.x) * (1 - factor);
-            camera.target.z += (worldZ - camera.target.z) * (1 - factor);
-            camera.radius *= factor;
-            camera.radius = clamp(camera.radius, lower, upper);
+            // 衝突制限を考慮した実効 lower を算出
+            const effectiveLower = Math.max(lower, terrainMinRadius());
+            const newRadius = clamp(camera.radius * factor, effectiveLower, upper);
+            if (Math.abs(newRadius - camera.radius) < 0.01) return;
+
+            const actualFactor = newRadius / camera.radius;
+            camera.target.x += (worldX - camera.target.x) * (1 - actualFactor);
+            camera.target.z += (worldZ - camera.target.z) * (1 - actualFactor);
+            camera.radius = newRadius;
             commitPanOffset();
         };
 
@@ -345,21 +377,23 @@ export class DefaultScene implements CreateSceneClass {
 
                     if (useVertical) {
                         // Phase 2: 垂直移動（カメラの緯度経度固定）
-                        if (zoomIn && camera.radius <= lower) return;
+                        const effectiveLower2 = Math.max(lower, terrainMinRadius());
+                        if (zoomIn && camera.radius <= effectiveLower2) return;
                         if (!zoomIn && camera.radius >= upper) return;
                         const sinB = Math.sin(camera.beta);
                         const camX = camera.target.x + camera.radius * sinB * Math.cos(camera.alpha);
                         const camZ = camera.target.z + camera.radius * sinB * Math.sin(camera.alpha);
-                        const newRadius = clamp(camera.radius * factor, lower, upper);
+                        const newRadius = clamp(camera.radius * factor, effectiveLower2, upper);
                         camera.target.x = camX - newRadius * sinB * Math.cos(camera.alpha);
                         camera.target.z = camZ - newRadius * sinB * Math.sin(camera.alpha);
                         camera.radius = newRadius;
                         commitPanOffset();
                     } else {
                         // Phase 1: ターゲットに向かってズーム
-                        if (zoomIn && camera.radius <= lower) return;
+                        const effectiveLower1 = Math.max(lower, terrainMinRadius());
+                        if (zoomIn && camera.radius <= effectiveLower1) return;
                         if (!zoomIn && camera.radius >= upper) return;
-                        camera.radius = clamp(camera.radius * factor, lower, upper);
+                        camera.radius = clamp(camera.radius * factor, effectiveLower1, upper);
                     }
                 }
             },
@@ -504,6 +538,14 @@ export class DefaultScene implements CreateSceneClass {
                     : "地図切替: 標準地図に変更"
             );
         });
+
+        // カメラ-地形衝突回避: 地面にめり込まないよう radius を補正してストップ
+        const clampCameraAboveTerrain = (): void => {
+            const minR = terrainMinRadius();
+            if (camera.radius >= minR) return;
+            camera.radius = minR;
+        };
+        scene.onBeforeRenderObservable.add(clampCameraAboveTerrain);
 
         // カメラ移動時の自動タイル更新
         tileManager.attachCamera();

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -52,6 +52,10 @@ export interface TileManager {
     readonly activeTileCount: number;
     readonly loadingCount: number;
     onStatusChange: ((status: string) => void) | null;
+    /** キャッシュ済み標高データからワールド座標のY値を返す（ヒットしなければ null） */
+    queryElevationAtWorld(wx: number, wz: number): number | null;
+    /** メッシュ頂点の標高が更新されたときに呼ばれるコールバック */
+    onTerrainUpdated: (() => void) | null;
 }
 
 interface ActiveTile {
@@ -210,6 +214,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
     let requestId = 0;
     let loadingCount = 0;
     let statusCallback: ((status: string) => void) | null = null;
+    let terrainUpdatedCallback: (() => void) | null = null;
     let debounceTimer: ReturnType<typeof setTimeout> | null = null;
     let cameraObserver: ReturnType<
         typeof camera.onViewMatrixChangedObservable.add
@@ -351,6 +356,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
             applyTexture(mesh, coord);
 
             activeTiles.set(key, { key, coord, mesh, tileSize });
+            terrainUpdatedCallback?.();
         } catch (e) {
             if (rid !== requestId) return;
             statusCallback?.(
@@ -411,6 +417,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
                 }
             }
         }
+        terrainUpdatedCallback?.();
     };
 
     /** 並列数制限付きのロードキュー */
@@ -647,6 +654,49 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         },
         get onStatusChange(): ((status: string) => void) | null {
             return statusCallback;
+        },
+
+        queryElevationAtWorld(wx: number, wz: number): number | null {
+            if (!currentCenter) return null;
+
+            for (let z = maxElevationZoom; z >= minElevationZoom; z--) {
+                const tileSize = tileSizeForZoom(z);
+                const center = convertTileZoom(currentCenter, z);
+                const { fracX, fracY } = computeSubTileOffset(currentCenter, z);
+
+                const tileXFloat = center.x + fracX + wx / tileSize;
+                const tileYFloat = center.y + fracY - wz / tileSize;
+
+                const tileXInt = Math.floor(tileXFloat);
+                const tileYInt = Math.floor(tileYFloat);
+
+                const key: TileKey = `${z}/${tileXInt}/${tileYInt}`;
+                const entry = cache.get(key);
+                if (!entry) continue;
+
+                const fracTileX = tileXFloat - tileXInt;
+                const fracTileY = tileYFloat - tileYInt;
+                const px = Math.min(
+                    TILE_SIZE - 1,
+                    Math.max(0, Math.round(fracTileX * (TILE_SIZE - 1)))
+                );
+                const py = Math.min(
+                    TILE_SIZE - 1,
+                    Math.max(0, Math.round(fracTileY * (TILE_SIZE - 1)))
+                );
+
+                const rawElev = entry.elevation[py * TILE_SIZE + px];
+                return (rawElev + currentAltitudeOffset) * heightScale;
+            }
+
+            return null;
+        },
+
+        set onTerrainUpdated(cb: (() => void) | null) {
+            terrainUpdatedCallback = cb;
+        },
+        get onTerrainUpdated(): (() => void) | null {
+            return terrainUpdatedCallback;
         },
     };
 };

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -344,6 +344,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
                 const normals = new Float32Array(typed.length);
                 VertexData.ComputeNormals(typed, idx, normals);
                 mesh.updateVerticesData(VertexBuffer.NormalKind, normals);
+                mesh.refreshBoundingInfo();
             }
 
             // テクスチャ
@@ -406,6 +407,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
                     const normals = new Float32Array(typed.length);
                     VertexData.ComputeNormals(typed, idx, normals);
                     mesh.updateVerticesData(VertexBuffer.NormalKind, normals);
+                    mesh.refreshBoundingInfo();
                 }
             }
         }

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -670,7 +670,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
                 const tileXInt = Math.floor(tileXFloat);
                 const tileYInt = Math.floor(tileYFloat);
 
-                const key: TileKey = `${z}/${tileXInt}/${tileYInt}`;
+                const key: TileKey = toTileKey({ zoom: z, x: tileXInt, y: tileYInt });
                 const entry = cache.get(key);
                 if (!entry) continue;
 

--- a/tests/tileManager.unit.spec.ts
+++ b/tests/tileManager.unit.spec.ts
@@ -18,6 +18,7 @@ const mockMeshInstance = () => ({
     getVerticesData: jest.fn(() => new Float32Array(3 * 129 * 129)),
     getIndices: jest.fn(() => new Uint32Array(6 * 128 * 128)),
     updateVerticesData: jest.fn(),
+    refreshBoundingInfo: jest.fn(),
 });
 
 jest.unstable_mockModule("@babylonjs/core/Meshes/Builders/groundBuilder", () => ({

--- a/tests/tileManager.unit.spec.ts
+++ b/tests/tileManager.unit.spec.ts
@@ -768,3 +768,205 @@ describe("標高データ全NaNフォールバック", () => {
         tm.dispose();
     });
 });
+
+/* ================================================================
+ * queryElevationAtWorld 単体テスト
+ * ================================================================ */
+describe("queryElevationAtWorld", () => {
+    afterEach(() => {
+        (gsiTileMock.loadElevationTile as jest.Mock).mockImplementation(
+            () => Promise.resolve(new Float32Array(256 * 256))
+        );
+        (gsiTileMock.tileEdgeMeters as jest.Mock).mockImplementation(
+            () => 1000
+        );
+    });
+
+    /**
+     * camera.radius が小さいとき computeBaseZoom が maxZoom(=14) を返し、
+     * タイルが zoom 14 でロードされる。
+     * minZoom=14 にすることで LOD による低zoom混在を防止。
+     */
+    const createNearCamera = () => {
+        const cam = createMockCamera();
+        (cam as any).radius = 500;
+        (cam as any).position = { x: 0, y: 500, z: 0 };
+        return cam;
+    };
+
+    it("setCenter前はnullを返す", () => {
+        const camera = createNearCamera();
+        const tm = createTileManager({
+            scene: {} as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            minZoom: 14,
+        });
+
+        expect(tm.queryElevationAtWorld(0, 0)).toBeNull();
+        tm.dispose();
+    });
+
+    it("中心座標でキャッシュ済み標高値を返す", async () => {
+        const elevData = new Float32Array(256 * 256);
+        elevData[0] = 100; // pixel (0,0) = 100m
+        (gsiTileMock.loadElevationTile as jest.Mock).mockImplementation(
+            () => Promise.resolve(elevData)
+        );
+
+        const camera = createNearCamera();
+        const tm = createTileManager({
+            scene: {} as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 5,
+            minZoom: 14,
+        });
+
+        await tm.setCenter(35.68, 139.77);
+        // ワールド原点 (0,0) は中心タイルのピクセル (0,0) に対応
+        const result = tm.queryElevationAtWorld(0, 0);
+        expect(result).toBe(100);
+        tm.dispose();
+    });
+
+    it("heightScaleが標高値に反映される", async () => {
+        const elevData = new Float32Array(256 * 256);
+        elevData[0] = 100;
+        (gsiTileMock.loadElevationTile as jest.Mock).mockImplementation(
+            () => Promise.resolve(elevData)
+        );
+
+        const camera = createNearCamera();
+        const tm = createTileManager({
+            scene: {} as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 2.0,
+            maxTiles: 5,
+            minZoom: 14,
+        });
+
+        await tm.setCenter(35.68, 139.77);
+        // (100 + 0) * 2.0 = 200
+        expect(tm.queryElevationAtWorld(0, 0)).toBe(200);
+        tm.dispose();
+    });
+
+    it("altitudeOffsetが標高値に反映される", async () => {
+        const elevData = new Float32Array(256 * 256);
+        elevData[0] = 100;
+        (gsiTileMock.loadElevationTile as jest.Mock).mockImplementation(
+            () => Promise.resolve(elevData)
+        );
+
+        const camera = createNearCamera();
+        const tm = createTileManager({
+            scene: {} as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 5,
+            minZoom: 14,
+        });
+
+        await tm.setCenter(35.68, 139.77, 50); // altitudeOffset = 50
+        // (100 + 50) * 1.0 = 150
+        expect(tm.queryElevationAtWorld(0, 0)).toBe(150);
+        tm.dispose();
+    });
+
+    it("heightScaleとaltitudeOffsetが同時に反映される", async () => {
+        const elevData = new Float32Array(256 * 256);
+        elevData[0] = 100;
+        (gsiTileMock.loadElevationTile as jest.Mock).mockImplementation(
+            () => Promise.resolve(elevData)
+        );
+
+        const camera = createNearCamera();
+        const tm = createTileManager({
+            scene: {} as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 2.0,
+            maxTiles: 5,
+            minZoom: 14,
+        });
+
+        await tm.setCenter(35.68, 139.77, 50);
+        // (100 + 50) * 2.0 = 300
+        expect(tm.queryElevationAtWorld(0, 0)).toBe(300);
+        tm.dispose();
+    });
+
+    it("全zoomレベルでキャッシュ未ヒットの座標はnullを返す", async () => {
+        (gsiTileMock.loadElevationTile as jest.Mock).mockImplementation(
+            () => Promise.resolve(new Float32Array(256 * 256))
+        );
+
+        const camera = createNearCamera();
+        const tm = createTileManager({
+            scene: {} as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 1,
+            minZoom: 14,
+            maxElevationZoom: 14,
+            minElevationZoom: 14, // フォールバック無し
+        });
+
+        await tm.setCenter(35.68, 139.77);
+        // 中心から十分離れた座標（50タイル分）はキャッシュに存在しない
+        const result = tm.queryElevationAtWorld(50000, 50000);
+        expect(result).toBeNull();
+        tm.dispose();
+    });
+
+    it("zoomフォールバック: 高zoom未ヒットでも低zoomキャッシュから値を返す", async () => {
+        // zoom依存の tileEdgeMeters: z14=1000, z13=2000
+        (gsiTileMock.tileEdgeMeters as jest.Mock<(lat: number, zoom: number) => number>).mockImplementation(
+            (_lat, zoom) => 1000 * Math.pow(2, 14 - zoom)
+        );
+
+        const elevData13 = new Float32Array(256 * 256);
+        // zoom13タイルのピクセル(64,64)に既知の値を設定
+        // wx=0, wz=-1000 → zoom13で fracTile=(0.25,0.25) → px=64, py=64
+        elevData13[64 * 256 + 64] = 777;
+
+        (gsiTileMock.loadElevationTile as jest.Mock<(zoom: number, x: number, y: number) => Promise<Float32Array>>).mockImplementation(
+            (zoom) => {
+                if (zoom >= 14) return Promise.reject(new Error("not available"));
+                return Promise.resolve(elevData13);
+            }
+        );
+
+        const camera = createNearCamera();
+        const tm = createTileManager({
+            scene: {} as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 1,
+            minZoom: 14,
+            maxElevationZoom: 14,
+            minElevationZoom: 13,
+        });
+
+        await tm.setCenter(35.68, 139.77);
+        // wx=0, wz=-1000 → zoom14キー"14/14547/6453"は未キャッシュ
+        // → zoom13キー"13/7273/3226"にフォールバックしてヒット
+        const result = tm.queryElevationAtWorld(0, -1000);
+        expect(result).toBe(777);
+        tm.dispose();
+    });
+});


### PR DESCRIPTION
## 概要

マウスホイールズームでカメラが地形メッシュにめり込む問題を修正。カメラ位置から地表面へのレイキャストで衝突検出し、`CAMERA_LOWER_RADIUS`（250m）を最低クリアランスとして維持する。

## 変更内容

### `src/scenes/default.ts`
- `terrainMinRadius()`: カメラ直下にレイキャストし、衝突回避に必要な最小 radius を算出
- `clampCameraAboveTerrain()`: 毎フレーム（`onBeforeRenderObservable`）で radius を補正
- `zoomTowardPoint()`: 衝突制限を考慮した `effectiveLower` で radius をクランプ
- ホイール Phase 1/2: `terrainMinRadius()` を適用
- チルト操作: 衝突時に beta を復元してストップ
- `Ray` インポートを明示化（`import { Ray }` に変更）

### `src/terrain/tileManager.ts`
- 頂点更新後に `mesh.refreshBoundingInfo()` を追加（2箇所）
  - レイキャストのバウンディングボックスを正しく更新するため

### `tests/tileManager.unit.spec.ts`
- モックメッシュに `refreshBoundingInfo: jest.fn()` を追加

## テスト結果
- `npm run build` ✅
- `npm run lint` ✅
- `npm run test:unit` ✅ (174/174)

Closes #51