### PR TITLE
docs(spec): JpmapTerrain.onCameraChange / CameraChangeEvent を spec/package.md に追記 (#138)

### DIFF
--- a/spec/package.md
+++ b/spec/package.md
@@ -180,7 +180,7 @@ interface JpmapTerrain {
 - **発火条件**: 値が変化したフレームのみ通知する（`epsilon = 1e-9` での比較）。
 - **初回登録時は即時発火しない**（変化があった次回以降のみ）。
 - 同一リスナーを複数回登録した場合は登録回数だけ呼ばれる。
-- リスナーが throw しても他リスナーへ伝播しない（内部で `console.error` により握りつぶす）。
+- リスナーが throw した場合でも、内部で例外を捕捉して `console.error` でログ出力し、他リスナーの処理は継続する。
 - `dispose()` 後に `onCameraChange` を呼び出した場合は登録されず、no-op の unsubscribe 関数を返す。
 
 **利用例:**
@@ -197,7 +197,7 @@ unsubscribe();
 
 ### 3.4 型定義
 
-`CameraChangeEvent` および `CameraChangeListener` は、パッケージエントリ `src/lib.ts` から re-export 済みである。
+`CameraChangeEvent` および `CameraChangeListener` は、`jpmap-terrain` から import 可能である（パッケージエントリで re-export 済み）。
 
 ```typescript
 /** `JpmapTerrain.onCameraChange` のリスナー引数 */

--- a/spec/package.md
+++ b/spec/package.md
@@ -158,7 +158,66 @@ interface JpmapTerrain {
 }
 ```
 
-### 3.4 利用例
+#### 3.3.4 カメラ変化イベント
+
+カメラ位置・姿勢（`lat` / `lon` / `altitude` / `azimuth` / `tilt`）の変化を購読する。
+
+```typescript
+interface JpmapTerrain {
+  /**
+   * カメラ変化リスナーを登録する。
+   *
+   * @param listener カメラ変化を受け取るリスナー
+   * @returns 登録解除関数（unsubscribe）
+   */
+  onCameraChange(listener: CameraChangeListener): () => void;
+}
+```
+
+**仕様:**
+
+- 戻り値は登録解除関数。呼び出すと当該リスナーのみが解除される。
+- **発火条件**: 値が変化したフレームのみ通知する（`epsilon = 1e-9` での比較）。
+- **初回登録時は即時発火しない**（変化があった次回以降のみ）。
+- 同一リスナーを複数回登録した場合は登録回数だけ呼ばれる。
+- リスナーが throw しても他リスナーへ伝播しない（内部で `console.error` により握りつぶす）。
+- `dispose()` 後に `onCameraChange` を呼び出した場合は登録されず、no-op の unsubscribe 関数を返す。
+
+**利用例:**
+
+```typescript
+const unsubscribe = viewer.onCameraChange((e) => {
+  console.log(`lat=${e.lat}, lon=${e.lon}, alt=${e.altitude}`);
+  console.log(`azimuth=${e.azimuth}, tilt=${e.tilt}`);
+});
+
+// 解除
+unsubscribe();
+```
+
+### 3.4 型定義
+
+`CameraChangeEvent` および `CameraChangeListener` は、パッケージエントリ `src/lib.ts` から re-export 済みである。
+
+```typescript
+/** `JpmapTerrain.onCameraChange` のリスナー引数 */
+interface CameraChangeEvent {
+  readonly lat: number;
+  readonly lon: number;
+  readonly altitude: number;
+  readonly azimuth: number;
+  readonly tilt: number;
+}
+
+/** `JpmapTerrain.onCameraChange` リスナー */
+type CameraChangeListener = (event: CameraChangeEvent) => void;
+```
+
+```typescript
+import type { CameraChangeEvent, CameraChangeListener } from "jpmap-terrain";
+```
+
+### 3.5 利用例
 
 ```html
 <div id="terrain-viewer" style="width: 800px; height: 600px;"></div>


### PR DESCRIPTION
## 概要

Issue #138 対応。PR #137（Issue #136）で追加した公開 API `JpmapTerrain.onCameraChange` および型 `CameraChangeEvent` / `CameraChangeListener` を `spec/package.md` に反映した。

## 変更内容

- `spec/package.md` §3.3.4「カメラ変化イベント」を新設
  - `onCameraChange(listener): () => void` のシグネチャと戻り値（unsubscribe）
  - 発火条件: 値変化時のみ（epsilon=1e-9 比較）
  - 初回登録時は即時発火しない
  - リスナーが throw しても他リスナーへ伝播しない（内部で `console.error`）
  - `dispose()` 後の `onCameraChange` 呼び出しは no-op の unsubscribe を返す
- §3.4「型定義」セクションを新設
  - `CameraChangeEvent`（lat / lon / altitude / azimuth / tilt）
  - `CameraChangeListener` 型
  - パッケージエントリ `src/lib.ts` から re-export 済みである旨を明記
- 既存「利用例」セクションは §3.5 へ繰り下げ

## 影響範囲

- ドキュメントのみ（`spec/package.md`）
- 実装・API への変更なし

## チェック

- [x] `npm run lint` 成功
- 実装ファイル（`src/lib/jpmapTerrain.ts` / `src/lib/types.ts`）のコメント・JSDoc と整合性を確認

## 関連

- Closes #138
- Related PR: #137
- Related Issue: #136