### PR TITLE
feat: カメラパン・チルト時のターゲットポイントを光軸上メッシュ交差点に変更

### DIFF
--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -276,6 +276,7 @@ export class DefaultScene implements CreateSceneClass {
         let activePointerId = -1;
         let dragAnchor: { x: number; z: number } | null = null;
         let dragPlaneY = 0;
+        let isOrbiting = false;
 
         canvas.addEventListener("contextmenu", (e) => e.preventDefault());
 
@@ -294,13 +295,44 @@ export class DefaultScene implements CreateSceneClass {
             dragPlaneY =
                 pick?.hit && pick.pickedPoint ? pick.pickedPoint.y : 0;
             dragAnchor = intersectPlane(sx, sy, dragPlaneY);
+            isOrbiting = false;
         });
 
         canvas.addEventListener("pointermove", (e: PointerEvent) => {
             if (!pointerDown || e.pointerId !== activePointerId) return;
 
             if (e.ctrlKey || e.metaKey) {
-                // Ctrl/Cmd + ドラッグ: 水平=パン(alpha)、垂直=チルト(beta)
+                // Ctrl/Cmd + ドラッグ: 光軸上メッシュ交差点を中心に回転
+                if (!isOrbiting) {
+                    // 初回: 光軸レイキャストで回転中心を決定
+                    const { alpha: a, beta: b, radius: r } = camera;
+                    const sinB = Math.sin(b);
+                    const cosB = Math.cos(b);
+                    const camX = camera.target.x + r * sinB * Math.cos(a);
+                    const camY = camera.target.y + r * cosB;
+                    const camZ = camera.target.z + r * sinB * Math.sin(a);
+                    const origin = new Vector3(camX, camY, camZ);
+                    const dir = new Vector3(
+                        camera.target.x - camX,
+                        camera.target.y - camY,
+                        camera.target.z - camZ,
+                    );
+                    const len = dir.length();
+                    if (len > 1e-6) {
+                        dir.scaleInPlace(1 / len);
+                        const ray = new Ray(origin, dir, CAMERA_FAR_CLIP);
+                        const hit = scene.pickWithRay(ray, (m) => m.name.startsWith("tile-ground-"));
+                        if (hit?.hit && hit.pickedPoint) {
+                            const pivot = hit.pickedPoint;
+                            const dx2 = camX - pivot.x;
+                            const dy2 = camY - pivot.y;
+                            const dz2 = camZ - pivot.z;
+                            camera.target.copyFrom(pivot);
+                            camera.radius = Math.sqrt(dx2 * dx2 + dy2 * dy2 + dz2 * dz2);
+                            isOrbiting = true;
+                        }
+                    }
+                }
                 const dx = e.clientX - lastPointerX;
                 const dy = e.clientY - lastPointerY;
                 lastPointerX = e.clientX;
@@ -333,12 +365,34 @@ export class DefaultScene implements CreateSceneClass {
                     }
                 }
             } else if (dragAnchor) {
+                // 回転モードから通常パンに切り替わった場合、target を復元
+                if (isOrbiting) {
+                    const ty = camera.target.y;
+                    if (Math.abs(ty) > 1e-6) {
+                        const cosB = Math.cos(camera.beta);
+                        if (Math.abs(cosB) > 1e-6) {
+                            const tanB = Math.sin(camera.beta) / cosB;
+                            camera.target.x -= ty * tanB * Math.cos(camera.alpha);
+                            camera.target.z -= ty * tanB * Math.sin(camera.alpha);
+                            camera.radius += ty / cosB;
+                        }
+                        camera.target.y = 0;
+                    }
+                    isOrbiting = false;
+                    // ジャンプ防止: dragAnchor を現在位置にリセット
+                    const rect2 = canvas.getBoundingClientRect();
+                    dragAnchor = intersectPlane(
+                        e.clientX - rect2.left,
+                        e.clientY - rect2.top,
+                        dragPlaneY,
+                    );
+                }
                 // 通常ドラッグ: 逐次差分でパン（毎フレームanchor更新）
                 const rect = canvas.getBoundingClientRect();
                 const sx = e.clientX - rect.left;
                 const sy = e.clientY - rect.top;
                 const current = intersectPlane(sx, sy, dragPlaneY);
-                if (current) {
+                if (current && dragAnchor) {
                     camera.target.x += dragAnchor.x - current.x;
                     camera.target.z += dragAnchor.z - current.z;
                     dragAnchor = intersectPlane(sx, sy, dragPlaneY);
@@ -352,6 +406,21 @@ export class DefaultScene implements CreateSceneClass {
             if (e.pointerId !== activePointerId) return;
             pointerDown = false;
             canvas.releasePointerCapture(e.pointerId);
+            // 回転モード終了: target.y を 0 に復元しカメラ位置を保持
+            if (isOrbiting) {
+                const ty = camera.target.y;
+                if (Math.abs(ty) > 1e-6) {
+                    const cosB = Math.cos(camera.beta);
+                    if (Math.abs(cosB) > 1e-6) {
+                        const tanB = Math.sin(camera.beta) / cosB;
+                        camera.target.x -= ty * tanB * Math.cos(camera.alpha);
+                        camera.target.z -= ty * tanB * Math.sin(camera.alpha);
+                        camera.radius += ty / cosB;
+                    }
+                    camera.target.y = 0;
+                }
+                isOrbiting = false;
+            }
             commitPanOffset();
         });
 
@@ -359,6 +428,20 @@ export class DefaultScene implements CreateSceneClass {
             pointerDown = false;
             activePointerId = -1;
             dragAnchor = null;
+            if (isOrbiting) {
+                const ty = camera.target.y;
+                if (Math.abs(ty) > 1e-6) {
+                    const cosB = Math.cos(camera.beta);
+                    if (Math.abs(cosB) > 1e-6) {
+                        const tanB = Math.sin(camera.beta) / cosB;
+                        camera.target.x -= ty * tanB * Math.cos(camera.alpha);
+                        camera.target.z -= ty * tanB * Math.sin(camera.alpha);
+                        camera.radius += ty / cosB;
+                    }
+                    camera.target.y = 0;
+                }
+                isOrbiting = false;
+            }
             commitPanOffset();
         };
 

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -277,6 +277,30 @@ export class DefaultScene implements CreateSceneClass {
         let dragAnchor: { x: number; z: number } | null = null;
         let dragPlaneY = 0;
         let isOrbiting = false;
+        let orbitDecided = false;
+
+        /** target.y を 0 に戻しつつカメラ位置を保持する補正 */
+        const flattenOrbitTarget = (): void => {
+            const ty = camera.target.y;
+            if (Math.abs(ty) > 1e-6) {
+                const cosB = Math.cos(camera.beta);
+                if (Math.abs(cosB) > 1e-6) {
+                    const tanB = Math.sin(camera.beta) / cosB;
+                    camera.target.x -= ty * tanB * Math.cos(camera.alpha);
+                    camera.target.z -= ty * tanB * Math.sin(camera.alpha);
+                    camera.radius += ty / cosB;
+                }
+                camera.target.y = 0;
+            }
+        };
+
+        /** isOrbiting ガード付きで flattenOrbitTarget → フラグリセット */
+        const endOrbit = (): void => {
+            if (isOrbiting) {
+                flattenOrbitTarget();
+                isOrbiting = false;
+            }
+        };
 
         canvas.addEventListener("contextmenu", (e) => e.preventDefault());
 
@@ -296,6 +320,7 @@ export class DefaultScene implements CreateSceneClass {
                 pick?.hit && pick.pickedPoint ? pick.pickedPoint.y : 0;
             dragAnchor = intersectPlane(sx, sy, dragPlaneY);
             isOrbiting = false;
+            orbitDecided = false;
         });
 
         canvas.addEventListener("pointermove", (e: PointerEvent) => {
@@ -303,7 +328,8 @@ export class DefaultScene implements CreateSceneClass {
 
             if (e.ctrlKey || e.metaKey) {
                 // Ctrl/Cmd + ドラッグ: 光軸上メッシュ交差点を中心に回転
-                if (!isOrbiting) {
+                if (!orbitDecided) {
+                    orbitDecided = true;
                     // 初回: 光軸レイキャストで回転中心を決定
                     const { alpha: a, beta: b, radius: r } = camera;
                     const sinB = Math.sin(b);
@@ -367,18 +393,7 @@ export class DefaultScene implements CreateSceneClass {
             } else if (dragAnchor) {
                 // 回転モードから通常パンに切り替わった場合、target を復元
                 if (isOrbiting) {
-                    const ty = camera.target.y;
-                    if (Math.abs(ty) > 1e-6) {
-                        const cosB = Math.cos(camera.beta);
-                        if (Math.abs(cosB) > 1e-6) {
-                            const tanB = Math.sin(camera.beta) / cosB;
-                            camera.target.x -= ty * tanB * Math.cos(camera.alpha);
-                            camera.target.z -= ty * tanB * Math.sin(camera.alpha);
-                            camera.radius += ty / cosB;
-                        }
-                        camera.target.y = 0;
-                    }
-                    isOrbiting = false;
+                    endOrbit();
                     // ジャンプ防止: dragAnchor を現在位置にリセット
                     const rect2 = canvas.getBoundingClientRect();
                     dragAnchor = intersectPlane(
@@ -407,20 +422,7 @@ export class DefaultScene implements CreateSceneClass {
             pointerDown = false;
             canvas.releasePointerCapture(e.pointerId);
             // 回転モード終了: target.y を 0 に復元しカメラ位置を保持
-            if (isOrbiting) {
-                const ty = camera.target.y;
-                if (Math.abs(ty) > 1e-6) {
-                    const cosB = Math.cos(camera.beta);
-                    if (Math.abs(cosB) > 1e-6) {
-                        const tanB = Math.sin(camera.beta) / cosB;
-                        camera.target.x -= ty * tanB * Math.cos(camera.alpha);
-                        camera.target.z -= ty * tanB * Math.sin(camera.alpha);
-                        camera.radius += ty / cosB;
-                    }
-                    camera.target.y = 0;
-                }
-                isOrbiting = false;
-            }
+            endOrbit();
             commitPanOffset();
         });
 
@@ -428,20 +430,7 @@ export class DefaultScene implements CreateSceneClass {
             pointerDown = false;
             activePointerId = -1;
             dragAnchor = null;
-            if (isOrbiting) {
-                const ty = camera.target.y;
-                if (Math.abs(ty) > 1e-6) {
-                    const cosB = Math.cos(camera.beta);
-                    if (Math.abs(cosB) > 1e-6) {
-                        const tanB = Math.sin(camera.beta) / cosB;
-                        camera.target.x -= ty * tanB * Math.cos(camera.alpha);
-                        camera.target.z -= ty * tanB * Math.sin(camera.alpha);
-                        camera.radius += ty / cosB;
-                    }
-                    camera.target.y = 0;
-                }
-                isOrbiting = false;
-            }
+            endOrbit();
             commitPanOffset();
         };
 


### PR DESCRIPTION
## 概要

カメラのCtrl/Cmd+ドラッグ（パン・チルト）操作時、回転中心をカメラ光軸上のメッシュ交差点に変更。

## 変更内容

- ドラッグ開始時にカメラ光軸のレイキャストでメッシュ交差点を取得し、`camera.target` を移動
- `camera.radius` を調整してカメラのワールド位置を保持
- ドラッグ中はターゲットポイントを固定
- ドラッグ終了時に `target.y = 0` へ復元（カメラ位置保持の座標変換）
- レイがメッシュにヒットしない場合は既存の挙動を維持
- チルト衝突回避（`resolveTiltCollision`）との整合性を確認済み

## 影響範囲

- UI挙動変更: Ctrl/Cmd+ドラッグの回転中心
- APIや型の変更なし

## 検証

- `npm run lint` 通過
- `npm run typecheck` 通過
- `npm run test:unit` 全236テスト通過