### PR TITLE
feat: タイルの境目を縫い合わせる (#71)

### DIFF
--- a/src/terrain/gsiTile.ts
+++ b/src/terrain/gsiTile.ts
@@ -61,7 +61,7 @@ export const decodeGsiElevation = (
 };
 
 /** 無効値(NaN)を周囲の有効ピクセルから補間する */
-const fillInvalidPixels = (
+export const fillInvalidPixels = (
     elev: Float32Array,
     width: number,
     height: number
@@ -151,7 +151,6 @@ export const loadElevationTile = async (
                 lastErr = new Error(`All NaN tile: ${url}`);
                 continue;
             }
-            fillInvalidPixels(elev, img.width, img.height);
             return elev;
         } catch (e) {
             lastErr = e;

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -224,6 +224,10 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         typeof camera.onViewMatrixChangedObservable.add
     > | null = null;
 
+    /** 再ステッチ待ちの隣接タイルキーを蓄積し、同一フレームで一括処理する */
+    const pendingRestitch = new Set<TileKey>();
+    let restitchRafId: number | null = null;
+
     // 現在の中心情報
     let currentCenter: TileCoord | null = null;
     let currentAltitudeOffset = 0;
@@ -514,7 +518,21 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         mesh.refreshBoundingInfo();
     };
 
-    /** 新タイルの隣接タイル（同zoom、アクティブなもの）の標高を再適用 */
+    /** 蓄積された再ステッチ対象タイルを一括処理する */
+    const flushRestitch = (): void => {
+        restitchRafId = null;
+        for (const key of pendingRestitch) {
+            const neighborTile = activeTiles.get(key);
+            if (!neighborTile) continue;
+            const entry = cache.get(key);
+            if (!entry) continue;
+            applyStitchedElevation(neighborTile.mesh, entry.elevation, neighborTile.coord);
+        }
+        pendingRestitch.clear();
+        terrainUpdatedCallback?.();
+    };
+
+    /** 新タイルの隣接タイル（同zoom、アクティブなもの）を再ステッチキューに追加 */
     const restitchNeighbors = (coord: TileCoord): void => {
         const { zoom: z, x, y } = coord;
         const deltas = [
@@ -523,11 +541,11 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         ];
         for (const [ddx, ddy] of deltas) {
             const neighborKey = toTileKey({ zoom: z, x: x + ddx, y: y + ddy });
-            const neighborTile = activeTiles.get(neighborKey);
-            if (!neighborTile) continue;
-            const entry = cache.get(neighborKey);
-            if (!entry) continue;
-            applyStitchedElevation(neighborTile.mesh, entry.elevation, neighborTile.coord);
+            if (!activeTiles.has(neighborKey)) continue;
+            pendingRestitch.add(neighborKey);
+        }
+        if (restitchRafId === null) {
+            restitchRafId = requestAnimationFrame(flushRestitch);
         }
     };
 
@@ -716,6 +734,11 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
 
         dispose(): void {
             this.detachCamera();
+            if (restitchRafId !== null) {
+                cancelAnimationFrame(restitchRafId);
+                restitchRafId = null;
+            }
+            pendingRestitch.clear();
             for (const [, tile] of activeTiles) {
                 meshPool.release(tile.mesh);
             }

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -22,7 +22,9 @@ import {
     loadElevationTile,
     textureUrl,
     MapType,
+    fillInvalidPixels,
 } from "./gsiTile";
+import { stitchTileEdges } from "./tileStitching";
 
 export interface TileManagerOptions {
     scene: Scene;
@@ -332,32 +334,17 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
             mesh.position.x = wx;
             mesh.position.z = wz;
 
-            // 標高適用
-            const pos = mesh.getVerticesData(VertexBuffer.PositionKind);
-            const idx = mesh.getIndices();
-            if (pos && idx) {
-                const typed =
-                    pos instanceof Float32Array
-                        ? pos
-                        : new Float32Array(pos);
-                applyElevation(
-                    typed,
-                    entry.elevation,
-                    currentAltitudeOffset,
-                    heightScale,
-                    subdivisions
-                );
-                mesh.updateVerticesData(VertexBuffer.PositionKind, typed);
-                const normals = new Float32Array(typed.length);
-                VertexData.ComputeNormals(typed, idx, normals);
-                mesh.updateVerticesData(VertexBuffer.NormalKind, normals);
-                mesh.refreshBoundingInfo();
-            }
+            // 標高適用（ステッチ＋NaN埋め）
+            applyStitchedElevation(mesh, entry.elevation, coord);
 
             // テクスチャ
             applyTexture(mesh, coord);
 
             activeTiles.set(key, { key, coord, mesh, tileSize });
+
+            // 隣接タイルのメッシュも再ステッチ
+            restitchNeighbors(coord);
+
             terrainUpdatedCallback?.();
         } catch (e) {
             if (rid !== requestId) return;
@@ -394,29 +381,10 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
             mesh.position.x = wx;
             mesh.position.z = wz;
 
-            // キャッシュから標高データを取得し再適用
+            // キャッシュから標高データを取得し再適用（ステッチ＋NaN埋め）
             const entry = cache.get(key);
             if (entry) {
-                const pos = mesh.getVerticesData(VertexBuffer.PositionKind);
-                const idx = mesh.getIndices();
-                if (pos && idx) {
-                    const typed =
-                        pos instanceof Float32Array
-                            ? pos
-                            : new Float32Array(pos);
-                    applyElevation(
-                        typed,
-                        entry.elevation,
-                        currentAltitudeOffset,
-                        heightScale,
-                        subdivisions
-                    );
-                    mesh.updateVerticesData(VertexBuffer.PositionKind, typed);
-                    const normals = new Float32Array(typed.length);
-                    VertexData.ComputeNormals(typed, idx, normals);
-                    mesh.updateVerticesData(VertexBuffer.NormalKind, normals);
-                    mesh.refreshBoundingInfo();
-                }
+                applyStitchedElevation(mesh, entry.elevation, coord);
             }
         }
         terrainUpdatedCallback?.();
@@ -493,6 +461,76 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         }
     };
 
+    /** 同じzoomの隣接タイル標高をキャッシュから取得 */
+    const getNeighborElevations = (coord: TileCoord): {
+        top?: Float32Array; bottom?: Float32Array;
+        left?: Float32Array; right?: Float32Array;
+        topLeft?: Float32Array; topRight?: Float32Array;
+        bottomLeft?: Float32Array; bottomRight?: Float32Array;
+    } => {
+        const { zoom: z, x, y } = coord;
+        const get = (nx: number, ny: number): Float32Array | undefined =>
+            cache.get(toTileKey({ zoom: z, x: nx, y: ny }))?.elevation;
+        return {
+            top: get(x, y - 1),
+            bottom: get(x, y + 1),
+            left: get(x - 1, y),
+            right: get(x + 1, y),
+            topLeft: get(x - 1, y - 1),
+            topRight: get(x + 1, y - 1),
+            bottomLeft: get(x - 1, y + 1),
+            bottomRight: get(x + 1, y + 1),
+        };
+    };
+
+    /** タイルの標高データをステッチ＋NaN埋めしてメッシュに適用 */
+    const applyStitchedElevation = (
+        mesh: Mesh,
+        elevation: Float32Array,
+        coord: TileCoord,
+    ): void => {
+        const pos = mesh.getVerticesData(VertexBuffer.PositionKind);
+        const idx = mesh.getIndices();
+        if (!pos || !idx) return;
+
+        const typed = pos instanceof Float32Array ? pos : new Float32Array(pos);
+
+        // 標高データのコピーを作成（キャッシュの元データを保持するため）
+        const stitched = new Float32Array(elevation);
+
+        // 隣接タイルと辺を縫い合わせ
+        const neighbors = getNeighborElevations(coord);
+        stitchTileEdges(stitched, neighbors, TILE_SIZE);
+
+        // NaN を埋める
+        fillInvalidPixels(stitched, TILE_SIZE, TILE_SIZE);
+
+        // メッシュに適用
+        applyElevation(typed, stitched, currentAltitudeOffset, heightScale, subdivisions);
+        mesh.updateVerticesData(VertexBuffer.PositionKind, typed);
+        const normals = new Float32Array(typed.length);
+        VertexData.ComputeNormals(typed, idx, normals);
+        mesh.updateVerticesData(VertexBuffer.NormalKind, normals);
+        mesh.refreshBoundingInfo();
+    };
+
+    /** 新タイルの隣接タイル（同zoom、アクティブなもの）の標高を再適用 */
+    const restitchNeighbors = (coord: TileCoord): void => {
+        const { zoom: z, x, y } = coord;
+        const deltas = [
+            [0, -1], [0, 1], [-1, 0], [1, 0],
+            [-1, -1], [1, -1], [-1, 1], [1, 1],
+        ];
+        for (const [ddx, ddy] of deltas) {
+            const neighborKey = toTileKey({ zoom: z, x: x + ddx, y: y + ddy });
+            const neighborTile = activeTiles.get(neighborKey);
+            if (!neighborTile) continue;
+            const entry = cache.get(neighborKey);
+            if (!entry) continue;
+            applyStitchedElevation(neighborTile.mesh, entry.elevation, neighborTile.coord);
+        }
+    };
+
     /** キャッシュ済み標高データからワールド座標のY値を返す（ヒットしなければ null） */
     const queryLocalElevation = (wx: number, wz: number): number | null => {
         if (!currentCenter) return null;
@@ -511,7 +549,9 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
             const fy = tileYFloat - tileYInt;
             const px = Math.min(TILE_SIZE - 1, Math.max(0, Math.round(fx * (TILE_SIZE - 1))));
             const py = Math.min(TILE_SIZE - 1, Math.max(0, Math.round(fy * (TILE_SIZE - 1))));
-            return (entry.elevation[py * TILE_SIZE + px] + currentAltitudeOffset) * heightScale;
+            const val = entry.elevation[py * TILE_SIZE + px];
+            if (Number.isNaN(val)) continue;
+            return (val + currentAltitudeOffset) * heightScale;
         }
         return null;
     };

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -549,7 +549,11 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         }
     };
 
