### PR TITLE
feat(camera): Ctrl/Cmd ドラッグ開始時に画面中央メッシュ交点を回転中心化 (#103)

### DIFF
--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -289,8 +289,10 @@ export class DefaultScene implements CreateSceneClass {
 
         /**
          * 新ターゲットに付け替え、カメラのワールド位置を保つよう alpha/beta/radius を再計算する。
-         * limit 逸脱・特異点時は何もせず既存 target を維持する。
-         * @returns 付け替えに成功したら true
+         * `computePoseForNewTarget` が limit 逸脱や退化ケースなどで `apply` を返せない場合は何もせず、
+         * 既存 target を維持する。なお、sin(beta)≈0 の特異点近傍では alpha を一意に再計算できなくても、
+         * current alpha を保持したまま `apply` される場合がある。
+         * @returns 付け替えを適用したら true
          */
         const retargetPreservingPose = (newTarget: {
             x: number;

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -11,6 +11,7 @@ import { createTileManager } from "../terrain/tileManager";
 import { createSkybox } from "../terrain/skybox";
 import { parseLatLonFromUrl, createUrlUpdater } from "../terrain/urlState";
 import { resolveTiltCollision, TILT_MAX_RADIUS_INCREASE_RATIO } from "../terrain/cameraCollision";
+import { computePoseForNewTarget } from "../terrain/cameraRetarget";
 
 const TERRAIN_SUBDIVISIONS = 128;
 const MAX_ZOOM = 18;
@@ -170,8 +171,9 @@ export class DefaultScene implements CreateSceneClass {
             gridResidualX = gridResidualX + newOffsetX - gridShiftX;
             gridResidualZ = gridResidualZ + newOffsetZ - gridShiftZ;
 
+            // target.y は retarget で地形高さに設定されている場合があるため保持する
+            // （0 代入するとリリース時に上下ジャンプが発生する）
             camera.target.x = gridResidualX;
-            camera.target.y = 0;
             camera.target.z = gridResidualZ;
 
             currentLat = newLat;
@@ -285,6 +287,38 @@ export class DefaultScene implements CreateSceneClass {
         let dragAnchor: { x: number; z: number } | null = null;
         let dragPlaneY = 0;
 
+        /**
+         * 新ターゲットに付け替え、カメラのワールド位置を保つよう alpha/beta/radius を再計算する。
+         * limit 逸脱・特異点時は何もせず既存 target を維持する。
+         * @returns 付け替えに成功したら true
+         */
+        const retargetPreservingPose = (newTarget: {
+            x: number;
+            y: number;
+            z: number;
+        }): boolean => {
+            const { alpha, beta, radius } = camera;
+            const sinB = Math.sin(beta);
+            const cosB = Math.cos(beta);
+            const camPos = {
+                x: camera.target.x + radius * sinB * Math.cos(alpha),
+                y: camera.target.y + radius * cosB,
+                z: camera.target.z + radius * sinB * Math.sin(alpha),
+            };
+            const result = computePoseForNewTarget(camPos, newTarget, alpha, {
+                lowerBeta: camera.lowerBetaLimit ?? 0,
+                upperBeta: camera.upperBetaLimit ?? Math.PI,
+                lowerRadius: camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS,
+                upperRadius: camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS,
+            });
+            if (result.action !== "apply") return false;
+            camera.target.copyFromFloats(newTarget.x, newTarget.y, newTarget.z);
+            camera.alpha = result.alpha;
+            camera.beta = result.beta;
+            camera.radius = result.radius;
+            return true;
+        };
+
         canvas.addEventListener("contextmenu", (e) => e.preventDefault());
 
         canvas.addEventListener("pointerdown", (e: PointerEvent) => {
@@ -298,6 +332,27 @@ export class DefaultScene implements CreateSceneClass {
             const rect = canvas.getBoundingClientRect();
             const sx = e.clientX - rect.left;
             const sy = e.clientY - rect.top;
+
+            // Ctrl/Cmd 押下開始時: 画面中央の地形メッシュ交点を回転中心にする
+            // （カメラのワールド位置は保持されるためジャンプは発生しない）
+            if (e.ctrlKey || e.metaKey) {
+                // 直前までの pan オフセットを lat/lon に反映してから target を差し替える
+                commitPanOffset();
+                const cx = canvas.clientWidth / 2;
+                const cy = canvas.clientHeight / 2;
+                const centerPick = scene.pick(cx, cy, (m) =>
+                    m.name.startsWith("tile-ground-")
+                );
+                if (centerPick?.hit && centerPick.pickedPoint) {
+                    const p = centerPick.pickedPoint;
+                    if (retargetPreservingPose({ x: p.x, y: p.y, z: p.z })) {
+                        // 新 target の xz を新たなグリッド残差基準として同期
+                        gridResidualX = camera.target.x;
+                        gridResidualZ = camera.target.z;
+                    }
+                }
+            }
+
             const pick = scene.pick(sx, sy);
             dragPlaneY =
                 pick?.hit && pick.pickedPoint ? pick.pickedPoint.y : 0;

--- a/src/terrain/cameraRetarget.ts
+++ b/src/terrain/cameraRetarget.ts
@@ -1,0 +1,74 @@
+/**
+ * ArcRotateCamera のターゲット付け替え結果。
+ * カメラのワールド位置を不変に保ったまま新ターゲットに対する (alpha, beta, radius)
+ * を算出する。limit 逸脱や特異点時は "skip" を返し、呼び出し側で既存値を維持させる。
+ */
+export type RetargetResult =
+    | { action: "apply"; alpha: number; beta: number; radius: number }
+    | { action: "skip"; reason: "degenerate" | "betaOutOfRange" | "radiusOutOfRange" };
+
+export interface RetargetLimits {
+    lowerBeta: number;
+    upperBeta: number;
+    lowerRadius: number;
+    upperRadius: number;
+}
+
+export interface Vec3 {
+    x: number;
+    y: number;
+    z: number;
+}
+
+/** degenerate 判定の距離しきい値（メートル） */
+const MIN_RADIUS_EPSILON = 1e-3;
+/** alpha 保持判定の sin(beta) しきい値（極近傍） */
+const SIN_BETA_EPSILON = 1e-4;
+
+/**
+ * カメラワールド位置 P を固定したまま新ターゲット newTarget に付け替える際の
+ * (alpha, beta, radius) を計算する。
+ *
+ * Babylon ArcRotateCamera の規約:
+ *   P = T + r * (sin(beta)*cos(alpha), cos(beta), sin(beta)*sin(alpha))
+ * から V = P - newTarget とおくと:
+ *   radius = |V|
+ *   beta   = acos(V.y / radius)
+ *   alpha  = atan2(V.z, V.x)
+ *
+ * @param camPos       現在のカメラワールド位置
+ * @param newTarget    新しいターゲット座標
+ * @param currentAlpha 特異点（真上/真下視点）時に保持するための現 alpha
+ * @param limits       適用可否判定に使う limit 値
+ */
+export function computePoseForNewTarget(
+    camPos: Vec3,
+    newTarget: Vec3,
+    currentAlpha: number,
+    limits: RetargetLimits,
+): RetargetResult {
+    const vx = camPos.x - newTarget.x;
+    const vy = camPos.y - newTarget.y;
+    const vz = camPos.z - newTarget.z;
+    const radius = Math.sqrt(vx * vx + vy * vy + vz * vz);
+
+    if (radius < MIN_RADIUS_EPSILON) {
+        return { action: "skip", reason: "degenerate" };
+    }
+    if (radius < limits.lowerRadius || radius > limits.upperRadius) {
+        return { action: "skip", reason: "radiusOutOfRange" };
+    }
+
+    // 浮動小数誤差で acos の定義域を外れないようクランプ
+    const cosBeta = Math.max(-1, Math.min(1, vy / radius));
+    const beta = Math.acos(cosBeta);
+
+    if (beta < limits.lowerBeta || beta > limits.upperBeta) {
+        return { action: "skip", reason: "betaOutOfRange" };
+    }
+
+    const sinBeta = Math.sqrt(Math.max(0, 1 - cosBeta * cosBeta));
+    const alpha = sinBeta < SIN_BETA_EPSILON ? currentAlpha : Math.atan2(vz, vx);
+
+    return { action: "apply", alpha, beta, radius };
+}

--- a/src/terrain/cameraRetarget.ts
+++ b/src/terrain/cameraRetarget.ts
@@ -1,7 +1,8 @@
 /**
  * ArcRotateCamera のターゲット付け替え結果。
  * カメラのワールド位置を不変に保ったまま新ターゲットに対する (alpha, beta, radius)
- * を算出する。limit 逸脱や特異点時は "skip" を返し、呼び出し側で既存値を維持させる。
+ * を算出する。limit 逸脱や退化ケースでは "skip" を返し、真上/真下付近の特異点では
+ * alpha に currentAlpha を採用した "apply" を返す。
  */
 export type RetargetResult =
     | { action: "apply"; alpha: number; beta: number; radius: number }

--- a/tests/cameraRetarget.unit.spec.ts
+++ b/tests/cameraRetarget.unit.spec.ts
@@ -1,0 +1,120 @@
+import { computePoseForNewTarget, RetargetLimits } from "../src/terrain/cameraRetarget";
+
+const LIMITS: RetargetLimits = {
+    lowerBeta: 0.1,
+    upperBeta: Math.PI / 2 - Math.PI / 12,
+    lowerRadius: 50,
+    upperRadius: 75000,
+};
+
+/** alpha, beta, radius, target から P を組み立てる（Babylon 規約と同じ式） */
+const buildCamPos = (
+    alpha: number,
+    beta: number,
+    radius: number,
+    target: { x: number; y: number; z: number },
+) => {
+    const sinB = Math.sin(beta);
+    const cosB = Math.cos(beta);
+    return {
+        x: target.x + radius * sinB * Math.cos(alpha),
+        y: target.y + radius * cosB,
+        z: target.z + radius * sinB * Math.sin(alpha),
+    };
+};
+
+describe("computePoseForNewTarget", () => {
+    describe("apply: ワールド位置を保持したまま新ターゲットに再射影", () => {
+        it("target を平行移動した場合、新 alpha/beta/radius で同じカメラ位置を復元できる", () => {
+            const target = { x: 0, y: 0, z: 0 };
+            const alpha = -Math.PI / 2;
+            const beta = Math.PI / 3;
+            const radius = 4000;
+            const camPos = buildCamPos(alpha, beta, radius, target);
+
+            const newTarget = { x: 1000, y: 100, z: -500 };
+            const result = computePoseForNewTarget(camPos, newTarget, alpha, LIMITS);
+            expect(result.action).toBe("apply");
+            if (result.action !== "apply") return;
+
+            const restored = buildCamPos(
+                result.alpha,
+                result.beta,
+                result.radius,
+                newTarget,
+            );
+            expect(restored.x).toBeCloseTo(camPos.x, 6);
+            expect(restored.y).toBeCloseTo(camPos.y, 6);
+            expect(restored.z).toBeCloseTo(camPos.z, 6);
+        });
+
+        it("初期カメラ方位 (alpha=-π/2) で target=原点のとき atan2(Vz,Vx) が -π/2 になる", () => {
+            const target = { x: 0, y: 0, z: 0 };
+            const alpha = -Math.PI / 2;
+            const beta = Math.PI / 3;
+            const radius = 4000;
+            const camPos = buildCamPos(alpha, beta, radius, target);
+
+            const result = computePoseForNewTarget(camPos, target, alpha, LIMITS);
+            expect(result.action).toBe("apply");
+            if (result.action !== "apply") return;
+            expect(result.alpha).toBeCloseTo(-Math.PI / 2, 6);
+            expect(result.beta).toBeCloseTo(beta, 6);
+            expect(result.radius).toBeCloseTo(radius, 6);
+        });
+    });
+
+    describe("skip: limit 逸脱や特異点で既存値を維持させる", () => {
+        it("カメラ位置と新ターゲットがほぼ一致するなら degenerate", () => {
+            const camPos = { x: 10, y: 10, z: 10 };
+            const newTarget = { x: 10, y: 10, z: 10 };
+            const result = computePoseForNewTarget(camPos, newTarget, 0, LIMITS);
+            expect(result).toEqual({ action: "skip", reason: "degenerate" });
+        });
+
+        it("radius が lowerRadius を下回ると radiusOutOfRange", () => {
+            const camPos = { x: 0, y: 10, z: 0 };
+            const newTarget = { x: 0, y: 0, z: 0 };
+            const result = computePoseForNewTarget(camPos, newTarget, 0, LIMITS);
+            expect(result).toEqual({ action: "skip", reason: "radiusOutOfRange" });
+        });
+
+        it("radius が upperRadius を超えると radiusOutOfRange", () => {
+            const camPos = { x: 100000, y: 0, z: 0 };
+            const newTarget = { x: 0, y: 0, z: 0 };
+            const result = computePoseForNewTarget(camPos, newTarget, 0, LIMITS);
+            expect(result).toEqual({ action: "skip", reason: "radiusOutOfRange" });
+        });
+
+        it("beta が upperBeta を超える水平視点だと betaOutOfRange", () => {
+            // カメラとターゲットがほぼ同じ高さ → beta ≈ π/2 で upperBeta を超える
+            const camPos = { x: 1000, y: 0, z: 0 };
+            const newTarget = { x: 0, y: 0, z: 0 };
+            const result = computePoseForNewTarget(camPos, newTarget, 0, LIMITS);
+            expect(result).toEqual({ action: "skip", reason: "betaOutOfRange" });
+        });
+
+        it("beta が lowerBeta を下回る真下視点だと betaOutOfRange", () => {
+            // カメラがターゲット真上 → beta ≈ 0 で lowerBeta を下回る
+            const camPos = { x: 0, y: 1000, z: 0 };
+            const newTarget = { x: 0, y: 0, z: 0 };
+            const result = computePoseForNewTarget(camPos, newTarget, 0, LIMITS);
+            expect(result).toEqual({ action: "skip", reason: "betaOutOfRange" });
+        });
+    });
+
+    describe("特異点: sin(beta)≈0 のとき alpha は currentAlpha を保持", () => {
+        it("真下視点（lowerBeta ちょうど）では currentAlpha が採用される", () => {
+            // lowerBeta = 0.1 → sin(0.1) ≈ 0.0998（しきい値 1e-4 を超えるため通常 atan2 が使われる想定）
+            // より極端なケース: limits を緩めて sin(beta)=0（真下視点）を許容し、alpha 保持を確認
+            const strictLimits: RetargetLimits = { ...LIMITS, lowerBeta: 0 };
+            const camPos = { x: 0, y: 1000, z: 0 };
+            const newTarget = { x: 0, y: 0, z: 0 };
+            const currentAlpha = 1.2345;
+            const result = computePoseForNewTarget(camPos, newTarget, currentAlpha, strictLimits);
+            expect(result.action).toBe("apply");
+            if (result.action !== "apply") return;
+            expect(result.alpha).toBe(currentAlpha);
+        });
+    });
+});


### PR DESCRIPTION
## 概要
Issue #103 対応。Ctrl/Cmd+ドラッグ開始時にカメラ光軸（画面中央）の地形メッシュ交点を camera.target に設定し、その点を回転中心にパン・チルトする。カメラのワールド位置を保持するため、開始時・ドラッグ中・リリース時いずれもジャンプは発生しない。

## 変更内容
- **新規** src/terrain/cameraRetarget.ts
  - 純関数 computePoseForNewTarget: カメラ位置を不変量として新 target に対する (alpha, beta, radius) を逆算。limit 逸脱・特異点時は skip を返す。
- **編集** src/scenes/default.ts
  - retargetPreservingPose ラッパ関数を追加。
  - pointerdown の Ctrl/Cmd 押下時に commitPanOffset → scene.pick(cx, cy, tile-ground フィルタ) → retargetPreservingPose → gridResidual 再同期の分岐を追加。
  - commitPanOffset の camera.target.y = 0 代入を撤廃（リリース時の上下ジャンプを防止）。
- **新規** tests/cameraRetarget.unit.spec.ts（8 ケース: 正常系・境界値・特異点）

## 影響範囲
- 画面/挙動: Ctrl/Cmd+ドラッグ時の回転中心のみ変更。通常ドラッグ・ズーム・方位磁針・各ボタンの挙動は従来通り。
- API/型: 変更なし（内部モジュール追加のみ）。
- ドキュメント: 変更なし。

## 検証
- npm run lint ✅
- npm run typecheck ✅
- npm run test:unit ✅（226 → 234 passed, 新規 8）
- npm run test:visuals ✅（スナップショット差分なし）
- 手動: 平地・山地で Ctrl+ドラッグ開始時に視点ジャンプがないこと、リリース時にもジャンプがないこと。