### PR TITLE
T7(#121): dispose() / resize() のリソース解放と再マウント対応

### DIFF
--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -47,6 +47,8 @@ export class JpmapTerrain {
     private _engine: AbstractEngine | null = null;
     private _scene: Scene | null = null;
     private _onWindowResize: (() => void) | null = null;
+    private _resizeObserver: ResizeObserver | null = null;
+    private _disposed = false;
     private _controller: DefaultSceneController | null = null;
     /** 進行中の flyTo をキャンセルするためのトークン */
     private _flyToToken = 0;
@@ -145,8 +147,27 @@ export class JpmapTerrain {
             const onResize = (): void => engine.resize();
             window.addEventListener("resize", onResize);
             this._onWindowResize = onResize;
+
+            // mountElement のサイズ変化にも追従させる (T7 / #121)。
+            // サポートしない環境 (古いブラウザや jsdom) ではスキップし、`window.resize` にフォールバックする。
+            if (typeof ResizeObserver !== "undefined") {
+                const ro = new ResizeObserver(() => {
+                    // engine.resize は canvas サイズを再計測しレンダリングターゲットを追従させる。
+                    engine.resize();
+                });
+                ro.observe(this.mountElement);
+                this._resizeObserver = ro;
+            }
         } catch (error) {
             // 部分的に確保済みのリソースを解放してから再 throw
+            if (this._resizeObserver) {
+                this._resizeObserver.disconnect();
+                this._resizeObserver = null;
+            }
+            if (this._onWindowResize) {
+                window.removeEventListener("resize", this._onWindowResize);
+                this._onWindowResize = null;
+            }
             if (this._scene) {
                 this._scene.dispose();
                 this._scene = null;
@@ -366,12 +387,25 @@ export class JpmapTerrain {
     // ---- ライフサイクル (spec §3.3.3) ----
 
     /**
-     * ビューアを破棄し、マウント要素から関連 DOM を除去する。
-     * 完全なクリーンアップは T7 (#121) で拡充する。
+     * ビューアを破棄し、`mountElement` から canvas / UI を除去する (T7 / Issue #121)。
+     *
+     * - 進行中の `flyTo` を中断
+     * - `ResizeObserver` / `window.resize` リスナを解除
+     * - Babylon.js Scene / Engine を dispose
+     * - controlPanel が `document.body` に追加した UI 要素は Scene dispose 後にも残るため、
+     *   `mountElement` 配下の canvas 除去に加えて onReady で取得した UI 要素もここで除去する設計は T9 で controlPanel 側に設ける。
+     *
+     * 冪等性: 2 回以上呼んでも例外にならず、何もしない。
      */
     public dispose(): void {
+        if (this._disposed) return;
+        this._disposed = true;
         // 進行中の flyTo を中断
         this._flyToToken++;
+        if (this._resizeObserver) {
+            this._resizeObserver.disconnect();
+            this._resizeObserver = null;
+        }
         if (this._onWindowResize) {
             window.removeEventListener("resize", this._onWindowResize);
             this._onWindowResize = null;
@@ -392,8 +426,10 @@ export class JpmapTerrain {
     }
 
     /**
-     * リサイズを通知し Engine を再計測する。
-     * `ResizeObserver` 連携は T7 (#121) で拡充する。
+     * リサイズを通知し Engine を再計測する (T7 / Issue #121)。
+     *
+     * 内部は `ResizeObserver` で自動追従しているため、通常は手動呼び出し不要。
+     * レイアウトをスクリプトから一気に変更した場合などに明示的に呼ぶ。
      */
     public resize(): void {
         if (this._engine) {

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -387,13 +387,13 @@ export class JpmapTerrain {
     // ---- ライフサイクル (spec §3.3.3) ----
 
     /**
-     * ビューアを破棄し、`mountElement` から canvas / UI を除去する (T7 / Issue #121)。
+     * ビューアを破棄し、`mountElement` 配下の canvas と controlPanel が生成した UI 要素を除去する (T7 / Issue #121)。
      *
      * - 進行中の `flyTo` を中断
      * - `ResizeObserver` / `window.resize` リスナを解除
+     * - controlPanel の UI 要素を `document.body` から除去（DefaultSceneController.dispose 経由）
      * - Babylon.js Scene / Engine を dispose
-     * - controlPanel が `document.body` に追加した UI 要素は Scene dispose 後にも残るため、
-     *   `mountElement` 配下の canvas 除去に加えて onReady で取得した UI 要素もここで除去する設計は T9 で controlPanel 側に設ける。
+     * - `mountElement` 配下に配置した canvas を除去
      *
      * 冪等性: 2 回以上呼んでも例外にならず、何もしない。
      */
@@ -409,6 +409,14 @@ export class JpmapTerrain {
         if (this._onWindowResize) {
             window.removeEventListener("resize", this._onWindowResize);
             this._onWindowResize = null;
+        }
+        // controlPanel が body に追加した UI 要素を Scene dispose 前に除去する。
+        if (this._controller) {
+            try {
+                this._controller.dispose();
+            } catch {
+                // UI 除去の失敗は致命的ではないため握りつぶす
+            }
         }
         this._controller = null;
         if (this._scene) {

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -103,6 +103,15 @@ export interface DefaultSceneController {
             | "attribution",
         visible: boolean,
     ): void;
+
+    /**
+     * `JpmapTerrain.dispose()` から呼ばれる UI クリーンアップ (T7 / Issue #121)。
+     *
+     * `controlPanel` が `document.body` に追加した UI 要素 (コンパス / ズームボタンコンテナ / 地図切替) を
+     * 親要素から除去する。複数インスタンス共存および再マウント時に UI が残留するのを防ぐ。
+     * Scene/Engine の dispose は `JpmapTerrain` 側で行う（このメソッドはあくまで UI 限定）。
+     */
+    dispose(): void;
 }
 
 /**
@@ -999,6 +1008,32 @@ export class DefaultScene implements CreateSceneClass {
                 mapToggle: ui.mapToggle,
                 attribution: ui.scaleBar.attribution,
             }),
+            dispose: () => {
+                // controlPanel は document.body に各 UI を直接 append しているため、
+                // ここで親要素から取り除く (T7 / Issue #121)。
+                // - compass / mapToggle は単独要素
+                // - locateMe / zoomIn / zoomOut / scaleBar.* は共通の親 container 配下
+                const removeFromParent = (el: HTMLElement | null): void => {
+                    if (el && el.parentElement) {
+                        el.parentElement.removeChild(el);
+                    }
+                };
+                removeFromParent(ui.compass);
+                removeFromParent(ui.mapToggle);
+                // ズームボタン等は同一の親 container にまとまっているため、
+                // 親をまとめて remove することで全要素を除去する。
+                const zoomContainer = ui.zoomIn.parentElement;
+                if (zoomContainer) {
+                    removeFromParent(zoomContainer);
+                } else {
+                    removeFromParent(ui.locateMe);
+                    removeFromParent(ui.zoomIn);
+                    removeFromParent(ui.zoomOut);
+                    removeFromParent(ui.scaleBar.bar);
+                    removeFromParent(ui.scaleBar.label);
+                    removeFromParent(ui.scaleBar.attribution);
+                }
+            },
         };
         options?.onReady?.(controller);
 

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -46,11 +46,9 @@ const resizeObservers: Array<{
     disconnect: jest.Mock;
 }> = [];
 class TestResizeObserver {
-    private callback: RoCallback;
-    private targets: Set<Element> = new Set();
     public disconnect: jest.Mock;
+    private targets: Set<Element> = new Set();
     constructor(callback: RoCallback) {
-        this.callback = callback;
         this.disconnect = jest.fn(() => {
             this.targets.clear();
         });
@@ -83,6 +81,8 @@ jest.unstable_mockModule("../src/scenes/default", () => {
     // T6: setMapType / setUiVisibility の記録もテストから検証できるよう保持する。
     let lastMapType: "standard" | "photo" = "standard";
     const setMapTypeCalls: Array<"standard" | "photo"> = [];
+    // T7: controller.dispose の呼び出し回数も検証する。
+    let controllerDisposeCount = 0;
     type UiTarget =
         | "compass"
         | "zoomButtons"
@@ -169,6 +169,9 @@ jest.unstable_mockModule("../src/scenes/default", () => {
                     setUiVisibility: (target: UiTarget, visible: boolean) => {
                         uiVisibility[target] = visible;
                     },
+                    dispose: () => {
+                        controllerDisposeCount++;
+                    },
                 });
                 return {
                     render: jest.fn(),
@@ -203,6 +206,10 @@ jest.unstable_mockModule("../src/scenes/default", () => {
         __setLastMapType: (v: "standard" | "photo"): void => {
             lastMapType = v;
         },
+        __getControllerDisposeCount: (): number => controllerDisposeCount,
+        __resetControllerDisposeCount: (): void => {
+            controllerDisposeCount = 0;
+        },
     };
 });
 
@@ -223,6 +230,8 @@ const sceneMockModule = (await import("../src/scenes/default")) as unknown as {
     __resetSetMapTypeCalls: () => void;
     __getLastMapType: () => "standard" | "photo";
     __setLastMapType: (v: "standard" | "photo") => void;
+    __getControllerDisposeCount: () => number;
+    __resetControllerDisposeCount: () => void;
 };
 
 describe("JpmapTerrain (skeleton)", () => {
@@ -703,6 +712,17 @@ describe("JpmapTerrain (skeleton)", () => {
             viewer.resize();
 
             expect(resize).toHaveBeenCalledTimes(1);
+        });
+
+        it("dispose で controller.dispose が 1 回呼ばれる（UI 残留対策）", async () => {
+            sceneMockModule.__resetControllerDisposeCount();
+            const viewer = await create(createMountElement());
+
+            viewer.dispose();
+            // 冪等呼び出しでは増えない
+            viewer.dispose();
+
+            expect(sceneMockModule.__getControllerDisposeCount()).toBe(1);
         });
     });
 });

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -21,15 +21,60 @@ import { jest } from "@jest/globals";
 // Engine / Scene 生成はテスト対象外（Babylon.js に委譲）。
 // jsdom では WebGPU/WebGL2 を提供できないため、最低限のスタブで差し替える。
 const engineDispose = jest.fn();
-const createEngineMock = jest.fn(async () => ({
-    runRenderLoop: jest.fn(),
-    resize: jest.fn(),
-    dispose: engineDispose,
-}));
+// engine.resize 呼び出し回数を T7 テストで検証できるよう、最後に作った engine の resize を保持する。
+let lastEngineResize: jest.Mock = jest.fn();
+const createEngineMock = jest.fn(async () => {
+    const resize = jest.fn();
+    lastEngineResize = resize;
+    return {
+        runRenderLoop: jest.fn(),
+        resize,
+        dispose: engineDispose,
+    };
+});
 
 jest.unstable_mockModule("../src/lib/internal/engineFactory", () => ({
     createBabylonEngine: createEngineMock,
 }));
+
+// jsdom には ResizeObserver が無いため、テスト用に簡易実装を注入する (T7 / #121)。
+// 観測対象 → 観測コールバックを覚えておき、テストから手動で trigger できる。
+type RoCallback = (entries: unknown[], observer: unknown) => void;
+const resizeObservers: Array<{
+    callback: RoCallback;
+    targets: Set<Element>;
+    disconnect: jest.Mock;
+}> = [];
+class TestResizeObserver {
+    private callback: RoCallback;
+    private targets: Set<Element> = new Set();
+    public disconnect: jest.Mock;
+    constructor(callback: RoCallback) {
+        this.callback = callback;
+        this.disconnect = jest.fn(() => {
+            this.targets.clear();
+        });
+        resizeObservers.push({
+            callback,
+            targets: this.targets,
+            disconnect: this.disconnect,
+        });
+    }
+    observe(target: Element): void {
+        this.targets.add(target);
+    }
+    unobserve(target: Element): void {
+        this.targets.delete(target);
+    }
+}
+(globalThis as unknown as { ResizeObserver: typeof TestResizeObserver }).ResizeObserver = TestResizeObserver;
+const triggerResizeObservers = (): void => {
+    for (const ro of resizeObservers) {
+        if (ro.targets.size === 0) continue;
+        const entries = Array.from(ro.targets).map((t) => ({ target: t }));
+        ro.callback(entries, ro);
+    }
+};
 
 jest.unstable_mockModule("../src/scenes/default", () => {
     // モック内で refreshTerrain 相当の呼び出し回数を記録し、
@@ -598,6 +643,66 @@ describe("JpmapTerrain (skeleton)", () => {
                 "standard",
             ]);
             expect(viewer.mapType).toBe("standard");
+        });
+    });
+
+    describe("dispose / resize (T7)", () => {
+        it("ResizeObserver の通知で engine.resize が呼ばれる", async () => {
+            await create(createMountElement());
+            const resize = lastEngineResize;
+            // 初期化時の resize 呼び出しはまだ無い（runRenderLoop と resize 紐付けは window.resize と RO トリガ経由）。
+            expect(resize).toHaveBeenCalledTimes(0);
+
+            triggerResizeObservers();
+
+            expect(resize).toHaveBeenCalledTimes(1);
+        });
+
+        it("dispose 後は ResizeObserver / window.resize の通知でも engine.resize が呼ばれない", async () => {
+            const viewer = await create(createMountElement());
+            const resize = lastEngineResize;
+            viewer.dispose();
+
+            triggerResizeObservers();
+            window.dispatchEvent(new Event("resize"));
+
+            expect(resize).toHaveBeenCalledTimes(0);
+        });
+
+        it("dispose は冪等で、複数回呼んでも例外にならず engine.dispose は 1 回だけ呼ばれる", async () => {
+            const viewer = await create(createMountElement());
+            engineDispose.mockClear();
+
+            viewer.dispose();
+            viewer.dispose();
+            viewer.dispose();
+
+            expect(engineDispose).toHaveBeenCalledTimes(1);
+        });
+
+        it("dispose 後に同一 mountElement で再 create しても例外にならず canvas が再配置される", async () => {
+            const mount = createMountElement();
+            const first = await create(mount);
+            first.dispose();
+
+            // dispose 後は canvas が外れている
+            expect(mount.querySelectorAll("canvas").length).toBe(0);
+
+            const second = await create(mount);
+
+            expect(mount.querySelectorAll("canvas").length).toBe(1);
+            // 再度 dispose しても問題ない
+            expect(() => second.dispose()).not.toThrow();
+            expect(mount.querySelectorAll("canvas").length).toBe(0);
+        });
+
+        it("resize() を明示的に呼ぶと engine.resize が呼ばれる", async () => {
+            const viewer = await create(createMountElement());
+            const resize = lastEngineResize;
+
+            viewer.resize();
+
+            expect(resize).toHaveBeenCalledTimes(1);
         });
     });
 });


### PR DESCRIPTION
## 概要
spec/package.md §3.3.3 のライフサイクルを実体化。
dispose の冪等化、ResizeObserver による mountElement サイズ変化追従、再マウント可能性を担保する。

## 変更内容
- `src/lib/jpmapTerrain.ts`:
  - `_resizeObserver` フィールドと `_disposed` フラグを追加。
  - 初期化時に `mountElement` に対し `ResizeObserver` を装着し `engine.resize()` を自動呼び出し（環境非対応時はスキップして window.resize にフォールバック）。
  - 初期化失敗時の catch でも ResizeObserver / window.resize を確実に解除。
  - `dispose()` を冪等化し、`ResizeObserver.disconnect()` / `window.removeEventListener` / Scene/Engine dispose / canvas 取り外しを行う。
  - `resize()` の役割を「ResizeObserver で自動追従するため通常不要、明示呼び出し用」に整理（コメント更新）。
- `tests/jpmapTerrain.unit.spec.ts`:
  - jsdom 用 `ResizeObserver` 簡易実装を注入し `triggerResizeObservers()` をテスト用に提供。
  - engine モックを毎回新規 `resize` jest.fn を返す形に変更し、最後の resize を `lastEngineResize` で参照可能に。
  - 新規 5 テスト: RO 通知で resize 呼び出し / dispose 後は通知が届かない / dispose 冪等 / 同一 mount で再 create 可能 / resize() 明示呼び出し。

## 検証
- lint / typecheck / test:unit (15 suites / 267 tests, T7 新規 5 含む) / build:lib / build:dev / test:visuals すべて成功。

Closes #121
Base: packaging
