### PR TITLE
T9(#123): デモ JpmapTerrain 化 / README 更新 / npm pack 検証

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,58 @@
 - 技術スタック: TypeScript / Babylon.js / Webpack / Playwright / Jest
 - バージョン: 0.0.1（開発初期）
 
-## クイックスタート
+## npm パッケージとしての利用
+
+`jpmap-terrain` は ESM / `.d.ts` 同梱の npm パッケージとして配布されます（`@babylonjs/core` は `peerDependency`）。
+任意の DOM 要素にマウントするだけで 3D 地形ビューアを埋め込めます。
+
+### インストール
+
+```shell
+npm install jpmap-terrain @babylonjs/core
+# 必要に応じて
+npm install @babylonjs/loaders @babylonjs/materials
+```
+
+### 利用例
+
+```html
+<div id="terrain-viewer" style="width: 800px; height: 600px;"></div>
+<script type="module">
+  import { JpmapTerrain } from "jpmap-terrain";
+
+  const viewer = await JpmapTerrain.create(
+    document.getElementById("terrain-viewer"),
+    {
+      engine: "webgpu",      // "webgpu" | "webgl2"
+      lat: 35.681236,
+      lon: 139.767125,
+      altitude: 2000,
+      azimuth: 0,
+      tilt: 45,
+      mapType: "standard",   // "standard" | "photo"
+    }
+  );
+
+  // プログラムで富士山に移動
+  await viewer.flyTo({
+    lat: 35.3606,
+    lon: 138.7274,
+    altitude: 8000,
+    duration: 2000,
+  });
+
+  // UI 制御
+  viewer.showCompass = false;
+
+  // 破棄
+  viewer.dispose();
+</script>
+```
+
+公開 API の詳細は [`spec/package.md`](spec/package.md) を参照してください。
+
+## クイックスタート（デモ開発）
 
 ```shell
 npm install
@@ -54,6 +105,7 @@ npm start
 | `npm start` | 開発サーバー起動（ホットリロード） |
 | `npm run build:dev` | 開発ビルド（typecheck 実行後に bundle） |
 | `npm run build` | 本番ビルド（typecheck 実行後に最適化 build） |
+| `npm run build:lib` | ライブラリビルド（`dist/` に ESM + `.d.ts` 出力） |
 | `npm run lint` | ESLint 実行 |
 | `npm run typecheck` | TypeScript 型チェック |
 | `npm run test:visuals` | Visual Regression Test 実行 |

--- a/README.md
+++ b/README.md
@@ -28,18 +28,20 @@ npm install @babylonjs/loaders @babylonjs/materials
 <script type="module">
   import { JpmapTerrain } from "jpmap-terrain";
 
-  const viewer = await JpmapTerrain.create(
-    document.getElementById("terrain-viewer"),
-    {
-      engine: "webgpu",      // "webgpu" | "webgl2"
-      lat: 35.681236,
-      lon: 139.767125,
-      altitude: 2000,
-      azimuth: 0,
-      tilt: 45,
-      mapType: "standard",   // "standard" | "photo"
-    }
-  );
+  const container = document.getElementById("terrain-viewer");
+  if (!container) {
+    throw new Error('Element with id "terrain-viewer" was not found.');
+  }
+
+  const viewer = await JpmapTerrain.create(container, {
+    engine: "webgpu",      // "webgpu" | "webgl2"
+    lat: 35.681236,
+    lon: 139.767125,
+    altitude: 2000,
+    azimuth: 0,
+    tilt: 45,
+    mapType: "standard",   // "standard" | "photo"
+  });
 
   // プログラムで富士山に移動
   await viewer.flyTo({

--- a/public/index.html
+++ b/public/index.html
@@ -16,7 +16,7 @@
         padding: 0;
       }
 
-      #renderCanvas {
+      #root {
         width: 100%;
         height: 100%;
         touch-action: none;
@@ -25,7 +25,7 @@
   </head>
 
   <body>
-    <canvas id="renderCanvas" touch-action="none"></canvas>
+    <div id="root"></div>
   </body>
 
 </html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,59 +1,46 @@
-import { Engine } from "@babylonjs/core/Engines/engine";
-import { WebGPUEngine } from "@babylonjs/core/Engines/webgpuEngine";
-import { getSceneModule } from "./createScene";
-import { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+/**
+ * 開発用デモエントリ (T9 / Issue #123)
+ *
+ * パッケージ公開 API である `JpmapTerrain` を直接利用してデモを起動する。
+ * - `?engine=webgpu|webgl` クエリで描画エンジンを切替（既定: 自動）
+ * - `#root` 要素にビューアをマウントする
+ *
+ * Playwright (tests/validation.spec.ts) と既存の手動デバッグ手段を保つため、
+ * NODE_ENV !== "production" のときだけ `window.scene` / `window.viewer` /
+ * `window.showToast` を露出する。これらは公開 API ではない。
+ */
+import { JpmapTerrain } from "./lib/jpmapTerrain";
+import type { EngineType } from "./lib/types";
 import { showToast } from "./terrain/controlPanel";
 
-export const babylonInit = async (): Promise<void> => {
-    const createSceneModule = getSceneModule();
-    const engineType =
-        new URLSearchParams(location.search).get("engine") ?? "webgl";
-    // Execute the pretasks, if defined
-    await Promise.all(createSceneModule.preTasks || []);
-    // Get the canvas element
-    const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
-    // Generate the BABYLON 3D engine
-    let engine: AbstractEngine;
-    if (engineType === "webgpu") {
-        const webGPUSupported = await WebGPUEngine.IsSupportedAsync;
-        if (webGPUSupported) {
-            // You can decide which WebGPU extensions to load when creating the engine. I am loading all of them
-            await import("@babylonjs/core/Engines/WebGPU/Extensions/");
-            const webgpu = engine = new WebGPUEngine(canvas, {
-                adaptToDeviceRatio: true,
-                antialias: true,
-            });
-            await webgpu.initAsync();
-            engine = webgpu;
-        } else {
-            engine = new Engine(canvas, true);
-        }
-    } else {
-        engine = new Engine(canvas, true);
-    }
+const DEMO_MOUNT_ID = "root";
 
-    // Create the scene
-    const scene = await createSceneModule.createScene(engine, canvas);
-
-    // Expose scene only in development/test builds for debugging and Playwright tests.
-    // This assignment is guarded by a NODE_ENV check so production-targeted builds
-    // can omit it when that condition is compiled away by the bundler/minifier.
-    if (process.env.NODE_ENV !== "production") {
-        (window as any).scene = scene;
-        (window as any).showToast = showToast;
-    }
-
-    // Register a render loop to repeatedly render the scene
-    engine.runRenderLoop(function () {
-        scene.render();
-    });
-
-    // Watch for browser/canvas resize events
-    window.addEventListener("resize", function () {
-        engine.resize();
-    });
+const resolveEngine = (): EngineType | undefined => {
+    const value = new URLSearchParams(location.search).get("engine");
+    if (value === "webgpu") return "webgpu";
+    // 既存デモは "webgl" 表記。新公開 API は "webgl2" に統一。
+    if (value === "webgl" || value === "webgl2") return "webgl2";
+    return undefined;
 };
 
-babylonInit().then(() => {
-    // scene started rendering, everything is initialized
+const start = async (): Promise<void> => {
+    const mount = document.getElementById(DEMO_MOUNT_ID);
+    if (!mount) {
+        throw new Error(`#${DEMO_MOUNT_ID} mount element not found`);
+    }
+    const engine = resolveEngine();
+    const viewer = await JpmapTerrain.create(mount, engine ? { engine } : {});
+
+    // 開発/テストビルドでのみデバッグ用に内部状態を露出する。
+    // （Playwright の `window.scene.isReady()` 等が依存しているため）
+    if (process.env.NODE_ENV !== "production") {
+        const debugRefs = viewer as unknown as { _scene?: unknown };
+        (window as unknown as { viewer: JpmapTerrain }).viewer = viewer;
+        (window as unknown as { scene: unknown }).scene = debugRefs._scene;
+        (window as unknown as { showToast: typeof showToast }).showToast = showToast;
+    }
+};
+
+start().catch((err) => {
+    console.error("[jpmap-terrain demo] failed to start:", err);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
  * 開発用デモエントリ (T9 / Issue #123)
  *
  * パッケージ公開 API である `JpmapTerrain` を直接利用してデモを起動する。
- * - `?engine=webgpu|webgl` クエリで描画エンジンを切替（既定: 自動）
+ * - `?engine=webgpu|webgl|webgl2` クエリで描画エンジンを切替（`webgl`/`webgl2` は `webgl2` に正規化。既定: 自動）
  * - `#root` 要素にビューアをマウントする
  *
  * Playwright (tests/validation.spec.ts) と既存の手動デバッグ手段を保つため、
@@ -33,10 +33,10 @@ const start = async (): Promise<void> => {
 
     // 開発/テストビルドでのみデバッグ用に内部状態を露出する。
     // （Playwright の `window.scene.isReady()` 等が依存しているため）
+    // `__debugScene` は @internal 扱いの公式デバッグアクセサ（spec/package.md には未記載）。
     if (process.env.NODE_ENV !== "production") {
-        const debugRefs = viewer as unknown as { _scene?: unknown };
         (window as unknown as { viewer: JpmapTerrain }).viewer = viewer;
-        (window as unknown as { scene: unknown }).scene = debugRefs._scene;
+        (window as unknown as { scene: unknown }).scene = viewer.__debugScene;
         (window as unknown as { showToast: typeof showToast }).showToast = showToast;
     }
 };

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -184,6 +184,20 @@ export class JpmapTerrain {
         }
     }
 
+    // ---- 内部デバッグ用アクセサ ----
+
+    /**
+     * 内部 Babylon.js Scene への参照を返す（デバッグ・テスト用途）。
+     *
+     * @internal このプロパティは公開 API ではない。
+     * 開発デモ (`src/index.ts`) と Playwright (`tests/validation.spec.ts`) のみが
+     * `window.scene` 経由で `Scene.isReady()` 等を参照するために使用する。
+     * 利用側コードからは参照しないこと。
+     */
+    public get __debugScene(): Scene | null {
+        return this._scene;
+    }
+
     // ---- 位置・カメラ制御 (spec §3.3.1) ----
 
     public get lat(): number {


### PR DESCRIPTION
## 概要
spec/package.md §6 T9 / Issue #123。既存デモを公開 API (`JpmapTerrain`) ベースに整理し、README にパッケージ利用例を追記、`npm pack --dry-run` で配布物が `dist/` のみであることを検証。

## 変更内容
- `src/index.ts`: 直接 Babylon Engine/Scene を生成する旧実装を撤去し、`JpmapTerrain.create(mountElement, { engine })` を使うデモに刷新
  - `?engine=webgpu|webgl|webgl2` クエリは互換維持（`webgl` → 新公開 API の `"webgl2"` にマッピング）
  - 開発/テストビルドのみ `window.viewer` / `window.scene` / `window.showToast` を露出（公開 API ではない。Playwright 互換のため）
- `public/index.html`: `<canvas id="renderCanvas">` を `<div id="root">` に変更（`JpmapTerrain` が canvas を内部生成するため）
- `README.md`: 「npm パッケージとしての利用」節を追加（インストール / 利用例 / 公開 API 参照）。`build:lib` スクリプトの説明を追加

## 配布物検証 (`npm pack --dry-run`)
```
LICENSE.md
README.md
dist/index.d.mts
dist/index.mjs
dist/index.mjs.map
package.json
```
`src/` / `tests/` / 設定ファイルは含まれない。

## 検証
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run build:dev` ✅
- `npm run build:lib` ✅
- `npm run test:unit` ✅ 16 suites / 277 tests
- `npm run test:visuals` ✅ 6 passed
- `npm pack --dry-run` ✅ dist/ + LICENSE/README/package.json のみ

## 影響
- 既存デモのエンジン切替パラメータ仕様は維持（`?engine=webgl` 互換）
- 既存 Visual Regression Test に変更なし（mount 要素経由でも `window.scene` を保てたため）

Closes #123
