### PR TITLE
feat: 衝突判定を緩和しメッシュに近づけるようにする

### DIFF
--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -19,7 +19,7 @@ const HEIGHT_SCALE = 1.0;
 const MIN_ZOOM = 2;
 
 /** カメラ最小距離（メートル） */
-const CAMERA_LOWER_RADIUS = 250;
+const CAMERA_LOWER_RADIUS = 50;
 /** カメラ最大距離（メートル） */
 const CAMERA_UPPER_RADIUS = 75000;
 /** 遠クリッピング面（メートル） */
@@ -50,7 +50,7 @@ export class DefaultScene implements CreateSceneClass {
         );
         camera.lowerRadiusLimit = CAMERA_LOWER_RADIUS;
         camera.upperRadiusLimit = CAMERA_UPPER_RADIUS;
-        camera.minZ = 10;
+        camera.minZ = 1;
         camera.maxZ = CAMERA_FAR_CLIP;
 
         // チルト制限（地面から20° = beta上限 7π/18）


### PR DESCRIPTION
## 概要

カメラの地形衝突判定を緩和し、メッシュにより近づけるようにする。

## 変更内容

- `CAMERA_LOWER_RADIUS` を 250 → 50 に変更（地形からの最小距離を緩和）
- `camera.minZ` を 10 → 1 に変更（近距離描画に対応）

## 影響範囲

- `src/scenes/default.ts` のカメラパラメータのみ
- カメラ操作体験の変化（地形により近づけるようになる）

## 確認済み

- [x] lint / typecheck 通過
- [x] ユニットテスト全パス（195件）
- [x] AI レビュー承認済み
- [x] 実機確認済み

Closes #92