### PR TITLE
feat: チルト角上限を緩和 (π/9→π/12) & lowerBetaLimitコメント追加

### DIFF
--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -54,8 +54,9 @@ export class DefaultScene implements CreateSceneClass {
         camera.minZ = 1;
         camera.maxZ = CAMERA_FAR_CLIP;
 
-        // チルト制限（地面から20° = beta上限 7π/18）
-        camera.upperBetaLimit = Math.PI / 2 - Math.PI / 9;
+        // チルト制限（地面から15° = beta上限 5π/12）
+        camera.upperBetaLimit = Math.PI / 2 - Math.PI / 12;
+        // beta=0（真下視点）はArcRotateCameraのジンバルロック・数値不安定を招くため最小値を設定
         camera.lowerBetaLimit = 0.1;
 
         // デフォルト入力をすべて無効化（カスタムハンドラで制御）

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -564,7 +564,7 @@ export class DefaultScene implements CreateSceneClass {
         ui.compass.style.cursor = "pointer";
         const resetCompassView = (): void => {
             const targetAlpha = -Math.PI / 2; // 北向き
-            const targetBeta = 0.1;           // ほぼ真下
+            const targetBeta = camera.lowerBetaLimit ?? 0.1; // ほぼ真下
             const duration = 400;             // ms
             const startAlpha = camera.alpha;
             const startBeta = camera.beta;


### PR DESCRIPTION
## 概要

Closes #85

カメラのチルト角（beta）の上限を緩和し、`lowerBetaLimit` の設定理由をコメントで明記する。

## 変更内容

- `upperBetaLimit` を `Math.PI / 2 - Math.PI / 9`（地面から20°）→ `Math.PI / 2 - Math.PI / 12`（地面から15°）に変更
- `lowerBetaLimit = 0.1` にジンバルロック回避の理由コメントを追加

## 変更ファイル

- `src/scenes/default.ts`（L57-L60）

## テスト

- [x] `npm run lint` 成功
- [x] `npm run typecheck` 成功
- [x] `npm run test:unit` 全236テスト成功