### PR TITLE
feat(package): JpmapTerrain クラス骨格 (#117)

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,8 +1,15 @@
 /**
  * jpmap-terrain パッケージエントリ
  *
- * T1 (#115) ではビルド基盤の動作確認のための空エントリのみを提供する。
- * `JpmapTerrain` クラス本体および公開型は後続 Issue (#117 以降) で追加する。
+ * 公開 API は spec/package.md §3 に従う。
+ * - クラス本体: `./lib/jpmapTerrain`
+ * - 公開型: `./lib/types`
  */
 
-export {};
+export { JpmapTerrain } from "./lib/jpmapTerrain";
+export type {
+    EngineType,
+    FlyToOptions,
+    JpmapTerrainOptions,
+    MapType,
+} from "./lib/types";

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -110,11 +110,12 @@ export class JpmapTerrain {
      * 実体は T5 (#119) で実装する。
      */
     public async flyTo(options: FlyToOptions): Promise<void> {
-        this._lat = options.lat;
-        this._lon = options.lon;
-        if (options.altitude !== undefined) this._altitude = options.altitude;
-        if (options.azimuth !== undefined) this._azimuth = options.azimuth;
-        if (options.tilt !== undefined) this._tilt = options.tilt;
+        // setter 経由で更新し、将来 setter に追加される副作用（T5: カメラ反映等）を共有する。
+        this.lat = options.lat;
+        this.lon = options.lon;
+        if (options.altitude !== undefined) this.altitude = options.altitude;
+        if (options.azimuth !== undefined) this.azimuth = options.azimuth;
+        if (options.tilt !== undefined) this.tilt = options.tilt;
         // T5 (#119) でアニメーション遷移を実装する。
     }
 

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -1,0 +1,183 @@
+/**
+ * `JpmapTerrain` クラス骨格（T3 / Issue #117）
+ *
+ * spec/package.md §3 (Initial Implementation) の API シグネチャを定義する。
+ * Babylon.js Scene / Engine への接続および UI 配線は後続 Issue で実装する。
+ *
+ * - T4 (#118): mountElement へのキャンバス・UI 配置と Scene 初期化
+ * - T5 (#119): カメラ get/set / flyTo の実体
+ * - T6 (#120): UI 表示 get/set / mapType 切替
+ * - T7 (#121): dispose / resize の実体
+ */
+
+import {
+    FlyToOptions,
+    JPMAP_TERRAIN_DEFAULTS,
+    JpmapTerrainOptions,
+    MapType,
+} from "./types";
+
+/**
+ * jpmap-terrain ビューア。
+ *
+ * インスタンスは `JpmapTerrain.create()` 経由でのみ生成する（async 初期化のため）。
+ */
+export class JpmapTerrain {
+    private readonly mountElement: HTMLElement;
+
+    private _lat: number;
+    private _lon: number;
+    private _altitude: number;
+    private _azimuth: number;
+    private _tilt: number;
+    private _mapType: MapType;
+
+    private _showCompass = true;
+    private _showZoomButtons = true;
+    private _showScaleBar = true;
+    private _showMapToggle = true;
+    private _showAttribution = true;
+
+    private constructor(mountElement: HTMLElement, options: JpmapTerrainOptions) {
+        this.mountElement = mountElement;
+        this._lat = options.lat ?? JPMAP_TERRAIN_DEFAULTS.lat;
+        this._lon = options.lon ?? JPMAP_TERRAIN_DEFAULTS.lon;
+        this._altitude = options.altitude ?? JPMAP_TERRAIN_DEFAULTS.altitude;
+        this._azimuth = options.azimuth ?? JPMAP_TERRAIN_DEFAULTS.azimuth;
+        this._tilt = options.tilt ?? JPMAP_TERRAIN_DEFAULTS.tilt;
+        this._mapType = options.mapType ?? JPMAP_TERRAIN_DEFAULTS.mapType;
+    }
+
+    /**
+     * 指定したマウント要素にビューアを生成する。
+     *
+     * @param mountElement キャンバスと UI を配置する DOM 要素
+     * @param options 初期化オプション（spec/package.md §3.2）
+     * @returns 初期化済みの `JpmapTerrain` インスタンス
+     */
+    public static async create(
+        mountElement: HTMLElement,
+        options: JpmapTerrainOptions = {},
+    ): Promise<JpmapTerrain> {
+        if (!mountElement) {
+            throw new TypeError("JpmapTerrain.create: mountElement is required");
+        }
+        const instance = new JpmapTerrain(mountElement, options);
+        // T4 (#118) で Scene / Engine 初期化処理を実装する。
+        return instance;
+    }
+
+    // ---- 位置・カメラ制御 (spec §3.3.1) ----
+
+    public get lat(): number {
+        return this._lat;
+    }
+    public set lat(value: number) {
+        this._lat = value;
+        // T5 (#119) で camera target に反映する。
+    }
+
+    public get lon(): number {
+        return this._lon;
+    }
+    public set lon(value: number) {
+        this._lon = value;
+    }
+
+    public get altitude(): number {
+        return this._altitude;
+    }
+    public set altitude(value: number) {
+        this._altitude = value;
+    }
+
+    public get azimuth(): number {
+        return this._azimuth;
+    }
+    public set azimuth(value: number) {
+        this._azimuth = value;
+    }
+
+    public get tilt(): number {
+        return this._tilt;
+    }
+    public set tilt(value: number) {
+        this._tilt = value;
+    }
+
+    /**
+     * 指定座標へカメラをアニメーション付きで移動する。
+     * 実体は T5 (#119) で実装する。
+     */
+    public async flyTo(options: FlyToOptions): Promise<void> {
+        this._lat = options.lat;
+        this._lon = options.lon;
+        if (options.altitude !== undefined) this._altitude = options.altitude;
+        if (options.azimuth !== undefined) this._azimuth = options.azimuth;
+        if (options.tilt !== undefined) this._tilt = options.tilt;
+        // T5 (#119) でアニメーション遷移を実装する。
+    }
+
+    // ---- UI 表示制御 (spec §3.3.2) ----
+
+    public get showCompass(): boolean {
+        return this._showCompass;
+    }
+    public set showCompass(value: boolean) {
+        this._showCompass = value;
+    }
+
+    public get showZoomButtons(): boolean {
+        return this._showZoomButtons;
+    }
+    public set showZoomButtons(value: boolean) {
+        this._showZoomButtons = value;
+    }
+
+    public get showScaleBar(): boolean {
+        return this._showScaleBar;
+    }
+    public set showScaleBar(value: boolean) {
+        this._showScaleBar = value;
+    }
+
+    public get showMapToggle(): boolean {
+        return this._showMapToggle;
+    }
+    public set showMapToggle(value: boolean) {
+        this._showMapToggle = value;
+    }
+
+    public get showAttribution(): boolean {
+        return this._showAttribution;
+    }
+    public set showAttribution(value: boolean) {
+        this._showAttribution = value;
+    }
+
+    public get mapType(): MapType {
+        return this._mapType;
+    }
+    public set mapType(value: MapType) {
+        this._mapType = value;
+        // T6 (#120) で地図種類切替を実装する。
+    }
+
+    // ---- ライフサイクル (spec §3.3.3) ----
+
+    /**
+     * ビューアを破棄し、マウント要素から関連 DOM を除去する。
+     * 実体は T7 (#121) で実装する。
+     */
+    public dispose(): void {
+        // T7 (#121) で Engine / Scene / DOM を解放する。
+    }
+
+    /**
+     * リサイズを通知する。
+     * 実体は T7 (#121) で実装する。
+     */
+    public resize(): void {
+        // T7 (#121) で Engine.resize() を呼び出す。
+    }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -50,7 +50,10 @@ export interface FlyToOptions {
     duration?: number;
 }
 
-/** spec/package.md §3.2 で定義されるデフォルト初期値 */
+/**
+ * spec/package.md §3.2 で定義されるデフォルト初期値（パッケージ内部用）。
+ * 公開 API には含めず、`JpmapTerrain` 内部からのみ参照する。
+ */
 export const JPMAP_TERRAIN_DEFAULTS = {
     engine: "webgpu" as EngineType,
     lat: 35.681236,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,62 @@
+/**
+ * jpmap-terrain 公開型定義
+ *
+ * spec/package.md §3 (Initial Implementation) に対応する型を提供する。
+ */
+
+/** 描画エンジン種別 */
+export type EngineType = "webgpu" | "webgl2";
+
+/** 地図種類 */
+export type MapType = "standard" | "photo";
+
+/**
+ * `JpmapTerrain.create` 初期化オプション。
+ * すべて任意指定で、未指定時は spec/package.md §3.2 のデフォルト値が適用される。
+ */
+export interface JpmapTerrainOptions {
+    /** 描画エンジン。WebGPU 非対応時は自動で WebGL2 にフォールバックする */
+    engine?: EngineType;
+    /** 緯度（度） */
+    lat?: number;
+    /** 経度（度） */
+    lon?: number;
+    /** 高度（メートル） */
+    altitude?: number;
+    /** カメラ方位角（度） */
+    azimuth?: number;
+    /** カメラチルト角（度） */
+    tilt?: number;
+    /** 地図種類 */
+    mapType?: MapType;
+}
+
+/**
+ * `JpmapTerrain.flyTo` のオプション。
+ * `lat` / `lon` は必須、その他は省略時に現在値を維持する。
+ */
+export interface FlyToOptions {
+    /** 目的地の緯度（度） */
+    lat: number;
+    /** 目的地の経度（度） */
+    lon: number;
+    /** 目的地の高度（メートル） */
+    altitude?: number;
+    /** 目的地の方位角（度） */
+    azimuth?: number;
+    /** 目的地のチルト角（度） */
+    tilt?: number;
+    /** 遷移時間（ミリ秒） */
+    duration?: number;
+}
+
+/** spec/package.md §3.2 で定義されるデフォルト初期値 */
+export const JPMAP_TERRAIN_DEFAULTS = {
+    engine: "webgpu" as EngineType,
+    lat: 35.681236,
+    lon: 139.767125,
+    altitude: 2000,
+    azimuth: 0,
+    tilt: 45,
+    mapType: "standard" as MapType,
+} as const;

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * `JpmapTerrain` クラス骨格のユニットテスト (T3 / Issue #117)
+ *
+ * - デフォルト値の適用
+ * - get/set による状態保持
+ * - flyTo による状態更新
+ * - mountElement 必須チェック
+ *
+ * Scene / Engine / DOM 連動は後続 Issue (T4 以降) で実装するため、
+ * ここでは公開 API の状態管理のみを担保する。
+ */
+
+import { JpmapTerrain } from "../src/lib/jpmapTerrain";
+
+describe("JpmapTerrain (skeleton)", () => {
+    const createMountElement = (): HTMLElement => document.createElement("div");
+
+    describe("create", () => {
+        it("オプション未指定時に spec/package.md §3.2 のデフォルト値が適用される", async () => {
+            const viewer = await JpmapTerrain.create(createMountElement());
+
+            expect(viewer.lat).toBeCloseTo(35.681236);
+            expect(viewer.lon).toBeCloseTo(139.767125);
+            expect(viewer.altitude).toBe(2000);
+            expect(viewer.azimuth).toBe(0);
+            expect(viewer.tilt).toBe(45);
+            expect(viewer.mapType).toBe("standard");
+        });
+
+        it("UI 表示フラグはデフォルトで全て true", async () => {
+            const viewer = await JpmapTerrain.create(createMountElement());
+
+            expect(viewer.showCompass).toBe(true);
+            expect(viewer.showZoomButtons).toBe(true);
+            expect(viewer.showScaleBar).toBe(true);
+            expect(viewer.showMapToggle).toBe(true);
+            expect(viewer.showAttribution).toBe(true);
+        });
+
+        it("オプション指定値が反映される", async () => {
+            const viewer = await JpmapTerrain.create(createMountElement(), {
+                lat: 36.2333,
+                lon: 137.6167,
+                altitude: 5000,
+                azimuth: 90,
+                tilt: 30,
+                mapType: "photo",
+            });
+
+            expect(viewer.lat).toBe(36.2333);
+            expect(viewer.lon).toBe(137.6167);
+            expect(viewer.altitude).toBe(5000);
+            expect(viewer.azimuth).toBe(90);
+            expect(viewer.tilt).toBe(30);
+            expect(viewer.mapType).toBe("photo");
+        });
+
+        it("mountElement が falsy の場合 TypeError を投げる", async () => {
+            await expect(
+                JpmapTerrain.create(null as unknown as HTMLElement),
+            ).rejects.toThrow(TypeError);
+        });
+    });
+
+    describe("getter / setter", () => {
+        it("位置・カメラ系プロパティが set した値を保持する", async () => {
+            const viewer = await JpmapTerrain.create(createMountElement());
+
+            viewer.lat = 40.0;
+            viewer.lon = 140.0;
+            viewer.altitude = 1234;
+            viewer.azimuth = 180;
+            viewer.tilt = 60;
+
+            expect(viewer.lat).toBe(40.0);
+            expect(viewer.lon).toBe(140.0);
+            expect(viewer.altitude).toBe(1234);
+            expect(viewer.azimuth).toBe(180);
+            expect(viewer.tilt).toBe(60);
+        });
+
+        it("UI 表示フラグが set した値を保持する", async () => {
+            const viewer = await JpmapTerrain.create(createMountElement());
+
+            viewer.showCompass = false;
+            viewer.showZoomButtons = false;
+            viewer.showScaleBar = false;
+            viewer.showMapToggle = false;
+            viewer.showAttribution = false;
+
+            expect(viewer.showCompass).toBe(false);
+            expect(viewer.showZoomButtons).toBe(false);
+            expect(viewer.showScaleBar).toBe(false);
+            expect(viewer.showMapToggle).toBe(false);
+            expect(viewer.showAttribution).toBe(false);
+        });
+
+        it("mapType が set した値を保持する", async () => {
+            const viewer = await JpmapTerrain.create(createMountElement());
+
+            viewer.mapType = "photo";
+            expect(viewer.mapType).toBe("photo");
+
+            viewer.mapType = "standard";
+            expect(viewer.mapType).toBe("standard");
+        });
+    });
+
+    describe("flyTo", () => {
+        it("lat / lon を必ず更新する", async () => {
+            const viewer = await JpmapTerrain.create(createMountElement());
+
+            await viewer.flyTo({ lat: 35.3606, lon: 138.7274 });
+
+            expect(viewer.lat).toBe(35.3606);
+            expect(viewer.lon).toBe(138.7274);
+        });
+
+        it("省略可能パラメータが渡された場合のみ更新する", async () => {
+            const viewer = await JpmapTerrain.create(createMountElement(), {
+                altitude: 1000,
+                azimuth: 10,
+                tilt: 20,
+            });
+
+            await viewer.flyTo({ lat: 0, lon: 0, altitude: 9999 });
+
+            expect(viewer.altitude).toBe(9999);
+            expect(viewer.azimuth).toBe(10);
+            expect(viewer.tilt).toBe(20);
+        });
+
+        it("altitude / azimuth / tilt が省略された場合は現在値を維持する", async () => {
+            const viewer = await JpmapTerrain.create(createMountElement(), {
+                altitude: 3000,
+                azimuth: 45,
+                tilt: 50,
+            });
+
+            await viewer.flyTo({ lat: 1, lon: 2 });
+
+            expect(viewer.altitude).toBe(3000);
+            expect(viewer.azimuth).toBe(45);
+            expect(viewer.tilt).toBe(50);
+        });
+    });
+
+    describe("lifecycle stubs", () => {
+        it("dispose / resize 呼び出しは例外を投げない", async () => {
+            const viewer = await JpmapTerrain.create(createMountElement());
+
+            expect(() => viewer.resize()).not.toThrow();
+            expect(() => viewer.dispose()).not.toThrow();
+        });
+    });
+});


### PR DESCRIPTION
## 概要
#117 (T3) 対応。spec/package.md §3 の API に対応する `JpmapTerrain` クラス骨格と公開型を追加。

## 変更内容
- `src/lib/types.ts` 新規:
  - `EngineType` / `MapType` / `JpmapTerrainOptions` / `FlyToOptions` / `JPMAP_TERRAIN_DEFAULTS`
- `src/lib/jpmapTerrain.ts` 新規:
  - `JpmapTerrain` クラス（private constructor / static async create）
  - 位置・カメラ制御 (lat/lon/altitude/azimuth/tilt) の get/set
  - flyTo (内部状態のみ更新)
  - UI 表示 5 項目 (showCompass/showZoomButtons/showScaleBar/showMapToggle/showAttribution) の get/set
  - mapType の get/set
  - dispose / resize スタブ
- `src/lib.ts`: 上記 2 ファイルから公開シンボルを re-export

## 範囲外（後続）
- T4 (#118): mountElement への canvas/UI 配置と Scene 初期化
- T5 (#119): カメラ get/set 反映と flyTo アニメーション
- T6 (#120): UI 表示切替 / mapType 反映
- T7 (#121): dispose / resize 実体

## 検証結果 (DoD)
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test:unit` ✅
- `npm run build:lib` ✅ (`dist/index.mjs` / `dist/index.d.mts` に JpmapTerrain と公開型がエクスポートされる)
- `npm pack --dry-run` ✅

Closes #117