### PR TITLE
T6(#120): UI 表示 get/set プロパティと mapType 切替実装

### DIFF
--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -115,6 +115,27 @@ export class JpmapTerrain {
                 urlSync: false,
                 onReady: (controller) => {
                     this._controller = controller;
+                    // T6: 初期表示状態を controller に反映する
+                    controller.setUiVisibility(
+                        "compass",
+                        this._showCompass,
+                    );
+                    controller.setUiVisibility(
+                        "zoomButtons",
+                        this._showZoomButtons,
+                    );
+                    controller.setUiVisibility(
+                        "scaleBar",
+                        this._showScaleBar,
+                    );
+                    controller.setUiVisibility(
+                        "mapToggle",
+                        this._showMapToggle,
+                    );
+                    controller.setUiVisibility(
+                        "attribution",
+                        this._showAttribution,
+                    );
                 },
             });
             this._scene = scene;
@@ -299,6 +320,7 @@ export class JpmapTerrain {
     }
     public set showCompass(value: boolean) {
         this._showCompass = value;
+        this._controller?.setUiVisibility("compass", value);
     }
 
     public get showZoomButtons(): boolean {
@@ -306,6 +328,7 @@ export class JpmapTerrain {
     }
     public set showZoomButtons(value: boolean) {
         this._showZoomButtons = value;
+        this._controller?.setUiVisibility("zoomButtons", value);
     }
 
     public get showScaleBar(): boolean {
@@ -313,6 +336,7 @@ export class JpmapTerrain {
     }
     public set showScaleBar(value: boolean) {
         this._showScaleBar = value;
+        this._controller?.setUiVisibility("scaleBar", value);
     }
 
     public get showMapToggle(): boolean {
@@ -320,6 +344,7 @@ export class JpmapTerrain {
     }
     public set showMapToggle(value: boolean) {
         this._showMapToggle = value;
+        this._controller?.setUiVisibility("mapToggle", value);
     }
 
     public get showAttribution(): boolean {
@@ -327,14 +352,15 @@ export class JpmapTerrain {
     }
     public set showAttribution(value: boolean) {
         this._showAttribution = value;
+        this._controller?.setUiVisibility("attribution", value);
     }
 
     public get mapType(): MapType {
-        return this._mapType;
+        return this._controller?.getMapType() ?? this._mapType;
     }
     public set mapType(value: MapType) {
         this._mapType = value;
-        // T6 (#120) で地図種類切替を実装する。
+        this._controller?.setMapType(value);
     }
 
     // ---- ライフサイクル (spec §3.3.3) ----

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -12,6 +12,7 @@ import { createSkybox } from "../terrain/skybox";
 import { parseLatLonFromUrl, createUrlUpdater } from "../terrain/urlState";
 import { resolveTiltCollision, TILT_MAX_RADIUS_INCREASE_RATIO } from "../terrain/cameraCollision";
 import { computePoseForNewTarget } from "../terrain/cameraRetarget";
+import { createUiVisibilityController } from "../terrain/uiVisibility";
 
 const TERRAIN_SUBDIVISIONS = 128;
 const MAX_ZOOM = 18;
@@ -988,29 +989,16 @@ export class DefaultScene implements CreateSceneClass {
                 tileManager.setMapType(internal);
                 updateMapToggleLabel(internal);
             },
-            setUiVisibility: (target, visible) => {
-                const display = visible ? "" : "none";
-                switch (target) {
-                    case "compass":
-                        ui.compass.style.display = display;
-                        break;
-                    case "zoomButtons":
-                        ui.locateMe.style.display = display;
-                        ui.zoomIn.style.display = display;
-                        ui.zoomOut.style.display = display;
-                        break;
-                    case "scaleBar":
-                        ui.scaleBar.bar.style.display = display;
-                        ui.scaleBar.label.style.display = display;
-                        break;
-                    case "mapToggle":
-                        ui.mapToggle.style.display = display;
-                        break;
-                    case "attribution":
-                        ui.scaleBar.attribution.style.display = display;
-                        break;
-                }
-            },
+            setUiVisibility: createUiVisibilityController({
+                compass: ui.compass,
+                locateMe: ui.locateMe,
+                zoomIn: ui.zoomIn,
+                zoomOut: ui.zoomOut,
+                scaleBarBar: ui.scaleBar.bar,
+                scaleBarLabel: ui.scaleBar.label,
+                mapToggle: ui.mapToggle,
+                attribution: ui.scaleBar.attribution,
+            }),
         };
         options?.onReady?.(controller);
 

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -83,6 +83,25 @@ export interface DefaultSceneController {
         },
         options?: { refreshTerrain?: boolean },
     ): void;
+
+    // ---- UI / mapType (T6 / Issue #120) ----
+
+    /** 現在の地図種類を spec 表記 (`standard` / `photo`) で返す */
+    getMapType(): "standard" | "photo";
+    /** 地図種類を切り替える。ボタン表示も一緒に追従させる */
+    setMapType(value: "standard" | "photo"): void;
+    /**
+     * コントロールパネル要素の表示・非表示を切り替える (spec §3.3.2)。
+     */
+    setUiVisibility(
+        target:
+            | "compass"
+            | "zoomButtons"
+            | "scaleBar"
+            | "mapToggle"
+            | "attribution",
+        visible: boolean,
+    ): void;
 }
 
 /**
@@ -849,16 +868,27 @@ export class DefaultScene implements CreateSceneClass {
         });
 
         // 地図切替ボタン
+        // クリック時 / controller.setMapType の双方からラベル更新を共通化する (T6)。
+        const updateMapToggleLabel = (current: "std" | "photo"): void => {
+            ui.mapToggle.textContent = current === "std" ? "写真" : "標準";
+            ui.mapToggle.setAttribute(
+                "aria-label",
+                current === "std"
+                    ? "地図切替: 写真地図に変更"
+                    : "地図切替: 標準地図に変更",
+            );
+        };
+        // 初期 mapType がオプション指定されていれば反映する (T6)。
+        if (options?.mapType) {
+            const initialInternal =
+                options.mapType === "standard" ? "std" : "photo";
+            tileManager.setMapType(initialInternal);
+            updateMapToggleLabel(initialInternal);
+        }
         ui.mapToggle.addEventListener("click", () => {
             const next = tileManager.mapType === "std" ? "photo" : "std";
             tileManager.setMapType(next);
-            ui.mapToggle.textContent = next === "std" ? "写真" : "標準";
-            ui.mapToggle.setAttribute(
-                "aria-label",
-                next === "std"
-                    ? "地図切替: 写真地図に変更"
-                    : "地図切替: 標準地図に変更"
-            );
+            updateMapToggleLabel(next);
         });
 
         // カメラ-地形衝突回避: 地面にめり込まないよう radius を補正してストップ
@@ -950,6 +980,37 @@ export class DefaultScene implements CreateSceneClass {
             setTilt: (value) => applyView({ tilt: value }, true),
             setView: (values, opts) =>
                 applyView(values, opts?.refreshTerrain ?? true),
+            // ---- T6 (Issue #120) ----
+            getMapType: () =>
+                tileManager.mapType === "std" ? "standard" : "photo",
+            setMapType: (value) => {
+                const internal = value === "standard" ? "std" : "photo";
+                tileManager.setMapType(internal);
+                updateMapToggleLabel(internal);
+            },
+            setUiVisibility: (target, visible) => {
+                const display = visible ? "" : "none";
+                switch (target) {
+                    case "compass":
+                        ui.compass.style.display = display;
+                        break;
+                    case "zoomButtons":
+                        ui.locateMe.style.display = display;
+                        ui.zoomIn.style.display = display;
+                        ui.zoomOut.style.display = display;
+                        break;
+                    case "scaleBar":
+                        ui.scaleBar.bar.style.display = display;
+                        ui.scaleBar.label.style.display = display;
+                        break;
+                    case "mapToggle":
+                        ui.mapToggle.style.display = display;
+                        break;
+                    case "attribution":
+                        ui.scaleBar.attribution.style.display = display;
+                        break;
+                }
+            },
         };
         options?.onReady?.(controller);
 

--- a/src/terrain/uiVisibility.ts
+++ b/src/terrain/uiVisibility.ts
@@ -1,0 +1,72 @@
+/**
+ * UI コントロール（コンパス / ズームボタン / スケールバー / 地図切替 / 出典）の
+ * 表示・非表示切替ロジック (T6 / Issue #120)。
+ *
+ * `controlPanel` は各要素にインライン `display: flex` 等を設定するため、
+ * 単純に `style.display = ""` で復元すると元のレイアウトが失われる。
+ * このモジュールは要素ごとの初期 `display` 値をスナップショットしておき、
+ * 表示時にはその値で復元することでレイアウト崩れを防ぐ。
+ */
+
+export type UiVisibilityTarget =
+    | "compass"
+    | "zoomButtons"
+    | "scaleBar"
+    | "mapToggle"
+    | "attribution";
+
+export interface UiVisibilityElements {
+    compass: HTMLElement;
+    locateMe: HTMLElement;
+    zoomIn: HTMLElement;
+    zoomOut: HTMLElement;
+    scaleBarBar: HTMLElement;
+    scaleBarLabel: HTMLElement;
+    mapToggle: HTMLElement;
+    attribution: HTMLElement;
+}
+
+/**
+ * 表示・非表示の切替関数を生成する。
+ * 戻り値の関数は `setUiVisibility(target, visible)` の形で呼び出せる。
+ */
+export const createUiVisibilityController = (
+    elements: UiVisibilityElements,
+): ((target: UiVisibilityTarget, visible: boolean) => void) => {
+    const captureDisplay = (el: HTMLElement): string => el.style.display || "";
+    const initial: Record<keyof UiVisibilityElements, string> = {
+        compass: captureDisplay(elements.compass),
+        locateMe: captureDisplay(elements.locateMe),
+        zoomIn: captureDisplay(elements.zoomIn),
+        zoomOut: captureDisplay(elements.zoomOut),
+        scaleBarBar: captureDisplay(elements.scaleBarBar),
+        scaleBarLabel: captureDisplay(elements.scaleBarLabel),
+        mapToggle: captureDisplay(elements.mapToggle),
+        attribution: captureDisplay(elements.attribution),
+    };
+    const apply = (key: keyof UiVisibilityElements, visible: boolean): void => {
+        elements[key].style.display = visible ? initial[key] : "none";
+    };
+    return (target, visible) => {
+        switch (target) {
+            case "compass":
+                apply("compass", visible);
+                break;
+            case "zoomButtons":
+                apply("locateMe", visible);
+                apply("zoomIn", visible);
+                apply("zoomOut", visible);
+                break;
+            case "scaleBar":
+                apply("scaleBarBar", visible);
+                apply("scaleBarLabel", visible);
+                break;
+            case "mapToggle":
+                apply("mapToggle", visible);
+                break;
+            case "attribution":
+                apply("attribution", visible);
+                break;
+        }
+    };
+};

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -35,6 +35,22 @@ jest.unstable_mockModule("../src/scenes/default", () => {
     // モック内で refreshTerrain 相当の呼び出し回数を記録し、
     // テストから検証できるよう getter を export する（T5 のバッチ refresh 検証用）。
     let refreshCallCount = 0;
+    // T6: setMapType / setUiVisibility の記録もテストから検証できるよう保持する。
+    let lastMapType: "standard" | "photo" = "standard";
+    const setMapTypeCalls: Array<"standard" | "photo"> = [];
+    type UiTarget =
+        | "compass"
+        | "zoomButtons"
+        | "scaleBar"
+        | "mapToggle"
+        | "attribution";
+    const uiVisibility: Record<UiTarget, boolean> = {
+        compass: true,
+        zoomButtons: true,
+        scaleBar: true,
+        mapToggle: true,
+        attribution: true,
+    };
     type ViewValues = {
         lat?: number;
         lon?: number;
@@ -53,6 +69,7 @@ jest.unstable_mockModule("../src/scenes/default", () => {
                     altitude?: number;
                     azimuth?: number;
                     tilt?: number;
+                    mapType?: "standard" | "photo";
                     onReady?: (controller: unknown) => void;
                 },
             ) => {
@@ -62,6 +79,7 @@ jest.unstable_mockModule("../src/scenes/default", () => {
                 let altitude = opts?.altitude ?? 0;
                 let azimuth = opts?.azimuth ?? 0;
                 let tilt = opts?.tilt ?? 0;
+                if (opts?.mapType) lastMapType = opts.mapType;
                 const refresh = (): void => {
                     refreshCallCount++;
                 };
@@ -98,6 +116,14 @@ jest.unstable_mockModule("../src/scenes/default", () => {
                         values: ViewValues,
                         options?: { refreshTerrain?: boolean },
                     ) => applyView(values, options?.refreshTerrain ?? true),
+                    getMapType: () => lastMapType,
+                    setMapType: (value: "standard" | "photo") => {
+                        lastMapType = value;
+                        setMapTypeCalls.push(value);
+                    },
+                    setUiVisibility: (target: UiTarget, visible: boolean) => {
+                        uiVisibility[target] = visible;
+                    },
                 });
                 return {
                     render: jest.fn(),
@@ -112,14 +138,46 @@ jest.unstable_mockModule("../src/scenes/default", () => {
         __resetRefreshCount: (): void => {
             refreshCallCount = 0;
         },
+        __getUiVisibility: (): Record<UiTarget, boolean> => ({
+            ...uiVisibility,
+        }),
+        __resetUiVisibility: (): void => {
+            uiVisibility.compass = true;
+            uiVisibility.zoomButtons = true;
+            uiVisibility.scaleBar = true;
+            uiVisibility.mapToggle = true;
+            uiVisibility.attribution = true;
+        },
+        __getSetMapTypeCalls: (): Array<"standard" | "photo"> => [
+            ...setMapTypeCalls,
+        ],
+        __resetSetMapTypeCalls: (): void => {
+            setMapTypeCalls.length = 0;
+        },
+        __getLastMapType: (): "standard" | "photo" => lastMapType,
+        __setLastMapType: (v: "standard" | "photo"): void => {
+            lastMapType = v;
+        },
     };
 });
 
 // jest.unstable_mockModule は hoist されないため、モック登録後に動的 import する。
 const { JpmapTerrain } = await import("../src/lib/jpmapTerrain");
+type UiTarget =
+    | "compass"
+    | "zoomButtons"
+    | "scaleBar"
+    | "mapToggle"
+    | "attribution";
 const sceneMockModule = (await import("../src/scenes/default")) as unknown as {
     __getRefreshCount: () => number;
     __resetRefreshCount: () => void;
+    __getUiVisibility: () => Record<UiTarget, boolean>;
+    __resetUiVisibility: () => void;
+    __getSetMapTypeCalls: () => Array<"standard" | "photo">;
+    __resetSetMapTypeCalls: () => void;
+    __getLastMapType: () => "standard" | "photo";
+    __setLastMapType: (v: "standard" | "photo") => void;
 };
 
 describe("JpmapTerrain (skeleton)", () => {
@@ -467,6 +525,79 @@ describe("JpmapTerrain (skeleton)", () => {
             viewer.tilt = 45;
 
             expect(sceneMockModule.__getRefreshCount()).toBe(0);
+        });
+    });
+
+    describe("UI visibility / mapType (T6)", () => {
+        beforeEach(() => {
+            sceneMockModule.__resetUiVisibility();
+            sceneMockModule.__resetSetMapTypeCalls();
+            sceneMockModule.__setLastMapType("standard");
+        });
+
+        it("create 直後は controller に各 UI の初期表示状態（既定すべて true）が反映される", async () => {
+            await create(createMountElement());
+            expect(sceneMockModule.__getUiVisibility()).toEqual({
+                compass: true,
+                zoomButtons: true,
+                scaleBar: true,
+                mapToggle: true,
+                attribution: true,
+            });
+        });
+
+        it("showXxx setter は対応する UI の表示状態を controller に反映する", async () => {
+            const viewer = await create(createMountElement());
+
+            viewer.showCompass = false;
+            viewer.showZoomButtons = false;
+            viewer.showScaleBar = false;
+            viewer.showMapToggle = false;
+            viewer.showAttribution = false;
+
+            expect(sceneMockModule.__getUiVisibility()).toEqual({
+                compass: false,
+                zoomButtons: false,
+                scaleBar: false,
+                mapToggle: false,
+                attribution: false,
+            });
+
+            // get は内部状態を返す
+            expect(viewer.showCompass).toBe(false);
+            expect(viewer.showZoomButtons).toBe(false);
+            expect(viewer.showScaleBar).toBe(false);
+            expect(viewer.showMapToggle).toBe(false);
+            expect(viewer.showAttribution).toBe(false);
+
+            viewer.showCompass = true;
+            expect(sceneMockModule.__getUiVisibility().compass).toBe(true);
+            expect(viewer.showCompass).toBe(true);
+        });
+
+        it("create に mapType を渡すと controller 経由で getter が返す値も反映される", async () => {
+            // モック内 lastMapType は createScene の opts.mapType で初期化される。
+            const viewer = await create(createMountElement(), {
+                mapType: "photo",
+            });
+            expect(viewer.mapType).toBe("photo");
+        });
+
+        it("mapType setter は controller.setMapType を呼び、getter にも反映される", async () => {
+            const viewer = await create(createMountElement());
+            expect(viewer.mapType).toBe("standard");
+
+            viewer.mapType = "photo";
+
+            expect(sceneMockModule.__getSetMapTypeCalls()).toEqual(["photo"]);
+            expect(viewer.mapType).toBe("photo");
+
+            viewer.mapType = "standard";
+            expect(sceneMockModule.__getSetMapTypeCalls()).toEqual([
+                "photo",
+                "standard",
+            ]);
+            expect(viewer.mapType).toBe("standard");
         });
     });
 });

--- a/tests/uiVisibility.unit.spec.ts
+++ b/tests/uiVisibility.unit.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * UI visibility controller のユニットテスト (T6 / Issue #120)。
+ *
+ * controlPanel の各要素が初期状態で `display: flex` 等のインライン style を持つ場合、
+ * 単純に `style.display = ""` で復元すると元のレイアウトが失われる。
+ * このテストでは「初期 display を保持しているか」「false → true で元の値に戻るか」を検証する。
+ */
+
+import { describe, it, expect, beforeEach } from "@jest/globals";
+
+import {
+    createUiVisibilityController,
+    UiVisibilityElements,
+} from "../src/terrain/uiVisibility";
+
+describe("createUiVisibilityController (T6)", () => {
+    const setupElements = (): UiVisibilityElements => {
+        const make = (display: string): HTMLDivElement => {
+            const el = document.createElement("div");
+            if (display) el.style.display = display;
+            return el;
+        };
+        return {
+            compass: make("flex"),
+            locateMe: make("flex"),
+            zoomIn: make("flex"),
+            zoomOut: make("flex"),
+            scaleBarBar: make(""),
+            scaleBarLabel: make(""),
+            mapToggle: make("flex"),
+            attribution: make(""),
+        };
+    };
+
+    let elements: UiVisibilityElements;
+    let setUi: ReturnType<typeof createUiVisibilityController>;
+
+    beforeEach(() => {
+        elements = setupElements();
+        setUi = createUiVisibilityController(elements);
+    });
+
+    it("非表示にすると display=none、再表示で初期 display 値（例: flex）が復元される", () => {
+        setUi("compass", false);
+        expect(elements.compass.style.display).toBe("none");
+
+        setUi("compass", true);
+        expect(elements.compass.style.display).toBe("flex");
+    });
+
+    it("初期 display が空の要素は再表示で空文字に戻る（block / inline 等のデフォルト維持）", () => {
+        setUi("attribution", false);
+        expect(elements.attribution.style.display).toBe("none");
+
+        setUi("attribution", true);
+        expect(elements.attribution.style.display).toBe("");
+    });
+
+    it("zoomButtons は locateMe / zoomIn / zoomOut すべてに適用される", () => {
+        setUi("zoomButtons", false);
+        expect(elements.locateMe.style.display).toBe("none");
+        expect(elements.zoomIn.style.display).toBe("none");
+        expect(elements.zoomOut.style.display).toBe("none");
+
+        setUi("zoomButtons", true);
+        expect(elements.locateMe.style.display).toBe("flex");
+        expect(elements.zoomIn.style.display).toBe("flex");
+        expect(elements.zoomOut.style.display).toBe("flex");
+    });
+
+    it("scaleBar は bar / label の両方に適用される", () => {
+        setUi("scaleBar", false);
+        expect(elements.scaleBarBar.style.display).toBe("none");
+        expect(elements.scaleBarLabel.style.display).toBe("none");
+
+        setUi("scaleBar", true);
+        expect(elements.scaleBarBar.style.display).toBe("");
+        expect(elements.scaleBarLabel.style.display).toBe("");
+    });
+
+    it("mapToggle / attribution が個別に切り替えできる", () => {
+        setUi("mapToggle", false);
+        expect(elements.mapToggle.style.display).toBe("none");
+        // 他要素は影響を受けない
+        expect(elements.compass.style.display).toBe("flex");
+        expect(elements.attribution.style.display).toBe("");
+
+        setUi("mapToggle", true);
+        expect(elements.mapToggle.style.display).toBe("flex");
+    });
+});


### PR DESCRIPTION
## 概要
spec/package.md §3.3.2 の UI コントロール 5 種の表示 get/set と `mapType` 切替を実装する。

## 変更内容
- `src/scenes/default.ts`:
  - `DefaultSceneController` に `getMapType` / `setMapType` / `setUiVisibility` を追加。
  - `mapToggle` ボタンクリックと `setMapType` の双方からラベル更新を行うよう関数化。
  - `options.mapType` 指定時に `tileManager.setMapType()` で初期反映。
- `src/lib/jpmapTerrain.ts`:
  - `showCompass` / `showZoomButtons` / `showScaleBar` / `showMapToggle` / `showAttribution` の setter を controller に配線。`onReady` 直後に初期表示状態をまとめて反映。
  - `mapType` getter は controller から、setter は `setMapType` を呼ぶ形に。
- `tests/jpmapTerrain.unit.spec.ts`:
  - モック controller に `setMapType` / `setUiVisibility` を実装し、確認用フックを export。
  - 新規 4 テスト追加（初期表示 / showXxx 反映 / 初期 mapType / mapType 切替）。

## 検証
- `npm run lint` / `npm run typecheck` / `npm run test:unit` (14 suites / 257 tests) / `npm run build:lib` / `npm run build:dev` / `npm run test:visuals` すべて成功。

Closes #120

Base: packaging