-    /** キャッシュ済み標高データからワールド座標のY値を返す（ヒットしなければ null） */
+    /**
+     * キャッシュ済み標高データからワールド座標のY値を返す（ヒットしなければ null）。
+     * メッシュ適用時（fillInvalidPixels）と同様に、NaN ピクセルは近傍8方向から補間する。
+     * 近傍にも有効値がなければ低 zoom へフォールバックし、全 zoom で見つからなければ null。
+     */
     const queryLocalElevation = (wx: number, wz: number): number | null => {
         if (!currentCenter) return null;
         for (let z = maxElevationZoom; z >= minElevationZoom; z--) {
@@ -568,8 +572,30 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
             const px = Math.min(TILE_SIZE - 1, Math.max(0, Math.round(fx * (TILE_SIZE - 1))));
             const py = Math.min(TILE_SIZE - 1, Math.max(0, Math.round(fy * (TILE_SIZE - 1))));
             const val = entry.elevation[py * TILE_SIZE + px];
-            if (Number.isNaN(val)) continue;
-            return (val + currentAltitudeOffset) * heightScale;
+            if (!Number.isNaN(val)) {
+                return (val + currentAltitudeOffset) * heightScale;
+            }
+            // NaN の場合は近傍8ピクセルから補間（fillInvalidPixels と同等の方針）。
+            // 近傍にも有効値がなければ低 zoom へフォールバックする。
+            let sum = 0;
+            let count = 0;
+            for (let dy = -1; dy <= 1; dy++) {
+                for (let dx = -1; dx <= 1; dx++) {
+                    if (dx === 0 && dy === 0) continue;
+                    const nx = px + dx;
+                    const ny = py + dy;
+                    if (nx < 0 || nx >= TILE_SIZE || ny < 0 || ny >= TILE_SIZE) continue;
+                    const nv = entry.elevation[ny * TILE_SIZE + nx];
+                    if (!Number.isNaN(nv)) {
+                        sum += nv;
+                        count++;
+                    }
+                }
+            }
+            if (count > 0) {
+                return (sum / count + currentAltitudeOffset) * heightScale;
+            }
+            // 近傍全て NaN → 低 zoom へフォールバック
         }
         return null;
     };

