### PR TITLE
T8(#122): JpmapTerrain ユニットテスト充実

### DIFF
--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -23,18 +23,19 @@ import { jest } from "@jest/globals";
 const engineDispose = jest.fn();
 // engine.resize 呼び出し回数を T7 テストで検証できるよう、最後に作った engine の resize を保持する。
 let lastEngineResize: jest.Mock = jest.fn();
-const createEngineMock = jest.fn(
-    async (...args: unknown[]) => {
-        void args;
-        const resize = jest.fn();
-        lastEngineResize = resize;
-        return {
-            runRenderLoop: jest.fn(),
-            resize,
-            dispose: engineDispose,
-        };
-    },
-);
+// 実際の `createBabylonEngine(canvas, preferred)` のシグネチャに合わせる。
+// 関数本体では未使用だが、`createEngineMock.mock.calls[i][1]` で第 2 引数（engine 種別）を
+// 検証する用途があるため、可変引数ではなく明示的なパラメータとして宣言する。
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const createEngineMock = jest.fn(async (_canvas: unknown, _preferred?: "webgpu" | "webgl2") => {
+    const resize = jest.fn();
+    lastEngineResize = resize;
+    return {
+        runRenderLoop: jest.fn(),
+        resize,
+        dispose: engineDispose,
+    };
+});
 
 jest.unstable_mockModule("../src/lib/internal/engineFactory", () => ({
     createBabylonEngine: createEngineMock,

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -23,15 +23,18 @@ import { jest } from "@jest/globals";
 const engineDispose = jest.fn();
 // engine.resize 呼び出し回数を T7 テストで検証できるよう、最後に作った engine の resize を保持する。
 let lastEngineResize: jest.Mock = jest.fn();
-const createEngineMock = jest.fn(async () => {
-    const resize = jest.fn();
-    lastEngineResize = resize;
-    return {
-        runRenderLoop: jest.fn(),
-        resize,
-        dispose: engineDispose,
-    };
-});
+const createEngineMock = jest.fn(
+    async (...args: unknown[]) => {
+        void args;
+        const resize = jest.fn();
+        lastEngineResize = resize;
+        return {
+            runRenderLoop: jest.fn(),
+            resize,
+            dispose: engineDispose,
+        };
+    },
+);
 
 jest.unstable_mockModule("../src/lib/internal/engineFactory", () => ({
     createBabylonEngine: createEngineMock,
@@ -723,6 +726,105 @@ describe("JpmapTerrain (skeleton)", () => {
             viewer.dispose();
 
             expect(sceneMockModule.__getControllerDisposeCount()).toBe(1);
+        });
+    });
+
+    describe("public API surface (T8)", () => {
+        it("JpmapTerrain.create は JpmapTerrain インスタンスを返す", async () => {
+            const viewer = await create(createMountElement());
+            expect(viewer).toBeInstanceOf(JpmapTerrain);
+        });
+
+        it("create に engine オプションを渡すと engineFactory に伝播する", async () => {
+            createEngineMock.mockClear();
+            await create(createMountElement(), { engine: "webgl2" });
+            expect(createEngineMock).toHaveBeenCalledTimes(1);
+            // createBabylonEngine(canvas, preferredEngine) のシグネチャ
+            const callArgs = createEngineMock.mock.calls[0];
+            expect(callArgs[1]).toBe("webgl2");
+        });
+
+        it("engine 未指定時はデフォルト (webgpu) で engineFactory を呼ぶ", async () => {
+            createEngineMock.mockClear();
+            await create(createMountElement());
+            expect(createEngineMock.mock.calls[0][1]).toBe("webgpu");
+        });
+
+        it("dispose 後の getter は最後に保持していた値を返す（コントローラ非経由）", async () => {
+            const viewer = await create(createMountElement(), {
+                lat: 35,
+                lon: 139,
+                altitude: 1500,
+                azimuth: 30,
+                tilt: 60,
+                mapType: "photo",
+            });
+            viewer.dispose();
+
+            // controller が解放された後はキャッシュ値を返す
+            expect(viewer.lat).toBe(35);
+            expect(viewer.lon).toBe(139);
+            expect(viewer.altitude).toBe(1500);
+            expect(viewer.azimuth).toBe(30);
+            expect(viewer.tilt).toBe(60);
+            // mapType の getter は controller 不在で内部値を返す
+            expect(viewer.mapType).toBe("photo");
+        });
+
+        it("dispose 後の setter は内部値だけ更新し例外にならない", async () => {
+            const viewer = await create(createMountElement());
+            viewer.dispose();
+
+            expect(() => {
+                viewer.lat = 10;
+                viewer.lon = 20;
+                viewer.altitude = 3000;
+                viewer.azimuth = 90;
+                viewer.tilt = 45;
+                viewer.showCompass = false;
+                viewer.mapType = "photo";
+            }).not.toThrow();
+
+            expect(viewer.lat).toBe(10);
+            expect(viewer.lon).toBe(20);
+            expect(viewer.altitude).toBe(3000);
+            expect(viewer.mapType).toBe("photo");
+            expect(viewer.showCompass).toBe(false);
+        });
+
+        it("dispose 中に進行中の flyTo はキャンセルされ Promise が resolve する", async () => {
+            const viewer = await create(createMountElement(), {
+                lat: 0,
+                lon: 0,
+                altitude: 1000,
+            });
+
+            const flying = viewer.flyTo({
+                lat: 35,
+                lon: 139,
+                altitude: 5000,
+                duration: 200,
+            });
+            // 即座に dispose してキャンセル
+            viewer.dispose();
+
+            await expect(flying).resolves.toBeUndefined();
+        });
+
+        it("flyTo で altitude / azimuth / tilt を省略した場合は現在値を維持する（実反映）", async () => {
+            const viewer = await create(createMountElement(), {
+                lat: 0,
+                lon: 0,
+                altitude: 2500,
+                azimuth: 45,
+                tilt: 60,
+            });
+
+            await viewer.flyTo({ lat: 1, lon: 2, duration: 0 });
+
+            expect(viewer.altitude).toBe(2500);
+            expect(viewer.azimuth).toBe(45);
+            expect(viewer.tilt).toBe(60);
         });
     });
 });

--- a/tests/libExports.unit.spec.ts
+++ b/tests/libExports.unit.spec.ts
@@ -1,0 +1,44 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * パッケージエントリ (`src/lib.ts`) の re-export 検証 (T8 / Issue #122)。
+ *
+ * 公開 API として spec/package.md §3 に記載した識別子が
+ * パッケージのトップレベルから参照できることを保証する。
+ *
+ * 値 export (`JpmapTerrain`) は実体を import し、
+ * 型 export は import 句で参照されることを TS コンパイラに任せる
+ * （typecheck が通ればこのテストファイルは成立する）。
+ */
+
+import { describe, it, expect } from "@jest/globals";
+
+import * as pkg from "../src/lib";
+import type {
+    EngineType,
+    FlyToOptions,
+    JpmapTerrainOptions,
+    MapType,
+} from "../src/lib";
+
+describe("package entry exports (T8)", () => {
+    it("JpmapTerrain クラスがトップレベルから export されている", () => {
+        expect(typeof pkg.JpmapTerrain).toBe("function");
+        // クラスとしての名称
+        expect(pkg.JpmapTerrain.name).toBe("JpmapTerrain");
+    });
+
+    it("公開型 (EngineType / MapType / JpmapTerrainOptions / FlyToOptions) が import できる（typecheck）", () => {
+        // 型は実行時に存在しないため、ダミー変数で参照を持たせる。
+        const engine: EngineType = "webgpu";
+        const map: MapType = "standard";
+        const opts: JpmapTerrainOptions = { engine, mapType: map };
+        const fly: FlyToOptions = { lat: 0, lon: 0 };
+
+        expect(engine).toBe("webgpu");
+        expect(map).toBe("standard");
+        expect(opts.engine).toBe("webgpu");
+        expect(fly.lat).toBe(0);
+    });
+});


### PR DESCRIPTION
## 概要
spec/package.md §6 T8 / Issue #122。`JpmapTerrain` 公開 API のユニットテストを充実。

## 背景
T5(#119)/T6(#120)/T7(#121) の段階で、コンストラクタ／getter・setter／カメラ連携／UI 可視性／dispose・resize の主要経路は既に網羅済み。
本 PR では Issue #122 DoD（create/get-set/flyTo/dispose）を確実に満たすため、不足していた以下の観点を補完する。

## 追加テスト
### tests/jpmapTerrain.unit.spec.ts — \`public API surface (T8)\` (7 ケース)
- \`JpmapTerrain.create\` 戻り値が \`JpmapTerrain\` インスタンスであること
- \`engine: \"webgl2\"\` オプションが \`createBabylonEngine\` の第 2 引数に伝播すること
- 既定 engine が \`webgpu\` であること
- \`dispose\` 後、各 getter (\`lat/lon/altitude/azimuth/tilt/mapType\`) がキャッシュ値を返すこと
- \`dispose\` 後、setter 呼び出しで例外を出さず内部値が更新されること
- \`flyTo\` 進行中に \`dispose\` しても Promise が resolve すること
- \`flyTo\` で \`altitude/azimuth/tilt\` を省略した場合に現在値が維持されること

### tests/libExports.unit.spec.ts (新規 / 2 ケース)
- パッケージエントリ \`src/lib.ts\` から \`JpmapTerrain\` クラスが re-export されていること
- 公開型 (\`EngineType\` / \`MapType\` / \`JpmapTerrainOptions\` / \`FlyToOptions\`) が import 可能であること（typecheck 保証）

## 実装メモ
- \`createEngineMock\` の引数情報を \`mock.calls[0][1]\` で参照するため、可変引数シグネチャに変更（lint クリア）

## 影響
- src 配下に変更なし（テスト追加のみ）
- 新規テストファイル 1, 既存テストファイル 1 修正

## 検証
- \`npm run lint\` ✅
- \`npm run typecheck\` ✅
- \`npm run test:unit\` ✅ 16 suites / 277 tests
- \`npm run build:lib\` ✅
- \`npm run build:dev\` ✅
- \`npm run test:visuals\` ✅ 6 passed

Closes #122