### PR TITLE
feat(terrain): elevation-aware zoom & LOD UX (#53)

### DIFF
--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -349,6 +349,48 @@ export class DefaultScene implements CreateSceneClass {
         canvas.addEventListener("lostpointercapture", resetPointerState);
 
         // ホイール / ダブルクリック: ポインタ方向にズーム
+
+        /** カメラ→ターゲット方向のレイで地形メッシュとの交差距離を返す（ミス時は null） */
+        const queryViewRayDistance = (): number | null => {
+            const { alpha, beta, radius } = camera;
+            const { x: tx, y: ty, z: tz } = camera.target;
+            const sinB = Math.sin(beta);
+            const cosB = Math.cos(beta);
+            const camX = tx + radius * sinB * Math.sin(alpha);
+            const camY = ty + radius * cosB;
+            const camZ = tz + radius * sinB * Math.cos(alpha);
+
+            const origin = new Vector3(camX, camY, camZ);
+
+            // ターゲット直下の地形標高でレイ目標点を補正
+            const terrainY = tileManager.queryElevationAtWorld(tx, tz);
+            const aimY = terrainY !== null ? Math.max(ty, terrainY) : ty;
+            const aim = new Vector3(tx, aimY, tz);
+
+            const direction = aim.subtract(origin);
+            const length = direction.length();
+            if (length < 1e-6) return null;
+            direction.scaleInPlace(1 / length);
+
+            const ray = new Ray(origin, direction, length * 2);
+            const pick = scene.pickWithRay(ray, (m) => m.name.startsWith("tile-ground-"));
+            if (pick?.hit && pick.distance > 0) {
+                return pick.distance;
+            }
+            return null;
+        };
+
+        /** レイキャスト距離の一定割合を1ステップとするホイールfactorを返す */
+        const WHEEL_STEP = 0.05;
+        const computeWheelFactor = (zoomIn: boolean): number => {
+            const rayDist = queryViewRayDistance();
+            const dist = rayDist ?? camera.radius;
+            const delta = dist * WHEEL_STEP;
+            return zoomIn
+                ? (camera.radius - delta) / camera.radius
+                : (camera.radius + delta) / camera.radius;
+        };
+
         const zoomTowardPoint = (
             worldX: number,
             worldZ: number,
@@ -413,14 +455,14 @@ export class DefaultScene implements CreateSceneClass {
                 const rect = canvas.getBoundingClientRect();
                 const hit = pickOrPlane(e.clientX - rect.left, e.clientY - rect.top);
                 if (hit && isPickNearTarget(hit)) {
-                    const factor = e.deltaY < 0 ? 0.95 : 1 / 0.95;
+                    const factor = computeWheelFactor(e.deltaY < 0);
                     zoomTowardPoint(hit.worldX, hit.worldZ, factor);
                 } else {
                     // 空のホイール操作: カメラ高度ベースの2段階ズーム
                     const upper = camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS;
                     const lower = camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
                     const zoomIn = e.deltaY < 0;
-                    const factor = zoomIn ? 0.95 : 1 / 0.95;
+                    const factor = computeWheelFactor(zoomIn);
                     const cameraHeight = camera.radius * Math.cos(camera.beta);
                     const useVertical = zoomIn
                         ? cameraHeight <= SKY_ZOOM_ALTITUDE_THRESHOLD

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -356,9 +356,9 @@ export class DefaultScene implements CreateSceneClass {
             const { x: tx, y: ty, z: tz } = camera.target;
             const sinB = Math.sin(beta);
             const cosB = Math.cos(beta);
-            const camX = tx + radius * sinB * Math.sin(alpha);
+            const camX = tx + radius * sinB * Math.cos(alpha);
             const camY = ty + radius * cosB;
-            const camZ = tz + radius * sinB * Math.cos(alpha);
+            const camZ = tz + radius * sinB * Math.sin(alpha);
 
             const origin = new Vector3(camX, camY, camZ);
 

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -71,6 +71,8 @@ const DEFAULT_CACHE_CAPACITY = 96;
 const DEFAULT_DEBOUNCE_MS = 200;
 /** Frustum 判定用の基準最大標高 (m) — 富士山 3776m + マージン */
 const MAX_BASE_ELEVATION = 4000;
+/** 有効カメラ距離の下限値（生の radius に対する比率） */
+const EFFECTIVE_RADIUS_MIN_RATIO = 0.05;
 
 /** 頂点Y座標を標高値で更新 */
 const applyElevation = (
@@ -491,6 +493,29 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         }
     };
 
+    /** キャッシュ済み標高データからワールド座標のY値を返す（ヒットしなければ null） */
+    const queryLocalElevation = (wx: number, wz: number): number | null => {
+        if (!currentCenter) return null;
+        for (let z = maxElevationZoom; z >= minElevationZoom; z--) {
+            const ts = tileSizeForZoom(z);
+            const center = convertTileZoom(currentCenter, z);
+            const { fracX, fracY } = computeSubTileOffset(currentCenter, z);
+            const tileXFloat = center.x + fracX + wx / ts;
+            const tileYFloat = center.y + fracY - wz / ts;
+            const tileXInt = Math.floor(tileXFloat);
+            const tileYInt = Math.floor(tileYFloat);
+            const key = toTileKey({ zoom: z, x: tileXInt, y: tileYInt });
+            const entry = cache.get(key);
+            if (!entry) continue;
+            const fx = tileXFloat - tileXInt;
+            const fy = tileYFloat - tileYInt;
+            const px = Math.min(TILE_SIZE - 1, Math.max(0, Math.round(fx * (TILE_SIZE - 1))));
+            const py = Math.min(TILE_SIZE - 1, Math.max(0, Math.round(fy * (TILE_SIZE - 1))));
+            return (entry.elevation[py * TILE_SIZE + px] + currentAltitudeOffset) * heightScale;
+        }
+        return null;
+    };
+
     /** 可視タイルを算出する共通ヘルパー */
     const computeVisible = (
         frustumPlanes: FrustumPlane[],
@@ -498,11 +523,17 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
     ): LodTileEntry[] => {
         if (!currentCenter) return [];
 
-        // カメラ→ターゲット距離（チルトやパンに依存せず安定）
-        const cameraDistance = camera.radius;
+        const rawCameraDistance = camera.radius;
+
+        // ターゲット直下の地形標高を差し引き、有効カメラ距離を算出する。
+        // チルト角に依存しない式を用いることで、チルト操作で baseZoom が変動することを防ぐ。
+        const terrainY = queryLocalElevation(camera.target.x, camera.target.z);
+        const effectiveRadius = terrainY !== null
+            ? Math.max(rawCameraDistance * EFFECTIVE_RADIUS_MIN_RATIO, rawCameraDistance - terrainY)
+            : rawCameraDistance;
 
         const baseZoom = computeBaseZoom(
-            cameraDistance,
+            effectiveRadius,
             tileSizeForZoom,
             zoom,
             minZoom
@@ -512,7 +543,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
             baseCenter: currentCenter,
             tileSizeForZoom,
             frustumPlanes,
-            cameraDistance,
+            cameraDistance: effectiveRadius,
             baseZoom,
             minZoom,
             maxTiles,
@@ -657,39 +688,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         },
 
         queryElevationAtWorld(wx: number, wz: number): number | null {
-            if (!currentCenter) return null;
-
-            for (let z = maxElevationZoom; z >= minElevationZoom; z--) {
-                const tileSize = tileSizeForZoom(z);
-                const center = convertTileZoom(currentCenter, z);
-                const { fracX, fracY } = computeSubTileOffset(currentCenter, z);
-
-                const tileXFloat = center.x + fracX + wx / tileSize;
-                const tileYFloat = center.y + fracY - wz / tileSize;
-
-                const tileXInt = Math.floor(tileXFloat);
-                const tileYInt = Math.floor(tileYFloat);
-
-                const key: TileKey = toTileKey({ zoom: z, x: tileXInt, y: tileYInt });
-                const entry = cache.get(key);
-                if (!entry) continue;
-
-                const fracTileX = tileXFloat - tileXInt;
-                const fracTileY = tileYFloat - tileYInt;
-                const px = Math.min(
-                    TILE_SIZE - 1,
-                    Math.max(0, Math.round(fracTileX * (TILE_SIZE - 1)))
-                );
-                const py = Math.min(
-                    TILE_SIZE - 1,
-                    Math.max(0, Math.round(fracTileY * (TILE_SIZE - 1)))
-                );
-
-                const rawElev = entry.elevation[py * TILE_SIZE + px];
-                return (rawElev + currentAltitudeOffset) * heightScale;
-            }
-
-            return null;
+            return queryLocalElevation(wx, wz);
         },
 
         set onTerrainUpdated(cb: (() => void) | null) {

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -539,6 +539,14 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
             minZoom
         );
 
+        // カメラ地上投影点（ターゲット基準のワールド座標）。
+        // チルトで見える手前側タイルをカメラ直下タイルと同じ zoom に揃えるために使用。
+        const sinB = Math.sin(camera.beta);
+        const cameraGroundOffset = {
+            x: rawCameraDistance * sinB * Math.sin(camera.alpha),
+            z: rawCameraDistance * sinB * Math.cos(camera.alpha),
+        };
+
         return computeMultiLodTiles({
             baseCenter: currentCenter,
             tileSizeForZoom,
@@ -548,6 +556,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
             minZoom,
             maxTiles,
             maxElevation,
+            cameraGroundOffset,
         });
     };
 

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -543,8 +543,8 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         // チルトで見える手前側タイルをカメラ直下タイルと同じ zoom に揃えるために使用。
         const sinB = Math.sin(camera.beta);
         const cameraGroundOffset = {
-            x: rawCameraDistance * sinB * Math.sin(camera.alpha),
-            z: rawCameraDistance * sinB * Math.cos(camera.alpha),
+            x: rawCameraDistance * sinB * Math.cos(camera.alpha),
+            z: rawCameraDistance * sinB * Math.sin(camera.alpha),
         };
 
         return computeMultiLodTiles({

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -557,6 +557,10 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
             maxTiles,
             maxElevation,
             cameraGroundOffset,
+            // zoom 判定の基準は生のカメラ距離。
+            // 高標高地で effectiveRadius が極小化しても、遠方タイルがすぐに低 zoom へ
+            // 落ちないようにする（急斜面での LOD 段差防止）。
+            zoomReferenceDistance: rawCameraDistance,
         });
     };
 

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -66,8 +66,8 @@ interface ActiveTile {
 }
 
 const DEFAULT_MAX_CONCURRENT = 4;
-const DEFAULT_MAX_TILES = 60;
-const DEFAULT_CACHE_CAPACITY = 96;
+const DEFAULT_MAX_TILES = 120;
+const DEFAULT_CACHE_CAPACITY = 192;
 const DEFAULT_DEBOUNCE_MS = 200;
 /** Frustum 判定用の基準最大標高 (m) — 富士山 3776m + マージン */
 const MAX_BASE_ELEVATION = 4000;

--- a/src/terrain/visibleTiles.ts
+++ b/src/terrain/visibleTiles.ts
@@ -223,6 +223,22 @@ export const computeMultiLodTiles = (
         }
     }
 
+    // Step 1.5: 近傍タイルのzoom平準化
+    // 近傍セル（cameraDistance×2.6以内）のzoomを最大値に揃える。
+    // 標高差のある地形でLOD段差が目立つのを防止する。
+    const nearbyThreshold = cameraDistance * 2.6;
+    let nearbyMaxZoom = minZoom;
+    for (const cell of gridCells) {
+        if (cell.dist < nearbyThreshold && cell.targetZoom > nearbyMaxZoom) {
+            nearbyMaxZoom = cell.targetZoom;
+        }
+    }
+    for (const cell of gridCells) {
+        if (cell.dist < nearbyThreshold) {
+            cell.targetZoom = nearbyMaxZoom;
+        }
+    }
+
     // Step 2: ズーム境界の重なり防止（昇格方式）
     // 親タイル内に高zoomセルが混在する場合、低zoomセルを z+1 に昇格。
     // 全セルが同一低zoomの親タイルはそのまま維持（遠方LODを保持）。

--- a/src/terrain/visibleTiles.ts
+++ b/src/terrain/visibleTiles.ts
@@ -458,9 +458,9 @@ export const computeMultiLodTiles = (
         const farCenter = convertTileZoom(baseCenter, z);
         const { fracX: farFracX, fracY: farFracY } = computeSubTileOffset(baseCenter, z);
 
-        // zoom z の距離上限: cameraDistance × 1.3 × 2^(baseZoom − z)
+        // zoom z の距離上限: zoomRefDistance × 1.3 × 2^(baseZoom − z)
         const zoomSteps = baseZoom - z;
-        const maxDistForZoom = cameraDistance * 1.3 * Math.pow(2, zoomSteps);
+        const maxDistForZoom = zoomRefDistance * 1.3 * Math.pow(2, zoomSteps);
         const farSearchRadius = Math.min(
             Math.ceil(maxDistForZoom / farTileSize) + 1,
             30

--- a/src/terrain/visibleTiles.ts
+++ b/src/terrain/visibleTiles.ts
@@ -120,6 +120,12 @@ export interface MultiLodTilesOptions {
     maxElevation?: number;
     /** baseZoom 格子の探索半径（省略時 14）。Far-field sweep 側の半径には影響しない。 */
     searchRadius?: number;
+    /**
+     * カメラの地上投影点（ターゲット基準のワールド座標）。
+     * 指定時は「ターゲットまたはカメラ地上投影点の近い方」の距離で zoom を決定する。
+     * チルトで見えてくる手前側タイルをカメラ直下と同じ zoom に揃える目的。
+     */
+    cameraGroundOffset?: { x: number; z: number };
 }
 
 const DEFAULT_SEARCH_RADIUS_LOD = 14;
@@ -164,6 +170,7 @@ export const computeMultiLodTiles = (
         maxTiles = DEFAULT_MAX_TILES,
         maxElevation = DEFAULT_MAX_ELEVATION,
         searchRadius = DEFAULT_SEARCH_RADIUS_LOD,
+        cameraGroundOffset,
     } = opts;
 
     if (baseZoom < minZoom) return [];
@@ -189,9 +196,13 @@ export const computeMultiLodTiles = (
     const gridHalf = gridTileSize / 2;
     const gridCenter = convertTileZoom(baseCenter, baseZoom);
 
-    // 探索半径: 画面をカバーできる最小半径と設定値の大きい方
-    const minRadiusForCoverage = Math.ceil(cameraDistance * 1.5 / gridTileSize);
-    const effectiveRadius = Math.max(searchRadius, Math.min(minRadiusForCoverage, 30));
+    // 探索半径: 画面をカバーできる最小半径と設定値の大きい方。
+    // cameraGroundOffset 指定時は、ターゲット〜カメラ地上投影点の距離も含めて広げる。
+    const offsetReach = cameraGroundOffset
+        ? Math.sqrt(cameraGroundOffset.x ** 2 + cameraGroundOffset.z ** 2)
+        : 0;
+    const minRadiusForCoverage = Math.ceil((cameraDistance * 1.5 + offsetReach) / gridTileSize);
+    const effectiveRadius = Math.max(searchRadius, Math.min(minRadiusForCoverage, 60));
 
     // baseCenter→gridCenter 変換で生じるサブタイルオフセット
     const { fracX, fracY } = computeSubTileOffset(baseCenter, baseZoom);
@@ -217,7 +228,31 @@ export const computeMultiLodTiles = (
                 )
             ) continue;
 
-            const dist = Math.sqrt(wx ** 2 + wz ** 2);
+            const distFromTarget = Math.sqrt(wx ** 2 + wz ** 2);
+            let dist = distFromTarget;
+            if (cameraGroundOffset) {
+                // 線分 [target(0,0) → cameraGround] からの距離。
+                // チルト時にカメラとターゲットの間に並ぶ手前側タイル群を
+                // 全て「近い」と判定し、カメラ直下と同じ zoom に揃える。
+                const cx = cameraGroundOffset.x;
+                const cz = cameraGroundOffset.z;
+                const segLenSq = cx * cx + cz * cz;
+                if (segLenSq > 1e-6) {
+                    // t = clamp((P - target) · (cameraGround - target) / |segment|², 0, 1)
+                    const tParam = Math.max(0, Math.min(1, (wx * cx + wz * cz) / segLenSq));
+                    const closestX = tParam * cx;
+                    const closestZ = tParam * cz;
+                    const distFromSegment = Math.sqrt(
+                        (wx - closestX) ** 2 + (wz - closestZ) ** 2,
+                    );
+                    dist = Math.min(dist, distFromSegment);
+                } else {
+                    dist = Math.min(
+                        dist,
+                        Math.sqrt((wx - cx) ** 2 + (wz - cz) ** 2),
+                    );
+                }
+            }
             const targetZoom = zoomForDist(dist);
             gridCells.push({ dx, dy, targetZoom, dist });
         }

--- a/src/terrain/visibleTiles.ts
+++ b/src/terrain/visibleTiles.ts
@@ -17,7 +17,7 @@ export interface VisibleTilesOptions {
     maxElevation?: number;
 }
 
-const DEFAULT_MAX_TILES = 50;
+const DEFAULT_MAX_TILES = 120;
 /** coveredBaseZoomCells / findUncoveredChildren で許容するzoom差の上限 */
 const MAX_COVERAGE_DIFF = 7;
 const DEFAULT_SEARCH_RADIUS = 4;

--- a/src/terrain/visibleTiles.ts
+++ b/src/terrain/visibleTiles.ts
@@ -122,7 +122,7 @@ export interface MultiLodTilesOptions {
     searchRadius?: number;
     /**
      * カメラの地上投影点（ターゲット基準のワールド座標）。
-     * 指定時は「ターゲットまたはカメラ地上投影点の近い方」の距離で zoom を決定する。
+     * 指定時は「線分 [target → cameraGround] への最短距離」で zoom を決定する。
      * チルトで見えてくる手前側タイルをカメラ直下と同じ zoom に揃える目的。
      */
     cameraGroundOffset?: { x: number; z: number };

--- a/src/terrain/visibleTiles.ts
+++ b/src/terrain/visibleTiles.ts
@@ -126,6 +126,13 @@ export interface MultiLodTilesOptions {
      * チルトで見えてくる手前側タイルをカメラ直下と同じ zoom に揃える目的。
      */
     cameraGroundOffset?: { x: number; z: number };
+    /**
+     * zoom 判定（距離閾値・近傍平準化範囲）の基準距離。
+     * 省略時は cameraDistance と同じ。
+     * 標高考慮で cameraDistance を小さく補正した場合でも、
+     * 距離閾値は生のカメラ距離を基準にしたい場合に指定する。
+     */
+    zoomReferenceDistance?: number;
 }
 
 const DEFAULT_SEARCH_RADIUS_LOD = 14;
@@ -171,19 +178,25 @@ export const computeMultiLodTiles = (
         maxElevation = DEFAULT_MAX_ELEVATION,
         searchRadius = DEFAULT_SEARCH_RADIUS_LOD,
         cameraGroundOffset,
+        zoomReferenceDistance,
     } = opts;
 
     if (baseZoom < minZoom) return [];
 
     const cameraDistance = Math.max(1, rawCameraDistance);
+    // 距離閾値判定の基準。未指定時は cameraDistance と同じ（後方互換）。
+    const zoomRefDistance = Math.max(
+        1,
+        zoomReferenceDistance !== undefined ? zoomReferenceDistance : cameraDistance,
+    );
 
     /**
      * ターゲットからの水平距離でzoomレベルを決定。
-     * cameraDistance×1.3以遠で段階的にzoomを下げる。
+     * zoomRefDistance×1.3以遠で段階的にzoomを下げる。
      */
     const zoomForDist = (dist: number): number => {
         let z = baseZoom;
-        let threshold = cameraDistance * 1.3;
+        let threshold = zoomRefDistance * 1.3;
         while (z > minZoom && dist >= threshold) {
             z--;
             threshold *= 2;
@@ -201,7 +214,7 @@ export const computeMultiLodTiles = (
     const offsetReach = cameraGroundOffset
         ? Math.sqrt(cameraGroundOffset.x ** 2 + cameraGroundOffset.z ** 2)
         : 0;
-    const minRadiusForCoverage = Math.ceil((cameraDistance * 1.5 + offsetReach) / gridTileSize);
+    const minRadiusForCoverage = Math.ceil((zoomRefDistance * 1.5 + offsetReach) / gridTileSize);
     const effectiveRadius = Math.max(searchRadius, Math.min(minRadiusForCoverage, 60));
 
     // baseCenter→gridCenter 変換で生じるサブタイルオフセット
@@ -259,9 +272,9 @@ export const computeMultiLodTiles = (
     }
 
     // Step 1.5: 近傍タイルのzoom平準化
-    // 近傍セル（cameraDistance×2.6以内）のzoomを最大値に揃える。
+    // 近傍セル（zoomRefDistance×2.6以内）のzoomを最大値に揃える。
     // 標高差のある地形でLOD段差が目立つのを防止する。
-    const nearbyThreshold = cameraDistance * 2.6;
+    const nearbyThreshold = zoomRefDistance * 2.6;
     let nearbyMaxZoom = minZoom;
     for (const cell of gridCells) {
         if (cell.dist < nearbyThreshold && cell.targetZoom > nearbyMaxZoom) {

--- a/tests/tileManager.unit.spec.ts
+++ b/tests/tileManager.unit.spec.ts
@@ -80,12 +80,44 @@ jest.unstable_mockModule("@babylonjs/core/Maths/math.frustum", () => ({
     },
 }));
 
-jest.unstable_mockModule("@babylonjs/core/Maths/math.vector", () => ({
-    Matrix: {
-        Identity: jest.fn(() => ({
-            m: new Float32Array(16),
-        })),
-    },
+jest.unstable_mockModule("@babylonjs/core/Maths/math.vector", () => {
+    class Vector3Mock {
+        x: number;
+        y: number;
+        z: number;
+        constructor(x = 0, y = 0, z = 0) {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+        }
+        subtract(other: Vector3Mock): Vector3Mock {
+            return new Vector3Mock(this.x - other.x, this.y - other.y, this.z - other.z);
+        }
+        length(): number {
+            return Math.sqrt(this.x ** 2 + this.y ** 2 + this.z ** 2);
+        }
+        scaleInPlace(s: number): Vector3Mock {
+            this.x *= s;
+            this.y *= s;
+            this.z *= s;
+            return this;
+        }
+        static Down(): Vector3Mock {
+            return new Vector3Mock(0, -1, 0);
+        }
+    }
+    return {
+        Matrix: {
+            Identity: jest.fn(() => ({
+                m: new Float32Array(16),
+            })),
+        },
+        Vector3: Vector3Mock,
+    };
+});
+
+jest.unstable_mockModule("@babylonjs/core/Culling/ray", () => ({
+    Ray: jest.fn<(...args: unknown[]) => unknown>().mockImplementation(() => ({})),
 }));
 
 jest.unstable_mockModule("@babylonjs/core/Maths/math.plane", () => ({
@@ -121,11 +153,21 @@ const gsiTileMock = await import("../src/terrain/gsiTile");
 
 const createMockCamera = () => {
     const observers: Array<() => void> = [];
+    const makeTarget = (x = 0, y = 0, z = 0) => ({
+        x, y, z,
+        subtract(other: { x: number; y: number; z: number }) {
+            return { x: x - other.x, y: y - other.y, z: z - other.z,
+                length() { return Math.sqrt((x - other.x) ** 2 + (y - other.y) ** 2 + (z - other.z) ** 2); },
+                scaleInPlace() { return this; },
+            };
+        },
+    });
     return {
         alpha: 0,
         beta: 0,
         radius: 4000,
         position: { x: 0, y: 4000, z: 0 },
+        target: makeTarget(),
         getScene: jest.fn(() => ({
             getEngine: jest.fn(() => ({})),
         })),
@@ -144,11 +186,16 @@ const createMockCamera = () => {
     } as never;
 };
 
+/** scene モック。pickWithRay はデフォルトでヒットなし（rayDist=null → rawRadius使用） */
+const createMockScene = () => ({
+    pickWithRay: jest.fn(() => ({ hit: false, distance: 0, pickedPoint: null })),
+});
+
 describe("createTileManager", () => {
     it("setCenter でタイルがロードされる", async () => {
         const camera = createMockCamera();
         const tm = createTileManager({
-            scene: {} as never,
+            scene: createMockScene() as never,
             camera,
             zoom: 14,
             subdivisions: 128,
@@ -163,7 +210,7 @@ describe("createTileManager", () => {
     it("onStatusChange コールバックが呼ばれる", async () => {
         const camera = createMockCamera();
         const tm = createTileManager({
-            scene: {} as never,
+            scene: createMockScene() as never,
             camera,
             zoom: 14,
             subdivisions: 128,
@@ -181,7 +228,7 @@ describe("createTileManager", () => {
     it("dispose 後に activeTileCount が 0 になる", async () => {
         const camera = createMockCamera();
         const tm = createTileManager({
-            scene: {} as never,
+            scene: createMockScene() as never,
             camera,
             zoom: 14,
             subdivisions: 128,
@@ -199,7 +246,7 @@ describe("createTileManager", () => {
     it("attachCamera/detachCamera が正常に動作する", () => {
         const camera = createMockCamera();
         const tm = createTileManager({
-            scene: {} as never,
+            scene: createMockScene() as never,
             camera,
             zoom: 14,
             subdivisions: 128,
@@ -371,7 +418,7 @@ describe("LOD連携", () => {
         (camera1 as any).position = { x: 0, y: 200, z: 0 };
 
         const tm1 = createTileManager({
-            scene: {} as never,
+            scene: createMockScene() as never,
             camera: camera1,
             zoom: 14,
             subdivisions: 128,
@@ -389,7 +436,7 @@ describe("LOD連携", () => {
         (camera2 as any).position = { x: 5000, y: 200, z: 5000 };
 
         const tm2 = createTileManager({
-            scene: {} as never,
+            scene: createMockScene() as never,
             camera: camera2,
             zoom: 14,
             subdivisions: 128,
@@ -417,7 +464,7 @@ describe("LOD連携", () => {
         (cameraNear as any).radius = 2400;
 
         const tmNear = createTileManager({
-            scene: {} as never,
+            scene: createMockScene() as never,
             camera: cameraNear,
             zoom: 14,
             subdivisions: 128,
@@ -438,7 +485,7 @@ describe("LOD連携", () => {
         (cameraFar as any).radius = 6000;
 
         const tmFar = createTileManager({
-            scene: {} as never,
+            scene: createMockScene() as never,
             camera: cameraFar,
             zoom: 14,
             subdivisions: 128,
@@ -484,7 +531,7 @@ describe("標高ズーム段階フォールバック", () => {
 
         const camera = createMockCamera();
         const tm = createTileManager({
-            scene: {} as never,
+            scene: createMockScene() as never,
             camera,
             zoom: 14,
             subdivisions: 128,
@@ -512,7 +559,7 @@ describe("標高ズーム段階フォールバック", () => {
 
         const camera = createMockCamera();
         const tm = createTileManager({
-            scene: {} as never,
+            scene: createMockScene() as never,
             camera,
             zoom: 14,
             subdivisions: 128,
@@ -537,7 +584,7 @@ describe("標高ズーム段階フォールバック", () => {
 
         const camera = createMockCamera();
         const tm = createTileManager({
-            scene: {} as never,
+            scene: createMockScene() as never,
             camera,
             zoom: 14,
             subdivisions: 128,
@@ -564,7 +611,7 @@ describe("標高ズーム段階フォールバック", () => {
 
         const camera = createMockCamera();
         const tm = createTileManager({
-            scene: {} as never,
+            scene: createMockScene() as never,
             camera,
             zoom: 14,
             subdivisions: 128,
@@ -596,7 +643,7 @@ describe("標高ズーム段階フォールバック", () => {
         const camera = createMockCamera();
         // maxElevationZoom=14, minZoom=2 → デフォルト minElevationZoom = max(2, 14-4) = 10
         const tm = createTileManager({
-            scene: {} as never,
+            scene: createMockScene() as never,
             camera,
             zoom: 14,
             subdivisions: 128,
@@ -624,7 +671,7 @@ describe("setMapType", () => {
     it("setMapType で地図タイプを切り替えると textureUrl が新しいタイプで呼ばれる", async () => {
         const camera = createMockCamera();
         const tm = createTileManager({
-            scene: {} as never,
+            scene: createMockScene() as never,
             camera,
             zoom: 14,
             subdivisions: 128,
@@ -656,7 +703,7 @@ describe("setMapType", () => {
     it("同じ地図タイプを設定しても textureUrl は呼ばれない", async () => {
         const camera = createMockCamera();
         const tm = createTileManager({
-            scene: {} as never,
+            scene: createMockScene() as never,
             camera,
             zoom: 14,
             subdivisions: 128,
@@ -747,7 +794,7 @@ describe("標高データ全NaNフォールバック", () => {
 
         const camera = createMockCamera();
         const tm = createTileManager({
-            scene: {} as never,
+            scene: createMockScene() as never,
             camera,
             zoom: 14,
             subdivisions: 128,
@@ -797,7 +844,7 @@ describe("queryElevationAtWorld", () => {
     it("setCenter前はnullを返す", () => {
         const camera = createNearCamera();
         const tm = createTileManager({
-            scene: {} as never,
+            scene: createMockScene() as never,
             camera,
             zoom: 14,
             subdivisions: 128,
@@ -818,7 +865,7 @@ describe("queryElevationAtWorld", () => {
 
         const camera = createNearCamera();
         const tm = createTileManager({
-            scene: {} as never,
+            scene: createMockScene() as never,
             camera,
             zoom: 14,
             subdivisions: 128,
@@ -843,7 +890,7 @@ describe("queryElevationAtWorld", () => {
 
         const camera = createNearCamera();
         const tm = createTileManager({
-            scene: {} as never,
+            scene: createMockScene() as never,
             camera,
             zoom: 14,
             subdivisions: 128,
@@ -867,7 +914,7 @@ describe("queryElevationAtWorld", () => {
 
         const camera = createNearCamera();
         const tm = createTileManager({
-            scene: {} as never,
+            scene: createMockScene() as never,
             camera,
             zoom: 14,
             subdivisions: 128,
@@ -891,7 +938,7 @@ describe("queryElevationAtWorld", () => {
 
         const camera = createNearCamera();
         const tm = createTileManager({
-            scene: {} as never,
+            scene: createMockScene() as never,
             camera,
             zoom: 14,
             subdivisions: 128,
@@ -913,7 +960,7 @@ describe("queryElevationAtWorld", () => {
 
         const camera = createNearCamera();
         const tm = createTileManager({
-            scene: {} as never,
+            scene: createMockScene() as never,
             camera,
             zoom: 14,
             subdivisions: 128,
@@ -951,7 +998,7 @@ describe("queryElevationAtWorld", () => {
 
         const camera = createNearCamera();
         const tm = createTileManager({
-            scene: {} as never,
+            scene: createMockScene() as never,
             camera,
             zoom: 14,
             subdivisions: 128,
@@ -968,5 +1015,180 @@ describe("queryElevationAtWorld", () => {
         const result = tm.queryElevationAtWorld(0, -1000);
         expect(result).toBe(777);
         tm.dispose();
+    });
+});
+
+/* ================================================================
+ * 地形標高を考慮したズームレベル最適化
+ * ================================================================ */
+describe("地形標高を考慮したズームレベル最適化", () => {
+    afterEach(() => {
+        (gsiTileMock.loadElevationTile as jest.Mock).mockImplementation(
+            () => Promise.resolve(new Float32Array(256 * 256))
+        );
+        (gsiTileMock.tileEdgeMeters as jest.Mock).mockImplementation(
+            () => 1000
+        );
+    });
+
+    it("高標高地形では effectiveRadius が radius - terrainY となり高zoomタイルが表示される", async () => {
+        // zoom依存の tileEdgeMeters: z14=1000, z13=2000, z12=4000
+        (gsiTileMock.tileEdgeMeters as jest.Mock<(lat: number, zoom: number) => number>).mockImplementation(
+            (_lat, zoom) => 1000 * Math.pow(2, 14 - zoom)
+        );
+
+        // 高標高（3776m）の標高データをロードさせる
+        const highElev = new Float32Array(256 * 256).fill(3776);
+        (gsiTileMock.loadElevationTile as jest.Mock).mockImplementation(
+            () => Promise.resolve(highElev)
+        );
+
+        const cameraHigh = createMockCamera();
+        (cameraHigh as any).radius = 8000;
+        (cameraHigh as any).beta = Math.PI / 3;
+
+        const tmHigh = createTileManager({
+            scene: createMockScene() as never,
+            camera: cameraHigh,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 200,
+            minZoom: 12,
+        });
+
+        await tmHigh.setCenter(35.36, 138.73);
+        // 標高キャッシュを反映させるため 2 回目の setCenter を実行
+        (gsiTileMock.textureUrl as jest.Mock).mockClear();
+        await tmHigh.setCenter(35.36, 138.73);
+
+        const zoomsHigh = (gsiTileMock.textureUrl as jest.Mock).mock.calls
+            .map((c) => (c as number[])[1]);
+        const maxZoomHigh = zoomsHigh.length > 0 ? Math.max(...zoomsHigh) : 12;
+
+        // 海面付近（標高0）では radius=8000 がそのまま使われ低zoom
+        (gsiTileMock.loadElevationTile as jest.Mock).mockImplementation(
+            () => Promise.resolve(new Float32Array(256 * 256))
+        );
+
+        const cameraLow = createMockCamera();
+        (cameraLow as any).radius = 8000;
+        (cameraLow as any).beta = Math.PI / 3;
+
+        const tmLow = createTileManager({
+            scene: createMockScene() as never,
+            camera: cameraLow,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 200,
+            minZoom: 12,
+        });
+
+        await tmLow.setCenter(35.68, 139.77);
+        (gsiTileMock.textureUrl as jest.Mock).mockClear();
+        await tmLow.setCenter(35.68, 139.77);
+
+        const zoomsLow = (gsiTileMock.textureUrl as jest.Mock).mock.calls
+            .map((c) => (c as number[])[1]);
+        const maxZoomLow = zoomsLow.length > 0 ? Math.max(...zoomsLow) : 12;
+
+        // 高標高時は低標高時より高zoomが選ばれる
+        expect(maxZoomHigh).toBeGreaterThanOrEqual(maxZoomLow);
+
+        tmHigh.dispose();
+        tmLow.dispose();
+    });
+
+    it("標高データ未キャッシュ時は raw radius がそのまま使われる", async () => {
+        const camera = createMockCamera();
+        (camera as any).radius = 4000;
+
+        const tm = createTileManager({
+            scene: createMockScene() as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 5,
+            minZoom: 12,
+        });
+
+        await tm.setCenter(35.68, 139.77);
+        // 標高未キャッシュでもクラッシュせずタイルがロードされる
+        expect(tm.activeTileCount).toBeGreaterThan(0);
+        tm.dispose();
+    });
+
+    it("effectiveRadius は下限ガード (rawRadius * 0.05) でクランプされる", async () => {
+        (gsiTileMock.tileEdgeMeters as jest.Mock<(lat: number, zoom: number) => number>).mockImplementation(
+            (_lat, zoom) => 1000 * Math.pow(2, 14 - zoom)
+        );
+
+        // 標高がradiusとほぼ同じ（radius-terrainY ≈ 0）でも下限でクランプされ安定
+        const extremeElev = new Float32Array(256 * 256).fill(7999);
+        (gsiTileMock.loadElevationTile as jest.Mock).mockImplementation(
+            () => Promise.resolve(extremeElev)
+        );
+
+        const camera = createMockCamera();
+        (camera as any).radius = 8000;
+        (camera as any).beta = Math.PI / 3;
+
+        const tm = createTileManager({
+            scene: createMockScene() as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 200,
+            minZoom: 12,
+        });
+
+        await tm.setCenter(35.36, 138.73);
+        // 下限ガード (rawRadius*0.05=400) でクランプされ、安定して動作する
+        expect(tm.activeTileCount).toBeGreaterThan(0);
+        tm.dispose();
+    });
+
+    it("同じ radius・標高でチルト角を変えても baseZoom が変わらない（チルト非依存）", async () => {
+        (gsiTileMock.tileEdgeMeters as jest.Mock<(lat: number, zoom: number) => number>).mockImplementation(
+            (_lat, zoom) => 1000 * Math.pow(2, 14 - zoom)
+        );
+
+        const highElev = new Float32Array(256 * 256).fill(3776);
+        (gsiTileMock.loadElevationTile as jest.Mock).mockImplementation(
+            () => Promise.resolve(highElev)
+        );
+
+        const runWithBeta = async (beta: number): Promise<number> => {
+            const camera = createMockCamera();
+            (camera as any).radius = 8000;
+            (camera as any).beta = beta;
+            const tm = createTileManager({
+                scene: createMockScene() as never,
+                camera,
+                zoom: 14,
+                subdivisions: 128,
+                heightScale: 1.0,
+                maxTiles: 200,
+                minZoom: 12,
+            });
+            await tm.setCenter(35.36, 138.73);
+            (gsiTileMock.textureUrl as jest.Mock).mockClear();
+            await tm.setCenter(35.36, 138.73);
+            const zooms = (gsiTileMock.textureUrl as jest.Mock).mock.calls
+                .map((c) => (c as number[])[1]);
+            tm.dispose();
+            return zooms.length > 0 ? Math.max(...zooms) : -1;
+        };
+
+        const zoomVertical = await runWithBeta(0.01);          // ほぼ真下
+        const zoomMid = await runWithBeta(Math.PI / 3);        // 60°
+        const zoomHorizontal = await runWithBeta(Math.PI / 2.1); // ほぼ水平
+
+        // チルト角を変えても baseZoom は同じ
+        expect(zoomVertical).toBe(zoomMid);
+        expect(zoomMid).toBe(zoomHorizontal);
     });
 });

--- a/tests/visibleTiles.unit.spec.ts
+++ b/tests/visibleTiles.unit.spec.ts
@@ -666,4 +666,137 @@ describe("computeMultiLodTiles", () => {
             expect(lowZoomTiles.length).toBeGreaterThan(0);
         });
     });
+
+    it("cameraGroundOffset 指定時、カメラ地上投影点付近の手前側タイルは高zoomになる", () => {
+        // チルトでカメラが X=-600 地点の上空にある状況を想定。
+        // ターゲット(0,0)からは 600 離れているが、カメラ地上投影点の近くになる。
+        const withOffset = computeMultiLodTiles({
+            baseCenter,
+            tileSizeForZoom,
+            frustumPlanes: allVisiblePlanes,
+            cameraDistance: 100,
+            baseZoom: 14,
+            minZoom: 12,
+            maxTiles: 1000,
+            searchRadius: 10,
+            cameraGroundOffset: { x: -600, z: 0 },
+        });
+
+        const withoutOffset = computeMultiLodTiles({
+            baseCenter,
+            tileSizeForZoom,
+            frustumPlanes: allVisiblePlanes,
+            cameraDistance: 100,
+            baseZoom: 14,
+            minZoom: 12,
+            maxTiles: 1000,
+            searchRadius: 10,
+        });
+
+        const covers = (entries: typeof withOffset, dx: number, dy: number): number | null => {
+            const targetX = baseCenter.x + dx;
+            const targetY = baseCenter.y + dy;
+            for (const e of entries) {
+                const diff = 14 - e.coord.zoom;
+                const minX = e.coord.x << diff;
+                const minY = e.coord.y << diff;
+                const maxX = minX + (1 << diff);
+                const maxY = minY + (1 << diff);
+                if (targetX >= minX && targetX < maxX && targetY >= minY && targetY < maxY) {
+                    return e.coord.zoom;
+                }
+            }
+            return null;
+        };
+
+        const zoomWith = covers(withOffset, -6, 0);
+        const zoomWithout = covers(withoutOffset, -6, 0);
+
+        expect(zoomWith).toBe(14);
+        expect(zoomWithout).not.toBeNull();
+        expect(zoomWith!).toBeGreaterThan(zoomWithout!);
+    });
+
+    it("cameraGroundOffset: 近傍平準化範囲外の手前側タイルも高zoomになる", () => {
+        const withOffset = computeMultiLodTiles({
+            baseCenter,
+            tileSizeForZoom,
+            frustumPlanes: allVisiblePlanes,
+            cameraDistance: 1000,
+            baseZoom: 14,
+            minZoom: 12,
+            maxTiles: 2000,
+            searchRadius: 40,
+            cameraGroundOffset: { x: -3500, z: 0 },
+        });
+
+        const withoutOffset = computeMultiLodTiles({
+            baseCenter,
+            tileSizeForZoom,
+            frustumPlanes: allVisiblePlanes,
+            cameraDistance: 1000,
+            baseZoom: 14,
+            minZoom: 12,
+            maxTiles: 2000,
+            searchRadius: 40,
+        });
+
+        const covers = (entries: typeof withOffset, dx: number, dy: number): number | null => {
+            const targetX = baseCenter.x + dx;
+            const targetY = baseCenter.y + dy;
+            for (const e of entries) {
+                const diff = 14 - e.coord.zoom;
+                const minX = e.coord.x << diff;
+                const minY = e.coord.y << diff;
+                const maxX = minX + (1 << diff);
+                const maxY = minY + (1 << diff);
+                if (targetX >= minX && targetX < maxX && targetY >= minY && targetY < maxY) {
+                    return e.coord.zoom;
+                }
+            }
+            return null;
+        };
+
+        const zoomWith = covers(withOffset, -35, 0);
+        const zoomWithout = covers(withoutOffset, -35, 0);
+
+        expect(zoomWith).not.toBeNull();
+        expect(zoomWithout).not.toBeNull();
+        expect(zoomWith!).toBeGreaterThan(zoomWithout!);
+    });
+
+    it("cameraGroundOffset: ターゲットとカメラ地上投影点の中間タイルも高zoomになる", () => {
+        const withOffset = computeMultiLodTiles({
+            baseCenter,
+            tileSizeForZoom,
+            frustumPlanes: allVisiblePlanes,
+            cameraDistance: 500,
+            baseZoom: 14,
+            minZoom: 12,
+            maxTiles: 2000,
+            searchRadius: 50,
+            cameraGroundOffset: { x: -4000, z: 0 },
+        });
+
+        const covers = (entries: typeof withOffset, dx: number, dy: number): number | null => {
+            const targetX = baseCenter.x + dx;
+            const targetY = baseCenter.y + dy;
+            for (const e of entries) {
+                const diff = 14 - e.coord.zoom;
+                const minX = e.coord.x << diff;
+                const minY = e.coord.y << diff;
+                const maxX = minX + (1 << diff);
+                const maxY = minY + (1 << diff);
+                if (targetX >= minX && targetX < maxX && targetY >= minY && targetY < maxY) {
+                    return e.coord.zoom;
+                }
+            }
+            return null;
+        };
+
+        for (const dx of [-10, -20, -30, -40]) {
+            const z = covers(withOffset, dx, 0);
+            expect(z).toBe(14);
+        }
+    });
 });

--- a/tests/visibleTiles.unit.spec.ts
+++ b/tests/visibleTiles.unit.spec.ts
@@ -614,4 +614,56 @@ describe("computeMultiLodTiles", () => {
             }
         });
     });
+
+    describe("近傍LOD平準化 (Step 1.5)", () => {
+        it("cameraDistance*2.6 以内の近傍タイル群は同一zoomに平準化される", () => {
+            // cameraDistance=200 → nearbyThreshold=520
+            // searchRadius=6, tileSize(14)=100 → dx=6*100=600, 境界近辺に差が出る構成
+            // Step 1.5により、dist<520 のタイルは最高zoom(14)に揃えられる
+            const result = computeMultiLodTiles({
+                baseCenter,
+                tileSizeForZoom,
+                frustumPlanes: allVisiblePlanes,
+                cameraDistance: 200,
+                baseZoom: 14,
+                minZoom: 12,
+                maxTiles: 500,
+                searchRadius: 6,
+            });
+
+            const nearbyThreshold = 200 * 2.6;
+            // dist < nearbyThreshold のタイルを抽出し、すべて同一zoomであることを確認
+            const nearbyEntries = result.filter((e) => {
+                const diff = 14 - e.coord.zoom;
+                const baseX = e.coord.x << diff;
+                const baseY = e.coord.y << diff;
+                const dx = (baseX - baseCenter.x) * 100;
+                const dy = (baseY - baseCenter.y) * 100;
+                const dist = Math.sqrt(dx * dx + dy * dy);
+                return dist < nearbyThreshold;
+            });
+
+            expect(nearbyEntries.length).toBeGreaterThan(0);
+            const zooms = new Set(nearbyEntries.map((e) => e.coord.zoom));
+            expect(zooms.size).toBe(1);
+        });
+
+        it("遠方タイルは近傍平準化の影響を受けず低zoomのまま", () => {
+            // nearbyThreshold を超える距離のタイルは元の低zoomを保持
+            const result = computeMultiLodTiles({
+                baseCenter,
+                tileSizeForZoom,
+                frustumPlanes: allVisiblePlanes,
+                cameraDistance: 200,
+                baseZoom: 14,
+                minZoom: 12,
+                maxTiles: 500,
+                searchRadius: 8,
+            });
+
+            // zoom14 以外のタイル（平準化対象外）が存在すること
+            const lowZoomTiles = result.filter((e) => e.coord.zoom < 14);
+            expect(lowZoomTiles.length).toBeGreaterThan(0);
+        });
+    });
 });

--- a/tests/visibleTiles.unit.spec.ts
+++ b/tests/visibleTiles.unit.spec.ts
@@ -799,4 +799,38 @@ describe("computeMultiLodTiles", () => {
             expect(z).toBe(14);
         }
     });
+
+    it("zoomReferenceDistance 指定時、距離閾値が基準距離側で算出される", () => {
+        // cameraDistance=25（標高差し引き後の極小値）
+        // zoomReferenceDistance=500（生のカメラ距離）
+        // 基準=25 なら threshold=32.5 で大半のタイルが最低zoomへ落ちる
+        // 基準=500 なら threshold=650 で近傍タイルは baseZoom を維持する
+        const withRef = computeMultiLodTiles({
+            baseCenter,
+            tileSizeForZoom,
+            frustumPlanes: allVisiblePlanes,
+            cameraDistance: 25,
+            baseZoom: 14,
+            minZoom: 12,
+            maxTiles: 500,
+            searchRadius: 6,
+            zoomReferenceDistance: 500,
+        });
+        const withoutRef = computeMultiLodTiles({
+            baseCenter,
+            tileSizeForZoom,
+            frustumPlanes: allVisiblePlanes,
+            cameraDistance: 25,
+            baseZoom: 14,
+            minZoom: 12,
+            maxTiles: 500,
+            searchRadius: 6,
+        });
+
+        const baseZoomCount = (entries: typeof withRef) =>
+            entries.filter((e) => e.coord.zoom === 14).length;
+
+        // zoomReferenceDistance 指定時は baseZoom(14) タイルが大幅に増える
+        expect(baseZoomCount(withRef)).toBeGreaterThan(baseZoomCount(withoutRef) * 2);
+    });
 });


### PR DESCRIPTION
Refs #53

## 概要
カメラ位置に対する地形標高を考慮した有効カメラ距離を導入し、高標高地（富士山など）で適切な高 zoom タイルが表示されるようにする。あわせて隣接タイルの LOD 段差・手前側タイルの解像度低下・ホイールズームのテンポを改善。

## 変更点（コミット単位）
1. `70a488f` feat(terrain): consider terrain elevation in effective camera distance
2. `b92ec09` feat(tiles): equalize near-camera LOD to avoid banding
3. `60b9a44` feat(tiles): align foreground tile zoom with camera subpoint on tilt
4. `47d4a18` chore(tiles): raise maxTiles and cache capacity defaults
5. `42f913f` feat(scene): adaptive wheel zoom step based on ray-cast distance
6. `7078295` fix(tiles): decouple zoom distance thresholds from elevation-adjusted radius

## 影響範囲
- src/terrain/visibleTiles.ts
- src/terrain/tileManager.ts
- src/scenes/default.ts
- tests/visibleTiles.unit.spec.ts, tests/tileManager.unit.spec.ts

## 確認
- npm run lint / npx tsc --noEmit / npm run test:unit（195件）すべて通過
- 目視: 35.356047,138.733819 真下視点・スケール 500m で LOD 段差解消を確認