--- a/src/terrain/tileStitching.ts
+++ b/src/terrain/tileStitching.ts
@@ -1,0 +1,126 @@
+/** 隣接タイルの標高データを辺・頂点で縫い合わせるユーティリティ */
+
+/** 隣接タイルの標高データ（同一zoomレベルのみ） */
+export interface StitchNeighbors {
+    top?: Float32Array;
+    bottom?: Float32Array;
+    left?: Float32Array;
+    right?: Float32Array;
+    topLeft?: Float32Array;
+    topRight?: Float32Array;
+    bottomLeft?: Float32Array;
+    bottomRight?: Float32Array;
+}
+
+/** NaN を除外した平均値を返す。すべて NaN なら NaN */
+export const nanMean = (values: readonly number[]): number => {
+    let sum = 0;
+    let count = 0;
+    for (const v of values) {
+        if (!Number.isNaN(v)) {
+            sum += v;
+            count++;
+        }
+    }
+    return count > 0 ? sum / count : NaN;
+};
+
+/**
+ * タイルの辺を隣接タイルと縫い合わせる。
+ * target を in-place で変更する。
+ *
+ * - 辺のピクセル（角を除く）は隣接タイルとの2値平均
+ * - 角のピクセルは最大4タイルの平均
+ * - NaN は平均計算から除外。全値が NaN の場合は変更しない
+ */
+export const stitchTileEdges = (
+    target: Float32Array,
+    neighbors: StitchNeighbors,
+    tileSize: number,
+): void => {
+    const last = tileSize - 1;
+
+    // --- 辺の縫い合わせ（角を除く） ---
+
+    // 上辺: target row=0 ↔ top row=last
+    if (neighbors.top) {
+        for (let col = 1; col < last; col++) {
+            const tIdx = col;
+            const nIdx = last * tileSize + col;
+            const avg = nanMean([target[tIdx], neighbors.top[nIdx]]);
+            if (!Number.isNaN(avg)) target[tIdx] = avg;
+        }
+    }
+
+    // 下辺: target row=last ↔ bottom row=0
+    if (neighbors.bottom) {
+        for (let col = 1; col < last; col++) {
+            const tIdx = last * tileSize + col;
+            const nIdx = col;
+            const avg = nanMean([target[tIdx], neighbors.bottom[nIdx]]);
+            if (!Number.isNaN(avg)) target[tIdx] = avg;
+        }
+    }
+
+    // 左辺: target col=0 ↔ left col=last
+    if (neighbors.left) {
+        for (let row = 1; row < last; row++) {
+            const tIdx = row * tileSize;
+            const nIdx = row * tileSize + last;
+            const avg = nanMean([target[tIdx], neighbors.left[nIdx]]);
+            if (!Number.isNaN(avg)) target[tIdx] = avg;
+        }
+    }
+
+    // 右辺: target col=last ↔ right col=0
+    if (neighbors.right) {
+        for (let row = 1; row < last; row++) {
+            const tIdx = row * tileSize + last;
+            const nIdx = row * tileSize;
+            const avg = nanMean([target[tIdx], neighbors.right[nIdx]]);
+            if (!Number.isNaN(avg)) target[tIdx] = avg;
+        }
+    }
+
+    // --- 角の縫い合わせ（最大4タイル平均） ---
+
+    // 左上 (0, 0)
+    {
+        const values: number[] = [target[0]];
+        if (neighbors.top) values.push(neighbors.top[last * tileSize]);
+        if (neighbors.left) values.push(neighbors.left[last]);
+        if (neighbors.topLeft) values.push(neighbors.topLeft[last * tileSize + last]);
+        const avg = nanMean(values);
+        if (!Number.isNaN(avg)) target[0] = avg;
+    }
+
+    // 右上 (0, last)
+    {
+        const values: number[] = [target[last]];
+        if (neighbors.top) values.push(neighbors.top[last * tileSize + last]);
+        if (neighbors.right) values.push(neighbors.right[0]);
+        if (neighbors.topRight) values.push(neighbors.topRight[last * tileSize]);
+        const avg = nanMean(values);
+        if (!Number.isNaN(avg)) target[last] = avg;
+    }
+
+    // 左下 (last, 0)
+    {
+        const values: number[] = [target[last * tileSize]];
+        if (neighbors.bottom) values.push(neighbors.bottom[0]);
+        if (neighbors.left) values.push(neighbors.left[last * tileSize + last]);
+        if (neighbors.bottomLeft) values.push(neighbors.bottomLeft[last]);
+        const avg = nanMean(values);
+        if (!Number.isNaN(avg)) target[last * tileSize] = avg;
+    }
+
+    // 右下 (last, last)
+    {
+        const values: number[] = [target[last * tileSize + last]];
+        if (neighbors.bottom) values.push(neighbors.bottom[last]);
+        if (neighbors.right) values.push(neighbors.right[last * tileSize]);
+        if (neighbors.bottomRight) values.push(neighbors.bottomRight[0]);
+        const avg = nanMean(values);
+        if (!Number.isNaN(avg)) target[last * tileSize + last] = avg;
+    }
+};

