### PR TITLE
ci: add dependabot.yml for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,13 @@ updates:
       # devDependenciesをまとめて1つのPRにする
       dev-dependencies:
         dependency-type: "development"
+        patterns:
+          - "*"
       # productionの依存はpatchとminorをグループ化
       production-minor-patch:
         dependency-type: "production"
         update-types:
           - "minor"
           - "patch"
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 10
+    groups:
+      # devDependenciesをまとめて1つのPRにする
+      dev-dependencies:
+        dependency-type: "development"
+      # productionの依存はpatchとminorをグループ化
+      production-minor-patch:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## 概要

Dependabot を有効化し、npm パッケージの依存関係を自動で最新に保つ設定を追加。

## 変更内容

- `.github/dependabot.yml` を新規追加
  - `npm` エコシステムを対象に weekly（毎週月曜・JST）で依存更新チェック
  - open-pull-requests-limit: 10
  - devDependencies をまとめて 1 つの PR にグループ化
  - production 依存の minor/patch をグループ化

## 影響範囲

- CI/CD 設定のみ。アプリケーションコードへの変更なし。

Closes #95