### PR TITLE
fix: 右下コンテナDIVのpointerEvents透過で地図操作を可能にする

### DIFF
--- a/src/terrain/controlPanel.ts
+++ b/src/terrain/controlPanel.ts
@@ -102,6 +102,7 @@ const createZoomButtons = (): {
         gap: "2px",
         alignItems: "flex-end",
         zIndex: "10",
+        pointerEvents: "none",
     });
 
     const makeBtn = (label: string, ariaLabel: string): HTMLButtonElement => {
@@ -126,6 +127,7 @@ const createZoomButtons = (): {
             justifyContent: "center",
             outline: "none",
             padding: "0",
+            pointerEvents: "auto",
         });
         btn.classList.add("cp-btn");
         return btn;

--- a/tests/controlPanel.unit.spec.ts
+++ b/tests/controlPanel.unit.spec.ts
@@ -4,11 +4,13 @@
 import { jest } from "@jest/globals";
 import { snapScale, formatScale, SCALE_STEPS, createControlPanel, showToast } from "../src/terrain/controlPanel";
 
+function cleanupDOM(): void {
+    document.body.innerHTML = "";
+    document.head.querySelectorAll("#cp-focus-style").forEach((el) => el.remove());
+}
+
 describe("createControlPanel locateMe ボタン", () => {
-    afterEach(() => {
-        document.body.innerHTML = "";
-        document.head.querySelectorAll("#cp-focus-style").forEach((el) => el.remove());
-    });
+    afterEach(cleanupDOM);
 
     it("locateMe ボタンが存在する", () => {
         const panel = createControlPanel();
@@ -43,10 +45,7 @@ describe("createControlPanel locateMe ボタン", () => {
 });
 
 describe("createControlPanel attribution", () => {
-    afterEach(() => {
-        document.body.innerHTML = "";
-        document.head.querySelectorAll("#cp-focus-style").forEach((el) => el.remove());
-    });
+    afterEach(cleanupDOM);
 
     it("scaleBar.attribution が地理院タイルへのリンクである", () => {
         const panel = createControlPanel();
@@ -72,10 +71,7 @@ describe("createControlPanel attribution", () => {
 });
 
 describe("createControlPanel pointerEvents 透過", () => {
-    afterEach(() => {
-        document.body.innerHTML = "";
-        document.head.querySelectorAll("#cp-focus-style").forEach((el) => el.remove());
-    });
+    afterEach(cleanupDOM);
 
     it("ズームボタンのコンテナ div に pointerEvents: none が設定されている", () => {
         const panel = createControlPanel();
@@ -157,7 +153,7 @@ describe("showToast", () => {
 
     afterEach(() => {
         jest.useRealTimers();
-        document.body.innerHTML = "";
+        cleanupDOM();
     });
 
     it("DOM にトースト要素が追加される", () => {

--- a/tests/controlPanel.unit.spec.ts
+++ b/tests/controlPanel.unit.spec.ts
@@ -71,6 +71,34 @@ describe("createControlPanel attribution", () => {
     });
 });
 
+describe("createControlPanel pointerEvents 透過", () => {
+    afterEach(() => {
+        document.body.innerHTML = "";
+        document.head.querySelectorAll("#cp-focus-style").forEach((el) => el.remove());
+    });
+
+    it("ズームボタンのコンテナ div に pointerEvents: none が設定されている", () => {
+        const panel = createControlPanel();
+        const container = panel.zoomIn.parentElement!;
+        expect(container.style.pointerEvents).toBe("none");
+    });
+
+    it("zoomIn ボタンに pointerEvents: auto が設定されている", () => {
+        const panel = createControlPanel();
+        expect(panel.zoomIn.style.pointerEvents).toBe("auto");
+    });
+
+    it("zoomOut ボタンに pointerEvents: auto が設定されている", () => {
+        const panel = createControlPanel();
+        expect(panel.zoomOut.style.pointerEvents).toBe("auto");
+    });
+
+    it("locateMe ボタンに pointerEvents: auto が設定されている", () => {
+        const panel = createControlPanel();
+        expect(panel.locateMe.style.pointerEvents).toBe("auto");
+    });
+});
+
 describe("snapScale", () => {
     it("小さい値は最小ステップ (1) にスナップされる", () => {
         expect(snapScale(0.5)).toBe(1);


### PR DESCRIPTION
## 概要

右下のボタンコンテナ DIV 上でマウスイベント（ドラッグ・ホイール）がマップに伝播しない問題を修正。

Fixes #86

## 変更内容

- `createZoomButtons()` のコンテナ div に `pointerEvents: "none"` を追加し、イベントを下層の canvas に透過
- `makeBtn()` で各ボタンに `pointerEvents: "auto"` を追加し、ボタン自体のクリックは維持
- `pointerEvents` 設定の単体テスト 4件追加

## 影響範囲

- UI挙動：コンテナ領域上でのマウス操作がマップに伝播するようになる
- 見た目の変更：なし
- ボタン（＋/−/現在地）・リンク（地理院タイル）は引き続き正常動作

## テスト結果

- `npm run lint` ✅
- `npm run test:unit` ✅ (27/27)
- `npm run typecheck` ✅
- ブラウザ手動テスト ✅
