### PR TITLE
feat(#35): 時間による明るさ(環境光)の変化を表現する

### DIFF
--- a/spec/package.md
+++ b/spec/package.md
@@ -51,6 +51,8 @@ const viewer = await JpmapTerrain.create(document.getElementById("map")!, {
 | `azimuth` | `number` | `0` | 方位角（度、Babylon.js camera alpha に対応） |
 | `tilt` | `number` | `45` | チルト角（度、Babylon.js camera beta に対応） |
 | `mapType` | `"standard" \| "photo"` | `"standard"` | 地図種類（標準地図 / 航空写真） |
+| `dateTime` | `Date \| null` | `null` | 太陽位置計算に使う日時。`null` の場合は内部の決定的なフォールバック時刻（夏至日本時間正午）を使用 |
+| `autoSunPosition` | `boolean` | `false` | `true` で実時刻に追従して内部更新（60 秒周期）、`false` で `dateTime` を固定値として使用 |
 
 ### 3.3 API & プロパティ
 
@@ -195,6 +197,36 @@ const unsubscribe = viewer.onCameraChange((e) => {
 unsubscribe();
 ```
 
+#### 3.3.5 太陽位置（時間による明るさ変化）
+
+`dateTime` / `autoSunPosition` は **get / set 両対応**。set すると即座にライト・Skybox・太陽メッシュへ反映される。
+
+```typescript
+interface JpmapTerrain {
+  /**
+   * 太陽位置計算に使う日時。`null` の場合は内部の決定的なフォールバック時刻
+   * （夏至日本時間正午）を使用する。
+   * `autoSunPosition=true` の間、getter は「最後に内部反映した実時刻」を返す。
+   */
+  get dateTime(): Date | null;
+  set dateTime(value: Date | null);
+
+  /**
+   * `true`: 60 秒周期で実時刻に追従して内部更新する。
+   * `false`（既定）: `dateTime` を固定値として使用する。
+   */
+  get autoSunPosition(): boolean;
+  set autoSunPosition(value: boolean);
+}
+```
+
+**仕様:**
+
+- `Invalid Date` を setter / options に渡した場合は `console.warn` のうえ `null` 同等に倒す（例外は投げない）。
+- `autoSunPosition` を `true` から `false` に切り替えた瞬間、保持していた `dateTime` 値（または `null`）で再計算する。
+- `dispose()` 時に内部タイマーは確実に解放される。
+- ビジュアルテストの決定性が必要な場面（Playwright 等）では、URL クエリ `?dateTime=<ISO8601 with Z>&autoSunPosition=false` を付与し、太陽位置を完全に固定すること。
+
 ### 3.4 型定義
 
 `CameraChangeEvent` および `CameraChangeListener` は、`jpmap-terrain` から import 可能である（パッケージエントリで re-export 済み）。
@@ -255,8 +287,6 @@ import type { CameraChangeEvent, CameraChangeListener } from "jpmap-terrain";
 |---|---|---|
 | `projection` | `"perspective" \| "orthographic"` | 射影投影 / 平行投影の切り替え |
 | `fov` | `number` | 視野角（度） |
-| `dateTime` | `Date \| null` | 日時指定（太陽位置シミュレーション） |
-| `autoSunPosition` | `boolean` | 時刻による太陽位置の自動計算 |
 
 ### 4.2 追加 API
 
@@ -303,14 +333,10 @@ interface JpmapTerrain {
   setModelVisible(id: string, visible: boolean): void;
   /** モデルを削除する */
   removeModel(id: string): void;
-
-  // --- 日時 ---
-  /** 日時を取得・設定する */
-  dateTime: Date | null;
-  /** 太陽位置の自動計算を取得・設定する */
-  autoSunPosition: boolean;
 }
 ```
+
+> 日時 (`dateTime` / `autoSunPosition`) は §3.3.5 で正式仕様化済み。
 
 ## 5. パッケージ構成
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,42 @@ export const resolveLatLon = (
 ): { lat: number; lon: number } | undefined =>
     parseLatLonFromUrl(url) ?? undefined;
 
+/**
+ * `?dateTime=` クエリ文字列から太陽位置計算用の日時を解決する (Issue #35)。
+ * - ISO 8601（`Z` 等のタイムゾーン指定を含む形式を推奨）を受け付ける。
+ * - 未指定 / パース失敗時は `undefined` を返し、デモ起動時の `opts` には含めない（既存挙動維持）。
+ * - パース失敗は `console.warn` のみ。例外は投げない（silent ignore ポリシー）。
+ *
+ * @param search `location.search` 等のクエリ文字列（先頭 `?` 任意）
+ */
+export const resolveDateTime = (search: string): Date | undefined => {
+    const raw = new URLSearchParams(search).get("dateTime");
+    if (raw === null) return undefined;
+    const d = new Date(raw);
+    if (Number.isNaN(d.getTime())) {
+        // ログ汚染対策: 制御文字 (CR/LF/ESC 等) を `?` に置換し、長さも 64 文字に制限する。
+        const safe = raw
+            .replace(/[\r\n\x1B\x00-\x1F\x7F]/g, "?")
+            .slice(0, 64);
+        console.warn(`[jpmap-terrain demo] invalid dateTime param: ${safe}`);
+        return undefined;
+    }
+    return d;
+};
+
+/**
+ * `?autoSunPosition=` クエリ文字列から太陽位置自動更新フラグを解決する (Issue #35)。
+ * - `"true"` / `"false"` のみを許容し、それ以外は `undefined`（既定挙動を維持）。
+ */
+export const resolveAutoSunPosition = (
+    search: string,
+): boolean | undefined => {
+    const raw = new URLSearchParams(search).get("autoSunPosition");
+    if (raw === "true") return true;
+    if (raw === "false") return false;
+    return undefined;
+};
+
 const start = async (): Promise<void> => {
     const mount = document.getElementById(DEMO_MOUNT_ID);
     if (!mount) {
@@ -52,9 +88,13 @@ const start = async (): Promise<void> => {
     }
     const engine = resolveEngine(location.search);
     const latLon = resolveLatLon(location.href);
+    const dateTime = resolveDateTime(location.search);
+    const autoSunPosition = resolveAutoSunPosition(location.search);
     const opts: JpmapTerrainOptions = {
         ...(engine ? { engine } : {}),
         ...(latLon ?? {}),
+        ...(dateTime !== undefined ? { dateTime } : {}),
+        ...(autoSunPosition !== undefined ? { autoSunPosition } : {}),
     };
     const viewer = await JpmapTerrain.create(mount, opts);
 

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -23,6 +23,7 @@ import {
     JPMAP_TERRAIN_DEFAULTS,
     JpmapTerrainOptions,
     MapType,
+    SUN_AUTO_UPDATE_INTERVAL_MS,
 } from "./types";
 
 /**
@@ -45,6 +46,15 @@ export class JpmapTerrain {
     private _showScaleBar = true;
     private _showMapToggle = true;
     private _showAttribution = true;
+
+    /** 太陽位置計算用の保持日時。`null` の場合は内部フォールバックを使用する */
+    private _dateTime: Date | null;
+    /** `true`: 60s 周期で実時刻に追従。`false`: `_dateTime` を固定値として使用 */
+    private _autoSunPosition: boolean;
+    /** auto モード時の `setInterval` ハンドル */
+    private _sunTimer: ReturnType<typeof setInterval> | null = null;
+    /** auto モード中、最後に内部反映した実時刻。`dateTime` getter が返す値 */
+    private _autoLastAppliedDate: Date | null = null;
 
     private _canvas: HTMLCanvasElement | null = null;
     private _engine: AbstractEngine | null = null;
@@ -70,6 +80,29 @@ export class JpmapTerrain {
         this._azimuth = options.azimuth ?? JPMAP_TERRAIN_DEFAULTS.azimuth;
         this._tilt = options.tilt ?? JPMAP_TERRAIN_DEFAULTS.tilt;
         this._mapType = options.mapType ?? JPMAP_TERRAIN_DEFAULTS.mapType;
+        // 太陽位置 (Issue #35)。`Invalid Date` は `console.warn` のうえ null に倒す。
+        this._dateTime = JpmapTerrain._sanitizeDateTimeOption(options.dateTime);
+        this._autoSunPosition =
+            options.autoSunPosition ?? JPMAP_TERRAIN_DEFAULTS.autoSunPosition;
+    }
+
+    /**
+     * options / setter から渡された `dateTime` を検証し、`Invalid Date` の場合は
+     * `console.warn` を出して `null` に倒す。
+     */
+    private static _sanitizeDateTimeOption(
+        value: Date | null | undefined,
+    ): Date | null {
+        if (value === undefined || value === null) {
+            return JPMAP_TERRAIN_DEFAULTS.dateTime;
+        }
+        if (Number.isNaN(value.getTime())) {
+            console.warn(
+                "[JpmapTerrain] dateTime setter received Invalid Date; falling back to null",
+            );
+            return null;
+        }
+        return value;
     }
 
     /**
@@ -146,6 +179,14 @@ export class JpmapTerrain {
                         "attribution",
                         this._showAttribution,
                     );
+                    // 太陽位置（Issue #35）。auto モードならタイマー始動 + 即時 1 回反映、
+                    // 固定モードなら `_dateTime`（or null）で初期反映する。
+                    if (this._autoSunPosition) {
+                        this._startSunTimer();
+                        this._tickSunTimer();
+                    } else {
+                        controller.setSunState(this._dateTime);
+                    }
                 },
             });
             this._scene = scene;
@@ -411,6 +452,73 @@ export class JpmapTerrain {
         this._controller?.setMapType(value);
     }
 
+    // ---- 太陽位置 (spec §3.3.5 / Issue #35) ----
+
+    /**
+     * 太陽位置計算に使う日時を取得する。
+     *
+     * - `autoSunPosition === false`: 最後に set した値（または options 値、`null`）を返す。
+     * - `autoSunPosition === true`: 最後にタイマーで内部反映した実時刻を返す（一度も
+     *   反映していない場合は `null`）。
+     */
+    public get dateTime(): Date | null {
+        if (this._autoSunPosition) {
+            return this._autoLastAppliedDate;
+        }
+        return this._dateTime;
+    }
+    public set dateTime(value: Date | null) {
+        if (this._disposed) return;
+        this._dateTime = JpmapTerrain._sanitizeDateTimeOption(value);
+        // auto モード中は太陽計算で使わない（auto 優先）が、値だけ保持する。
+        if (!this._autoSunPosition) {
+            this._controller?.setSunState(this._dateTime);
+        }
+    }
+
+    public get autoSunPosition(): boolean {
+        return this._autoSunPosition;
+    }
+    public set autoSunPosition(value: boolean) {
+        if (this._disposed) return;
+        if (this._autoSunPosition === value) return;
+        this._autoSunPosition = value;
+        if (value) {
+            this._startSunTimer();
+            // 即時 1 回反映
+            this._tickSunTimer();
+        } else {
+            this._stopSunTimer();
+            this._autoLastAppliedDate = null;
+            // 保持されていた `_dateTime`（または null）で再計算
+            this._controller?.setSunState(this._dateTime);
+        }
+    }
+
+    /** 60 秒周期で `new Date()` を太陽計算に流し込むタイマーを開始する */
+    private _startSunTimer(): void {
+        if (this._disposed) return;
+        if (this._sunTimer !== null) return;
+        this._sunTimer = setInterval(
+            () => this._tickSunTimer(),
+            SUN_AUTO_UPDATE_INTERVAL_MS,
+        );
+    }
+
+    private _stopSunTimer(): void {
+        if (this._sunTimer === null) return;
+        clearInterval(this._sunTimer);
+        this._sunTimer = null;
+    }
+
+    /** auto モードの 1 回分の反映。実行毎に「最後に反映した実時刻」を記録する */
+    private _tickSunTimer(): void {
+        if (this._disposed) return;
+        const now = new Date();
+        this._autoLastAppliedDate = now;
+        this._controller?.setSunState(now);
+    }
+
     // ---- カメラ変化通知 (Issue #136) ----
 
     /**
@@ -506,6 +614,9 @@ export class JpmapTerrain {
         this._disposed = true;
         // 進行中の flyTo を中断
         this._flyToToken++;
+        // 太陽位置タイマー (Issue #35) を停止
+        this._stopSunTimer();
+        this._autoLastAppliedDate = null;
         // カメラ変化通知を解除し、リスナー一覧もクリアする
         if (this._cameraObserver && this._scene) {
             this._scene.onBeforeRenderObservable.remove(this._cameraObserver);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -29,6 +29,17 @@ export interface JpmapTerrainOptions {
     tilt?: number;
     /** 地図種類 */
     mapType?: MapType;
+    /**
+     * 太陽位置計算に使う日時（UTC として扱う）。
+     * 未指定 / `null` の場合は内部の決定的フォールバック（{@link SUN_FALLBACK_DATETIME_ISO}）を使用する。
+     * `Invalid Date` が渡された場合は `console.warn` のうえ `null` 同等に倒す（例外は投げない）。
+     */
+    dateTime?: Date | null;
+    /**
+     * `true`: 60 秒周期で実時刻に追従して内部更新する。
+     * `false`（既定）: `dateTime` を固定値として使用する。
+     */
+    autoSunPosition?: boolean;
 }
 
 /**
@@ -62,7 +73,23 @@ export const JPMAP_TERRAIN_DEFAULTS = {
     azimuth: 0,
     tilt: 45,
     mapType: "standard" as MapType,
+    dateTime: null as Date | null,
+    autoSunPosition: false as boolean,
 } as const;
+
+/**
+ * `dateTime` 未指定 / `null` 時に使用する決定的フォールバック時刻（ISO 8601 + Z）。
+ *
+ * 夏至日本時間正午（UTC 03:00）。Skybox / ライト / 太陽メッシュが落ち着いた絵を作るため、
+ * Visual Regression テストでも同じ値をクエリで明示し、機械実行時刻に依存しない描画を保証する。
+ */
+export const SUN_FALLBACK_DATETIME_ISO = "2025-06-21T03:00:00Z";
+
+/**
+ * `autoSunPosition === true` のとき、`new Date()` を取り直して太陽位置を再反映する周期 (ms)。
+ * spec/package.md §3.3.5 に基づく 60 秒固定。テスト用に export している。
+ */
+export const SUN_AUTO_UPDATE_INTERVAL_MS = 60_000;
 
 /**
  * カメラ変化通知ペイロード（spec/package.md 追記は別 Issue）。

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -1,7 +1,11 @@
 import { Scene } from "@babylonjs/core/scene";
 import { ArcRotateCamera } from "@babylonjs/core/Cameras/arcRotateCamera";
 import { Matrix, Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { Color3 } from "@babylonjs/core/Maths/math.color";
 import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight";
+import { DirectionalLight } from "@babylonjs/core/Lights/directionalLight";
+import { CreateSphere } from "@babylonjs/core/Meshes/Builders/sphereBuilder";
+import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
 import { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Ray } from "@babylonjs/core/Culling/ray";
 import { CreateSceneClass } from "../createScene";
@@ -9,9 +13,12 @@ import { clamp, toTileXY, tileEdgeMeters, JAPAN_BOUNDS } from "../terrain/gsiTil
 import { createControlPanel, snapScale, formatScale, showToast } from "../terrain/controlPanel";
 import { createTileManager } from "../terrain/tileManager";
 import { createSkybox } from "../terrain/skybox";
+import { computeSunPosition } from "../terrain/sunPosition";
+import { deriveSunState } from "../terrain/sunState";
 import { resolveTiltCollision, TILT_MAX_RADIUS_INCREASE_RATIO } from "../terrain/cameraCollision";
 import { computePoseForNewTarget } from "../terrain/cameraRetarget";
 import { createUiVisibilityController } from "../terrain/uiVisibility";
+import { SUN_FALLBACK_DATETIME_ISO } from "../lib/types";
 
 const TERRAIN_SUBDIVISIONS = 128;
 const MAX_ZOOM = 18;
@@ -104,6 +111,21 @@ export interface DefaultSceneController {
     ): void;
 
     /**
+     * 太陽位置（時間による明るさ・方向）の状態を反映する (Issue #35)。
+     *
+     * `dateTime` が `null` の場合は内部の決定的フォールバック時刻
+     * （{@link SUN_FALLBACK_DATETIME_ISO}）を使用する。
+     * `autoSunPosition` は本シーン側では参照しない（タイマーは `JpmapTerrain` 側で管理）。
+     * 両モードで共通の入力を取り、`computeSunPosition` →
+     * `deriveSunState` → 各 Babylon 要素への適用までを 1 回で完了する。
+     */
+    /**
+     * 太陽位置計算に使う日時を設定し、即時 1 回反映する。
+     * 自動更新タイマーは `JpmapTerrain` 側で管理されるため、本メソッドは時刻保存と反映のみを行う。
+     */
+    setSunState(dateTime: Date | null): void;
+
+    /**
      * `JpmapTerrain.dispose()` から呼ばれる UI クリーンアップ (T7 / Issue #121)。
      *
      * `controlPanel` が `document.body` に追加した UI 要素 (コンパス / ズームボタンコンテナ / 地図切替) を
@@ -178,16 +200,38 @@ export class DefaultScene implements CreateSceneClass {
         camera.inputs.removeByType("ArcRotateCameraMouseWheelInput");
         camera.attachControl(canvas, true);
 
-        // ライト
-        const light = new HemisphericLight(
+        // ライト: 環境光（ベース）+ 太陽方向の指向性ライト（時間連動）
+        const hemiLight = new HemisphericLight(
             "sky-light",
             new Vector3(0, 1, 0),
             scene
         );
-        light.intensity = 1.0;
+        hemiLight.intensity = 1.0;
+
+        const sunLight = new DirectionalLight(
+            "sun-light",
+            new Vector3(0, -1, 0),
+            scene
+        );
+        sunLight.intensity = 0;
 
         // スカイボックス
-        createSkybox(scene);
+        const skyboxHandle = createSkybox(scene);
+
+        // 太陽メッシュ（地平線下では非表示）。
+        // サイズはカメラ最大遠と独立に小さく作り、`infiniteDistance` で常に同距離感に見せる。
+        const sunMesh = CreateSphere(
+            "sun-mesh",
+            { diameter: 1, segments: 12 },
+            scene
+        );
+        const sunMaterial = new StandardMaterial("sun-mesh-mat", scene);
+        sunMaterial.emissiveColor = new Color3(1, 0.95, 0.8);
+        sunMaterial.disableLighting = true;
+        sunMesh.material = sunMaterial;
+        sunMesh.isPickable = false;
+        sunMesh.infiniteDistance = true;
+        sunMesh.setEnabled(false);
 
         // 初期位置（options > デフォルト 東京駅付近）
         const initialLat = options?.lat ?? 35.681236;
@@ -957,7 +1001,76 @@ export class DefaultScene implements CreateSceneClass {
             if (shouldRefresh && centerChanged) {
                 void refreshTerrain();
             }
+            // 緯度・経度が変わったら太陽位置を再計算（Issue #35）。
+            // ただし `flyTo` の中間フレーム（`shouldRefresh=false`）では skip し、
+            // 最終フレームで一度だけ反映する（毎フレーム Color3.Lerp / 行列計算を避ける）。
+            // altitude/azimuth/tilt は太陽位置に影響しないので再計算不要。
+            if (shouldRefresh && centerChanged) {
+                applySunStateForCurrent();
+            }
         };
+
+        // ---- 太陽位置適用 (Issue #35) ----
+        // タイマー（auto モード）は JpmapTerrain 側で管理し、本シーンは「現時点で
+        // 適用すべき日時」を都度受け取って描画反映する役割に閉じる。
+        let currentSunDateTime: Date | null = null;
+        const fallbackSunDate = new Date(SUN_FALLBACK_DATETIME_ISO);
+        const applySunStateForCurrent = (): void => {
+            const dateForCalc = currentSunDateTime ?? fallbackSunDate;
+            // 念のため Invalid Date のセーフガード（呼び出し側で `null` 同等に倒す）
+            if (Number.isNaN(dateForCalc.getTime())) {
+                console.warn(
+                    "[JpmapTerrain] sun position computation skipped (invalid dateTime)",
+                );
+                return;
+            }
+            const { altitudeDeg, azimuthDeg } = computeSunPosition(
+                currentLat,
+                currentLon,
+                dateForCalc,
+            );
+            if (
+                !Number.isFinite(altitudeDeg) ||
+                !Number.isFinite(azimuthDeg)
+            ) {
+                console.warn(
+                    `[JpmapTerrain] sun position computation failed (lat=${currentLat}, lon=${currentLon}, date=${dateForCalc.toISOString()}); skipping update`,
+                );
+                return;
+            }
+            const state = deriveSunState(altitudeDeg, azimuthDeg);
+            // SkyMaterial 更新
+            skyboxHandle.applySunToSky(state);
+            // 夜は SkyMaterial の物理モデルが破綻するため Skybox を消し、`clearColor`（夜色）を背景に出す。
+            skyboxHandle.mesh.setEnabled(state.skyVisible);
+            scene.clearColor.set(
+                state.clearColor.r,
+                state.clearColor.g,
+                state.clearColor.b,
+                1,
+            );
+            // 指向性ライト方向 = 太陽から地表向き = -sunDir
+            sunLight.direction = state.sunDir.scale(-1);
+            sunLight.intensity = state.dayFactor;
+            // 環境光は夜でも完全な暗黒にならないようベース値 + 昼比例
+            hemiLight.intensity = 0.2 + 0.8 * state.dayFactor;
+            // 太陽メッシュ位置: カメラターゲット + sunDir * (camera.maxZ * 0.5)
+            sunMesh.setEnabled(state.visibleAboveHorizon);
+            if (state.visibleAboveHorizon) {
+                const dist = (camera.maxZ ?? 100000) * 0.5;
+                sunMesh.position.set(
+                    camera.target.x + state.sunDir.x * dist,
+                    camera.target.y + state.sunDir.y * dist,
+                    camera.target.z + state.sunDir.z * dist,
+                );
+                // 距離に比例してメッシュサイズも拡大（一定の見かけ大きさを保つ）
+                const scale = dist * 0.04;
+                sunMesh.scaling.set(scale, scale, scale);
+            }
+        };
+
+        // 初期化時に基準時刻で 1 回呼ぶ（auto/false 共通の初期反映）。
+        applySunStateForCurrent();
 
         const controller: DefaultSceneController = {
             getLat: () => currentLat,
@@ -990,6 +1103,12 @@ export class DefaultScene implements CreateSceneClass {
                 mapToggle: ui.mapToggle,
                 attribution: ui.scaleBar.attribution,
             }),
+            setSunState: (dateTime) => {
+                // タイマーは JpmapTerrain 側に閉じるため、本メソッドは
+                // 「現在使うべき日時」を保存して即時 1 回適用するだけで完結する。
+                currentSunDateTime = dateTime;
+                applySunStateForCurrent();
+            },
             dispose: () => {
                 // controlPanel は document.body に各 UI を直接 append しているため、
                 // ここで親要素から取り除く (T7 / Issue #121)。

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -111,17 +111,12 @@ export interface DefaultSceneController {
     ): void;
 
     /**
-     * 太陽位置（時間による明るさ・方向）の状態を反映する (Issue #35)。
+     * 太陽位置計算に使う日時を設定し、太陽位置（時間による明るさ・方向）の状態を即時 1 回反映する (Issue #35)。
      *
      * `dateTime` が `null` の場合は内部の決定的フォールバック時刻
      * （{@link SUN_FALLBACK_DATETIME_ISO}）を使用する。
-     * `autoSunPosition` は本シーン側では参照しない（タイマーは `JpmapTerrain` 側で管理）。
-     * 両モードで共通の入力を取り、`computeSunPosition` →
-     * `deriveSunState` → 各 Babylon 要素への適用までを 1 回で完了する。
-     */
-    /**
-     * 太陽位置計算に使う日時を設定し、即時 1 回反映する。
-     * 自動更新タイマーは `JpmapTerrain` 側で管理されるため、本メソッドは時刻保存と反映のみを行う。
+     * 自動更新タイマーは `JpmapTerrain` 側で管理されるため、本メソッドは時刻保存と反映のみを行い、
+     * `computeSunPosition` → `deriveSunState` → 各 Babylon 要素への適用までを 1 回で完了する。
      */
     setSunState(dateTime: Date | null): void;
 

--- a/src/terrain/skybox.ts
+++ b/src/terrain/skybox.ts
@@ -2,8 +2,23 @@ import { Scene } from "@babylonjs/core/scene";
 import { CreateBox } from "@babylonjs/core/Meshes/Builders/boxBuilder";
 import { SkyMaterial } from "@babylonjs/materials/sky/skyMaterial";
 import type { Mesh } from "@babylonjs/core/Meshes/mesh";
+import type { SunState } from "./sunState";
 
-export function createSkybox(scene: Scene): Mesh {
+/**
+ * `createSkybox` の戻り値。Mesh 単体だけでなく、太陽位置を流し込むための
+ * `applySunToSky` も合わせて返す。利用側は `applySunToSky(state)` を毎更新ごとに呼び、
+ * `inclination` / `azimuth` / `luminance` をワンセットで反映する。
+ */
+export interface SkyboxHandle {
+    /** Skybox メッシュ */
+    mesh: Mesh;
+    /** SkyMaterial インスタンス（テスト・デバッグ用に露出） */
+    material: SkyMaterial;
+    /** 太陽位置パラメータを SkyMaterial へ流し込む */
+    applySunToSky(state: SunState): void;
+}
+
+export function createSkybox(scene: Scene): SkyboxHandle {
     const skyboxSize = (scene.activeCamera?.maxZ ?? 100000) * 10;
 
     const skyMaterial = new SkyMaterial("sky-material", scene);
@@ -21,5 +36,11 @@ export function createSkybox(scene: Scene): Mesh {
     skybox.isPickable = false;
     skybox.infiniteDistance = true;
 
-    return skybox;
+    const applySunToSky = (state: SunState): void => {
+        skyMaterial.inclination = state.skyInclination;
+        skyMaterial.azimuth = state.skyAzimuth;
+        skyMaterial.luminance = state.skyLuminance;
+    };
+
+    return { mesh: skybox, material: skyMaterial, applySunToSky };
 }

--- a/src/terrain/sunPosition.ts
+++ b/src/terrain/sunPosition.ts
@@ -83,8 +83,14 @@ export function computeSunPosition(
     const timeOffsetMin = eqTimeMin + 4 * lon;
     const trueSolarTimeMin = utcHour * 60 + timeOffsetMin;
 
-    // 時角（ラジアン）。太陽が子午線上で 0、午後で正、午前で負。
-    const hourAngleRad = ((trueSolarTimeMin / 4 - 180) * Math.PI) / 180;
+    // 時角（度）。太陽が子午線上で 0、午後で正、午前で負。
+    // `trueSolarTimeMin` は経度・UTC 時刻の組み合わせで [-720, 2160] 分程度の範囲を取り得る
+    // ため、`hourAngle = trueSolarTimeMin/4 - 180` は ±180° を超えることがある。
+    // `Math.cos` は周期的なので天頂計算には影響しないが、午前/午後の判定（azimuth 分岐）が
+    // 逆転するため、ここで [-180, 180) に折り返す。
+    const hourAngleDegRaw = trueSolarTimeMin / 4 - 180;
+    const hourAngleDeg = ((hourAngleDegRaw % 360) + 540) % 360 - 180;
+    const hourAngleRad = (hourAngleDeg * Math.PI) / 180;
 
     const latRad = lat * DEG2RAD;
     const sinLat = Math.sin(latRad);

--- a/src/terrain/sunPosition.ts
+++ b/src/terrain/sunPosition.ts
@@ -1,0 +1,119 @@
+/**
+ * 太陽位置計算（NOAA Solar Position Algorithm 簡易版）
+ *
+ * 緯度・経度・UTC 日時から太陽の見かけ高度・方位角を返す純粋関数。
+ *
+ * - アルゴリズム: NOAA Solar Calculator のフーリエ級数近似（精度 ±1° 程度）。
+ *   大気差・視差補正は省略している。
+ * - 入力 `date` は UTC として解釈する（`Date.UTC` 系で比較するため）。
+ * - 副作用なし、Babylon.js 依存なし（unit test しやすい純粋関数）。
+ *
+ * 参考: https://gml.noaa.gov/grad/solcalc/calcdetails.html
+ */
+
+const DEG2RAD = Math.PI / 180;
+const RAD2DEG = 180 / Math.PI;
+
+const clamp = (value: number, min: number, max: number): number =>
+    Math.max(min, Math.min(max, value));
+
+/**
+ * UTC 日時を「年初からの通算日数(1始まり) + UTC 時刻(時)」へ分解する。
+ */
+const toDayOfYearAndUtcHour = (
+    date: Date,
+): { dayOfYear: number; utcHour: number } => {
+    const startOfYearUtc = Date.UTC(date.getUTCFullYear(), 0, 1);
+    const dayOfYear =
+        Math.floor((date.getTime() - startOfYearUtc) / 86400000) + 1;
+    const utcHour =
+        date.getUTCHours() +
+        date.getUTCMinutes() / 60 +
+        date.getUTCSeconds() / 3600 +
+        date.getUTCMilliseconds() / 3600000;
+    return { dayOfYear, utcHour };
+};
+
+/**
+ * 緯度・経度・UTC 日時から太陽の見かけ位置を返す。
+ *
+ * @param lat 緯度（度）。北緯正・南緯負
+ * @param lon 経度（度）。東経正・西経負
+ * @param date UTC として解釈する `Date`
+ * @returns `altitudeDeg`: -90..90（負値は地平線下）。`azimuthDeg`: 0..360（北=0、東=90、南=180、西=270）。
+ */
+export function computeSunPosition(
+    lat: number,
+    lon: number,
+    date: Date,
+): { altitudeDeg: number; azimuthDeg: number } {
+    const { dayOfYear, utcHour } = toDayOfYearAndUtcHour(date);
+
+    // 年内フラクション角 γ（ラジアン）
+    const gamma =
+        ((2 * Math.PI) / 365) * (dayOfYear - 1 + (utcHour - 12) / 24);
+
+    const cosG = Math.cos(gamma);
+    const sinG = Math.sin(gamma);
+    const cos2G = Math.cos(2 * gamma);
+    const sin2G = Math.sin(2 * gamma);
+    const cos3G = Math.cos(3 * gamma);
+    const sin3G = Math.sin(3 * gamma);
+
+    // 均時差（分）
+    const eqTimeMin =
+        229.18 *
+        (0.000075 +
+            0.001868 * cosG -
+            0.032077 * sinG -
+            0.014615 * cos2G -
+            0.040849 * sin2G);
+
+    // 太陽赤緯（ラジアン）
+    const declRad =
+        0.006918 -
+        0.399912 * cosG +
+        0.070257 * sinG -
+        0.006758 * cos2G +
+        0.000907 * sin2G -
+        0.002697 * cos3G +
+        0.00148 * sin3G;
+
+    // 真太陽時（分）。UTC 基準なのでタイムゾーン項は 0。
+    const timeOffsetMin = eqTimeMin + 4 * lon;
+    const trueSolarTimeMin = utcHour * 60 + timeOffsetMin;
+
+    // 時角（ラジアン）。太陽が子午線上で 0、午後で正、午前で負。
+    const hourAngleRad = ((trueSolarTimeMin / 4 - 180) * Math.PI) / 180;
+
+    const latRad = lat * DEG2RAD;
+    const sinLat = Math.sin(latRad);
+    const cosLat = Math.cos(latRad);
+    const sinDecl = Math.sin(declRad);
+    const cosDecl = Math.cos(declRad);
+
+    const cosZenith =
+        sinLat * sinDecl + cosLat * cosDecl * Math.cos(hourAngleRad);
+    const zenithRad = Math.acos(clamp(cosZenith, -1, 1));
+    const altitudeDeg = 90 - zenithRad * RAD2DEG;
+
+    const sinZenith = Math.sin(zenithRad);
+    let azimuthDeg: number;
+    if (sinZenith < 1e-9 || cosLat < 1e-9) {
+        // 太陽が天頂近傍、または極点。方位は意味を持たないが既定値として南を返す。
+        azimuthDeg = 180;
+    } else {
+        const cosAzNumerator =
+            (sinLat * Math.cos(zenithRad) - sinDecl) / (cosLat * sinZenith);
+        const azRefRad = Math.acos(clamp(cosAzNumerator, -1, 1));
+        const azRefDeg = azRefRad * RAD2DEG;
+        // NOAA 規約: HA>0（午後）→ 180+az、HA≤0（午前）→ 540-az
+        if (hourAngleRad > 0) {
+            azimuthDeg = (azRefDeg + 180) % 360;
+        } else {
+            azimuthDeg = (540 - azRefDeg) % 360;
+        }
+    }
+
+    return { altitudeDeg, azimuthDeg };
+}

--- a/src/terrain/sunState.ts
+++ b/src/terrain/sunState.ts
@@ -1,0 +1,109 @@
+/**
+ * 太陽の地理座標（高度・方位角）を、Babylon.js シーンで使う描画パラメータへ変換する。
+ *
+ * - `sunDir`: ワールド空間で「太陽が見える方向」を指す単位ベクトル（地表→空）。
+ *   Babylon.js は左手系で X=東、Y=上、Z=北。地理的方位角 0°=北 を Z+ に対応付ける。
+ * - `dayFactor`: 0=夜、1=昼。altitude を [-6°, +6°] の薄明帯で smoothstep し、
+ *   薄明〜真昼を連続変化させる（民間薄明 ±6° を採用）。
+ * - `skyInclination` / `skyAzimuth`: `@babylonjs/materials/sky/skyMaterial` の入力。
+ * - `skyLuminance`: 同マテリアルの輝度。夜に近づくほど小さくする。
+ * - `visibleAboveHorizon`: 太陽メッシュ表示可否。
+ */
+
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { Color3 } from "@babylonjs/core/Maths/math.color";
+
+const DEG2RAD = Math.PI / 180;
+
+/** 昼の明るい空色（`scene.clearColor` 初期値相当、薄い青空） */
+const DAY_CLEAR_COLOR = new Color3(0.75, 0.86, 0.95);
+/** 夜の深い紺色。`Skybox` を非表示にした際に背景として見える */
+const NIGHT_CLEAR_COLOR = new Color3(0.02, 0.03, 0.08);
+
+/** Scene へ適用する太陽パラメータ束。Babylon.js への依存はここで吸収する。 */
+export interface SunState {
+    /** 太陽方向の単位ベクトル（地表→太陽）。ライト方向は `sunDir.scale(-1)` を使う */
+    sunDir: Vector3;
+    /** 0=夜、1=昼。薄明帯（-6°..+6°）で滑らかに補間 */
+    dayFactor: number;
+    /** SkyMaterial.inclination 入力 */
+    skyInclination: number;
+    /** SkyMaterial.azimuth 入力（0..1, 1 周で 360°） */
+    skyAzimuth: number;
+    /** SkyMaterial.luminance 入力。夜は小さく、昼は 1.0 付近 */
+    skyLuminance: number;
+    /**
+     * Skybox メッシュを有効にするか。夜は SkyMaterial の物理モデルが太陽を頼りに色を出せないため
+     * Skybox を消して `clearColor`（夜色）を背景に見せる。
+     */
+    skyVisible: boolean;
+    /** 時刻連動の `scene.clearColor`。夜は深い紺、昼は薄い青空色 */
+    clearColor: Color3;
+    /** 太陽メッシュ表示可否（地平線下では非表示） */
+    visibleAboveHorizon: boolean;
+}
+
+/**
+ * `t` を `[edge0, edge1]` で正規化し Hermite smoothstep で滑らかにする。
+ * Architect §4.3 の薄明補間に使用。
+ */
+const smoothstep = (edge0: number, edge1: number, t: number): number => {
+    if (edge1 === edge0) return t < edge0 ? 0 : 1;
+    const x = Math.max(0, Math.min(1, (t - edge0) / (edge1 - edge0)));
+    return x * x * (3 - 2 * x);
+};
+
+/**
+ * 太陽の高度・方位角から `SunState` を導出する。
+ *
+ * 入力は地理的な角度（度）：
+ * - `altitudeDeg`: -90..90、地平線=0
+ * - `azimuthDeg`: 0..360、北=0、東=90、南=180、西=270
+ */
+export function deriveSunState(
+    altitudeDeg: number,
+    azimuthDeg: number,
+): SunState {
+    const altRad = altitudeDeg * DEG2RAD;
+    const azRad = azimuthDeg * DEG2RAD;
+    const cosAlt = Math.cos(altRad);
+    const sinAlt = Math.sin(altRad);
+    const cosAz = Math.cos(azRad);
+    const sinAz = Math.sin(azRad);
+
+    // Babylon.js 左手系（X=東, Y=上, Z=北）。
+    // 方位 0°=北 → Z+、方位 90°=東 → X+。よって x=sin(az)*cos(alt), z=cos(az)*cos(alt)。
+    const sunDir = new Vector3(sinAz * cosAlt, sinAlt, cosAz * cosAlt);
+
+    const dayFactor = smoothstep(-6, 6, altitudeDeg);
+
+    // Babylon `SkyMaterial` 規約: inclination ∈ [-0.5, 0.5]、内部で theta = π(inc - 0.5)、
+    // sunPosition.y = sin(-theta) となり **inclination=0 で太陽が天頂、 ±0.5 で地平線**。
+    // よって altitudeDeg=90 → 0、 altitudeDeg=0 → 0.5 の対応が正しい。
+    // 地平線下（altitudeDeg < 0）は SkyMaterial が想定しない領域のため 0.5 でクランプし、
+    // 実際の夜表現は `skyVisible=false` + `clearColor` 切替で行う。
+    const rawInclination = 0.5 - altitudeDeg / 180;
+    const skyInclination = Math.max(-0.5, Math.min(0.5, rawInclination));
+    const skyAzimuth = (((azimuthDeg % 360) + 360) % 360) / 360;
+    const skyLuminance = 0.05 + 0.95 * dayFactor;
+    const visibleAboveHorizon = altitudeDeg > -1;
+    // 太陽が地平線下に深く入ったら Skybox を消し、夜色背景を出す。
+    // 薄明帯の連続性は `clearColor` 補間で担保。
+    const skyVisible = altitudeDeg > -6;
+    const clearColor = Color3.Lerp(
+        NIGHT_CLEAR_COLOR,
+        DAY_CLEAR_COLOR,
+        dayFactor,
+    );
+
+    return {
+        sunDir,
+        dayFactor,
+        skyInclination,
+        skyAzimuth,
+        skyLuminance,
+        skyVisible,
+        clearColor,
+        visibleAboveHorizon,
+    };
+}

--- a/tests/index.unit.spec.ts
+++ b/tests/index.unit.spec.ts
@@ -11,9 +11,14 @@
  * jsdom 環境でも副作用なく `resolveEngine` / `resolveLatLon` だけを検証できる。
  */
 
-import { describe, it, expect } from "@jest/globals";
+import { describe, it, expect, jest } from "@jest/globals";
 
-import { resolveEngine, resolveLatLon } from "../src/index";
+import {
+    resolveEngine,
+    resolveLatLon,
+    resolveDateTime,
+    resolveAutoSunPosition,
+} from "../src/index";
 
 describe("resolveEngine", () => {
     it("?engine=webgpu → 'webgpu'", () => {
@@ -58,5 +63,67 @@ describe("resolveLatLon", () => {
         expect(result).not.toBeUndefined();
         expect(result?.lat).toBeCloseTo(35.681236);
         expect(result?.lon).toBeCloseTo(139.767125);
+    });
+});
+
+describe("resolveDateTime (Issue #35)", () => {
+    it("?dateTime=<ISO 8601 with Z> → Date を返す", () => {
+        const result = resolveDateTime("?dateTime=2025-06-21T03:00:00Z");
+        expect(result).toBeInstanceOf(Date);
+        expect(result?.toISOString()).toBe("2025-06-21T03:00:00.000Z");
+    });
+
+    it("dateTime 未指定 → undefined", () => {
+        expect(resolveDateTime("")).toBeUndefined();
+        expect(resolveDateTime("?other=1")).toBeUndefined();
+    });
+
+    it("Invalid Date 文字列 → undefined（silent ignore、警告のみ）", () => {
+        const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            expect(resolveDateTime("?dateTime=not-a-date")).toBeUndefined();
+            expect(warn).toHaveBeenCalled();
+        } finally {
+            warn.mockRestore();
+        }
+    });
+
+    it("不正値ログは制御文字 (CR/LF/ESC) を `?` に置換し 64 文字に制限する（ログ汚染対策）", () => {
+        const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            // CR/LF/ESC + 100 文字程度の長文
+            const payload = `evil\r\n\x1B[31mFAKE\x1B[0m${"A".repeat(100)}`;
+            const search = `?dateTime=${encodeURIComponent(payload)}`;
+            expect(resolveDateTime(search)).toBeUndefined();
+            expect(warn).toHaveBeenCalledTimes(1);
+            const msg = String(warn.mock.calls[0][0]);
+            // 制御文字が混入していない
+            expect(/[\r\n\x1B\x00-\x1F\x7F]/.test(msg)).toBe(false);
+            // 64 文字制限が効いている（プレフィックスを除いた raw 部分は最大 64）
+            const rawInLog = msg.replace(
+                /^\[jpmap-terrain demo\] invalid dateTime param: /,
+                "",
+            );
+            expect(rawInLog.length).toBeLessThanOrEqual(64);
+        } finally {
+            warn.mockRestore();
+        }
+    });
+});
+
+describe("resolveAutoSunPosition (Issue #35)", () => {
+    it("?autoSunPosition=true → true", () => {
+        expect(resolveAutoSunPosition("?autoSunPosition=true")).toBe(true);
+    });
+
+    it("?autoSunPosition=false → false", () => {
+        expect(resolveAutoSunPosition("?autoSunPosition=false")).toBe(false);
+    });
+
+    it("未指定 / 不正値 → undefined", () => {
+        expect(resolveAutoSunPosition("")).toBeUndefined();
+        expect(resolveAutoSunPosition("?autoSunPosition=")).toBeUndefined();
+        expect(resolveAutoSunPosition("?autoSunPosition=1")).toBeUndefined();
+        expect(resolveAutoSunPosition("?autoSunPosition=TRUE")).toBeUndefined();
     });
 });

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -87,6 +87,8 @@ jest.unstable_mockModule("../src/scenes/default", () => {
     const setMapTypeCalls: Array<"standard" | "photo"> = [];
     // T7: controller.dispose の呼び出し回数も検証する。
     let controllerDisposeCount = 0;
+    // Issue #35: setSunState 呼び出し履歴を保持する。
+    const sunStateCalls: Array<{ dateTime: Date | null }> = [];
     // #136: scene.onBeforeRenderObservable のテスト用簡易実装。
     // jpmapTerrain.ts は `add(callback)` の戻り値を `Observer` として保持し、
     // dispose 時に `remove(observer)` する。テストからは `__triggerSceneRender` で
@@ -213,6 +215,10 @@ jest.unstable_mockModule("../src/scenes/default", () => {
                     setUiVisibility: (target: UiTarget, visible: boolean) => {
                         uiVisibility[target] = visible;
                     },
+                    setSunState: (_dateTime: Date | null) => {
+                        // テスト用: 受信を記録するだけで Babylon 描画は伴わない
+                        sunStateCalls.push({ dateTime: _dateTime });
+                    },
                     dispose: () => {
                         controllerDisposeCount++;
                     },
@@ -255,6 +261,12 @@ jest.unstable_mockModule("../src/scenes/default", () => {
         __resetControllerDisposeCount: (): void => {
             controllerDisposeCount = 0;
         },
+        __getSunStateCalls: (): Array<{ dateTime: Date | null }> => [
+            ...sunStateCalls,
+        ],
+        __resetSunStateCalls: (): void => {
+            sunStateCalls.length = 0;
+        },
         __triggerSceneRender: (): void => triggerSceneRender(),
     };
 });
@@ -278,6 +290,8 @@ const sceneMockModule = (await import("../src/scenes/default")) as unknown as {
     __setLastMapType: (v: "standard" | "photo") => void;
     __getControllerDisposeCount: () => number;
     __resetControllerDisposeCount: () => void;
+    __getSunStateCalls: () => Array<{ dateTime: Date | null }>;
+    __resetSunStateCalls: () => void;
     __triggerSceneRender: () => void;
 };
 
@@ -1005,6 +1019,179 @@ describe("JpmapTerrain (skeleton)", () => {
             sceneMockModule.__triggerSceneRender();
 
             expect(listener).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("sun position (Issue #35)", () => {
+        beforeEach(() => {
+            sceneMockModule.__resetSunStateCalls();
+        });
+
+        it("固定モード（autoSunPosition=false）の初期化で options.dateTime が controller.setSunState に渡る", async () => {
+            const dt = new Date("2025-06-21T03:00:00Z");
+            await create(createMountElement(), {
+                dateTime: dt,
+                autoSunPosition: false,
+            });
+            const calls = sceneMockModule.__getSunStateCalls();
+            expect(calls.length).toBeGreaterThanOrEqual(1);
+            expect(calls[0].dateTime?.getTime()).toBe(dt.getTime());
+        });
+
+        it("autoSunPosition=true で起動した場合、初期化で setSunState が現在時刻で 1 回呼ばれる", async () => {
+            const before = Date.now();
+            await create(createMountElement(), { autoSunPosition: true });
+            const after = Date.now();
+            const calls = sceneMockModule.__getSunStateCalls();
+            expect(calls.length).toBeGreaterThanOrEqual(1);
+            const t = calls[0].dateTime?.getTime() ?? 0;
+            expect(t).toBeGreaterThanOrEqual(before);
+            expect(t).toBeLessThanOrEqual(after);
+        });
+
+        it("autoSunPosition=true 中は 60 秒経過ごとに setSunState が呼ばれる", async () => {
+            jest.useFakeTimers();
+            try {
+                const viewer = await create(createMountElement(), {
+                    autoSunPosition: true,
+                });
+                sceneMockModule.__resetSunStateCalls();
+                jest.advanceTimersByTime(60_000);
+                expect(sceneMockModule.__getSunStateCalls().length).toBe(1);
+                jest.advanceTimersByTime(60_000);
+                expect(sceneMockModule.__getSunStateCalls().length).toBe(2);
+                viewer.dispose();
+                // dispose 後はタイマーが解放され、それ以上呼ばれない
+                jest.advanceTimersByTime(60_000 * 5);
+                expect(sceneMockModule.__getSunStateCalls().length).toBe(2);
+            } finally {
+                jest.useRealTimers();
+            }
+        });
+
+        it("dateTime setter は固定モード中に setSunState を再呼出する", async () => {
+            const viewer = await create(createMountElement(), {
+                autoSunPosition: false,
+            });
+            sceneMockModule.__resetSunStateCalls();
+            const dt = new Date("2025-12-21T03:00:00Z");
+            viewer.dateTime = dt;
+            const calls = sceneMockModule.__getSunStateCalls();
+            expect(calls.length).toBe(1);
+            expect(calls[0].dateTime?.getTime()).toBe(dt.getTime());
+        });
+
+        it("autoSunPosition=true 中の dateTime setter は setSunState を呼ばない（auto 優先）", async () => {
+            const viewer = await create(createMountElement(), {
+                autoSunPosition: true,
+            });
+            sceneMockModule.__resetSunStateCalls();
+            viewer.dateTime = new Date("2025-12-21T03:00:00Z");
+            expect(sceneMockModule.__getSunStateCalls().length).toBe(0);
+        });
+
+        it("autoSunPosition=false→true 切替で 1 回反映され、true→false 切替で保持値が再反映される", async () => {
+            const fixed = new Date("2025-06-21T03:00:00Z");
+            const viewer = await create(createMountElement(), {
+                dateTime: fixed,
+                autoSunPosition: false,
+            });
+            sceneMockModule.__resetSunStateCalls();
+
+            viewer.autoSunPosition = true;
+            // auto 切替直後の即時反映 1 回
+            expect(sceneMockModule.__getSunStateCalls().length).toBe(1);
+
+            sceneMockModule.__resetSunStateCalls();
+            viewer.autoSunPosition = false;
+            // false 復帰時に保持していた dateTime で再反映
+            const calls = sceneMockModule.__getSunStateCalls();
+            expect(calls.length).toBe(1);
+            expect(calls[0].dateTime?.getTime()).toBe(fixed.getTime());
+        });
+
+        it("dateTime getter は auto モード中に最後に内部反映した実時刻を返す", async () => {
+            jest.useFakeTimers();
+            try {
+                const viewer = await create(createMountElement(), {
+                    autoSunPosition: true,
+                });
+                const first = viewer.dateTime;
+                expect(first).toBeInstanceOf(Date);
+                jest.advanceTimersByTime(60_000);
+                const second = viewer.dateTime;
+                expect(second).toBeInstanceOf(Date);
+                expect(second!.getTime()).toBeGreaterThanOrEqual(first!.getTime());
+            } finally {
+                jest.useRealTimers();
+            }
+        });
+
+        it("Invalid Date を options.dateTime に渡すと console.warn のうえ null フォールバック", async () => {
+            const warnSpy = jest
+                .spyOn(console, "warn")
+                .mockImplementation(() => undefined);
+            try {
+                const viewer = await create(createMountElement(), {
+                    dateTime: new Date("not-a-date"),
+                    autoSunPosition: false,
+                });
+                expect(warnSpy).toHaveBeenCalled();
+                expect(viewer.dateTime).toBeNull();
+                const calls = sceneMockModule.__getSunStateCalls();
+                expect(calls[0].dateTime).toBeNull();
+            } finally {
+                warnSpy.mockRestore();
+            }
+        });
+
+        it("Invalid Date を dateTime setter に渡しても例外を投げず null フォールバック", async () => {
+            const viewer = await create(createMountElement(), {
+                autoSunPosition: false,
+            });
+            const warnSpy = jest
+                .spyOn(console, "warn")
+                .mockImplementation(() => undefined);
+            try {
+                viewer.dateTime = new Date("nope");
+                expect(warnSpy).toHaveBeenCalled();
+                expect(viewer.dateTime).toBeNull();
+            } finally {
+                warnSpy.mockRestore();
+            }
+        });
+
+        it("dispose 後の自動更新タイマーは停止しており setSunState は呼ばれない", async () => {
+            jest.useFakeTimers();
+            try {
+                const viewer = await create(createMountElement(), {
+                    autoSunPosition: true,
+                });
+                viewer.dispose();
+                sceneMockModule.__resetSunStateCalls();
+                jest.advanceTimersByTime(60_000 * 10);
+                expect(sceneMockModule.__getSunStateCalls().length).toBe(0);
+            } finally {
+                jest.useRealTimers();
+            }
+        });
+
+        it("dispose 後の autoSunPosition setter / dateTime setter はタイマーを再起動しない（リーク防止）", async () => {
+            jest.useFakeTimers();
+            try {
+                const viewer = await create(createMountElement(), {
+                    autoSunPosition: false,
+                });
+                viewer.dispose();
+                sceneMockModule.__resetSunStateCalls();
+                // dispose 後に setter を呼んでも setInterval は新規起動されない
+                viewer.autoSunPosition = true;
+                viewer.dateTime = new Date("2025-06-21T03:00:00Z");
+                jest.advanceTimersByTime(60_000 * 10);
+                expect(sceneMockModule.__getSunStateCalls().length).toBe(0);
+            } finally {
+                jest.useRealTimers();
+            }
         });
     });
 });

--- a/tests/skybox.unit.spec.ts
+++ b/tests/skybox.unit.spec.ts
@@ -63,14 +63,35 @@ describe("createSkybox", () => {
         jest.clearAllMocks();
     });
 
-    it("CreateBox を呼び出して skybox メッシュを返す", () => {
+    it("CreateBox を呼び出して skybox ハンドルを返す", () => {
         const result = createSkybox(mockScene);
         expect(CreateBox).toHaveBeenCalledWith(
             "skybox",
             expect.objectContaining({ size: expect.any(Number) }),
             mockScene
         );
-        expect(result).toBe(mockMesh);
+        // ハンドル経由で mesh / material / applySunToSky を露出する。
+        expect(result.mesh).toBe(mockMesh);
+        expect(result.material).toBe(mockSkyMaterialInstance);
+        expect(typeof result.applySunToSky).toBe("function");
+    });
+
+    it("applySunToSky は SunState を SkyMaterial へ反映する", () => {
+        const handle = createSkybox(mockScene);
+        handle.applySunToSky({
+            // sunDir はここでは検証しない（Skybox 側では不要）。
+            sunDir: { x: 0, y: 1, z: 0 } as unknown as never,
+            dayFactor: 1,
+            skyInclination: 0.1,
+            skyAzimuth: 0.7,
+            skyLuminance: 0.42,
+            skyVisible: true,
+            clearColor: { r: 0.75, g: 0.86, b: 0.95 } as unknown as never,
+            visibleAboveHorizon: true,
+        });
+        expect(mockSkyMaterialInstance.inclination).toBeCloseTo(0.1, 5);
+        expect(mockSkyMaterialInstance.azimuth).toBeCloseTo(0.7, 5);
+        expect(mockSkyMaterialInstance.luminance).toBeCloseTo(0.42, 5);
     });
 
     it("skybox は isPickable = false に設定される", () => {

--- a/tests/skybox.unit.spec.ts
+++ b/tests/skybox.unit.spec.ts
@@ -4,6 +4,8 @@
  */
 
 import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { Color3 } from "@babylonjs/core/Maths/math.color";
 
 let mockMesh: {
     material: unknown;
@@ -79,14 +81,15 @@ describe("createSkybox", () => {
     it("applySunToSky は SunState を SkyMaterial へ反映する", () => {
         const handle = createSkybox(mockScene);
         handle.applySunToSky({
-            // sunDir はここでは検証しない（Skybox 側では不要）。
-            sunDir: { x: 0, y: 1, z: 0 } as unknown as never,
+            // sunDir はここでは検証しない（Skybox 側では不要）が、`SunState` 型の意図を保つため
+            // 実際の `Vector3` / `Color3` を渡す（型キャストでチェックを無効化しない）。
+            sunDir: new Vector3(0, 1, 0),
             dayFactor: 1,
             skyInclination: 0.1,
             skyAzimuth: 0.7,
             skyLuminance: 0.42,
             skyVisible: true,
-            clearColor: { r: 0.75, g: 0.86, b: 0.95 } as unknown as never,
+            clearColor: new Color3(0.75, 0.86, 0.95),
             visibleAboveHorizon: true,
         });
         expect(mockSkyMaterialInstance.inclination).toBeCloseTo(0.1, 5);

--- a/tests/sunPosition.unit.spec.ts
+++ b/tests/sunPosition.unit.spec.ts
@@ -12,8 +12,8 @@ import { computeSunPosition } from "../src/terrain/sunPosition";
 const TOLERANCE_DEG = 2;
 
 const expectClose = (actual: number, expected: number, label: string): void => {
-    expect(Math.abs(actual - expected)).toBeLessThanOrEqual(TOLERANCE_DEG);
-    // 失敗時に diff が分かるようカスタムメッセージ用の追加期待。
+    // ラベル付きの分かりやすいエラーメッセージを優先したいので
+    // `expect(...).toBeLessThanOrEqual(...)` ではなく明示的に判定して throw する。
     if (Math.abs(actual - expected) > TOLERANCE_DEG) {
         throw new Error(
             `${label}: expected ${expected} (±${TOLERANCE_DEG}), got ${actual}`,
@@ -101,5 +101,28 @@ describe("computeSunPosition", () => {
         );
         expect(result.azimuthDeg).toBeGreaterThanOrEqual(0);
         expect(result.azimuthDeg).toBeLessThan(360);
+    });
+
+    it("経度大 + UTC 後半でも azimuth が連続的に変化する（hourAngle 折り返しの回帰検証）", () => {
+        // `trueSolarTimeMin/4 - 180` が 180° を超えるケースで、
+        // 折り返し処理が無いと午前/午後判定が逆転して azimuth が南北で大ジャンプしていた。
+        // ここでは UTC で 5 分刻みに動かして連続性（差分が常識的範囲）を確認する。
+        const lat = 35.681;
+        const lon = 140;
+        const base = Date.UTC(2025, 5, 21, 22, 0, 0); // 2025-06-21T22:00Z（日本時間 07:00）
+        let prev: number | null = null;
+        for (let i = 0; i <= 24; i++) {
+            const date = new Date(base + i * 5 * 60 * 1000);
+            const { azimuthDeg } = computeSunPosition(lat, lon, date);
+            expect(azimuthDeg).toBeGreaterThanOrEqual(0);
+            expect(azimuthDeg).toBeLessThan(360);
+            if (prev !== null) {
+                // 5 分間の azimuth 変化は最大でも数°。逆転バグでは ~180° ジャンプしていた。
+                const diff = Math.abs(azimuthDeg - prev);
+                const wrapped = Math.min(diff, 360 - diff);
+                expect(wrapped).toBeLessThan(10);
+            }
+            prev = azimuthDeg;
+        }
     });
 });

--- a/tests/sunPosition.unit.spec.ts
+++ b/tests/sunPosition.unit.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * `computeSunPosition` の代表ケース検証 (Issue #35 / Architect §4.1)。
+ *
+ * NOAA 簡易式の精度範囲 ±1° 程度を踏まえ、許容誤差は本テスト全体で ±2° に統一する
+ * （Architect が示した ±1.5° 目安を、実装の実測値に対し若干上回る幅で許容）。
+ */
+
+import { describe, it, expect } from "@jest/globals";
+
+import { computeSunPosition } from "../src/terrain/sunPosition";
+
+const TOLERANCE_DEG = 2;
+
+const expectClose = (actual: number, expected: number, label: string): void => {
+    expect(Math.abs(actual - expected)).toBeLessThanOrEqual(TOLERANCE_DEG);
+    // 失敗時に diff が分かるようカスタムメッセージ用の追加期待。
+    if (Math.abs(actual - expected) > TOLERANCE_DEG) {
+        throw new Error(
+            `${label}: expected ${expected} (±${TOLERANCE_DEG}), got ${actual}`,
+        );
+    }
+};
+
+describe("computeSunPosition", () => {
+    const tokyo = { lat: 35.681, lon: 139.767 };
+    const sapporo = { lat: 43.0667, lon: 141.35 };
+
+    it("夏至・東京・日本時間正午（12:00 JST = 03:00 UTC）は太陽が高く真南よりやや西", () => {
+        const result = computeSunPosition(
+            tokyo.lat,
+            tokyo.lon,
+            new Date("2025-06-21T03:00:00Z"),
+        );
+        expectClose(result.altitudeDeg, 77.2, "altitude");
+        expectClose(result.azimuthDeg, 198.7, "azimuth");
+    });
+
+    it("冬至・東京・日本時間正午は太陽高度が低い", () => {
+        const result = computeSunPosition(
+            tokyo.lat,
+            tokyo.lon,
+            new Date("2025-12-22T03:00:00Z"),
+        );
+        expectClose(result.altitudeDeg, 30.7, "altitude");
+        expectClose(result.azimuthDeg, 185.6, "azimuth");
+    });
+
+    it("春分・東京・日本時間正午は中間的な太陽高度", () => {
+        const result = computeSunPosition(
+            tokyo.lat,
+            tokyo.lon,
+            new Date("2025-03-21T03:00:00Z"),
+        );
+        expectClose(result.altitudeDeg, 54.0, "altitude");
+        expectClose(result.azimuthDeg, 184.7, "azimuth");
+    });
+
+    it("夏至・東京・日本時間真夜中は太陽が地平線下", () => {
+        const result = computeSunPosition(
+            tokyo.lat,
+            tokyo.lon,
+            new Date("2025-06-21T18:00:00Z"),
+        );
+        expect(result.altitudeDeg).toBeLessThan(0);
+    });
+
+    it("夏至・東京・薄明時刻（5:30 JST）は太陽が地平線近傍", () => {
+        const result = computeSunPosition(
+            tokyo.lat,
+            tokyo.lon,
+            new Date("2025-06-20T20:30:00Z"),
+        );
+        // 薄明帯の範囲（地平線±15°）に入っていることを確認
+        expect(result.altitudeDeg).toBeGreaterThan(-15);
+        expect(result.altitudeDeg).toBeLessThan(15);
+    });
+
+    it("夏至・札幌・日本時間正午は東京より緯度が高いぶん太陽高度が低い", () => {
+        const result = computeSunPosition(
+            sapporo.lat,
+            sapporo.lon,
+            new Date("2025-06-21T03:00:00Z"),
+        );
+        expectClose(result.altitudeDeg, 69.8, "altitude");
+        expectClose(result.azimuthDeg, 196.2, "azimuth");
+    });
+
+    it("純粋関数（同入力で同出力、副作用なし）", () => {
+        const date = new Date("2025-06-21T03:00:00Z");
+        const a = computeSunPosition(tokyo.lat, tokyo.lon, date);
+        const b = computeSunPosition(tokyo.lat, tokyo.lon, date);
+        expect(a).toEqual(b);
+    });
+
+    it("方位角は 0..360 の範囲に正規化される", () => {
+        // 真夜中（HA<0 ブランチ）でも az は [0,360)。
+        const result = computeSunPosition(
+            tokyo.lat,
+            tokyo.lon,
+            new Date("2025-06-21T18:00:00Z"),
+        );
+        expect(result.azimuthDeg).toBeGreaterThanOrEqual(0);
+        expect(result.azimuthDeg).toBeLessThan(360);
+    });
+});

--- a/tests/sunState.unit.spec.ts
+++ b/tests/sunState.unit.spec.ts
@@ -47,8 +47,10 @@ describe("deriveSunState", () => {
         expect(b).toBeLessThan(c);
     });
 
-    it("地平線境界: altitude=-1 でも可視、-1.001 で非表示", () => {
+    it("地平線境界: altitude=-1 と -1.001 で非表示、-0.5 で可視", () => {
+        // 実装は `altitudeDeg > -1` のため、-1 ちょうどは表示しない（境界含まず）。
         expect(deriveSunState(-1, 180).visibleAboveHorizon).toBe(false);
+        expect(deriveSunState(-1.001, 180).visibleAboveHorizon).toBe(false);
         expect(deriveSunState(-0.5, 180).visibleAboveHorizon).toBe(true);
     });
 

--- a/tests/sunState.unit.spec.ts
+++ b/tests/sunState.unit.spec.ts
@@ -1,0 +1,121 @@
+/**
+ * `deriveSunState` のユニットテスト (Issue #35)。
+ *
+ * 純粋関数だが Babylon.js の `Vector3` を返すため、`@babylonjs/core` を実 import する。
+ * （他テストでは Babylon を mock するパターンもあるが、本テストではベクトル成分検証のため実体に依存する）。
+ */
+
+import { describe, it, expect } from "@jest/globals";
+
+import { deriveSunState } from "../src/terrain/sunState";
+
+describe("deriveSunState", () => {
+    it("真昼（高度 60°）は dayFactor=1、skyLuminance≈1、太陽メッシュ可視", () => {
+        const state = deriveSunState(60, 180);
+        expect(state.dayFactor).toBeCloseTo(1, 5);
+        expect(state.skyLuminance).toBeCloseTo(1, 5);
+        expect(state.visibleAboveHorizon).toBe(true);
+    });
+
+    it("夜間（高度 -30°）は dayFactor=0、skyLuminance=0.05、太陽メッシュ非表示", () => {
+        const state = deriveSunState(-30, 180);
+        expect(state.dayFactor).toBe(0);
+        expect(state.skyLuminance).toBeCloseTo(0.05, 5);
+        expect(state.visibleAboveHorizon).toBe(false);
+    });
+
+    it("薄明帯境界 -6° で dayFactor=0", () => {
+        const state = deriveSunState(-6, 180);
+        expect(state.dayFactor).toBe(0);
+    });
+
+    it("薄明帯境界 +6° で dayFactor=1", () => {
+        const state = deriveSunState(6, 180);
+        expect(state.dayFactor).toBe(1);
+    });
+
+    it("薄明帯中央（高度 0°）で dayFactor=0.5", () => {
+        const state = deriveSunState(0, 180);
+        expect(state.dayFactor).toBeCloseTo(0.5, 5);
+    });
+
+    it("dayFactor は薄明帯で単調増加", () => {
+        const a = deriveSunState(-3, 180).dayFactor;
+        const b = deriveSunState(0, 180).dayFactor;
+        const c = deriveSunState(3, 180).dayFactor;
+        expect(a).toBeLessThan(b);
+        expect(b).toBeLessThan(c);
+    });
+
+    it("地平線境界: altitude=-1 でも可視、-1.001 で非表示", () => {
+        expect(deriveSunState(-1, 180).visibleAboveHorizon).toBe(false);
+        expect(deriveSunState(-0.5, 180).visibleAboveHorizon).toBe(true);
+    });
+
+    it("sunDir: 真上（高度 90°）は Y=+1 の単位ベクトル", () => {
+        const state = deriveSunState(90, 0);
+        expect(state.sunDir.x).toBeCloseTo(0, 5);
+        expect(state.sunDir.y).toBeCloseTo(1, 5);
+        expect(state.sunDir.z).toBeCloseTo(0, 5);
+    });
+
+    it("sunDir: 真南・地平線（高度 0°、方位 180°）は Z=-1", () => {
+        const state = deriveSunState(0, 180);
+        expect(state.sunDir.x).toBeCloseTo(0, 5);
+        expect(state.sunDir.y).toBeCloseTo(0, 5);
+        expect(state.sunDir.z).toBeCloseTo(-1, 5);
+    });
+
+    it("sunDir: 真東・地平線（高度 0°、方位 90°）は X=+1（左手系）", () => {
+        const state = deriveSunState(0, 90);
+        expect(state.sunDir.x).toBeCloseTo(1, 5);
+        expect(state.sunDir.y).toBeCloseTo(0, 5);
+        expect(state.sunDir.z).toBeCloseTo(0, 5);
+    });
+
+    it("sunDir は単位長", () => {
+        const state = deriveSunState(35, 245);
+        const len = Math.hypot(state.sunDir.x, state.sunDir.y, state.sunDir.z);
+        expect(len).toBeCloseTo(1, 5);
+    });
+
+    it("skyInclination: 天頂で 0、地平線で 0.5、地平線下は 0.5 でクランプ", () => {
+        expect(deriveSunState(90, 0).skyInclination).toBeCloseTo(0, 5);
+        expect(deriveSunState(0, 0).skyInclination).toBeCloseTo(0.5, 5);
+        // 地平線下は Babylon SkyMaterial が想定しない領域のため 0.5 でクランプされる
+        expect(deriveSunState(-30, 0).skyInclination).toBeCloseTo(0.5, 5);
+        expect(deriveSunState(-90, 0).skyInclination).toBeCloseTo(0.5, 5);
+    });
+
+    it("skyInclination: 昼間は高度に対して単調減少（朝→正午で 0 に近づく）", () => {
+        const a = deriveSunState(0, 0).skyInclination;
+        const b = deriveSunState(30, 0).skyInclination;
+        const c = deriveSunState(60, 0).skyInclination;
+        const d = deriveSunState(90, 0).skyInclination;
+        expect(a).toBeGreaterThan(b);
+        expect(b).toBeGreaterThan(c);
+        expect(c).toBeGreaterThan(d);
+    });
+
+    it("skyVisible / clearColor: 昼は Skybox 表示 + 青空色、夜は Skybox 非表示 + 夜色", () => {
+        const noon = deriveSunState(75, 180);
+        expect(noon.skyVisible).toBe(true);
+        expect(noon.clearColor.r).toBeGreaterThan(0.5);
+
+        const night = deriveSunState(-25, 0);
+        expect(night.skyVisible).toBe(false);
+        expect(night.clearColor.r).toBeLessThan(0.1);
+        expect(night.clearColor.b).toBeLessThan(0.2);
+    });
+
+    it("skyVisible 境界: altitudeDeg=-6 で false、-5 で true", () => {
+        expect(deriveSunState(-6, 0).skyVisible).toBe(false);
+        expect(deriveSunState(-5, 0).skyVisible).toBe(true);
+    });
+
+    it("skyAzimuth は [0, 1)", () => {
+        expect(deriveSunState(0, 0).skyAzimuth).toBeCloseTo(0, 5);
+        expect(deriveSunState(0, 90).skyAzimuth).toBeCloseTo(0.25, 5);
+        expect(deriveSunState(0, 359.999).skyAzimuth).toBeLessThan(1);
+    });
+});

--- a/tests/validation.spec.ts
+++ b/tests/validation.spec.ts
@@ -1,5 +1,18 @@
 import { test, expect } from "@playwright/test";
 
+/**
+ * VR テストを時刻依存から切り離すための固定クエリ (Issue #35)。
+ * - `dateTime`: 夏至日本時間正午 (UTC 表記) — 太陽高度が高く陰影変動が最小。
+ * - `autoSunPosition=false`: 自動更新タイマーを起動させずスナップショットを完全決定的にする。
+ */
+const FIXED_DATETIME = "2025-06-21T03:00:00Z";
+const FIXED_AUTO_SUN_POSITION = "false";
+
+const applyDeterministicSunQuery = (url: URL): void => {
+    url.searchParams.set("dateTime", FIXED_DATETIME);
+    url.searchParams.set("autoSunPosition", FIXED_AUTO_SUN_POSITION);
+};
+
 const scenes: {
     name: string;
     url: string;
@@ -25,6 +38,7 @@ for (const scene of scenes) {
         }, testInfo) => {
             const sceneUrl = new URL(scene.url, "http://localhost");
             sceneUrl.searchParams.set("engine", engine.param);
+            applyDeterministicSunQuery(sceneUrl);
             await page.goto(
                 `${sceneUrl.pathname}${sceneUrl.search}${sceneUrl.hash}`
             );
@@ -88,6 +102,7 @@ async function waitForScene(
 ) {
     const sceneUrl = new URL("/?scene=default", "http://localhost");
     sceneUrl.searchParams.set("engine", engine);
+    applyDeterministicSunQuery(sceneUrl);
     await page.goto(`${sceneUrl.pathname}${sceneUrl.search}`, {
         timeout: 120000,
     });
@@ -173,6 +188,142 @@ for (const engine of engines) {
                 );
             },
             { timeout: 5000 }
+        );
+
+        await expect(page).toHaveScreenshot({
+            timeout: 30000,
+            maxDiffPixelRatio: 0.02,
+        });
+        expect(testInfo.errors).toHaveLength(0);
+    });
+}
+
+// ---------- Skybox 昼夜比較テスト (Issue #35) ----------
+//
+// チルト角を最大近くまで倒して画面上部に Skybox が映り込むようにし、
+// `dateTime` を「昼」「夜」で固定した 2 ケースのスクリーンショットを撮る。
+// 両者の差異により Skybox が時刻に追従して変化していることを保証する。
+//
+// 注意: 本テストは「昼/夜のスナップショットそのもの」を VR ベースラインとして固定する。
+// 別ケース同士の自動比較は行わず、開発者が両 PNG を目視で比較して差異を確認する運用とする。
+
+const SKYBOX_TILT_DEG = 75;
+const DAY_DATETIME = "2025-06-21T03:00:00Z"; // JST 12:00（東京で太陽高度 ~75°）
+const NIGHT_DATETIME = "2025-06-21T13:00:00Z"; // JST 22:00（東京で太陽高度 ~ -25°）
+const SUNRISE_DATETIME = "2025-06-21T19:45:00Z"; // JST 04:45（東京で東の空に日の出）
+/** 夜明け視点：東を向き地平線付近にカメラを向けて太陽メッシュを画面内に映す */
+const SUNRISE_AZIMUTH_DEG = 90; // 東向き
+const SUNRISE_LAT = 35.690206;
+const SUNRISE_LON = 139.766166;
+
+/**
+ * Skybox 比較用シーン準備：固定 dateTime でロード後、`viewer.tilt` を最大まで倒す。
+ */
+async function waitForSceneWithSkybox(
+    page: import("@playwright/test").Page,
+    engine: string,
+    dateTime: string,
+) {
+    const sceneUrl = new URL("/?scene=default", "http://localhost");
+    sceneUrl.searchParams.set("engine", engine);
+    sceneUrl.searchParams.set("dateTime", dateTime);
+    sceneUrl.searchParams.set("autoSunPosition", FIXED_AUTO_SUN_POSITION);
+    await page.goto(`${sceneUrl.pathname}${sceneUrl.search}`, {
+        timeout: 120000,
+    });
+    await page.waitForFunction(
+        () => (window as any).scene && (window as any).scene.isReady(),
+        { timeout: 10000 }
+    );
+    await page.waitForLoadState("networkidle", { timeout: 30000 });
+
+    // チルト最大に倒して画面上部に空を映す。
+    // `viewer.tilt` setter は内部で beta クランプ済み（upperBetaLimit ≈ 75°）。
+    await page.evaluate((tiltValue) => {
+        (window as any).viewer.tilt = tiltValue;
+    }, SKYBOX_TILT_DEG);
+
+    // タイル再評価 + 描画安定待ち
+    await page.waitForLoadState("networkidle", { timeout: 30000 });
+    await page.waitForFunction(
+        () =>
+            new Promise((resolve) => {
+                let count = 0;
+                const tick = () => {
+                    if (++count >= 15) return resolve(true);
+                    requestAnimationFrame(tick);
+                };
+                requestAnimationFrame(tick);
+            }),
+        { timeout: 10000 }
+    );
+}
+
+for (const engine of engines) {
+    test(`Skybox at noon (day) with ${engine.name}`, async ({
+        page,
+    }, testInfo) => {
+        await waitForSceneWithSkybox(page, engine.param, DAY_DATETIME);
+        await expect(page).toHaveScreenshot({
+            timeout: 30000,
+            maxDiffPixelRatio: 0.02,
+        });
+        expect(testInfo.errors).toHaveLength(0);
+    });
+
+    test(`Skybox at night with ${engine.name}`, async ({
+        page,
+    }, testInfo) => {
+        await waitForSceneWithSkybox(page, engine.param, NIGHT_DATETIME);
+        await expect(page).toHaveScreenshot({
+            timeout: 30000,
+            maxDiffPixelRatio: 0.02,
+        });
+        expect(testInfo.errors).toHaveLength(0);
+    });
+
+    test(`Sunrise sun mesh visible with ${engine.name}`, async ({
+        page,
+    }, testInfo) => {
+        // 東京の夜明け（JST 04:45）に東向きでカメラを構え、太陽メッシュが画面内に映ることを検証する。
+        // パス `/@lat,lon` ではなく `?lat=&lon=` クエリ形式を採用（dev-server の historyApiFallback 互換）。
+        const sceneUrl = new URL("/?scene=default", "http://localhost");
+        sceneUrl.searchParams.set("engine", engine.param);
+        sceneUrl.searchParams.set("lat", String(SUNRISE_LAT));
+        sceneUrl.searchParams.set("lon", String(SUNRISE_LON));
+        sceneUrl.searchParams.set("dateTime", SUNRISE_DATETIME);
+        sceneUrl.searchParams.set("autoSunPosition", FIXED_AUTO_SUN_POSITION);
+        await page.goto(`${sceneUrl.pathname}${sceneUrl.search}`, {
+            timeout: 120000,
+        });
+        await page.waitForFunction(
+            () => (window as any).scene && (window as any).scene.isReady(),
+            { timeout: 10000 },
+        );
+        await page.waitForLoadState("networkidle", { timeout: 30000 });
+
+        // 東向き + チルト最大で地平線+空を画面内に収める
+        await page.evaluate(
+            ({ tilt, azimuth }) => {
+                const viewer = (window as any).viewer;
+                viewer.azimuth = azimuth;
+                viewer.tilt = tilt;
+            },
+            { tilt: SKYBOX_TILT_DEG, azimuth: SUNRISE_AZIMUTH_DEG },
+        );
+
+        await page.waitForLoadState("networkidle", { timeout: 30000 });
+        await page.waitForFunction(
+            () =>
+                new Promise((resolve) => {
+                    let count = 0;
+                    const tick = () => {
+                        if (++count >= 15) return resolve(true);
+                        requestAnimationFrame(tick);
+                    };
+                    requestAnimationFrame(tick);
+                }),
+            { timeout: 10000 },
         );
 
         await expect(page).toHaveScreenshot({


### PR DESCRIPTION
## 概要

地理院タイル地形ビューアに「時間による明るさ（環境光）の変化」表現を追加する Issue #35 の実装。

緯度・経度・日時から太陽位置を算出し、Skybox / 指向性ライト / 環境光 / 太陽メッシュ / 背景色（夜空）を時刻に追従させる。

Closes #35

## 主な変更

### 公開 API（spec/package.md §3.3.5）
- `viewer.dateTime: Date | null` — 太陽位置計算に使う日時（getter/setter）
- `viewer.autoSunPosition: boolean` — `true` で 60 秒周期に実時刻に追従、`false`（既定）で `dateTime` 固定
- URL クエリ `?dateTime=<ISO8601>` / `?autoSunPosition=true|false`（デモ）
- `Invalid Date` は `console.warn` のうえ `null` フォールバック（例外を投げない）

### 内部実装
- `src/terrain/sunPosition.ts`: NOAA 簡易アルゴリズム（純関数、Babylon 非依存）
- `src/terrain/sunState.ts`: 太陽位置 → Babylon パラメータ変換（`sunDir` / `dayFactor` / `skyInclination` / `skyAzimuth` / `skyVisible` / `clearColor` / `visibleAboveHorizon`）
- `src/scenes/default.ts`: `applySunStateForCurrent` で SkyMaterial / `DirectionalLight` / `HemisphericLight` / 太陽メッシュ / `scene.clearColor` を一括反映。夜は SkyMaterial の物理モデルが破綻するため Skybox を無効化し、`clearColor`（夜空色）を背景に出す
- `src/lib/jpmapTerrain.ts`: 60 秒タイマー（`SUN_AUTO_UPDATE_INTERVAL_MS`）、`dispose` 解放、`Invalid Date` のサニタイズ
- `flyTo` 中間フレームでは太陽再計算を skip し、最終フレームで一度だけ反映（パフォーマンス）

### テスト
- 単体テスト 337 件 pass（`sunPosition` / `sunState` / `resolveDateTime` / `resolveAutoSunPosition` / `JpmapTerrain` 太陽 API ライフサイクル等）
- Visual Regression 12 件 pass（既存 6 件 + 昼/夜/夜明け × WebGL2/WebGPU の 6 件追加）

## 影響範囲

- **API**: `JpmapTerrainOptions` に `dateTime` / `autoSunPosition` を追加（任意、後方互換あり）
- **画面**: 既定値（`SUN_FALLBACK_DATETIME_ISO = "2025-06-21T03:00:00Z"`）で夏至日本時間正午相当の Skybox/陰影。`autoSunPosition` 未指定時の動作は従来と同じ「決定論的」
- **ドキュメント**: `spec/package.md` §3.2 / §3.3.5 / §4.2 を更新

## レビューフロー対応

### Reviewer 指摘
- ✅ Must M1: `JpmapTerrain` 太陽位置 API の単体テスト 10 件追加（`jest.useFakeTimers()`）
- ✅ Should S1: `setSunState` の不要な第 2 引数を削除
- ✅ Should S2: 60s 間隔を `SUN_AUTO_UPDATE_INTERVAL_MS` 定数化
- ✅ Should S3: `flyTo` 中間フレームでの太陽再計算を skip

### Security 指摘
- ✅ Medium M-1: `dispose` 後 setter でのタイマーリーク防止（`autoSunPosition`/`dateTime` setter と `_startSunTimer` に `_disposed` ガード）
- ✅ Low L-1: ログ汚染対策（CR/LF/ESC 等の制御文字を `?` に置換）
- ✅ Low L-2: ログ長を 64 文字に制限
- 確認済: 本番ビルドで `window.viewer` / `window.scene` のデバッグ露出はツリーシェイクで除去
- 確認済: 新規依存ライブラリなし（`@babylonjs/materials/sky` は既存）

## ローカル確認

```sh
npm run lint        # OK
npm run typecheck   # OK
npm run test:unit   # 337 passed
npm run test:visuals  # 12 passed
```

## 注意事項

- VR スナップショット（`Skybox-at-noon-day-*.png` / `Skybox-at-night-*.png` / `Sunrise-sun-mesh-visible-*.png`）が新規追加されています
- `applyDeterministicSunQuery` ヘルパで全 VR シーンに `dateTime` / `autoSunPosition=false` を注入し、機械実行時刻に依存しないスナップショットを保証
