### PR TITLE
chore(package): @babylonjs/* peerDependencies 化 (#116)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,14 +10,14 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@babylonjs/assets": "^5.20.0",
-        "@babylonjs/gui-editor": "^9.3.4",
-        "@babylonjs/havok": "^1.3.12",
-        "@babylonjs/inspector": "^9.3.4",
         "ammo.js": "github:kripken/ammo.js",
         "recast-detour": "^1.6.4"
       },
       "devDependencies": {
         "@babylonjs/core": "^9.3.4",
+        "@babylonjs/gui-editor": "^9.3.4",
+        "@babylonjs/havok": "^1.3.12",
+        "@babylonjs/inspector": "^9.3.4",
         "@babylonjs/loaders": "^9.3.4",
         "@babylonjs/materials": "^9.3.4",
         "@playwright/test": "^1.59.1",
@@ -547,6 +547,7 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -604,6 +605,7 @@
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@babylonjs/addons/-/addons-9.3.0.tgz",
       "integrity": "sha512-coisH8hFQLAUnEBmPEcI6gNZ9XfhBSGC+weuBodLPx7cTHp1vM+GScspphU6oNlnVUAmyCjsE7Kd7CW1Js06Pg==",
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
@@ -621,6 +623,7 @@
       "version": "9.3.4",
       "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-9.3.4.tgz",
       "integrity": "sha512-ZwaIfw9o9kpvloErFaV28QEyofubZu67gFKzxSOcbZwqqitIF8p7xbvt6QHAnIhczEKVYLYilzqyKIlNqYcaqw==",
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true
     },
@@ -628,6 +631,7 @@
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@babylonjs/gui/-/gui-9.3.0.tgz",
       "integrity": "sha512-ln/uJQX3QmGkJEk4BDIj2b/QbusTAfzLGKc8xzy2jKPS+kWDMbre67Dnk9j1rqvlWDpRtFG/MNq0a/y/AKcCXA==",
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
@@ -638,6 +642,7 @@
       "version": "9.3.4",
       "resolved": "https://registry.npmjs.org/@babylonjs/gui-editor/-/gui-editor-9.3.4.tgz",
       "integrity": "sha512-zsLosvvPoyYfKuxIS9NAtmDpV0Fqumq+Od0T2E5byir3e4uxIMVn1GuFRVsDM7F+8xYrrNYAkBRw7wjBF87H3w==",
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
@@ -651,6 +656,7 @@
       "version": "1.3.12",
       "resolved": "https://registry.npmjs.org/@babylonjs/havok/-/havok-1.3.12.tgz",
       "integrity": "sha512-KR5Z7DBkVEgdvHLMDh2VWe/nHvUG8+MdLBiAE0iM19KIHAPqPRVITPAZKx4SQusK5nqm4ZXDcKv5OYtViIxLzA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/emscripten": "^1.39.6"
@@ -660,6 +666,7 @@
       "version": "9.3.4",
       "resolved": "https://registry.npmjs.org/@babylonjs/inspector/-/inspector-9.3.4.tgz",
       "integrity": "sha512-kr2hAVgipnc4IRvxNDeX2DgKRuYmP/QfD0L5goBLG02hBGJGBeU7kRnHxbUUJrmr5PLtReTKSBEsqvx1kHE7cA==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "babylon-inspector": "bin/inspector-cli.mjs"
@@ -685,6 +692,7 @@
       "version": "9.3.4",
       "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-9.3.4.tgz",
       "integrity": "sha512-3HA8OUaqa5/Q9Jl7g2poN+YGQy1qGd0CHbYkkZoKeKE68fZNtWPQbKHMJzP+0wmoJHorVaLLwDxZFsG9oG0xQA==",
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
@@ -696,6 +704,7 @@
       "version": "9.3.4",
       "resolved": "https://registry.npmjs.org/@babylonjs/materials/-/materials-9.3.4.tgz",
       "integrity": "sha512-9nakZasS28K4y0m9EgdOiGDKlcCCVknwjKJ7u+CtmcNGuVD9kg4qa2BCLillgApircn86CuygaiJF3ht3K2GfA==",
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
@@ -706,6 +715,7 @@
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@babylonjs/serializers/-/serializers-9.3.0.tgz",
       "integrity": "sha512-VRfWCnsi21pC56qX/Ahdu8Y+/UWORlDjP+Q6YkAnDeaLDc5jiemtB8VywG/cu5nHMgJu1YzhK4MsBkU0Kj4DWg==",
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
@@ -841,6 +851,7 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz",
       "integrity": "sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -894,6 +905,7 @@
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
       "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@epic-web/invariant": {
@@ -1443,6 +1455,7 @@
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
       "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@floating-ui/utils": "^0.2.11"
@@ -1452,6 +1465,7 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@floating-ui/devtools/-/devtools-0.2.3.tgz",
       "integrity": "sha512-ZTcxTvgo9CRlP7vJV62yCxdqmahHTGpSTi5QaTDgGoyQq0OyjaVZhUhXv/qdkQFOI3Sxlfmz0XGG4HaZMsDf8Q==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@floating-ui/dom": "^1.0.0"
@@ -1461,6 +1475,7 @@
       "version": "1.7.6",
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
       "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1472,12 +1487,14 @@
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@fluentui-contrib/react-resize-handle": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/@fluentui-contrib/react-resize-handle/-/react-resize-handle-0.8.4.tgz",
       "integrity": "sha512-g3cJ3q+nn32BB5b5mEtuSh6sGNYOGcKvRxQljvfg+UAhStceCPZYRM8gF+HswPPhQ0LUR6h780WMe072ndR6Lw==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1496,6 +1513,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@fluentui-contrib/react-virtualizer/-/react-virtualizer-1.0.0.tgz",
       "integrity": "sha512-z1KE+OyCTICkOeyCmFI0nlNRTPAhCv2ZhCIDjebnlkNQMIcMtTrI/ogy4Fu8UgbFP+WReE50JeduLtM+Sst+1A==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1516,6 +1534,7 @@
       "version": "9.0.8",
       "resolved": "https://registry.npmjs.org/@fluentui/keyboard-keys/-/keyboard-keys-9.0.8.tgz",
       "integrity": "sha512-iUSJUUHAyTosnXK8O2Ilbfxma+ZyZPMua5vB028Ys96z80v+LFwntoehlFsdH3rMuPsA8GaC1RE7LMezwPBPdw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@swc/helpers": "^0.5.1"
@@ -1525,6 +1544,7 @@
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@fluentui/priority-overflow/-/priority-overflow-9.3.0.tgz",
       "integrity": "sha512-yaBC0R4e+4ZlCWDulB5S+xBrlnLwfzdg68GaarCqQO8OHjLg7Ah05xTj7PsAYcoHeEg/9vYeBwGXBpRO8+Tjqw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@swc/helpers": "^0.5.1"
@@ -1534,6 +1554,7 @@
       "version": "9.10.0",
       "resolved": "https://registry.npmjs.org/@fluentui/react-accordion/-/react-accordion-9.10.0.tgz",
       "integrity": "sha512-EwjRfBdC3esMEP++PddyF7bVMSv9+t2W8AY5GkNcwDsqAW3D4zhlvxXBAb3qmpgXy4qMxRWGL8cEaiWgMpH1sg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-aria": "^9.17.10",
@@ -1560,6 +1581,7 @@
       "version": "9.0.0-beta.138",
       "resolved": "https://registry.npmjs.org/@fluentui/react-alert/-/react-alert-9.0.0-beta.138.tgz",
       "integrity": "sha512-mE3nMx1ngevvmFcp/2sePyJrdE8nme7eqCv1ppUT+mTIA1RYkR8hzBld1+DV1qJYc+F6DCeg4gImuQuu1OXiGA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-avatar": "^9.11.0",
@@ -1583,6 +1605,7 @@
       "version": "9.17.10",
       "resolved": "https://registry.npmjs.org/@fluentui/react-aria/-/react-aria-9.17.10.tgz",
       "integrity": "sha512-KqS2XcdN84XsgVG4fAESyOBfixN7zbObWfQVLNZ2gZrp2b1hPGVYfQ6J4WOO0vXMKYp0rre/QMOgDm6/srL0XQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -1603,6 +1626,7 @@
       "version": "9.11.0",
       "resolved": "https://registry.npmjs.org/@fluentui/react-avatar/-/react-avatar-9.11.0.tgz",
       "integrity": "sha512-3MogJIiOGilKh9y/sWy0Cali1tpvWQNwcs2ryL7EVXi5xwTfKQM/WEgEnW2z+KtumDQUsRqlCHCSoi+x+BF8Qg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-badge": "^9.5.1",
@@ -1629,6 +1653,7 @@
       "version": "9.5.1",
       "resolved": "https://registry.npmjs.org/@fluentui/react-badge/-/react-badge-9.5.1.tgz",
       "integrity": "sha512-OHS15ovGFPShrAA9U+hCyloJEyffC9gdif0a27AOIB9aVlF/hTzG7toxxulcg4ar4F9X3xXk/uccCCa2kzK0Gw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-icons": "^2.0.245",
@@ -1650,6 +1675,7 @@
       "version": "9.4.0",
       "resolved": "https://registry.npmjs.org/@fluentui/react-breadcrumb/-/react-breadcrumb-9.4.0.tgz",
       "integrity": "sha512-QpCjYlM3JTMnNwh/sDehDbuAVjTcgSfjkPdSmFaPk2lPHpER32CBcJVhheP9en2U5NbW1e+Gtvq8y06RN8FCWw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-aria": "^9.17.10",
@@ -1675,6 +1701,7 @@
       "version": "9.9.0",
       "resolved": "https://registry.npmjs.org/@fluentui/react-button/-/react-button-9.9.0.tgz",
       "integrity": "sha512-aH3aSjKyxIiNb9jJOUaaIq47w7jP5ESFSRzvMjcWOETvlWo4QgNqEOOsYqpcltM1OrQZ0sTy/isxppRcyMDlcQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -1699,6 +1726,7 @@
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/@fluentui/react-card/-/react-card-9.6.0.tgz",
       "integrity": "sha512-vgBvhtSzQDa01aOP9zdhJXFLsZAiDVslRfX3HmlIo1pAMt8w+PBq+ypDp1wxM7HPFpj9+RYcERRKtf4MSNP9Nw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -1722,6 +1750,7 @@
       "version": "9.9.6",
       "resolved": "https://registry.npmjs.org/@fluentui/react-carousel/-/react-carousel-9.9.6.tgz",
       "integrity": "sha512-Ae7DKwQsidRBjUQeiXffRUi8i/26jMgJd24rDVLeQUvoUhs+z/SA9iZN/QMuNl02E291MAEruENKzzkshvfYfg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-aria": "^9.17.10",
@@ -1751,6 +1780,7 @@
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/@fluentui/react-checkbox/-/react-checkbox-9.6.0.tgz",
       "integrity": "sha512-GMgB1Yx2WP6cISIZoRTyXp2VkJBR8t1+wRyY63RRcofL/ziqqBhz++kl317lbVv7QxnXZh6KlVuoPROWFDQuaw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-field": "^9.5.0",
@@ -1775,6 +1805,7 @@
       "version": "9.2.15",
       "resolved": "https://registry.npmjs.org/@fluentui/react-color-picker/-/react-color-picker-9.2.15.tgz",
       "integrity": "sha512-RMmawl7g4gUYLuTQG2QwCcR9fGC+vDD+snsBlXtObpj/cKpeDmYif46g88pYv86jeIXY1zsjINmLpELmz+uFmw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ctrl/tinycolor": "^3.3.4",
@@ -1798,6 +1829,7 @@
       "version": "9.17.0",
       "resolved": "https://registry.npmjs.org/@fluentui/react-combobox/-/react-combobox-9.17.0.tgz",
       "integrity": "sha512-04JTIrXCAbG8HnczFVzJsUJO+NJQ2d/JPynXlmTq7KCMw0BssiF//7IAPFnTiMYmS7jcwc9Uh4ZeFrw+czA79g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -1826,6 +1858,7 @@
       "version": "9.73.7",
       "resolved": "https://registry.npmjs.org/@fluentui/react-components/-/react-components-9.73.7.tgz",
       "integrity": "sha512-hLxXEAiiMEMmFR3jEYgFPOV5lnNzu6SJU0NtyMCn1Tf4HXgCfy4h700e+GzuAsL1RlQAYC35HplcZHcEffwTIQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1903,6 +1936,7 @@
       "version": "9.2.15",
       "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.15.tgz",
       "integrity": "sha512-QymBntFLJNZ9VfTOaBn2ApUSSSC5UuDW8ZcgPJPA+06XEFH+U9Zny2d9QAg1xYNYwIGWahWGQ+7ATOuLxtB8Jw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-utilities": "^9.26.2",
@@ -1920,6 +1954,7 @@
       "version": "9.17.3",
       "resolved": "https://registry.npmjs.org/@fluentui/react-dialog/-/react-dialog-9.17.3.tgz",
       "integrity": "sha512-rF5l8n5yhaB//ZHns0my3Tviir7R8NVyRgTtvV2gLhG58YM7qpm54oraG83uwlXCcZp0wlg2LuIe1cZ559ex1A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -1948,6 +1983,7 @@
       "version": "9.7.0",
       "resolved": "https://registry.npmjs.org/@fluentui/react-divider/-/react-divider-9.7.0.tgz",
       "integrity": "sha512-U8Nhrghjeh+XCGM4B7aHYosd6fXaxHC3MpZi7DB0xQ20ljn5cSTpBt4Yvl+tB9ld2+/eM8wekx1GVKyI4yWa3g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-jsx-runtime": "^9.4.1",
@@ -1968,6 +2004,7 @@
       "version": "9.11.6",
       "resolved": "https://registry.npmjs.org/@fluentui/react-drawer/-/react-drawer-9.11.6.tgz",
       "integrity": "sha512-E+k3eKVb/xKPm2RH5Q1xBjL89NeB1GXtYHO6qRlhQ9auYVTlaBCR7f/ZfIIJJ2x8MzfntQljyl94VARtmZYnyA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-dialog": "^9.17.3",
@@ -1993,6 +2030,7 @@
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/@fluentui/react-field/-/react-field-9.5.0.tgz",
       "integrity": "sha512-yGjB9RXqKrolkkjyAsKVdrH2Xeinj+vromrSCJelgMJ3Q3D6YkExHQzgtdzqo0fVPppnEA4oDKL3Vqqnz/G5Ug==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-context-selector": "^9.2.15",
@@ -2016,6 +2054,7 @@
       "version": "2.0.324",
       "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.324.tgz",
       "integrity": "sha512-wbtIQWwoTWNU6KyuF59zZ1viFv1i68iwVa1+so/QnfNKNHIXa2MEZ375Vg/pcubFBqlTxsKMrCBFtHEIzBHG/Q==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2030,6 +2069,7 @@
       "version": "9.4.0",
       "resolved": "https://registry.npmjs.org/@fluentui/react-image/-/react-image-9.4.0.tgz",
       "integrity": "sha512-BpcBlmkukm7YYf6PTCbAIMkeCXc8+7aq2eMADsxF5gFD8j3d5lBY3cKByOWRM1NvXcMXmqXr/hQP+ovqNAHzEA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-jsx-runtime": "^9.4.1",
@@ -2050,6 +2090,7 @@
       "version": "9.0.0-beta.114",
       "resolved": "https://registry.npmjs.org/@fluentui/react-infobutton/-/react-infobutton-9.0.0-beta.114.tgz",
       "integrity": "sha512-3mqnlIcRc0PuW7rsxLFjzqnI/IITZIrHRt8Zwcm8NX7XZIK3wfODb9ytmQDYU/5IfwiSXC+xozqhI6kttaE3iw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-icons": "^2.0.237",
@@ -2073,6 +2114,7 @@
       "version": "9.4.19",
       "resolved": "https://registry.npmjs.org/@fluentui/react-infolabel/-/react-infolabel-9.4.19.tgz",
       "integrity": "sha512-b/3ETF5DPgHcRUcj85iGyiEXUFozFq+IY6tPcyCiUcmIoKScD8McFaHozjpaVqngLbCz0uKNNA0JDy1x/T2ItQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-icons": "^2.0.245",
@@ -2097,6 +2139,7 @@
       "version": "9.8.1",
       "resolved": "https://registry.npmjs.org/@fluentui/react-input/-/react-input-9.8.1.tgz",
       "integrity": "sha512-ZlMeYBf1EQg4alI5+9gfx3Icmq3xibPiIYeARtFzOKJ2XzpnD4d/yswx3IDkzXCbqw9rSHtHV03vEeYLUPPTGw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-field": "^9.5.0",
@@ -2118,6 +2161,7 @@
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.4.1.tgz",
       "integrity": "sha512-ZodSm7jRa4kaLKDi+emfHFMP/IDnYwFQQAI2BdtKbVrvfwvzPRprGcnTgivnqKBT1ROvKOCY2ddz7+yZzesnNw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-utilities": "^9.26.2",
@@ -2132,6 +2176,7 @@
       "version": "9.4.0",
       "resolved": "https://registry.npmjs.org/@fluentui/react-label/-/react-label-9.4.0.tgz",
       "integrity": "sha512-joQ7YNz2dgwDd134sc7e8/vxfFKBUT5AdWx0apT0ohWKgh7RBjB3AdXsaJ8FaMKMNZIGTxZVsP4hHcGsWMTAFw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-jsx-runtime": "^9.4.1",
@@ -2152,6 +2197,7 @@
       "version": "9.8.0",
       "resolved": "https://registry.npmjs.org/@fluentui/react-link/-/react-link-9.8.0.tgz",
       "integrity": "sha512-TH5LS4iuQ4jYzlR84A4n7lQTKaJuiuuGFHMIxoEqtKeMoL9F5AiabuBs6m7Q7clSdTrrcRMNzXLuEFarQrzGTQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -2174,6 +2220,7 @@
       "version": "9.6.13",
       "resolved": "https://registry.npmjs.org/@fluentui/react-list/-/react-list-9.6.13.tgz",
       "integrity": "sha512-MIP0XKxU68m8VsBCyNBame46nnZ94FCNUArw9T2JuumyKMgV07C+sNhXCe9BCVpUr8e2Hfofo7CZjAsXWDZ0nw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -2198,6 +2245,7 @@
       "version": "9.24.0",
       "resolved": "https://registry.npmjs.org/@fluentui/react-menu/-/react-menu-9.24.0.tgz",
       "integrity": "sha512-HqIwEM6lPropSHUnbPFufLYdkAIVca87XbNQHCTes4QSLeaF4oEjlBH60rIqQ52k78FwZuUFIciWkSChxJ9ekg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -2227,6 +2275,7 @@
       "version": "9.6.23",
       "resolved": "https://registry.npmjs.org/@fluentui/react-message-bar/-/react-message-bar-9.6.23.tgz",
       "integrity": "sha512-mGnFmYWx6tq36OMTdVtJmxyn3j0p+Shll3+w4W2fW8fcOVSeyrnZ++HLmpurUkVzwI2xR2lL842kxC3GtbwmNw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-button": "^9.9.0",
@@ -2252,6 +2301,7 @@
       "version": "9.14.0",
       "resolved": "https://registry.npmjs.org/@fluentui/react-motion/-/react-motion-9.14.0.tgz",
       "integrity": "sha512-gOy8+fUP1KQRM/J6mRhioCMmUrHW9jbLF0DZ9T8nKPQsLrLaSXHxnnI8DcKZjlYc2fKuZitBnbpximgff6HajQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-shared-contexts": "^9.26.2",
@@ -2269,6 +2319,7 @@
       "version": "0.15.3",
       "resolved": "https://registry.npmjs.org/@fluentui/react-motion-components-preview/-/react-motion-components-preview-0.15.3.tgz",
       "integrity": "sha512-dUH2+GmEWX9q2ojx70VfFLRqzA9fR4YISC6daXkz3iPx4PtesTDn7jwsuXXquaAhltJeBptJ8+K4jbtBrwCMYQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-motion": "*",
@@ -2286,6 +2337,7 @@
       "version": "9.3.23",
       "resolved": "https://registry.npmjs.org/@fluentui/react-nav/-/react-nav-9.3.23.tgz",
       "integrity": "sha512-Z9hA70n5i62sO9IJItkX5+v1F7Lo/539joPaHCLHHca+rySQQZKqy8zLRIfLbh/qF8Nm04ywY19Qt14XjI59cQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-aria": "^9.17.10",
@@ -2316,6 +2368,7 @@
       "version": "9.7.1",
       "resolved": "https://registry.npmjs.org/@fluentui/react-overflow/-/react-overflow-9.7.1.tgz",
       "integrity": "sha512-Ml1GlcLrAUv31d9WN15WGOZv32gzDtZD5Mp1MOQ3ichDfTtxrswIch7MDzZ8hLMGf/7Y2IzBpV8iFR1XdSrGBA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/priority-overflow": "^9.3.0",
@@ -2336,6 +2389,7 @@
       "version": "9.7.2",
       "resolved": "https://registry.npmjs.org/@fluentui/react-persona/-/react-persona-9.7.2.tgz",
       "integrity": "sha512-u6buhC6Haf8YewBnZAzi49YCwiC8vt0O0YPADemk+4uJ8bhCnayzLxMYGuQ95XO4HFhvVnSPEYjMDdKrMO1hIw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-avatar": "^9.11.0",
@@ -2358,6 +2412,7 @@
       "version": "9.14.1",
       "resolved": "https://registry.npmjs.org/@fluentui/react-popover/-/react-popover-9.14.1.tgz",
       "integrity": "sha512-EODa5yWSfDLPDurjWoZXfkf2ccnbQQbk3s1XYRzxA6RDfdVqUI5W64RJzHWBiNhOLzQEhd6Qb4e6Mshj4FSbdQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -2386,6 +2441,7 @@
       "version": "9.8.11",
       "resolved": "https://registry.npmjs.org/@fluentui/react-portal/-/react-portal-9.8.11.tgz",
       "integrity": "sha512-2eg4MdW7e2UGRYWPg05GCytAjWYNd55YOP9+iUDINoQwwto9oeFTtZRyn08HYw37cSNqoH24qGz/VBctzTkqDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-shared-contexts": "^9.26.2",
@@ -2405,6 +2461,7 @@
       "version": "9.22.0",
       "resolved": "https://registry.npmjs.org/@fluentui/react-positioning/-/react-positioning-9.22.0.tgz",
       "integrity": "sha512-i3DLC4jd4MoYSZMYLKQNUTpkjKAJ0snIcihvkrjt2jpvv34CifKJhqVtjFQ470pRW4XNx/pBBX07vdXpA3poxA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@floating-ui/devtools": "^0.2.3",
@@ -2427,6 +2484,7 @@
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/@fluentui/react-progress/-/react-progress-9.5.0.tgz",
       "integrity": "sha512-VcWXI6UJfBkrDuC/e9oR4YBlpnLUE+FqRRjMG4mVXV+AJzFiljF3mQkFAj94G6dsr54TcoDXC6oydgXLCOTW2A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-field": "^9.5.0",
@@ -2449,6 +2507,7 @@
       "version": "9.22.15",
       "resolved": "https://registry.npmjs.org/@fluentui/react-provider/-/react-provider-9.22.15.tgz",
       "integrity": "sha512-a+ImgL9DOlylDM4UYPnxQTA3yXxbVj+O0iNEyTZ6fMzdMsHzpALU4GAq6tOyW4L7RaQtRBmNpVfwTCEKpqaTJQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-icons": "^2.0.245",
@@ -2472,6 +2531,7 @@
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@fluentui/react-radio/-/react-radio-9.6.1.tgz",
       "integrity": "sha512-QBoV6l8fVLP+H9Tigq/Y6boiEqMDRhhVMkIfUiWFbnsU/Uc7J5fxW8GoNqzMmoOmC7yvQ/g4jsoTQF27+PzK5w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-field": "^9.5.0",
@@ -2495,6 +2555,7 @@
       "version": "9.4.0",
       "resolved": "https://registry.npmjs.org/@fluentui/react-rating/-/react-rating-9.4.0.tgz",
       "integrity": "sha512-qVesFNgQ7uuX8z9d8xqxIXn5ax06xffgBr/eAuZfqVYZG5aRrPHHRoiWf0HDrYD4Lb/HRBLPtbNihNxhXj/LEA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-icons": "^2.0.245",
@@ -2517,6 +2578,7 @@
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/@fluentui/react-search/-/react-search-9.4.1.tgz",
       "integrity": "sha512-Lv2zhPad7SDhMd5NeabXluw4y0Gov9YxDkJhjShMnkiN3yCOA5tlVviNvRXOXxy0gS//d8CiGJ5mBT1bzz2Rrw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-icons": "^2.0.245",
@@ -2539,6 +2601,7 @@
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/@fluentui/react-select/-/react-select-9.5.0.tgz",
       "integrity": "sha512-pGOD6MBwQsiHKkEdNmVrTavcfC9pOjt4nz/DRlFD444j6iR1PALlus5cNOp7A0JOnGDDvW+1afIvgySCqN0oiA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-field": "^9.5.0",
@@ -2561,6 +2624,7 @@
       "version": "9.26.2",
       "resolved": "https://registry.npmjs.org/@fluentui/react-shared-contexts/-/react-shared-contexts-9.26.2.tgz",
       "integrity": "sha512-upKXkwlIp5oIhELr4clAZXQkuCd4GDXM6GZEz8BOmRO+PnxyqmycCXvxDxsmi6XN+0vkGM4joiIgkB14o/FctQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2576,6 +2640,7 @@
       "version": "9.7.1",
       "resolved": "https://registry.npmjs.org/@fluentui/react-skeleton/-/react-skeleton-9.7.1.tgz",
       "integrity": "sha512-9WniFEe6gbhkZuBurpQNFmMMhP/Ox84Xm9/iu6q8OmnRkFCyZrEuCFlWGDffnBREKIJqE0VJn5ZrUYWMMh45KA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-field": "^9.5.0",
@@ -2597,6 +2662,7 @@
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@fluentui/react-slider/-/react-slider-9.6.1.tgz",
       "integrity": "sha512-ytF1gOEho8DrI817H8WCBsck1RXOlW7JRXYtu9VwH3SnDRM2Jz1CNxbou80+BpvyR1KKkvCc/JSgREgUAnkRAQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-field": "^9.5.0",
@@ -2619,6 +2685,7 @@
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@fluentui/react-spinbutton/-/react-spinbutton-9.6.1.tgz",
       "integrity": "sha512-szqGlEfeJYkBzszEWBjj7ux522ckw9YtKAH0CS0Npd0xcY1GFkdywPwJMOoRUhsO08BOhv6P70Wlx0eYqURgIA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -2642,6 +2709,7 @@
       "version": "9.8.1",
       "resolved": "https://registry.npmjs.org/@fluentui/react-spinner/-/react-spinner-9.8.1.tgz",
       "integrity": "sha512-vSM5FwjASEor8NBOJx/1MLp8VCw7+pOJqZSvMn29LrUmMbgSZ6CifZFx0GfiX+1fM0EZ2/pqJzFFHpoQQubAyw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-jsx-runtime": "^9.4.1",
@@ -2663,6 +2731,7 @@
       "version": "9.5.1",
       "resolved": "https://registry.npmjs.org/@fluentui/react-swatch-picker/-/react-swatch-picker-9.5.1.tgz",
       "integrity": "sha512-7rs4dgnFMV2m/2A1tkevrVfThVEJs9crnVWCiSE4XADb9hFp7mqVyN8dKbQCJJMXODLF/Bc90nTCtLV8WaEj4Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-context-selector": "^9.2.15",
@@ -2687,6 +2756,7 @@
       "version": "9.7.1",
       "resolved": "https://registry.npmjs.org/@fluentui/react-switch/-/react-switch-9.7.1.tgz",
       "integrity": "sha512-61zJhxG9UBcZ+5T/Dk9yzOJDCOc2ZMZef/ImgIMB4lVsyWs/3n/ec/PKPwjp9SNz2FhQvayhMytEbGzri00jGw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-field": "^9.5.0",
@@ -2711,6 +2781,7 @@
       "version": "9.19.14",
       "resolved": "https://registry.npmjs.org/@fluentui/react-table/-/react-table-9.19.14.tgz",
       "integrity": "sha512-IZ3tDqlQDC+R6nzX4thU8A7Aw3BMhbBZ5tgMOHnW733Xfton7wqKiumjsGJBnef3I48mqnBHJZQEzWBgzLsdqg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -2739,6 +2810,7 @@
       "version": "9.12.0",
       "resolved": "https://registry.npmjs.org/@fluentui/react-tabs/-/react-tabs-9.12.0.tgz",
       "integrity": "sha512-gKCi1XNDYRvF6R5wETeQptzQRVBlM7VETaQHS/ue1x7+Vo42MbWMtYOmvqeg5CPjqy2hAwch0IA9bzWEQAm2ZA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-context-selector": "^9.2.15",
@@ -2761,6 +2833,7 @@
       "version": "9.26.13",
       "resolved": "https://registry.npmjs.org/@fluentui/react-tabster/-/react-tabster-9.26.13.tgz",
       "integrity": "sha512-uOuJj7jn1ME52Vc685/Ielf6srK/sfFQA5zBIbXIvy2Eisfp7R1RmJe2sXWoszz/Fu/XDkPwdM/GLv23N3vrvQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-shared-contexts": "^9.26.2",
@@ -2782,6 +2855,7 @@
       "version": "9.8.5",
       "resolved": "https://registry.npmjs.org/@fluentui/react-tag-picker/-/react-tag-picker-9.8.5.tgz",
       "integrity": "sha512-uhZUWDdg7zmQNjb1/5YI3l6agSDg/yFFaYZDH4eQDOmKIm35jAT2GmEMZVomZZVW/dDhZpezfMWZA5r442cZYQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -2812,6 +2886,7 @@
       "version": "9.8.0",
       "resolved": "https://registry.npmjs.org/@fluentui/react-tags/-/react-tags-9.8.0.tgz",
       "integrity": "sha512-O/Kf8pFgS0/eguzDCPm8FmrPG64dU36xTI1uYKwgF6iVOpmWFjk+7aPQtkoFHQzVwl1iLUL4mQFSutR4A8s38Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -2837,6 +2912,7 @@
       "version": "9.6.20",
       "resolved": "https://registry.npmjs.org/@fluentui/react-teaching-popover/-/react-teaching-popover-9.6.20.tgz",
       "integrity": "sha512-XB/SJXdJabulcDBp6z4NNSFOcAnaOoIUZdmzqpx09UxtQwU/eFnYvZw/k1SI8Nc7IpHBgjzId8gHy6jvaN8JHw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-aria": "^9.17.10",
@@ -2864,6 +2940,7 @@
       "version": "9.6.15",
       "resolved": "https://registry.npmjs.org/@fluentui/react-text/-/react-text-9.6.15.tgz",
       "integrity": "sha512-YB1azhq8MGfnYTGlEAX1mzcFZ6CvqkkaxaCogU4TM9BtPgQ1YUAxE01RMenl8VVi8W9hNbJKkuc8R8GzYwzT4Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-jsx-runtime": "^9.4.1",
@@ -2884,6 +2961,7 @@
       "version": "9.7.1",
       "resolved": "https://registry.npmjs.org/@fluentui/react-textarea/-/react-textarea-9.7.1.tgz",
       "integrity": "sha512-YG0j202PRLDLZZDn8QQgREd4Ery2fDYMYb2HUvFdfo6MuSXMvv0RCKEUBCgajIXsHwT31Hsg5+xzM40X4jlOBg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-field": "^9.5.0",
@@ -2905,6 +2983,7 @@
       "version": "9.2.1",
       "resolved": "https://registry.npmjs.org/@fluentui/react-theme/-/react-theme-9.2.1.tgz",
       "integrity": "sha512-lJxfz7LmmglFz+c9C41qmMqaRRZZUPtPPl9DWQ79vH+JwZd4dkN7eA78OTRwcGCOTPEKoLTX72R+EFaWEDlX+w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/tokens": "1.0.0-alpha.23",
@@ -2915,6 +2994,7 @@
       "version": "9.7.16",
       "resolved": "https://registry.npmjs.org/@fluentui/react-toast/-/react-toast-9.7.16.tgz",
       "integrity": "sha512-Yq4yJboYqtdL5pNJBIYlSdT/kR6m449O95taJCh/msXJyRgqQZ46EmpTcwsxu3D55LTHbqI6Vxu+AikDYH1W7w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -2942,6 +3022,7 @@
       "version": "9.7.7",
       "resolved": "https://registry.npmjs.org/@fluentui/react-toolbar/-/react-toolbar-9.7.7.tgz",
       "integrity": "sha512-49nrRvGqJfdXhwaKZfNIcTiZSqTbThNG8uCa0FvJ88cO11PRPGcr5s6u3plUVxDXUKXpZJ7PKr/TTA0MvP7yIg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-button": "^9.9.0",
@@ -2967,6 +3048,7 @@
       "version": "9.10.0",
       "resolved": "https://registry.npmjs.org/@fluentui/react-tooltip/-/react-tooltip-9.10.0.tgz",
       "integrity": "sha512-+aM0S1mcXy8XKKWgU3TocqTxHjcai7fHns3KwONLJPTp3jXTjyqEoj/o4XX1ka2IM3gdOFfyUU0Gfvw708dn9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -2991,6 +3073,7 @@
       "version": "9.15.16",
       "resolved": "https://registry.npmjs.org/@fluentui/react-tree/-/react-tree-9.15.16.tgz",
       "integrity": "sha512-WP4WjbF/UWCp0JKaZsMFtah/kXu+mxqN8/kghppRYfVHWzLiMgFAPB/OzrGejLNwx+ai3t2dHOIHxXHnR1jYHA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -3022,6 +3105,7 @@
       "version": "9.26.2",
       "resolved": "https://registry.npmjs.org/@fluentui/react-utilities/-/react-utilities-9.26.2.tgz",
       "integrity": "sha512-Yp2GGNoWifj8Z/VVir4HyRumRsqXnLJd4IP/Y70vEm9ruAvyqUvfn+1lQUuA+k/Reqw8GI+Ix7FTo3rogixZBg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
@@ -3037,6 +3121,7 @@
       "version": "9.0.0-alpha.111",
       "resolved": "https://registry.npmjs.org/@fluentui/react-virtualizer/-/react-virtualizer-9.0.0-alpha.111.tgz",
       "integrity": "sha512-yku++0779Ve1RNz6y/HWjlXKd2x1wCSbWMydT2IdCICBVwolXjPYMpkqqZUSjbJ0N9gl6BfsCBpU9Dfe2bR8Zg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-jsx-runtime": "^9.4.1",
@@ -3056,6 +3141,7 @@
       "version": "1.0.0-alpha.23",
       "resolved": "https://registry.npmjs.org/@fluentui/tokens/-/tokens-1.0.0-alpha.23.tgz",
       "integrity": "sha512-uxrzF9Z+J10naP0pGS7zPmzSkspSS+3OJDmYIK3o1nkntQrgBXq3dBob4xSlTDm5aOQ0kw6EvB9wQgtlyy4eKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@swc/helpers": "^0.5.1"
@@ -3065,6 +3151,7 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/@griffel/core/-/core-1.20.1.tgz",
       "integrity": "sha512-ld1mX04zpmeHn8agx4slSEh8kJ+8or3Y0x9gsJNKSKn6GdCkZBSiGUh+oBXCBn8RKzz8l60TA9IhVSStnyKekA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@emotion/hash": "^0.9.0",
@@ -3079,6 +3166,7 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/@griffel/react/-/react-1.6.1.tgz",
       "integrity": "sha512-mNM4/+dIXzqeHboWpVZ1/jiwTAYNc5/8y/V/HasnQ2QXnV6gSUYpeUk/0n6IFU3NJmVJly9JrLSfNo0hM/IFeA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@griffel/core": "^1.20.1",
@@ -3092,6 +3180,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@griffel/style-types/-/style-types-1.4.0.tgz",
       "integrity": "sha512-vNDfOGV7RN/XkA7vxgf7Z5HgW8eiBm5cHT9wQPhsKB4pxWom5u6eQ9CkYE5mCCTSPl9H6Nd1NBai04d4P6BD7Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.3"
@@ -4697,6 +4786,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4832,6 +4922,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
       "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -5137,6 +5228,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5147,6 +5239,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
@@ -6334,6 +6427,7 @@
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-9.3.0.tgz",
       "integrity": "sha512-idoAq8UWrLnQEU/3hUTc0Apwvci+fblSaTGxeW3GxZq2bNWrrf2Q0wBgYu4mWPRpoH2MB6ZvaBue6mQQYWthrQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true
     },
@@ -7228,6 +7322,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -7534,6 +7629,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -7541,6 +7637,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel-autoplay/-/embla-carousel-autoplay-8.6.0.tgz",
       "integrity": "sha512-OBu5G3nwaSXkZCo1A6LTaFMZ8EpkYbwIaH+bPqdBnDGQ2fh4+NbzjXjs2SktoPNKCtflfVMc75njaDHOYXcrsA==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "embla-carousel": "8.6.0"
@@ -7550,6 +7647,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel-fade/-/embla-carousel-fade-8.6.0.tgz",
       "integrity": "sha512-qaYsx5mwCz72ZrjlsXgs1nKejSrW+UhkbOMwLgfRT7w2LtdEB03nPRI06GHuHv5ac2USvbEiX2/nAHctcDwvpg==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "embla-carousel": "8.6.0"
@@ -10331,6 +10429,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/keyborg/-/keyborg-2.6.0.tgz",
       "integrity": "sha512-o5kvLbuTF+o326CMVYpjlaykxqYP9DphFQZ2ZpgrvBouyvOxyEB7oqe8nOLFpiV5VCtz0D3pt8gXQYWpLpBnmA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/keyv": {
@@ -10526,6 +10625,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.memoize": {
@@ -11814,6 +11914,7 @@
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -11824,6 +11925,7 @@
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -12176,6 +12278,7 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.16.1.tgz",
       "integrity": "sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.1.2"
@@ -12239,6 +12342,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -12945,6 +13049,7 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
       "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/sucrase": {
@@ -13033,6 +13138,7 @@
       "version": "8.7.0",
       "resolved": "https://registry.npmjs.org/tabster/-/tabster-8.7.0.tgz",
       "integrity": "sha512-AKYquti8AdWzuqJdQo4LUMQDZrHoYQy6V+8yUq2PmgLZV10EaB+8BD0nWOfC/3TBp4mPNg4fbHkz6SFtkr0PpA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "keyborg": "2.6.0",
@@ -13580,6 +13686,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD",
       "peer": true
     },
@@ -13914,6 +14021,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -13923,6 +14031,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-3.1.1.tgz",
       "integrity": "sha512-I4diPp9Cq6ieSUH2wu+fDAVQO43xwtulo+fKEidHUwZPnYImbtkTjzIJYcDcJqxgmX31GVqNFURodvcgHcW0pA==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babylonjs/assets": "^5.20.0",
         "ammo.js": "github:kripken/ammo.js",
         "recast-detour": "^1.6.4"
       },
@@ -611,13 +610,6 @@
       "peerDependencies": {
         "@babylonjs/core": "^9.0.0"
       }
-    },
-    "node_modules/@babylonjs/assets": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/assets/-/assets-5.20.0.tgz",
-      "integrity": "sha512-a6Mm519h9XtXg8Of0qC+DmwWp+jcolZv+Z/LSG+b/8Fh7kS3gFjHXctKSrln2zMiTxcbYfeBqtOUpGtlV8F2bA==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "Apache-2.0"
     },
     "node_modules/@babylonjs/core": {
       "version": "9.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,16 +10,16 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@babylonjs/assets": "^5.20.0",
-        "@babylonjs/core": "^9.3.4",
         "@babylonjs/gui-editor": "^9.3.4",
         "@babylonjs/havok": "^1.3.12",
         "@babylonjs/inspector": "^9.3.4",
-        "@babylonjs/loaders": "^9.3.4",
-        "@babylonjs/materials": "^9.3.4",
         "ammo.js": "github:kripken/ammo.js",
         "recast-detour": "^1.6.4"
       },
       "devDependencies": {
+        "@babylonjs/core": "^9.3.4",
+        "@babylonjs/loaders": "^9.3.4",
+        "@babylonjs/materials": "^9.3.4",
         "@playwright/test": "^1.59.1",
         "@types/jest": "^30.0.0",
         "@types/node": "^25.6.0",
@@ -45,6 +45,19 @@
         "webpack-cli": "^7.0.2",
         "webpack-dev-server": "^5.2.3",
         "webpack-merge": "^6.0.1"
+      },
+      "peerDependencies": {
+        "@babylonjs/core": "^9.0.0",
+        "@babylonjs/loaders": "^9.0.0",
+        "@babylonjs/materials": "^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@babylonjs/loaders": {
+          "optional": true
+        },
+        "@babylonjs/materials": {
+          "optional": true
+        }
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/package.json
+++ b/package.json
@@ -15,18 +15,31 @@
     "dist"
   ],
   "sideEffects": false,
+  "peerDependencies": {
+    "@babylonjs/core": "^9.0.0",
+    "@babylonjs/loaders": "^9.0.0",
+    "@babylonjs/materials": "^9.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@babylonjs/loaders": {
+      "optional": true
+    },
+    "@babylonjs/materials": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "@babylonjs/assets": "^5.20.0",
-    "@babylonjs/core": "^9.3.4",
     "@babylonjs/gui-editor": "^9.3.4",
     "@babylonjs/havok": "^1.3.12",
     "@babylonjs/inspector": "^9.3.4",
-    "@babylonjs/loaders": "^9.3.4",
-    "@babylonjs/materials": "^9.3.4",
     "ammo.js": "github:kripken/ammo.js",
     "recast-detour": "^1.6.4"
   },
   "devDependencies": {
+    "@babylonjs/core": "^9.3.4",
+    "@babylonjs/loaders": "^9.3.4",
+    "@babylonjs/materials": "^9.3.4",
     "@playwright/test": "^1.59.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.6.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     }
   },
   "dependencies": {
-    "@babylonjs/assets": "^5.20.0",
     "ammo.js": "github:kripken/ammo.js",
     "recast-detour": "^1.6.4"
   },

--- a/package.json
+++ b/package.json
@@ -30,14 +30,14 @@
   },
   "dependencies": {
     "@babylonjs/assets": "^5.20.0",
-    "@babylonjs/gui-editor": "^9.3.4",
-    "@babylonjs/havok": "^1.3.12",
-    "@babylonjs/inspector": "^9.3.4",
     "ammo.js": "github:kripken/ammo.js",
     "recast-detour": "^1.6.4"
   },
   "devDependencies": {
     "@babylonjs/core": "^9.3.4",
+    "@babylonjs/gui-editor": "^9.3.4",
+    "@babylonjs/havok": "^1.3.12",
+    "@babylonjs/inspector": "^9.3.4",
     "@babylonjs/loaders": "^9.3.4",
     "@babylonjs/materials": "^9.3.4",
     "@playwright/test": "^1.59.1",


### PR DESCRIPTION
## 概要
#116 (T2) 対応。`@babylonjs/core` / `@babylonjs/loaders` / `@babylonjs/materials` を `dependencies` から `peerDependencies` (`^9.0.0`) へ移行。さらにレビュー指摘を受け、`src/` で未参照の Babylon.js 関連パッケージを整理。

## 変更内容
- `peerDependencies` に 3 パッケージを追加 (`^9.0.0`)
- `peerDependenciesMeta` で `@babylonjs/loaders` / `@babylonjs/materials` を `optional: true` に
- `devDependencies` には同バージョンを残し、webpack デモ / 単体テストの動作を維持
- 未参照だった `@babylonjs/gui-editor` / `@babylonjs/inspector` / `@babylonjs/havok` を `devDependencies` に移動 (PR #126 レビュー対応)
- 未参照だった `@babylonjs/assets` を完全削除 (PR #126 レビュー対応)

## 残課題（本 PR 範囲外）
- `ammo.js` / `recast-detour` も `src/` 配下では未 import。Babylon.js Physics プラグインが動的解決する可能性があり、削除には別途動作検証が必要なため別 Issue 扱いとする。

## 検証結果 (DoD)
- `npm install` ✅
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test:unit` ✅ 227/227
- `npm run build:lib` ✅ (`dist/index.mjs` / `dist/index.d.mts`)
- `npm pack --dry-run` ✅
- `npm run build:dev` ✅
- `npm run test:visuals` ✅

## 影響範囲
- ライブラリ利用者は `@babylonjs/core` (および任意で `loaders`/`materials`) を別途インストールする必要あり
- 本リポジトリ内の demo / tests は devDependencies により従来通り動作

Closes #116