--- a/tests/tileManager.unit.spec.ts
+++ b/tests/tileManager.unit.spec.ts
@@ -1017,6 +1017,189 @@ describe("queryElevationAtWorld", () => {
         expect(result).toBe(777);
         tm.dispose();
     });
+
+    /* ── NaN 挙動テスト（海域タイル等） ── */
+
+    it("NaNピクセルのみのタイル（海域等）でnullを返す", async () => {
+        const nanData = new Float32Array(256 * 256).fill(NaN);
+        (gsiTileMock.loadElevationTile as jest.Mock).mockImplementation(
+            () => Promise.resolve(nanData)
+        );
+
+        const camera = createNearCamera();
+        const tm = createTileManager({
+            scene: createMockScene() as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 5,
+            minZoom: 14,
+            maxElevationZoom: 14,
+            minElevationZoom: 14,
+        });
+
+        await tm.setCenter(35.68, 139.77);
+        expect(tm.queryElevationAtWorld(0, 0)).toBeNull();
+        tm.dispose();
+    });
+
+    it("NaNピクセル位置で低zoomへフォールバックし有効値を返す", async () => {
+        (gsiTileMock.tileEdgeMeters as jest.Mock<(lat: number, zoom: number) => number>).mockImplementation(
+            (_lat, zoom) => 1000 * Math.pow(2, 14 - zoom)
+        );
+
+        // zoom14 クエリ対象タイル: 全NaN（海域想定）
+        const nanData14 = new Float32Array(256 * 256).fill(NaN);
+        // zoom13: ピクセル(64,64)に有効値42を設定
+        // wx=0, wz=-1000 → zoom13で fracTile=(0.25,0.25) → px=64, py=64
+        const elevData13 = new Float32Array(256 * 256).fill(NaN);
+        elevData13[64 * 256 + 64] = 42;
+
+        (gsiTileMock.loadElevationTile as jest.Mock<(zoom: number, x: number, y: number) => Promise<Float32Array>>).mockImplementation(
+            (zoom, x, y) => {
+                // クエリ対象の zoom14 タイル (14547,6453) は NaN で成功
+                if (zoom === 14 && x === 14547 && y === 6453) {
+                    return Promise.resolve(nanData14);
+                }
+                // その他の zoom14 タイルは失敗 → zoom13 キャッシュ生成を誘発
+                if (zoom >= 14) {
+                    return Promise.reject(new Error("not available"));
+                }
+                return Promise.resolve(elevData13);
+            }
+        );
+
+        const camera = createNearCamera();
+        const tm = createTileManager({
+            scene: createMockScene() as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 5,
+            minZoom: 14,
+            maxElevationZoom: 14,
+            minElevationZoom: 13,
+        });
+
+        await tm.setCenter(35.68, 139.77);
+        // wx=0, wz=-1000 → zoom14キー"14/14547/6453"はNaN
+        // → zoom13キー"13/7273/3226"にフォールバック → pixel(64,64)=42
+        const result = tm.queryElevationAtWorld(0, -1000);
+        expect(result).toBe(42);
+        tm.dispose();
+    });
+
+    it("全zoomレベルでNaNの場合nullを返す（フォールバック全滅）", async () => {
+        (gsiTileMock.tileEdgeMeters as jest.Mock<(lat: number, zoom: number) => number>).mockImplementation(
+            (_lat, zoom) => 1000 * Math.pow(2, 14 - zoom)
+        );
+
+        const nanData = new Float32Array(256 * 256).fill(NaN);
+        (gsiTileMock.loadElevationTile as jest.Mock<(zoom: number, x: number, y: number) => Promise<Float32Array>>).mockImplementation(
+            (zoom, x, y) => {
+                // クエリ対象タイル (14547,6453) はNaNで成功
+                if (zoom === 14 && x === 14547 && y === 6453) {
+                    return Promise.resolve(new Float32Array(nanData));
+                }
+                // 他のzoom14は失敗 → zoom13キャッシュ生成を誘発（NaN）
+                if (zoom >= 14) {
+                    return Promise.reject(new Error("not available"));
+                }
+                // zoom13もNaN
+                return Promise.resolve(new Float32Array(nanData));
+            }
+        );
+
+        const camera = createNearCamera();
+        const tm = createTileManager({
+            scene: createMockScene() as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 5,
+            minZoom: 14,
+            maxElevationZoom: 14,
+            minElevationZoom: 12,
+        });
+
+        await tm.setCenter(35.68, 139.77);
+        // zoom14→13→12 全てNaN → null
+        expect(tm.queryElevationAtWorld(0, -1000)).toBeNull();
+        tm.dispose();
+    });
+
+    it("NaNフォールバック結果にheightScaleとaltitudeOffsetが反映される", async () => {
+        (gsiTileMock.tileEdgeMeters as jest.Mock<(lat: number, zoom: number) => number>).mockImplementation(
+            (_lat, zoom) => 1000 * Math.pow(2, 14 - zoom)
+        );
+
+        // zoom14 クエリ対象: 全NaN
+        const nanData14 = new Float32Array(256 * 256).fill(NaN);
+        // zoom13: ピクセル(64,64)に有効値50
+        const elevData13 = new Float32Array(256 * 256).fill(NaN);
+        elevData13[64 * 256 + 64] = 50;
+
+        (gsiTileMock.loadElevationTile as jest.Mock<(zoom: number, x: number, y: number) => Promise<Float32Array>>).mockImplementation(
+            (zoom, x, y) => {
+                if (zoom === 14 && x === 14547 && y === 6453) {
+                    return Promise.resolve(nanData14);
+                }
+                if (zoom >= 14) {
+                    return Promise.reject(new Error("not available"));
+                }
+                return Promise.resolve(elevData13);
+            }
+        );
+
+        const camera = createNearCamera();
+        const tm = createTileManager({
+            scene: createMockScene() as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 2.0,
+            maxTiles: 5,
+            minZoom: 14,
+            maxElevationZoom: 14,
+            minElevationZoom: 13,
+        });
+
+        await tm.setCenter(35.68, 139.77, 10); // altitudeOffset = 10
+        // wx=0, wz=-1000 → zoom14 NaN → zoom13 フォールバック → 50取得
+        // (50 + 10) * 2.0 = 120
+        const result = tm.queryElevationAtWorld(0, -1000);
+        expect(result).toBe(120);
+        tm.dispose();
+    });
+
+    it("NaN混在タイルで有効ピクセルは正しく返す", async () => {
+        const mixedData = new Float32Array(256 * 256).fill(NaN);
+        mixedData[0] = 88; // ピクセル(0,0)のみ有効
+        (gsiTileMock.loadElevationTile as jest.Mock).mockImplementation(
+            () => Promise.resolve(mixedData)
+        );
+
+        const camera = createNearCamera();
+        const tm = createTileManager({
+            scene: createMockScene() as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 5,
+            minZoom: 14,
+            maxElevationZoom: 14,
+            minElevationZoom: 14,
+        });
+
+        await tm.setCenter(35.68, 139.77);
+        // ピクセル(0,0)は有効値88 → フォールバック不要でそのまま返す
+        expect(tm.queryElevationAtWorld(0, 0)).toBe(88);
+        tm.dispose();
+    });
 });
 
 /* ================================================================

--- a/tests/tileManager.unit.spec.ts
+++ b/tests/tileManager.unit.spec.ts
@@ -146,6 +146,7 @@ jest.unstable_mockModule("../src/terrain/gsiTile", () => ({
     stdTextureUrl: jest.fn(() => "https://example.com/tile.png"),
     photoTextureUrl: jest.fn(() => "https://example.com/photo.jpg"),
     textureUrl: jest.fn(() => "https://example.com/tile.png"),
+    fillInvalidPixels: jest.fn(),
 }));
 
 const { createTileManager, extractSubTileElevation, computeTextureUvParams } = await import("../src/terrain/tileManager");

--- a/tests/tileStitching.unit.spec.ts
+++ b/tests/tileStitching.unit.spec.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect } from "@jest/globals";
+import { nanMean, stitchTileEdges, StitchNeighbors } from "../src/terrain/tileStitching";
+
+// --- nanMean ---
+
+describe("nanMean", () => {
+    it("通常の数値の平均を返す", () => {
+        expect(nanMean([2, 4, 6])).toBe(4);
+    });
+
+    it("NaN を除外して平均を計算する", () => {
+        expect(nanMean([NaN, 4, 6])).toBe(5);
+    });
+
+    it("すべて NaN なら NaN を返す", () => {
+        expect(nanMean([NaN, NaN, NaN])).toBeNaN();
+    });
+
+    it("空配列は NaN を返す", () => {
+        expect(nanMean([])).toBeNaN();
+    });
+
+    it("要素1つでもそのまま返す", () => {
+        expect(nanMean([42])).toBe(42);
+    });
+
+    it("NaN 1つ + 有効値1つ → 有効値を返す", () => {
+        expect(nanMean([NaN, 10])).toBe(10);
+    });
+});
+
+// --- stitchTileEdges ---
+
+/** size×size の Float32Array を指定値で埋める */
+const fill = (size: number, value: number): Float32Array =>
+    new Float32Array(size * size).fill(value);
+
+/** size×size の Float32Array を NaN で埋める */
+const fillNaN = (size: number): Float32Array => {
+    const arr = new Float32Array(size * size);
+    arr.fill(NaN);
+    return arr;
+};
+
+describe("stitchTileEdges", () => {
+    const S = 4; // 小さいタイルサイズでテスト
+
+    it("隣接タイルなしの場合は何も変わらない", () => {
+        const target = fill(S, 10);
+        const copy = new Float32Array(target);
+        stitchTileEdges(target, {}, S);
+        expect(target).toEqual(copy);
+    });
+
+    it("上辺を隣接タイルと平均する（角を除く）", () => {
+        const target = fill(S, 10);
+        const top = fill(S, 20);
+        stitchTileEdges(target, { top }, S);
+
+        // 上辺の col=1,2 (角を除く) は (10+20)/2 = 15
+        expect(target[1]).toBe(15);
+        expect(target[2]).toBe(15);
+
+        // 内部ピクセルは変わらない
+        expect(target[S + 1]).toBe(10);
+    });
+
+    it("下辺を隣接タイルと平均する（角を除く）", () => {
+        const target = fill(S, 10);
+        const bottom = fill(S, 30);
+        stitchTileEdges(target, { bottom }, S);
+
+        const lastRow = (S - 1) * S;
+        expect(target[lastRow + 1]).toBe(20);
+        expect(target[lastRow + 2]).toBe(20);
+    });
+
+    it("左辺を隣接タイルと平均する（角を除く）", () => {
+        const target = fill(S, 10);
+        const left = fill(S, 6);
+        stitchTileEdges(target, { left }, S);
+
+        // row=1,2 の col=0 は (10+6)/2 = 8
+        expect(target[1 * S]).toBe(8);
+        expect(target[2 * S]).toBe(8);
+    });
+
+    it("右辺を隣接タイルと平均する（角を除く）", () => {
+        const target = fill(S, 10);
+        const right = fill(S, 0);
+        stitchTileEdges(target, { right }, S);
+
+        // row=1,2 の col=last は (10+0)/2 = 5
+        expect(target[1 * S + (S - 1)]).toBe(5);
+        expect(target[2 * S + (S - 1)]).toBe(5);
+    });
+
+    it("左上角を最大4タイルで平均する", () => {
+        const target = fill(S, 10);
+        const top = fill(S, 20);
+        const left = fill(S, 30);
+        const topLeft = fill(S, 40);
+        stitchTileEdges(target, { top, left, topLeft }, S);
+
+        // 左上 = mean(10,20,30,40) = 25
+        expect(target[0]).toBe(25);
+    });
+
+    it("右上角を最大4タイルで平均する", () => {
+        const target = fill(S, 10);
+        const top = fill(S, 20);
+        const right = fill(S, 30);
+        const topRight = fill(S, 40);
+        stitchTileEdges(target, { top, right, topRight }, S);
+
+        expect(target[S - 1]).toBe(25);
+    });
+
+    it("左下角を最大4タイルで平均する", () => {
+        const target = fill(S, 10);
+        const bottom = fill(S, 20);
+        const left = fill(S, 30);
+        const bottomLeft = fill(S, 40);
+        stitchTileEdges(target, { bottom, left, bottomLeft }, S);
+
+        expect(target[(S - 1) * S]).toBe(25);
+    });
+
+    it("右下角を最大4タイルで平均する", () => {
+        const target = fill(S, 10);
+        const bottom = fill(S, 20);
+        const right = fill(S, 30);
+        const bottomRight = fill(S, 40);
+        stitchTileEdges(target, { bottom, right, bottomRight }, S);
+
+        expect(target[(S - 1) * S + (S - 1)]).toBe(25);
+    });
+
+    it("角に隣接タイルが2つだけのとき2タイル平均になる", () => {
+        const target = fill(S, 10);
+        const top = fill(S, 30);
+        stitchTileEdges(target, { top }, S);
+
+        // 左上 = mean(10, 30) = 20（left, topLeft なし）
+        expect(target[0]).toBe(20);
+    });
+
+    it("NaN を含む隣接タイルの辺はNaNを除外して平均する", () => {
+        const target = fill(S, 10);
+        const top = fillNaN(S);
+        stitchTileEdges(target, { top }, S);
+
+        // top が全 NaN → target のみで平均 = 10 (変更なし)
+        expect(target[1]).toBe(10);
+        expect(target[2]).toBe(10);
+    });
+
+    it("target も隣接タイルも NaN の場合は変更しない", () => {
+        const target = fillNaN(S);
+        const top = fillNaN(S);
+        stitchTileEdges(target, { top }, S);
+
+        expect(target[1]).toBeNaN();
+        expect(target[2]).toBeNaN();
+    });
+
+    it("target の辺が NaN、隣接が有効値なら隣接値になる", () => {
+        const target = fillNaN(S);
+        const top = fill(S, 50);
+        stitchTileEdges(target, { top }, S);
+
+        // target[1] = NaN, top の対応ピクセルは 50 → mean = 50
+        expect(target[1]).toBe(50);
+        expect(target[2]).toBe(50);
+    });
+
+    it("NaN 角: 一部のみ有効値なら有効値だけで平均する", () => {
+        const target = fill(S, 10);
+        const top = fillNaN(S);
+        const left = fill(S, 30);
+        const topLeft = fillNaN(S);
+        stitchTileEdges(target, { top, left, topLeft }, S);
+
+        // mean(10, NaN, 30, NaN) = mean(10, 30) = 20
+        expect(target[0]).toBe(20);
+    });
+
+    it("全辺と全角を同時に処理できる", () => {
+        const target = fill(S, 0);
+        const neighbors: StitchNeighbors = {
+            top: fill(S, 4),
+            bottom: fill(S, 4),
+            left: fill(S, 4),
+            right: fill(S, 4),
+            topLeft: fill(S, 4),
+            topRight: fill(S, 4),
+            bottomLeft: fill(S, 4),
+            bottomRight: fill(S, 4),
+        };
+        stitchTileEdges(target, neighbors, S);
+
+        // 辺 = (0+4)/2 = 2
+        expect(target[1]).toBe(2); // top edge
+        expect(target[(S - 1) * S + 1]).toBe(2); // bottom edge
+        expect(target[1 * S]).toBe(2); // left edge
+        expect(target[1 * S + (S - 1)]).toBe(2); // right edge
+
+        // 角 = mean(0,4,4,4) = 3
+        expect(target[0]).toBe(3);
+        expect(target[S - 1]).toBe(3);
+        expect(target[(S - 1) * S]).toBe(3);
+        expect(target[(S - 1) * S + (S - 1)]).toBe(3);
+
+        // 内部 = 変わらない
+        expect(target[S + 1]).toBe(0);
+    });
+
+    it("実際のタイルサイズ 256 でも動作する", () => {
+        const SIZE = 256;
+        const target = fill(SIZE, 100);
+        const right = fill(SIZE, 200);
+        stitchTileEdges(target, { right }, SIZE);
+
+        // 右辺 row=1 col=255 = (100+200)/2 = 150
+        expect(target[1 * SIZE + 255]).toBe(150);
+        // 内部は変わらない
+        expect(target[1 * SIZE + 254]).toBe(100);
+    });
+});


