### PR TITLE
fix: チルト操作時の地形コリジョンを自動ズームアウトで回避

### DIFF
--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -10,6 +10,7 @@ import { createControlPanel, snapScale, formatScale, showToast } from "../terrai
 import { createTileManager } from "../terrain/tileManager";
 import { createSkybox } from "../terrain/skybox";
 import { parseLatLonFromUrl, createUrlUpdater } from "../terrain/urlState";
+import { resolveTiltCollision, TILT_MAX_RADIUS_INCREASE_RATIO } from "../terrain/cameraCollision";
 
 const TERRAIN_SUBDIVISIONS = 128;
 const MAX_ZOOM = 18;
@@ -311,9 +312,24 @@ export class DefaultScene implements CreateSceneClass {
                     camera.lowerBetaLimit ?? 0,
                     camera.upperBetaLimit ?? Math.PI
                 );
-                // チルト変更で地形に衝突するなら beta を復元
-                if (camera.radius < terrainMinRadius()) {
+                // チルト変更で地形に衝突するなら自動ズームアウトで回避
+                const prevRadius = camera.radius;
+                const tiltResult = resolveTiltCollision(
+                    camera.radius,
+                    terrainMinRadius(),
+                    camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS,
+                    TILT_MAX_RADIUS_INCREASE_RATIO,
+                );
+                if (tiltResult.action === "revert") {
                     camera.beta = prevBeta;
+                } else if (tiltResult.action === "zoomOut") {
+                    camera.radius = tiltResult.radius;
+                    // radius 変更でカメラ位置が移動するため再検証
+                    // 新位置でまだ衝突するなら beta・radius 両方を復元
+                    if (camera.radius < terrainMinRadius()) {
+                        camera.beta = prevBeta;
+                        camera.radius = prevRadius;
+                    }
                 }
             } else if (dragAnchor) {
                 // 通常ドラッグ: 逐次差分でパン（毎フレームanchor更新）

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -313,7 +313,7 @@ export class DefaultScene implements CreateSceneClass {
                     camera.upperBetaLimit ?? Math.PI
                 );
                 // チルト変更で地形に衝突するなら自動ズームアウトで回避
-                const prevRadius = camera.radius;
+                const radiusBeforeTilt = camera.radius;
                 const tiltResult = resolveTiltCollision(
                     camera.radius,
                     terrainMinRadius(),
@@ -328,7 +328,7 @@ export class DefaultScene implements CreateSceneClass {
                     // 新位置でまだ衝突するなら beta・radius 両方を復元
                     if (camera.radius < terrainMinRadius()) {
                         camera.beta = prevBeta;
-                        camera.radius = prevRadius;
+                        camera.radius = radiusBeforeTilt;
                     }
                 }
             } else if (dragAnchor) {

--- a/src/terrain/cameraCollision.ts
+++ b/src/terrain/cameraCollision.ts
@@ -1,7 +1,7 @@
 /**
  * チルト操作による地形コリジョン解決結果
  * - "none": コリジョンなし（変更不要）
- * - "zoomOut": 自動ズームアウトで解決可能（radius を返す）
+ * - "zoomOut": ズームアウトを試行（radius を needed まで増やして再検証）
  * - "revert": ズームアウト量が過大（チルト中止）
  */
 export type TiltCollisionResult =

--- a/src/terrain/cameraCollision.ts
+++ b/src/terrain/cameraCollision.ts
@@ -1,0 +1,33 @@
+/**
+ * チルト操作による地形コリジョン解決結果
+ * - "none": コリジョンなし（変更不要）
+ * - "zoomOut": 自動ズームアウトで解決可能（radius を返す）
+ * - "revert": ズームアウト量が過大（チルト中止）
+ */
+export type TiltCollisionResult =
+    | { action: "none" }
+    | { action: "zoomOut"; radius: number }
+    | { action: "revert" };
+
+/** チルト時の自動ズームアウト: radius 増加率の上限（超えたらチルト中止） */
+export const TILT_MAX_RADIUS_INCREASE_RATIO = 0.5;
+
+/**
+ * チルト変更後のコリジョンを解決する。
+ * @param currentRadius - 現在の camera.radius
+ * @param minRadius - 新しい beta での terrainMinRadius
+ * @param upperRadius - camera.upperRadiusLimit
+ * @param maxIncreaseRatio - radius 増加率の上限（0.5 = 50%）
+ */
+export function resolveTiltCollision(
+    currentRadius: number,
+    minRadius: number,
+    upperRadius: number,
+    maxIncreaseRatio: number,
+): TiltCollisionResult {
+    if (currentRadius >= minRadius) return { action: "none" };
+    const maxAllowed = currentRadius * (1 + maxIncreaseRatio);
+    const needed = Math.min(minRadius, upperRadius);
+    if (needed > maxAllowed) return { action: "revert" };
+    return { action: "zoomOut", radius: needed };
+}

--- a/tests/cameraCollision.unit.spec.ts
+++ b/tests/cameraCollision.unit.spec.ts
@@ -1,0 +1,94 @@
+import { resolveTiltCollision, TILT_MAX_RADIUS_INCREASE_RATIO } from "../src/terrain/cameraCollision";
+
+describe("resolveTiltCollision", () => {
+    const ratio = TILT_MAX_RADIUS_INCREASE_RATIO;
+
+    describe("コリジョンなし", () => {
+        it("currentRadius >= minRadius なら none を返す", () => {
+            const result = resolveTiltCollision(200, 150, 75000, ratio);
+            expect(result).toEqual({ action: "none" });
+        });
+
+        it("currentRadius == minRadius でも none を返す", () => {
+            const result = resolveTiltCollision(200, 200, 75000, ratio);
+            expect(result).toEqual({ action: "none" });
+        });
+    });
+
+    describe("自動ズームアウト", () => {
+        it("増加率が閾値内なら zoomOut を返す", () => {
+            // radius 200 → minRadius 250 (25% 増加、閾値 50% 以内)
+            const result = resolveTiltCollision(200, 250, 75000, ratio);
+            expect(result).toEqual({ action: "zoomOut", radius: 250 });
+        });
+
+        it("増加率がちょうど閾値なら zoomOut を返す", () => {
+            // radius 200 → minRadius 300 (50% 増加、閾値ちょうど)
+            const result = resolveTiltCollision(200, 300, 75000, ratio);
+            expect(result).toEqual({ action: "zoomOut", radius: 300 });
+        });
+
+        it("minRadius が upperRadius を超える場合は upperRadius にクランプ", () => {
+            const result = resolveTiltCollision(200, 350, 280, ratio);
+            // needed = min(350, 280) = 280, maxAllowed = 300 → 280 <= 300 → zoomOut
+            expect(result).toEqual({ action: "zoomOut", radius: 280 });
+        });
+    });
+
+    describe("チルト中止（revert）", () => {
+        it("増加率が閾値を超えたら revert を返す", () => {
+            // radius 200 → minRadius 400 (100% 増加、閾値 50% 超過)
+            const result = resolveTiltCollision(200, 400, 75000, ratio);
+            expect(result).toEqual({ action: "revert" });
+        });
+
+        it("壁状の大きな高低差を想定した大幅な増加で revert", () => {
+            // radius 100 → minRadius 1000 (900% 増加)
+            const result = resolveTiltCollision(100, 1000, 75000, ratio);
+            expect(result).toEqual({ action: "revert" });
+        });
+
+        it("upperRadius でクランプしても閾値超過なら revert", () => {
+            // radius 200, minRadius 500, upper 400
+            // needed = min(500, 400) = 400, maxAllowed = 300 → revert
+            const result = resolveTiltCollision(200, 500, 400, ratio);
+            expect(result).toEqual({ action: "revert" });
+        });
+    });
+
+    describe("カスタム maxIncreaseRatio", () => {
+        it("ratio=0.2 で 25% 増加は revert", () => {
+            const result = resolveTiltCollision(200, 250, 75000, 0.2);
+            expect(result).toEqual({ action: "revert" });
+        });
+
+        it("ratio=1.0 で 80% 増加は zoomOut", () => {
+            const result = resolveTiltCollision(200, 360, 75000, 1.0);
+            expect(result).toEqual({ action: "zoomOut", radius: 360 });
+        });
+    });
+
+    describe("TILT_MAX_RADIUS_INCREASE_RATIO 定数", () => {
+        it("0.5（50%）であること", () => {
+            expect(TILT_MAX_RADIUS_INCREASE_RATIO).toBe(0.5);
+        });
+    });
+
+    describe("境界値", () => {
+        it("currentRadius が 0 のとき minRadius > 0 なら revert（ゼロ除算回避）", () => {
+            // maxAllowed = 0 * 1.5 = 0, needed = 100 → revert
+            const result = resolveTiltCollision(0, 100, 75000, ratio);
+            expect(result).toEqual({ action: "revert" });
+        });
+
+        it("currentRadius も minRadius も 0 なら none", () => {
+            const result = resolveTiltCollision(0, 0, 75000, ratio);
+            expect(result).toEqual({ action: "none" });
+        });
+
+        it("非常に小さい差分（1未満の増加）で zoomOut", () => {
+            const result = resolveTiltCollision(200, 200.5, 75000, ratio);
+            expect(result).toEqual({ action: "zoomOut", radius: 200.5 });
+        });
+    });
+});


### PR DESCRIPTION
Fixes #94

## 概要

チルト操作（Ctrl+ドラッグ）時に地形メッシュとのコリジョンで beta が即復元されチルトできない問題を修正。

## 変更内容

### 新規: `src/terrain/cameraCollision.ts`
- 純粋関数 `resolveTiltCollision()` を追加
- 3パターンの判定: `none`（コリジョンなし） / `zoomOut`（自動ズームアウト） / `revert`（チルト中止）
- radius 増加率 50% 以内なら自動ズームアウト、超過なら壁状の高低差と判断しチルト中止

### 修正: `src/scenes/default.ts`
- Ctrl+ドラッグのチルト処理を `resolveTiltCollision()` で分岐
- `zoomOut` 適用後にカメラ新位置で `terrainMinRadius()` を再検証し、まだ衝突する場合は beta・radius 両方を復元

### 新規: `tests/cameraCollision.unit.spec.ts`
- `resolveTiltCollision` のユニットテスト 14 ケース（正常系 / ズームアウト / リバート / 境界値 / カスタム比率）

## 検証結果

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test:unit` ✅ (209/209)