### PR TITLE
fix: コンパスリセット時にカメラ光軸と地形メッシュ交点を中心座標にする

### DIFF
--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -563,6 +563,16 @@ export class DefaultScene implements CreateSceneClass {
         // 方位磁針: 北向き・真下にスムーズアニメーション
         ui.compass.style.cursor = "pointer";
         const resetCompassView = (): void => {
+            // カメラ光軸と地形メッシュの交点を新しい中心座標にする
+            const cx = canvas.clientWidth / 2;
+            const cy = canvas.clientHeight / 2;
+            const centerHit = pickOrPlane(cx, cy);
+            if (centerHit) {
+                camera.target.x = centerHit.worldX;
+                camera.target.z = centerHit.worldZ;
+                commitPanOffset();
+            }
+
             const targetAlpha = -Math.PI / 2; // 北向き
             const targetBeta = camera.lowerBetaLimit ?? 0.1; // ほぼ真下
             const duration = 400;             // ms

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -442,6 +442,7 @@ export class DefaultScene implements CreateSceneClass {
             sx: number,
             sy: number
         ): { worldX: number; worldZ: number } | null => {
+            // scene.pick() は内部で DPR スケーリングを行うため CSS 座標をそのまま渡す
             const pick = scene.pick(sx, sy);
             if (pick?.hit && pick.pickedPoint) {
                 return {


### PR DESCRIPTION
## 概要

コンパス（方位磁針）クリック時の中心座標を、カメラの光軸と地形メッシュの交点にある緯度・経度に変更します。

Closes #105

## 変更内容

`resetCompassView()` のアニメーション開始前に以下の処理を追加:

1. 画面中央（`canvas.clientWidth/2`, `clientHeight/2`）で `pickOrPlane()` を実行し、カメラ光軸と地形メッシュの交点を取得
2. 交点が取れた場合、`camera.target` を交点座標に更新し `commitPanOffset()` で緯度経度を確定
3. 交点が取れない場合（空を見ている等）は従来どおり alpha/beta のみ変更

## 影響範囲

- **UI**: コンパスクリック時のカメラ中心位置が変わる（画面中央の地形交点が新しい中心になる）
- **既存操作**: パン・ズーム・チルト操作には影響なし

## 検証

- `npm run lint`: パス
- `npm run test:unit`: 全236テスト パス
- AIレビュー: 承認