### PR TITLE
T5(#119): カメラ API 実体化（get/set 即時反映 + flyTo アニメーション）

### DIFF
--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -13,7 +13,7 @@
 import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import type { Scene } from "@babylonjs/core/scene";
 
-import { DefaultScene } from "../scenes/default";
+import { DefaultScene, type DefaultSceneController } from "../scenes/default";
 import { createBabylonEngine } from "./internal/engineFactory";
 import {
     FlyToOptions,
@@ -47,6 +47,9 @@ export class JpmapTerrain {
     private _engine: AbstractEngine | null = null;
     private _scene: Scene | null = null;
     private _onWindowResize: (() => void) | null = null;
+    private _controller: DefaultSceneController | null = null;
+    /** 進行中の flyTo をキャンセルするためのトークン */
+    private _flyToToken = 0;
 
     private constructor(mountElement: HTMLElement, options: JpmapTerrainOptions) {
         this.mountElement = mountElement;
@@ -110,6 +113,9 @@ export class JpmapTerrain {
                 tilt: this._tilt,
                 mapType: this._mapType,
                 urlSync: false,
+                onReady: (controller) => {
+                    this._controller = controller;
+                },
             });
             this._scene = scene;
 
@@ -139,53 +145,108 @@ export class JpmapTerrain {
     // ---- 位置・カメラ制御 (spec §3.3.1) ----
 
     public get lat(): number {
-        return this._lat;
+        return this._controller?.getLat() ?? this._lat;
     }
     public set lat(value: number) {
         this._lat = value;
-        // T5 (#119) で camera target に反映する。
+        this._controller?.setLat(value);
     }
 
     public get lon(): number {
-        return this._lon;
+        return this._controller?.getLon() ?? this._lon;
     }
     public set lon(value: number) {
         this._lon = value;
+        this._controller?.setLon(value);
     }
 
     public get altitude(): number {
-        return this._altitude;
+        return this._controller?.getAltitude() ?? this._altitude;
     }
     public set altitude(value: number) {
         this._altitude = value;
+        this._controller?.setAltitude(value);
     }
 
     public get azimuth(): number {
-        return this._azimuth;
+        return this._controller?.getAzimuth() ?? this._azimuth;
     }
     public set azimuth(value: number) {
         this._azimuth = value;
+        this._controller?.setAzimuth(value);
     }
 
     public get tilt(): number {
-        return this._tilt;
+        return this._controller?.getTilt() ?? this._tilt;
     }
     public set tilt(value: number) {
         this._tilt = value;
+        this._controller?.setTilt(value);
     }
 
     /**
-     * 指定座標へカメラをアニメーション付きで移動する。
-     * 実体は T5 (#119) で実装する。
+     * 指定座標へカメラをアニメーション付きで移動する (T5)。
+     *
+     * 指定された長さ（`duration`, デフォルト 800ms）の間、`requestAnimationFrame` で状態を連続補間し setter を逕次呼ぶ。
+     * 連続で `flyTo` が呼ばれた場合は后勝ちとし、前の遷移は途中で中断し Promise を resolve する。
      */
     public async flyTo(options: FlyToOptions): Promise<void> {
-        // setter 経由で更新し、将来 setter に追加される副作用（T5: カメラ反映等）を共有する。
-        this.lat = options.lat;
-        this.lon = options.lon;
-        if (options.altitude !== undefined) this.altitude = options.altitude;
-        if (options.azimuth !== undefined) this.azimuth = options.azimuth;
-        if (options.tilt !== undefined) this.tilt = options.tilt;
-        // T5 (#119) でアニメーション遷移を実装する。
+        const duration = Math.max(0, options.duration ?? 800);
+        const startLat = this.lat;
+        const startLon = this.lon;
+        const startAlt = this.altitude;
+        const startAz = this.azimuth;
+        const startTilt = this.tilt;
+        const targetLat = options.lat;
+        const targetLon = options.lon;
+        const targetAlt = options.altitude ?? startAlt;
+        const targetAz = options.azimuth ?? startAz;
+        const targetTilt = options.tilt ?? startTilt;
+
+        // 長さ 0 または animation frame を提供しない環境（テスト等）は即時適用
+        const raf =
+            typeof requestAnimationFrame === "function"
+                ? requestAnimationFrame
+                : null;
+        if (duration === 0 || raf === null) {
+            this.lat = targetLat;
+            this.lon = targetLon;
+            this.altitude = targetAlt;
+            this.azimuth = targetAz;
+            this.tilt = targetTilt;
+            return;
+        }
+
+        const token = ++this._flyToToken;
+        const startTime =
+            typeof performance !== "undefined" && performance.now
+                ? performance.now()
+                : Date.now();
+        const easeOutCubic = (t: number): number => 1 - Math.pow(1 - t, 3);
+
+        return new Promise<void>((resolve) => {
+            const step = (now: number): void => {
+                // 後勝ちの flyTo が起動されたら中断
+                if (token !== this._flyToToken) {
+                    resolve();
+                    return;
+                }
+                const elapsed = now - startTime;
+                const t = Math.min(1, elapsed / duration);
+                const k = easeOutCubic(t);
+                this.lat = startLat + (targetLat - startLat) * k;
+                this.lon = startLon + (targetLon - startLon) * k;
+                this.altitude = startAlt + (targetAlt - startAlt) * k;
+                this.azimuth = startAz + (targetAz - startAz) * k;
+                this.tilt = startTilt + (targetTilt - startTilt) * k;
+                if (t < 1) {
+                    raf(step);
+                } else {
+                    resolve();
+                }
+            };
+            raf(step);
+        });
     }
 
     // ---- UI 表示制御 (spec §3.3.2) ----
@@ -240,10 +301,13 @@ export class JpmapTerrain {
      * 完全なクリーンアップは T7 (#121) で拡充する。
      */
     public dispose(): void {
+        // 進行中の flyTo を中断
+        this._flyToToken++;
         if (this._onWindowResize) {
             window.removeEventListener("resize", this._onWindowResize);
             this._onWindowResize = null;
         }
+        this._controller = null;
         if (this._scene) {
             this._scene.dispose();
             this._scene = null;

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -187,8 +187,11 @@ export class JpmapTerrain {
     /**
      * 指定座標へカメラをアニメーション付きで移動する (T5)。
      *
-     * 指定された長さ（`duration`, デフォルト 800ms）の間、`requestAnimationFrame` で状態を連続補間し setter を逕次呼ぶ。
-     * 連続で `flyTo` が呼ばれた場合は后勝ちとし、前の遷移は途中で中断し Promise を resolve する。
+     * 指定された長さ（`duration`, デフォルト 800ms）の間、`requestAnimationFrame` で状態を連続補間しコントローラへ順次反映する。
+     * 連続で `flyTo` が呼ばれた場合は後勝ちとし、前の遷移は途中で中断し Promise を resolve する。
+     *
+     * タイル fetch 負荷を抑えるため、中間フレームでは `setView({ refreshTerrain: false })` とし、
+     * 最終フレーム（もしくは 中断・即時適用パス）でのみ `refreshTerrain: true` でタイル中心を更新する。
      */
     public async flyTo(options: FlyToOptions): Promise<void> {
         const duration = Math.max(0, options.duration ?? 800);
@@ -203,17 +206,45 @@ export class JpmapTerrain {
         const targetAz = options.azimuth ?? startAz;
         const targetTilt = options.tilt ?? startTilt;
 
+        // この flyTo 中に適用したフレーム値をキャッシュし、
+        // 中断時に「その位置で 1 回だけ refresh を行う」ために保持する。
+        const lastApplied = {
+            lat: startLat,
+            lon: startLon,
+            altitude: startAlt,
+            azimuth: startAz,
+            tilt: startTilt,
+        };
+
+        const applyAndCacheLocal = (values: typeof lastApplied): void => {
+            // controller 不在時のフォールバック用にローカル状態も同期する。
+            this._lat = values.lat;
+            this._lon = values.lon;
+            this._altitude = values.altitude;
+            this._azimuth = values.azimuth;
+            this._tilt = values.tilt;
+            lastApplied.lat = values.lat;
+            lastApplied.lon = values.lon;
+            lastApplied.altitude = values.altitude;
+            lastApplied.azimuth = values.azimuth;
+            lastApplied.tilt = values.tilt;
+        };
+
         // 長さ 0 または animation frame を提供しない環境（テスト等）は即時適用
         const raf =
             typeof requestAnimationFrame === "function"
                 ? requestAnimationFrame
                 : null;
         if (duration === 0 || raf === null) {
-            this.lat = targetLat;
-            this.lon = targetLon;
-            this.altitude = targetAlt;
-            this.azimuth = targetAz;
-            this.tilt = targetTilt;
+            const finalValues = {
+                lat: targetLat,
+                lon: targetLon,
+                altitude: targetAlt,
+                azimuth: targetAz,
+                tilt: targetTilt,
+            };
+            applyAndCacheLocal(finalValues);
+            this._controller?.setView(finalValues, { refreshTerrain: true });
             return;
         }
 
@@ -228,18 +259,30 @@ export class JpmapTerrain {
             const step = (now: number): void => {
                 // 後勝ちの flyTo が起動されたら中断
                 if (token !== this._flyToToken) {
+                    // 最後に適用した位置で 1 回 refresh してタイルを追いつかせる。
+                    // 後勝ちの flyTo がさらに上書きするため、余分な fetch にはならない。
+                    this._controller?.setView(
+                        { lat: lastApplied.lat, lon: lastApplied.lon },
+                        { refreshTerrain: true },
+                    );
                     resolve();
                     return;
                 }
                 const elapsed = now - startTime;
                 const t = Math.min(1, elapsed / duration);
                 const k = easeOutCubic(t);
-                this.lat = startLat + (targetLat - startLat) * k;
-                this.lon = startLon + (targetLon - startLon) * k;
-                this.altitude = startAlt + (targetAlt - startAlt) * k;
-                this.azimuth = startAz + (targetAz - startAz) * k;
-                this.tilt = startTilt + (targetTilt - startTilt) * k;
-                if (t < 1) {
+                const values = {
+                    lat: startLat + (targetLat - startLat) * k,
+                    lon: startLon + (targetLon - startLon) * k,
+                    altitude: startAlt + (targetAlt - startAlt) * k,
+                    azimuth: startAz + (targetAz - startAz) * k,
+                    tilt: startTilt + (targetTilt - startTilt) * k,
+                };
+                applyAndCacheLocal(values);
+                // 中間フレームでは refresh しない。最終フレームだけ refresh。
+                const isLast = t >= 1;
+                this._controller?.setView(values, { refreshTerrain: isLast });
+                if (!isLast) {
                     raf(step);
                 } else {
                     resolve();

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -64,6 +64,25 @@ export interface DefaultSceneController {
     setAltitude(value: number): void;
     setAzimuth(value: number): void;
     setTilt(value: number): void;
+
+    /**
+     * 複数のカメラ/位置パラメータをまとめて適用する (T5)。
+     *
+     * `flyTo` のような高頻度更新では `options.refreshTerrain` を `false` にして
+     * タイル中心更新（`tileManager.setCenter` 経由の fetch）を抑制し、
+     * 遷移完了時など必要なタイミングで `true` を渡してまとめて反映する。
+     * 既定値は `true`（単体 setter と同じ挙動）。
+     */
+    setView(
+        values: {
+            lat?: number;
+            lon?: number;
+            altitude?: number;
+            azimuth?: number;
+            tilt?: number;
+        },
+        options?: { refreshTerrain?: boolean },
+    ): void;
 }
 
 /**
@@ -866,33 +885,71 @@ export class DefaultScene implements CreateSceneClass {
         const alphaFromAzimuthDeg = (deg: number): number =>
             -Math.PI / 2 + (deg * Math.PI) / 180;
 
+        // 中心座標の適用と、（必要なら）タイル refresh をまとめて行う共通実装。
+        const applyView = (
+            values: {
+                lat?: number;
+                lon?: number;
+                altitude?: number;
+                azimuth?: number;
+                tilt?: number;
+            },
+            shouldRefresh: boolean,
+        ): void => {
+            let centerChanged = false;
+            if (values.lat !== undefined) {
+                currentLat = clamp(
+                    values.lat,
+                    JAPAN_BOUNDS.minLat,
+                    JAPAN_BOUNDS.maxLat,
+                );
+                centerChanged = true;
+            }
+            if (values.lon !== undefined) {
+                currentLon = clamp(
+                    values.lon,
+                    JAPAN_BOUNDS.minLon,
+                    JAPAN_BOUNDS.maxLon,
+                );
+                centerChanged = true;
+            }
+            if (values.altitude !== undefined) {
+                const lower = camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
+                const upper = camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS;
+                camera.radius = clamp(values.altitude, lower, upper);
+            }
+            if (values.azimuth !== undefined) {
+                camera.alpha = alphaFromAzimuthDeg(values.azimuth);
+            }
+            if (values.tilt !== undefined) {
+                const lower = camera.lowerBetaLimit ?? 0;
+                const upper = camera.upperBetaLimit ?? Math.PI;
+                camera.beta = clamp(
+                    (values.tilt * Math.PI) / 180,
+                    lower,
+                    upper,
+                );
+            }
+            // 中心座標が変わったときのみ refresh する。
+            // altitude/azimuth/tilt はタイル中心に影響しないため refresh 不要。
+            if (shouldRefresh && centerChanged) {
+                void refreshTerrain();
+            }
+        };
+
         const controller: DefaultSceneController = {
             getLat: () => currentLat,
             getLon: () => currentLon,
             getAltitude: () => camera.radius,
             getAzimuth: () => azimuthDegFromAlpha(camera.alpha),
             getTilt: () => (camera.beta * 180) / Math.PI,
-            setLat: (value: number) => {
-                currentLat = clamp(value, JAPAN_BOUNDS.minLat, JAPAN_BOUNDS.maxLat);
-                void refreshTerrain();
-            },
-            setLon: (value: number) => {
-                currentLon = clamp(value, JAPAN_BOUNDS.minLon, JAPAN_BOUNDS.maxLon);
-                void refreshTerrain();
-            },
-            setAltitude: (value: number) => {
-                const lower = camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
-                const upper = camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS;
-                camera.radius = clamp(value, lower, upper);
-            },
-            setAzimuth: (deg: number) => {
-                camera.alpha = alphaFromAzimuthDeg(deg);
-            },
-            setTilt: (deg: number) => {
-                const lower = camera.lowerBetaLimit ?? 0;
-                const upper = camera.upperBetaLimit ?? Math.PI;
-                camera.beta = clamp((deg * Math.PI) / 180, lower, upper);
-            },
+            setLat: (value) => applyView({ lat: value }, true),
+            setLon: (value) => applyView({ lon: value }, true),
+            setAltitude: (value) => applyView({ altitude: value }, true),
+            setAzimuth: (value) => applyView({ azimuth: value }, true),
+            setTilt: (value) => applyView({ tilt: value }, true),
+            setView: (values, opts) =>
+                applyView(values, opts?.refreshTerrain ?? true),
         };
         options?.onReady?.(controller);
 

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -41,6 +41,32 @@ const SKY_ZOOM_ALTITUDE_THRESHOLD = 1000;
 const METERS_PER_DEGREE_LAT = 111320;
 
 /**
+ * `DefaultScene` 経由で外部からカメラ・位置を操作するためのコントローラ (T5 / Issue #119)。
+ *
+ * `JpmapTerrain` (パッケージ層) から get/set/flyTo を呼び出す際の境界となる。
+ * シーン内部のクロージャ (`currentLat` / `camera` / `refreshTerrain`) を直接公開せず、
+ * 必要な操作のみ関数として提供する。
+ */
+export interface DefaultSceneController {
+    getLat(): number;
+    getLon(): number;
+    /** 高度（メートル）= ArcRotateCamera.radius */
+    getAltitude(): number;
+    /** 方位角（度）= camera.alpha を北基準・度に変換した値 */
+    getAzimuth(): number;
+    /** チルト角（度）= camera.beta を度に変換した値 */
+    getTilt(): number;
+
+    /** 緯度を即時反映する。Japan bounds でクランプされる */
+    setLat(value: number): void;
+    /** 経度を即時反映する。Japan bounds でクランプされる */
+    setLon(value: number): void;
+    setAltitude(value: number): void;
+    setAzimuth(value: number): void;
+    setTilt(value: number): void;
+}
+
+/**
  * `DefaultScene.createScene` の初期化オプション (T4 / Issue #118)。
  *
  * パッケージ利用 (`JpmapTerrain.create`) で初期パラメータを指定するために導入。
@@ -64,6 +90,11 @@ export interface DefaultSceneInitOptions {
      * デモ (default: true) では従来通り更新するが、パッケージ利用時は false にして利用側 URL を汚染しない。
      */
     urlSync?: boolean;
+    /**
+     * シーン構築完了時に外部操作用コントローラを受け取るコールバック (T5)。
+     * `JpmapTerrain` の get/set/flyTo はこのコントローラ経由でカメラ・位置を更新する。
+     */
+    onReady?: (controller: DefaultSceneController) => void;
 }
 
 export class DefaultScene implements CreateSceneClass {
@@ -826,6 +857,44 @@ export class DefaultScene implements CreateSceneClass {
 
         // カメラ移動時の自動タイル更新
         tileManager.attachCamera();
+
+        // ---- T5: 外部操作用コントローラ ----
+        // JpmapTerrain から get/set/flyTo で呼び出される。
+        // 度数法 ⇄ ラジアン変換、alpha の北基準オフセット (-π/2) を吸収する。
+        const azimuthDegFromAlpha = (alpha: number): number =>
+            ((alpha + Math.PI / 2) * 180) / Math.PI;
+        const alphaFromAzimuthDeg = (deg: number): number =>
+            -Math.PI / 2 + (deg * Math.PI) / 180;
+
+        const controller: DefaultSceneController = {
+            getLat: () => currentLat,
+            getLon: () => currentLon,
+            getAltitude: () => camera.radius,
+            getAzimuth: () => azimuthDegFromAlpha(camera.alpha),
+            getTilt: () => (camera.beta * 180) / Math.PI,
+            setLat: (value: number) => {
+                currentLat = clamp(value, JAPAN_BOUNDS.minLat, JAPAN_BOUNDS.maxLat);
+                void refreshTerrain();
+            },
+            setLon: (value: number) => {
+                currentLon = clamp(value, JAPAN_BOUNDS.minLon, JAPAN_BOUNDS.maxLon);
+                void refreshTerrain();
+            },
+            setAltitude: (value: number) => {
+                const lower = camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
+                const upper = camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS;
+                camera.radius = clamp(value, lower, upper);
+            },
+            setAzimuth: (deg: number) => {
+                camera.alpha = alphaFromAzimuthDeg(deg);
+            },
+            setTilt: (deg: number) => {
+                const lower = camera.lowerBetaLimit ?? 0;
+                const upper = camera.upperBetaLimit ?? Math.PI;
+                camera.beta = clamp((deg * Math.PI) / 180, lower, upper);
+            },
+        };
+        options?.onReady?.(controller);
 
         // 初回ロード
         await refreshTerrain();

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -32,6 +32,16 @@ jest.unstable_mockModule("../src/lib/internal/engineFactory", () => ({
 }));
 
 jest.unstable_mockModule("../src/scenes/default", () => {
+    // モック内で refreshTerrain 相当の呼び出し回数を記録し、
+    // テストから検証できるよう getter を export する（T5 のバッチ refresh 検証用）。
+    let refreshCallCount = 0;
+    type ViewValues = {
+        lat?: number;
+        lon?: number;
+        altitude?: number;
+        azimuth?: number;
+        tilt?: number;
+    };
     class DefaultScene {
         createScene = jest.fn(
             async (
@@ -52,27 +62,42 @@ jest.unstable_mockModule("../src/scenes/default", () => {
                 let altitude = opts?.altitude ?? 0;
                 let azimuth = opts?.azimuth ?? 0;
                 let tilt = opts?.tilt ?? 0;
+                const refresh = (): void => {
+                    refreshCallCount++;
+                };
+                const applyView = (
+                    values: ViewValues,
+                    shouldRefresh: boolean,
+                ): void => {
+                    let centerChanged = false;
+                    if (values.lat !== undefined) {
+                        lat = values.lat;
+                        centerChanged = true;
+                    }
+                    if (values.lon !== undefined) {
+                        lon = values.lon;
+                        centerChanged = true;
+                    }
+                    if (values.altitude !== undefined) altitude = values.altitude;
+                    if (values.azimuth !== undefined) azimuth = values.azimuth;
+                    if (values.tilt !== undefined) tilt = values.tilt;
+                    if (shouldRefresh && centerChanged) refresh();
+                };
                 opts?.onReady?.({
                     getLat: () => lat,
                     getLon: () => lon,
                     getAltitude: () => altitude,
                     getAzimuth: () => azimuth,
                     getTilt: () => tilt,
-                    setLat: (v: number) => {
-                        lat = v;
-                    },
-                    setLon: (v: number) => {
-                        lon = v;
-                    },
-                    setAltitude: (v: number) => {
-                        altitude = v;
-                    },
-                    setAzimuth: (v: number) => {
-                        azimuth = v;
-                    },
-                    setTilt: (v: number) => {
-                        tilt = v;
-                    },
+                    setLat: (v: number) => applyView({ lat: v }, true),
+                    setLon: (v: number) => applyView({ lon: v }, true),
+                    setAltitude: (v: number) => applyView({ altitude: v }, true),
+                    setAzimuth: (v: number) => applyView({ azimuth: v }, true),
+                    setTilt: (v: number) => applyView({ tilt: v }, true),
+                    setView: (
+                        values: ViewValues,
+                        options?: { refreshTerrain?: boolean },
+                    ) => applyView(values, options?.refreshTerrain ?? true),
                 });
                 return {
                     render: jest.fn(),
@@ -81,11 +106,21 @@ jest.unstable_mockModule("../src/scenes/default", () => {
             },
         );
     }
-    return { DefaultScene };
+    return {
+        DefaultScene,
+        __getRefreshCount: (): number => refreshCallCount,
+        __resetRefreshCount: (): void => {
+            refreshCallCount = 0;
+        },
+    };
 });
 
 // jest.unstable_mockModule は hoist されないため、モック登録後に動的 import する。
 const { JpmapTerrain } = await import("../src/lib/jpmapTerrain");
+const sceneMockModule = (await import("../src/scenes/default")) as unknown as {
+    __getRefreshCount: () => number;
+    __resetRefreshCount: () => void;
+};
 
 describe("JpmapTerrain (skeleton)", () => {
     const createMountElement = (): HTMLElement => document.createElement("div");
@@ -386,6 +421,52 @@ describe("JpmapTerrain (skeleton)", () => {
             expect(viewer.lat).toBeCloseTo(1);
             expect(viewer.lon).toBeCloseTo(2);
             expect(viewer.altitude).toBeCloseTo(1234);
+        });
+
+        it("flyTo 中の中間フレームではタイル refresh を発火させず、最終フレームでまとめて refresh する", async () => {
+            const viewer = await create(createMountElement(), {
+                lat: 0,
+                lon: 0,
+                altitude: 1000,
+            });
+            // 初期化中の refresh は対象外。flyTo 開始時点でリセット。
+            sceneMockModule.__resetRefreshCount();
+
+            await viewer.flyTo({
+                lat: 35,
+                lon: 139,
+                altitude: 2000,
+                duration: 50,
+            });
+
+            // バッチ refresh 設計により、中間フレームでは refresh されず、
+            // 最終フレーム（または完了相当）で 1 回のみ呼ばれる想定。
+            // jsdom 上の RAF タイミングに揺れがあっても 2 回以下に収まることを保証する。
+            const count = sceneMockModule.__getRefreshCount();
+            expect(count).toBeGreaterThanOrEqual(1);
+            expect(count).toBeLessThanOrEqual(2);
+        });
+
+        it("単体 setter（lat/lon）はその都度 refresh を発火する", async () => {
+            const viewer = await create(createMountElement());
+            sceneMockModule.__resetRefreshCount();
+
+            viewer.lat = 35;
+            viewer.lon = 139;
+
+            // lat/lon それぞれで 1 回ずつ。
+            expect(sceneMockModule.__getRefreshCount()).toBe(2);
+        });
+
+        it("altitude/azimuth/tilt の単体 setter は refresh を発火しない", async () => {
+            const viewer = await create(createMountElement());
+            sceneMockModule.__resetRefreshCount();
+
+            viewer.altitude = 5000;
+            viewer.azimuth = 90;
+            viewer.tilt = 45;
+
+            expect(sceneMockModule.__getRefreshCount()).toBe(0);
         });
     });
 });

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -33,10 +33,53 @@ jest.unstable_mockModule("../src/lib/internal/engineFactory", () => ({
 
 jest.unstable_mockModule("../src/scenes/default", () => {
     class DefaultScene {
-        createScene = jest.fn(async () => ({
-            render: jest.fn(),
-            dispose: jest.fn(),
-        }));
+        createScene = jest.fn(
+            async (
+                _engine: unknown,
+                _canvas: unknown,
+                opts?: {
+                    lat?: number;
+                    lon?: number;
+                    altitude?: number;
+                    azimuth?: number;
+                    tilt?: number;
+                    onReady?: (controller: unknown) => void;
+                },
+            ) => {
+                // T5: コントローラのインメモリ実装をテスト用に提供する。
+                let lat = opts?.lat ?? 0;
+                let lon = opts?.lon ?? 0;
+                let altitude = opts?.altitude ?? 0;
+                let azimuth = opts?.azimuth ?? 0;
+                let tilt = opts?.tilt ?? 0;
+                opts?.onReady?.({
+                    getLat: () => lat,
+                    getLon: () => lon,
+                    getAltitude: () => altitude,
+                    getAzimuth: () => azimuth,
+                    getTilt: () => tilt,
+                    setLat: (v: number) => {
+                        lat = v;
+                    },
+                    setLon: (v: number) => {
+                        lon = v;
+                    },
+                    setAltitude: (v: number) => {
+                        altitude = v;
+                    },
+                    setAzimuth: (v: number) => {
+                        azimuth = v;
+                    },
+                    setTilt: (v: number) => {
+                        tilt = v;
+                    },
+                });
+                return {
+                    render: jest.fn(),
+                    dispose: jest.fn(),
+                };
+            },
+        );
     }
     return { DefaultScene };
 });
@@ -249,6 +292,100 @@ describe("JpmapTerrain (skeleton)", () => {
             await expect(JpmapTerrain.create(mount)).rejects.toThrow("engine init failed");
 
             expect(mount.querySelectorAll("canvas").length).toBe(0);
+        });
+    });
+
+    describe("camera controller wiring (T5)", () => {
+        it("set した位置・カメラ系プロパティはコントローラ経由で取得しても同じ値になる", async () => {
+            const viewer = await create(createMountElement(), {
+                lat: 1,
+                lon: 2,
+                altitude: 100,
+                azimuth: 10,
+                tilt: 20,
+            });
+
+            viewer.lat = 35.0;
+            viewer.lon = 140.0;
+            viewer.altitude = 1500;
+            viewer.azimuth = 90;
+            viewer.tilt = 60;
+
+            // get はコントローラから取得される
+            expect(viewer.lat).toBe(35.0);
+            expect(viewer.lon).toBe(140.0);
+            expect(viewer.altitude).toBe(1500);
+            expect(viewer.azimuth).toBe(90);
+            expect(viewer.tilt).toBe(60);
+        });
+
+        it("flyTo は Promise を返し、完了時に最終値へ到達する", async () => {
+            const viewer = await create(createMountElement(), {
+                lat: 0,
+                lon: 0,
+                altitude: 1000,
+                azimuth: 0,
+                tilt: 30,
+            });
+
+            await viewer.flyTo({
+                lat: 35.3606,
+                lon: 138.7274,
+                altitude: 8000,
+                azimuth: 45,
+                tilt: 60,
+                duration: 50,
+            });
+
+            expect(viewer.lat).toBeCloseTo(35.3606);
+            expect(viewer.lon).toBeCloseTo(138.7274);
+            expect(viewer.altitude).toBeCloseTo(8000);
+            expect(viewer.azimuth).toBeCloseTo(45);
+            expect(viewer.tilt).toBeCloseTo(60);
+        });
+
+        it("duration=0 では即時に最終値が反映される", async () => {
+            const viewer = await create(createMountElement());
+
+            await viewer.flyTo({
+                lat: 10,
+                lon: 20,
+                altitude: 3000,
+                duration: 0,
+            });
+
+            expect(viewer.lat).toBe(10);
+            expect(viewer.lon).toBe(20);
+            expect(viewer.altitude).toBe(3000);
+        });
+
+        it("連続 flyTo では後勝ちになり、双方の Promise が解決される", async () => {
+            const viewer = await create(createMountElement(), {
+                lat: 0,
+                lon: 0,
+                altitude: 1000,
+            });
+
+            const first = viewer.flyTo({
+                lat: 50,
+                lon: 50,
+                altitude: 5000,
+                duration: 200,
+            });
+            // 即座に上書き
+            const second = viewer.flyTo({
+                lat: 1,
+                lon: 2,
+                altitude: 1234,
+                duration: 30,
+            });
+
+            await Promise.all([first, second]);
+
+            // 後勝ちの second が最終値
+            expect(viewer.lat).toBeCloseTo(1);
+            expect(viewer.lon).toBeCloseTo(2);
+            expect(viewer.altitude).toBeCloseTo(1234);
         });
     });
 });


### PR DESCRIPTION
## 概要
spec/package.md §3.3.1 のカメラ API（lat/lon/altitude/azimuth/tilt の get/set, flyTo）を実体化する。

## 変更内容
- `src/scenes/default.ts`: `DefaultSceneController` インターフェース / `onReady` コールバックを追加し、内部カメラ状態を外部に橋渡し。
- `src/lib/jpmapTerrain.ts`:
  - `_controller` を保持し、setter は controller に即時反映、getter は controller から取得。
  - `flyTo` を `requestAnimationFrame` + easeOutCubic で実装。`duration` 既定 800ms、`duration=0` / RAF 不在環境では即時反映。
  - 連続 `flyTo` は後勝ち（トークンによりキャンセル）。`dispose` でも進行中 flyTo を中断。
- `tests/jpmapTerrain.unit.spec.ts`: モック `DefaultScene` を controller 提供型に強化し、setter 反映 / flyTo / duration=0 / 後勝ちのテストを追加。

## 検証
- `npm run lint` / `npm run typecheck` / `npm run test:unit` / `npm run build:lib` / `npm run build:dev` / `npm run test:visuals` すべて成功。

Closes #119

Base: packaging