### PR TITLE
docs(readme): URLフォーマット (/@lat,lon?engine=...) を追記 (#139)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,22 +77,25 @@ npm start
 - WebGPU: `http://localhost:8080/?scene=default&engine=webgpu`
 - WebGL2: `http://localhost:8080/?scene=default&engine=webgl2`
 
-`webgpu` 指定時に未対応ブラウザの場合は WebGL にフォールバックします。
+`webgpu` 指定時に未対応ブラウザの場合は WebGL2 にフォールバックします。
 
 ## URL フォーマット（緯度経度・エンジン指定）
 
-開発デモエントリ（`src/index.ts`）は、Google Maps 互換のパス形式 `/@緯度,経度` と `engine` クエリパラメータをサポートします。
+開発デモエントリ（`src/index.ts`）は、Google Maps 互換のパス形式 `/@緯度,経度` と `engine` クエリパラメータをサポートします。ここで説明するのは開発デモ用 URL の仕様であり、npm パッケージの公開 API（`EngineType` は `"webgpu" | "webgl2"`）とは別です。
 
-- 形式: `http://localhost:8080/@<lat>,<lon>?engine=<webgpu|webgl|webgl2>`
+- 形式: `http://localhost:8080/@<lat>,<lon>?engine=<webgpu|webgl|webgl2>`（`webgl` は URL クエリでのみ後方互換として受け付け、内部的に `webgl2` に正規化）
 - 例:
   - `http://localhost:8080/@35.681236,139.767125?engine=webgpu`（東京駅・WebGPU）
   - `http://localhost:8080/@35.3606,138.7274?engine=webgl2`（富士山・WebGL2）
 
 ### `engine` パラメータ
 
-- 取りうる値: `webgpu` / `webgl` / `webgl2`
-- `webgl` は内部的に `webgl2` に正規化されます
+以下は開発デモ URL の `engine` クエリパラメータに対する仕様です。
+
+- `webgpu` / `webgl2` を指定できます
+- `webgl` は URL クエリでのみ後方互換として受け付けられる別名で、内部的に `webgl2` に正規化されます
 - 省略時は自動選択（WebGPU 利用可能なら WebGPU、未対応なら WebGL2 にフォールバック）
+- npm パッケージの公開 API で指定できる `engine` は `"webgpu" | "webgl2"` です
 
 ### 緯度経度の扱い
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,28 @@ npm start
 
 `webgpu` 指定時に未対応ブラウザの場合は WebGL にフォールバックします。
 
+## URL フォーマット（緯度経度・エンジン指定）
+
+開発デモエントリ（`src/index.ts`）は、Google Maps 互換のパス形式 `/@緯度,経度` と `engine` クエリパラメータをサポートします。
+
+- 形式: `http://localhost:8080/@<lat>,<lon>?engine=<webgpu|webgl|webgl2>`
+- 例:
+  - `http://localhost:8080/@35.681236,139.767125?engine=webgpu`（東京駅・WebGPU）
+  - `http://localhost:8080/@35.3606,138.7274?engine=webgl2`（富士山・WebGL2）
+
+### `engine` パラメータ
+
+- 取りうる値: `webgpu` / `webgl` / `webgl2`
+- `webgl` は内部的に `webgl2` に正規化されます
+- 省略時は自動選択（WebGPU 利用可能なら WebGPU、未対応なら WebGL2 にフォールバック）
+
+### 緯度経度の扱い
+
+- 緯度経度は `JAPAN_BOUNDS`（緯度 20〜46、経度 122〜154）でクランプされます
+- カメラ移動に追従して、URL のパスは `/@lat,lon` 形式に書き戻されます（既存のクエリパラメータは保持）
+
+実装の詳細は `src/index.ts` および `src/terrain/urlState.ts` を参照してください。
+
 ## 開発ガイド
 
 ### エントリポイント


### PR DESCRIPTION
## 概要

Issue #139 対応。README に開発デモエントリの URL フォーマット `/@緯度,経度?engine=webgpu|webgl2` を追記。

## 変更内容

- `## URL フォーマット（緯度経度・エンジン指定）` セクションを新設
  - パス形式 `/@<lat>,<lon>` の例（東京駅・富士山）
  - `engine` パラメータの取りうる値（`webgpu` / `webgl` / `webgl2`、`webgl` は `webgl2` に正規化）
  - 省略時の自動選択／WebGL フォールバック挙動
  - 緯度経度は `JAPAN_BOUNDS` でクランプされる旨
  - カメラ移動で URL のパスが `/@lat,lon` に書き戻される旨

## 影響範囲

- ドキュメントのみ（`README.md`）。コード・API・挙動の変更なし。

## 確認

- `npm run lint` 成功

## 関連

- Closes #139
- 関連 PR: #137
- 関連 Issue: #136