### PR TITLE
feat(#136): URLで緯度経度・engineを指定可能にする / JpmapTerrain.onCameraChange を追加

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
 
   <title>jpmap_terrain – 3D地形ビューア</title>
   <meta name="description" content="地理院タイルの標高データから3D地形を表示するWebアプリ">
-  <meta name="author" content="Masaru Ebata">
+  <meta name="author" content="8ga3">
     <style>
       html,
       body {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,35 +1,66 @@
 /**
- * 開発用デモエントリ (T9 / Issue #123)
+ * 開発用デモエントリ (T9 / Issue #123, #136)
  *
  * パッケージ公開 API である `JpmapTerrain` を直接利用してデモを起動する。
- * - `?engine=webgpu|webgl|webgl2` クエリで描画エンジンを切替（`webgl`/`webgl2` は `webgl2` に正規化。既定: 自動）
- * - `#root` 要素にビューアをマウントする
+ * - URL 形式: `/@lat,lon?engine=webgpu|webgl|webgl2`（`webgl`/`webgl2` は `webgl2` に正規化、既定: 自動）
+ * - `#root` 要素にビューアをマウントする。
+ * - URL ↔ カメラ同期はパッケージ層から切り離し、デモ層 (本ファイル) で
+ *   `parseLatLonFromUrl` で初期値を解決し、`onCameraChange` で URL を更新する。
  *
  * Playwright (tests/validation.spec.ts) と既存の手動デバッグ手段を保つため、
  * NODE_ENV !== "production" のときだけ `window.scene` / `window.viewer` /
  * `window.showToast` を露出する。これらは公開 API ではない。
  */
 import { JpmapTerrain } from "./lib/jpmapTerrain";
-import type { EngineType } from "./lib/types";
+import type { EngineType, JpmapTerrainOptions } from "./lib/types";
 import { showToast } from "./terrain/controlPanel";
+import { parseLatLonFromUrl, createUrlUpdater } from "./terrain/urlState";
 
 const DEMO_MOUNT_ID = "root";
 
-const resolveEngine = (): EngineType | undefined => {
-    const value = new URLSearchParams(location.search).get("engine");
+/**
+ * `?engine=` クエリ文字列から描画エンジン種別を解決する。
+ * - `webgpu` → `"webgpu"`
+ * - `webgl` / `webgl2` → `"webgl2"`（旧表記との互換のため正規化）
+ * - 上記以外 / 未指定 → `undefined`（自動判定にフォールバック）
+ *
+ * @param search `location.search` 等のクエリ文字列（先頭 `?` 任意）
+ */
+export const resolveEngine = (search: string): EngineType | undefined => {
+    const value = new URLSearchParams(search).get("engine");
     if (value === "webgpu") return "webgpu";
-    // 既存デモは "webgl" 表記。新公開 API は "webgl2" に統一。
     if (value === "webgl" || value === "webgl2") return "webgl2";
     return undefined;
 };
+
+/**
+ * URL から初期表示の緯度経度を解決する。
+ * 内部的に {@link parseLatLonFromUrl} を再利用する薄いラッパー。
+ *
+ * @param url 解析対象 URL（`location.href` 等）
+ * @returns 取得できた場合は `{ lat, lon }`、取得できない場合は `undefined`
+ */
+export const resolveLatLon = (
+    url: string,
+): { lat: number; lon: number } | undefined =>
+    parseLatLonFromUrl(url) ?? undefined;
 
 const start = async (): Promise<void> => {
     const mount = document.getElementById(DEMO_MOUNT_ID);
     if (!mount) {
         throw new Error(`#${DEMO_MOUNT_ID} mount element not found`);
     }
-    const engine = resolveEngine();
-    const viewer = await JpmapTerrain.create(mount, engine ? { engine } : {});
+    const engine = resolveEngine(location.search);
+    const latLon = resolveLatLon(location.href);
+    const opts: JpmapTerrainOptions = {
+        ...(engine ? { engine } : {}),
+        ...(latLon ?? {}),
+    };
+    const viewer = await JpmapTerrain.create(mount, opts);
+
+    // URL 同期: カメラ変化のたびに `/@lat,lon` 形式へ反映する（既存クエリは保持）。
+    const urlUpdater = createUrlUpdater(200);
+    viewer.onCameraChange((event) => urlUpdater(event.lat, event.lon));
 
     // 開発/テストビルドでのみデバッグ用に内部状態を露出する。
     // （Playwright の `window.scene.isReady()` 等が依存しているため）
@@ -41,6 +72,13 @@ const start = async (): Promise<void> => {
     }
 };
 
-start().catch((err) => {
-    console.error("[jpmap-terrain demo] failed to start:", err);
-});
+// テスト環境（jest）では副作用としてのデモ起動をスキップする。
+// jsdom 環境でも `#root` が無ければ `start()` 内で例外になるため、明示的にガードする。
+if (
+    typeof document !== "undefined" &&
+    document.getElementById(DEMO_MOUNT_ID) !== null
+) {
+    start().catch((err) => {
+        console.error("[jpmap-terrain demo] failed to start:", err);
+    });
+}

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -8,6 +8,8 @@
 
 export { JpmapTerrain } from "./lib/jpmapTerrain";
 export type {
+    CameraChangeEvent,
+    CameraChangeListener,
     EngineType,
     FlyToOptions,
     JpmapTerrainOptions,

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -447,9 +447,15 @@ export class JpmapTerrain {
     /**
      * 現在のカメラ状態を取得し、前回スナップショットから変化があれば登録リスナーへ通知する。
      * 初回（`_lastCameraSnapshot === null`）はスナップショットだけ更新し発火しない。
+     *
+     * リスナー未登録時はスナップショット生成も比較も行わずに即 return することで、
+     * `onCameraChange` を使わない利用形態のフレーム毎オーバーヘッドを避ける。
+     * （次回登録時には `_lastCameraSnapshot === null` から再開するため、
+     * 「登録直後に発火しない」仕様を引き続き満たす。）
      */
     private _notifyIfChanged(): void {
         if (this._disposed) return;
+        if (this._cameraListeners.length === 0) return;
         const snapshot: CameraChangeEvent = {
             lat: this.lat,
             lon: this.lon,

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -11,11 +11,14 @@
  */
 
 import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { Observer } from "@babylonjs/core/Misc/observable";
 import type { Scene } from "@babylonjs/core/scene";
 
 import { DefaultScene, type DefaultSceneController } from "../scenes/default";
 import { createBabylonEngine } from "./internal/engineFactory";
 import {
+    CameraChangeEvent,
+    CameraChangeListener,
     FlyToOptions,
     JPMAP_TERRAIN_DEFAULTS,
     JpmapTerrainOptions,
@@ -52,6 +55,12 @@ export class JpmapTerrain {
     private _controller: DefaultSceneController | null = null;
     /** 進行中の flyTo をキャンセルするためのトークン */
     private _flyToToken = 0;
+    /** `onCameraChange` で登録されたリスナー一覧 */
+    private _cameraListeners: CameraChangeListener[] = [];
+    /** `scene.onBeforeRenderObservable` への登録ハンドル */
+    private _cameraObserver: Observer<Scene> | null = null;
+    /** 直近にリスナー通知した値のスナップショット（初回は null） */
+    private _lastCameraSnapshot: CameraChangeEvent | null = null;
 
     private constructor(mountElement: HTMLElement, options: JpmapTerrainOptions) {
         this.mountElement = mountElement;
@@ -114,7 +123,6 @@ export class JpmapTerrain {
                 azimuth: this._azimuth,
                 tilt: this._tilt,
                 mapType: this._mapType,
-                urlSync: false,
                 onReady: (controller) => {
                     this._controller = controller;
                     // T6: 初期表示状態を controller に反映する
@@ -143,6 +151,11 @@ export class JpmapTerrain {
             this._scene = scene;
 
             engine.runRenderLoop(() => scene.render());
+
+            // カメラ変化監視: 毎フレーム前に現在値スナップショットを取り、差分があればリスナー通知。
+            this._cameraObserver = scene.onBeforeRenderObservable.add(() =>
+                this._notifyIfChanged(),
+            );
 
             const onResize = (): void => engine.resize();
             window.addEventListener("resize", onResize);
@@ -398,6 +411,77 @@ export class JpmapTerrain {
         this._controller?.setMapType(value);
     }
 
+    // ---- カメラ変化通知 (Issue #136) ----
+
+    /**
+     * カメラ位置・姿勢のいずれかが変化したタイミングで呼ばれるリスナーを登録する。
+     *
+     * - 戻り値の関数で登録解除（複数回呼んでも安全）。
+     * - 初回登録時の即時発火は行わない。
+     * - 比較精度: epsilon = 1e-9。
+     * - 同一リスナーを複数回登録した場合は登録回数だけ呼ばれる単純動作。
+     * - リスナーが throw しても他リスナーへ伝播し、`console.error` で握りつぶす。
+     * - `dispose()` 後の呼び出しは何もせず、no-op の unsubscribe を返す。
+     *
+     * @param listener カメラ変化を受け取るリスナー
+     * @returns 登録解除関数
+     */
+    public onCameraChange(listener: CameraChangeListener): () => void {
+        if (this._disposed) {
+            return () => {
+                /* no-op: viewer is already disposed */
+            };
+        }
+        this._cameraListeners.push(listener);
+        let removed = false;
+        return (): void => {
+            if (removed) return;
+            removed = true;
+            const idx = this._cameraListeners.indexOf(listener);
+            if (idx !== -1) {
+                this._cameraListeners.splice(idx, 1);
+            }
+        };
+    }
+
+    /**
+     * 現在のカメラ状態を取得し、前回スナップショットから変化があれば登録リスナーへ通知する。
+     * 初回（`_lastCameraSnapshot === null`）はスナップショットだけ更新し発火しない。
+     */
+    private _notifyIfChanged(): void {
+        if (this._disposed) return;
+        const snapshot: CameraChangeEvent = {
+            lat: this.lat,
+            lon: this.lon,
+            altitude: this.altitude,
+            azimuth: this.azimuth,
+            tilt: this.tilt,
+        };
+        const prev = this._lastCameraSnapshot;
+        if (prev === null) {
+            this._lastCameraSnapshot = snapshot;
+            return;
+        }
+        const eps = 1e-9;
+        const changed =
+            Math.abs(snapshot.lat - prev.lat) > eps ||
+            Math.abs(snapshot.lon - prev.lon) > eps ||
+            Math.abs(snapshot.altitude - prev.altitude) > eps ||
+            Math.abs(snapshot.azimuth - prev.azimuth) > eps ||
+            Math.abs(snapshot.tilt - prev.tilt) > eps;
+        if (!changed) return;
+        this._lastCameraSnapshot = snapshot;
+        // iterate 中の add/remove 安全のためスナップショットを取って iterate
+        const listeners = this._cameraListeners.slice();
+        for (const listener of listeners) {
+            try {
+                listener(snapshot);
+            } catch (err) {
+                console.error("[JpmapTerrain] onCameraChange listener threw:", err);
+            }
+        }
+    }
+
     // ---- ライフサイクル (spec §3.3.3) ----
 
     /**
@@ -416,6 +500,13 @@ export class JpmapTerrain {
         this._disposed = true;
         // 進行中の flyTo を中断
         this._flyToToken++;
+        // カメラ変化通知を解除し、リスナー一覧もクリアする
+        if (this._cameraObserver && this._scene) {
+            this._scene.onBeforeRenderObservable.remove(this._cameraObserver);
+        }
+        this._cameraObserver = null;
+        this._cameraListeners = [];
+        this._lastCameraSnapshot = null;
         if (this._resizeObserver) {
             this._resizeObserver.disconnect();
             this._resizeObserver = null;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -63,3 +63,18 @@ export const JPMAP_TERRAIN_DEFAULTS = {
     tilt: 45,
     mapType: "standard" as MapType,
 } as const;
+
+/**
+ * カメラ変化通知ペイロード（spec/package.md 追記は別 Issue）。
+ * `JpmapTerrain.onCameraChange` のリスナー引数。
+ */
+export interface CameraChangeEvent {
+    readonly lat: number;
+    readonly lon: number;
+    readonly altitude: number;
+    readonly azimuth: number;
+    readonly tilt: number;
+}
+
+/** `JpmapTerrain.onCameraChange` リスナー */
+export type CameraChangeListener = (event: CameraChangeEvent) => void;

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -117,12 +117,13 @@ export interface DefaultSceneController {
  * `DefaultScene.createScene` の初期化オプション (T4 / Issue #118)。
  *
  * パッケージ利用 (`JpmapTerrain.create`) で初期パラメータを指定するために導入。
- * 既存デモ (`src/index.ts`) からは未指定で呼び出され、従来通り URL → デフォルト値の順で解決する。
+ * URL からの初期位置解決はデモ層 (`src/index.ts`) に移管されており (Issue #136)、
+ * このシーン側では「options で指定された値 > デフォルト値」の順で解決する。
  */
 export interface DefaultSceneInitOptions {
-    /** 初期緯度（度）。指定時は URL/デフォルトより優先 */
+    /** 初期緯度（度）。未指定時はデフォルト値（東京駅付近）を用いる */
     lat?: number;
-    /** 初期経度（度）。指定時は URL/デフォルトより優先 */
+    /** 初期経度（度）。未指定時はデフォルト値（東京駅付近）を用いる */
     lon?: number;
     /** カメラ高度＝ArcRotateCamera radius（メートル） */
     altitude?: number;

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -9,7 +9,6 @@ import { clamp, toTileXY, tileEdgeMeters, JAPAN_BOUNDS } from "../terrain/gsiTil
 import { createControlPanel, snapScale, formatScale, showToast } from "../terrain/controlPanel";
 import { createTileManager } from "../terrain/tileManager";
 import { createSkybox } from "../terrain/skybox";
-import { parseLatLonFromUrl, createUrlUpdater } from "../terrain/urlState";
 import { resolveTiltCollision, TILT_MAX_RADIUS_INCREASE_RATIO } from "../terrain/cameraCollision";
 import { computePoseForNewTarget } from "../terrain/cameraRetarget";
 import { createUiVisibilityController } from "../terrain/uiVisibility";
@@ -134,11 +133,6 @@ export interface DefaultSceneInitOptions {
     /** 地図種類（T6 で配線） */
     mapType?: "standard" | "photo";
     /**
-     * `?lat=&lon=` を URL クエリへ反映するか。
-     * デモ (default: true) では従来通り更新するが、パッケージ利用時は false にして利用側 URL を汚染しない。
-     */
-    urlSync?: boolean;
-    /**
      * シーン構築完了時に外部操作用コントローラを受け取るコールバック (T5)。
      * `JpmapTerrain` の get/set/flyTo はこのコントローラ経由でカメラ・位置を更新する。
      */
@@ -154,7 +148,6 @@ export class DefaultScene implements CreateSceneClass {
         const azimuthDeg = options?.azimuth ?? 0;
         const tiltDeg = options?.tilt ?? 45;
         const altitude = options?.altitude ?? 2000;
-        const urlSync = options?.urlSync ?? true;
 
         const scene = new Scene(engine);
         scene.clearColor.set(0.75, 0.86, 0.95, 1);
@@ -195,19 +188,9 @@ export class DefaultScene implements CreateSceneClass {
         // スカイボックス
         createSkybox(scene);
 
-        // 初期位置（options > URLパラメータ > デフォルト 東京駅付近）
-        const urlLatLon = parseLatLonFromUrl(window.location.href);
-        const initialLat = options?.lat ?? urlLatLon?.lat ?? 35.681236;
-        const initialLon = options?.lon ?? urlLatLon?.lon ?? 139.767125;
-
-        // URL 自動更新（パッケージ利用時は無効化）
-        const urlUpdater = createUrlUpdater(200);
-        const noopUrlUpdater = (): void => {
-            /* urlSync=false: パッケージ利用時は URL を変更しない */
-        };
-        const updateUrl: (lat: number, lon: number) => void = urlSync
-            ? urlUpdater
-            : noopUrlUpdater;
+        // 初期位置（options > デフォルト 東京駅付近）
+        const initialLat = options?.lat ?? 35.681236;
+        const initialLon = options?.lon ?? 139.767125;
 
         // UIパネル
         const ui = createControlPanel();
@@ -244,7 +227,6 @@ export class DefaultScene implements CreateSceneClass {
                 JAPAN_BOUNDS.minLon,
                 JAPAN_BOUNDS.maxLon
             );
-            updateUrl(currentLat, currentLon);
             await tileManager.setCenter(currentLat, currentLon, 0);
         };
 
@@ -295,7 +277,6 @@ export class DefaultScene implements CreateSceneClass {
 
             currentLat = newLat;
             currentLon = newLon;
-            updateUrl(newLat, newLon);
             void refreshTerrain();
         };
 

--- a/tests/index.unit.spec.ts
+++ b/tests/index.unit.spec.ts
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * デモエントリ (`src/index.ts`) の純粋関数 export ユニットテスト (Issue #136)。
+ *
+ * - `resolveEngine`: クエリ文字列からエンジン種別を解決する。
+ * - `resolveLatLon`: URL から初期表示の緯度経度を解決する（`parseLatLonFromUrl` の薄いラッパー）。
+ *
+ * `src/index.ts` 内の `start()` は `#root` 要素の存在で発火を抑制しているため、
+ * jsdom 環境でも副作用なく `resolveEngine` / `resolveLatLon` だけを検証できる。
+ */
+
+import { describe, it, expect } from "@jest/globals";
+
+import { resolveEngine, resolveLatLon } from "../src/index";
+
+describe("resolveEngine", () => {
+    it("?engine=webgpu → 'webgpu'", () => {
+        expect(resolveEngine("?engine=webgpu")).toBe("webgpu");
+    });
+
+    it("?engine=webgl → 'webgl2'（旧表記の正規化）", () => {
+        expect(resolveEngine("?engine=webgl")).toBe("webgl2");
+    });
+
+    it("?engine=webgl2 → 'webgl2'", () => {
+        expect(resolveEngine("?engine=webgl2")).toBe("webgl2");
+    });
+
+    it("engine 未指定 → undefined", () => {
+        expect(resolveEngine("")).toBeUndefined();
+        expect(resolveEngine("?other=1")).toBeUndefined();
+    });
+
+    it("不正値 → undefined", () => {
+        expect(resolveEngine("?engine=opengl")).toBeUndefined();
+        expect(resolveEngine("?engine=")).toBeUndefined();
+    });
+});
+
+describe("resolveLatLon", () => {
+    it("/@lat,lon パスから lat/lon を取り出す", () => {
+        const result = resolveLatLon("http://localhost/@35.681236,139.767125");
+        expect(result).not.toBeUndefined();
+        expect(result?.lat).toBeCloseTo(35.681236);
+        expect(result?.lon).toBeCloseTo(139.767125);
+    });
+
+    it("URL に lat/lon 情報が無い場合は undefined を返す", () => {
+        expect(resolveLatLon("http://localhost/")).toBeUndefined();
+    });
+
+    it("クエリパラメータ ?lat=&lon= も解釈する（parseLatLonFromUrl にデリゲート）", () => {
+        const result = resolveLatLon(
+            "http://localhost/?lat=35.681236&lon=139.767125",
+        );
+        expect(result).not.toBeUndefined();
+        expect(result?.lat).toBeCloseTo(35.681236);
+        expect(result?.lon).toBeCloseTo(139.767125);
+    });
+});

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -87,6 +87,46 @@ jest.unstable_mockModule("../src/scenes/default", () => {
     const setMapTypeCalls: Array<"standard" | "photo"> = [];
     // T7: controller.dispose の呼び出し回数も検証する。
     let controllerDisposeCount = 0;
+    // #136: scene.onBeforeRenderObservable のテスト用簡易実装。
+    // jpmapTerrain.ts は `add(callback)` の戻り値を `Observer` として保持し、
+    // dispose 時に `remove(observer)` する。テストからは `__triggerSceneRender` で
+    // 全 observer を疑似発火させる。
+    type SceneObserver = { callback: () => void };
+    const sceneObservables: Array<{
+        observers: SceneObserver[];
+        add: (cb: () => void) => SceneObserver;
+        remove: (obs: SceneObserver) => boolean;
+    }> = [];
+    const createSceneObservable = (): {
+        add: (cb: () => void) => SceneObserver;
+        remove: (obs: SceneObserver) => boolean;
+    } => {
+        const observers: SceneObserver[] = [];
+        const obs = {
+            observers,
+            add: (cb: () => void): SceneObserver => {
+                const o: SceneObserver = { callback: cb };
+                observers.push(o);
+                return o;
+            },
+            remove: (target: SceneObserver): boolean => {
+                const idx = observers.indexOf(target);
+                if (idx === -1) return false;
+                observers.splice(idx, 1);
+                return true;
+            },
+        };
+        sceneObservables.push(obs);
+        return obs;
+    };
+    const triggerSceneRender = (): void => {
+        for (const obs of sceneObservables) {
+            // iterate 中の add/remove 安全のため slice
+            for (const o of obs.observers.slice()) {
+                o.callback();
+            }
+        }
+    };
     type UiTarget =
         | "compass"
         | "zoomButtons"
@@ -180,6 +220,7 @@ jest.unstable_mockModule("../src/scenes/default", () => {
                 return {
                     render: jest.fn(),
                     dispose: jest.fn(),
+                    onBeforeRenderObservable: createSceneObservable(),
                 };
             },
         );
@@ -214,6 +255,7 @@ jest.unstable_mockModule("../src/scenes/default", () => {
         __resetControllerDisposeCount: (): void => {
             controllerDisposeCount = 0;
         },
+        __triggerSceneRender: (): void => triggerSceneRender(),
     };
 });
 
@@ -236,6 +278,7 @@ const sceneMockModule = (await import("../src/scenes/default")) as unknown as {
     __setLastMapType: (v: "standard" | "photo") => void;
     __getControllerDisposeCount: () => number;
     __resetControllerDisposeCount: () => void;
+    __triggerSceneRender: () => void;
 };
 
 describe("JpmapTerrain (skeleton)", () => {
@@ -826,6 +869,142 @@ describe("JpmapTerrain (skeleton)", () => {
             expect(viewer.altitude).toBe(2500);
             expect(viewer.azimuth).toBe(45);
             expect(viewer.tilt).toBe(60);
+        });
+    });
+
+    describe("onCameraChange (Issue #136)", () => {
+        it("初回登録時には即時発火しない", async () => {
+            const viewer = await create(createMountElement());
+            const listener = jest.fn();
+
+            viewer.onCameraChange(listener);
+
+            expect(listener).not.toHaveBeenCalled();
+        });
+
+        it("カメラ値変更後の onBeforeRender でリスナーが呼ばれる", async () => {
+            const viewer = await create(createMountElement(), {
+                lat: 0,
+                lon: 0,
+                altitude: 1000,
+                azimuth: 0,
+                tilt: 30,
+            });
+            const listener = jest.fn();
+            viewer.onCameraChange(listener);
+
+            // 1 度目の発火: 値未変更だが初回スナップショット作成のみ。
+            sceneMockModule.__triggerSceneRender();
+            expect(listener).not.toHaveBeenCalled();
+
+            viewer.lat = 35;
+            sceneMockModule.__triggerSceneRender();
+
+            expect(listener).toHaveBeenCalledTimes(1);
+            const event = listener.mock.calls[0][0] as {
+                lat: number;
+                lon: number;
+                altitude: number;
+                azimuth: number;
+                tilt: number;
+            };
+            expect(event.lat).toBe(35);
+            expect(event.lon).toBe(0);
+            expect(event.altitude).toBe(1000);
+        });
+
+        it("値が変化しなければ発火しない（連続 render でも 1 回のみ）", async () => {
+            const viewer = await create(createMountElement());
+            const listener = jest.fn();
+            viewer.onCameraChange(listener);
+            sceneMockModule.__triggerSceneRender(); // snapshot 初期化
+
+            viewer.lon = 140;
+            sceneMockModule.__triggerSceneRender();
+            sceneMockModule.__triggerSceneRender();
+            sceneMockModule.__triggerSceneRender();
+
+            expect(listener).toHaveBeenCalledTimes(1);
+        });
+
+        it("unsubscribe 後は呼ばれず、複数回呼んでも安全", async () => {
+            const viewer = await create(createMountElement());
+            const listener = jest.fn();
+            const unsubscribe = viewer.onCameraChange(listener);
+            sceneMockModule.__triggerSceneRender(); // snapshot 初期化
+
+            viewer.lat = 35;
+            sceneMockModule.__triggerSceneRender();
+            expect(listener).toHaveBeenCalledTimes(1);
+
+            unsubscribe();
+            unsubscribe(); // 多重呼び出しでも例外にならない
+            viewer.lat = 36;
+            sceneMockModule.__triggerSceneRender();
+
+            expect(listener).toHaveBeenCalledTimes(1);
+        });
+
+        it("同一リスナーを複数回登録した場合は登録回数だけ呼ばれる", async () => {
+            const viewer = await create(createMountElement());
+            const listener = jest.fn();
+            viewer.onCameraChange(listener);
+            viewer.onCameraChange(listener);
+            sceneMockModule.__triggerSceneRender();
+
+            viewer.lat = 35;
+            sceneMockModule.__triggerSceneRender();
+
+            expect(listener).toHaveBeenCalledTimes(2);
+        });
+
+        it("リスナーが throw しても他リスナーへの伝播が継続する", async () => {
+            const viewer = await create(createMountElement());
+            const errorSpy = jest
+                .spyOn(console, "error")
+                .mockImplementation(() => {});
+            const failing = jest.fn(() => {
+                throw new Error("listener failure");
+            });
+            const ok = jest.fn();
+            viewer.onCameraChange(failing);
+            viewer.onCameraChange(ok);
+            sceneMockModule.__triggerSceneRender();
+
+            viewer.lat = 35;
+            sceneMockModule.__triggerSceneRender();
+
+            expect(failing).toHaveBeenCalledTimes(1);
+            expect(ok).toHaveBeenCalledTimes(1);
+            expect(errorSpy).toHaveBeenCalled();
+
+            errorSpy.mockRestore();
+        });
+
+        it("dispose 後の onCameraChange は no-op の unsubscribe を返す", async () => {
+            const viewer = await create(createMountElement());
+            viewer.dispose();
+
+            const listener = jest.fn();
+            const unsubscribe = viewer.onCameraChange(listener);
+
+            expect(typeof unsubscribe).toBe("function");
+            expect(() => unsubscribe()).not.toThrow();
+            // dispose 後は scene observer が外れているのでそもそも発火しない
+            expect(listener).not.toHaveBeenCalled();
+        });
+
+        it("dispose 後はリスナーも発火しない（既登録ぶん）", async () => {
+            const viewer = await create(createMountElement());
+            const listener = jest.fn();
+            viewer.onCameraChange(listener);
+            sceneMockModule.__triggerSceneRender();
+            viewer.dispose();
+
+            // dispose 済みの scene observer は除去されているため発火しない
+            sceneMockModule.__triggerSceneRender();
+
+            expect(listener).not.toHaveBeenCalled();
         });
     });
 });

--- a/tests/libExports.unit.spec.ts
+++ b/tests/libExports.unit.spec.ts
@@ -16,6 +16,8 @@ import { describe, it, expect } from "@jest/globals";
 
 import * as pkg from "../src/lib";
 import type {
+    CameraChangeEvent,
+    CameraChangeListener,
     EngineType,
     FlyToOptions,
     JpmapTerrainOptions,
@@ -40,5 +42,21 @@ describe("package entry exports (T8)", () => {
         expect(map).toBe("standard");
         expect(opts.engine).toBe("webgpu");
         expect(fly.lat).toBe(0);
+    });
+
+    it("CameraChangeEvent / CameraChangeListener 型が import できる（typecheck）", () => {
+        const event: CameraChangeEvent = {
+            lat: 35.681236,
+            lon: 139.767125,
+            altitude: 2000,
+            azimuth: 0,
+            tilt: 45,
+        };
+        let received: CameraChangeEvent | null = null;
+        const listener: CameraChangeListener = (e) => {
+            received = e;
+        };
+        listener(event);
+        expect(received).toEqual(event);
     });
 });


### PR DESCRIPTION
## 概要

Closes #136

開発デモエントリで `http://localhost:8080/@緯度,経度?engine=webgpu` 形式の URL から初期表示位置と描画エンジンを指定可能にしました。あわせて、URL 同期ロジックをライブラリパッケージから外し、デモエントリ側に集約しました。

ライブラリには新たに公開購読 API `JpmapTerrain.onCameraChange` を追加し、デモ層からカメラ位置変化を購読して URL に反映する構成にしています。

## 主な変更

### ライブラリ層
- `JpmapTerrain.onCameraChange(listener): () => void` を追加（プレーン関数型、unsubscribe 戻り値、初回非発火、epsilon=1e-9 比較で値変化時のみ通知、throw 隔離、dispose 連携）
- `CameraChangeEvent` / `CameraChangeListener` 型を `src/lib/types.ts` に追加し、パッケージエントリ `src/lib.ts` から re-export
- `DefaultSceneInitOptions.urlSync` フィールドおよび内部 URL 同期ロジックを完全に除去
- `JpmapTerrain.initAsync` の `urlSync: false` 指定を削除

### デモ層
- `src/index.ts` に `resolveEngine` / `resolveLatLon` 純粋関数を追加（テスト容易化のため export）
- 起動時に URL から lat/lon/engine を解決し `JpmapTerrain.create()` に渡す
- 起動後 `viewer.onCameraChange` を購読し、`createUrlUpdater(200)` で URL を `/@lat,lon` 形式に書き戻す
- jsdom テスト時に `start()` が発火しないよう `#root` 要素の存在でガード

### テスト
- `tests/index.unit.spec.ts`（新規）: `resolveEngine` / `resolveLatLon` のユニットテスト
- `tests/jpmapTerrain.unit.spec.ts`: `onCameraChange` テスト群追加（初回非発火 / 値変化発火 / unsubscribe / 多重登録 / throw 隔離 / dispose 後 no-op）
- `tests/libExports.unit.spec.ts`: 新規型 re-export を検証

## 影響範囲

- 公開 API: `JpmapTerrain.onCameraChange` / `CameraChangeEvent` / `CameraChangeListener` を追加（破壊的変更なし）
- 内部 API: `DefaultSceneInitOptions.urlSync` を削除（パッケージ内部のみで参照されており外部影響なし）
- 既存挙動: ライブラリ単体では URL を一切変更しなくなる（従来も `urlSync: false` 固定で書き戻していなかったため実質変化なし）

## 検証結果

- npm run lint: PASS
- npm run typecheck: PASS
- npm run test:unit: PASS（17 suites / 294 tests）
- npm run test:visuals: PASS（6/6、基準画像差分なし）
- npm run build: PASS

## 備考（別 Issue 化推奨）

- `spec/package.md` への `onCameraChange` / `CameraChangeEvent` 反映
- README の URL フォーマット記載追加

## レビュー対応

Issue #136 のコメントに記録した Architect 設計および Reviewer 指摘事項（MED-1: 公開型の re-export）に対応済み。