### PR DESCRIPTION
## 概要

同一ズームレベルの隣接タイル間の標高値を辺・頂点で平均化し、地形メッシュの隙間を解消する。

Closes #71

## 変更内容

### 新規ファイル
- **`src/terrain/tileStitching.ts`**: 隣接タイルの辺・角の標高を縫い合わせるユーティリティ
  - `stitchTileEdges`: 辺は2タイル平均、角は最大4タイル平均。NaN は除外して計算
  - `nanMean`: NaN を除外した平均値計算

### 変更ファイル
- **`src/terrain/gsiTile.ts`**: `fillInvalidPixels` を export。`loadElevationTile` から NaN 埋め呼び出しを除去（raw データを返す）
- **`src/terrain/tileManager.ts`**: 
  - メッシュ適用前にステッチ → NaN 埋め → 適用の順で処理
  - 新タイルロード時に隣接タイルも再ステッチ (`restitchNeighbors`)
  - `queryLocalElevation` に NaN スキップ追加

### テスト
- **`tests/tileStitching.unit.spec.ts`** (新規): 22テスト
- **`tests/tileManager.unit.spec.ts`**: モックに `fillInvalidPixels` 追加

## 影響範囲

| 対象 | 影響 |
|------|------|
| 画面 | 隣接タイル間の隙間が解消される |
| API | `fillInvalidPixels` が export に変更。`loadElevationTile` の戻り値に NaN が含まれるようになる（破壊的変更だがモジュール内部のみ） |

## 検証結果

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test:unit` ✅ (11スイート / 231テスト通過)
