### PR TITLE
feat: 太陽陰影 API (#39) と dateTime TZ オフセット修正 (#143)

### DIFF
--- a/spec/package.md
+++ b/spec/package.md
@@ -239,7 +239,7 @@ interface JpmapTerrain {
 **`showSunShadows` 仕様 (Issue #39):**
 
 - 既定 `false`（OFF）。OFF 時は `ShadowGenerator` を生成せず、GPU 負荷を発生させない。
-- `true` を set すると `ShadowGenerator`（解像度 1024 / `useBlurExponentialShadowMap` / `darkness=0.4`）を生成し、現時点でアクティブな地形タイルおよび以後追加されるタイルメッシュを caster / receiver として登録する。
+- `true` を set すると `ShadowGenerator`（解像度 1024 / `usePercentageCloserFiltering=true` / `darkness=0.4`）を生成し、現時点でアクティブな地形タイルおよび以後追加されるタイルメッシュを caster / receiver として登録する。
 - `false` に戻すと caster/receiver 設定を解除し `ShadowGenerator` を dispose する。
 - 同値の再 set は no-op。`dispose()` 後の set も no-op。
 - `dispose()` 時に `ShadowGenerator` は確実に解放される。

--- a/spec/package.md
+++ b/spec/package.md
@@ -53,6 +53,7 @@ const viewer = await JpmapTerrain.create(document.getElementById("map")!, {
 | `mapType` | `"standard" \| "photo"` | `"standard"` | 地図種類（標準地図 / 航空写真） |
 | `dateTime` | `Date \| null` | `null` | 太陽位置計算に使う日時。`null` の場合は内部の決定的なフォールバック時刻（夏至日本時間正午）を使用 |
 | `autoSunPosition` | `boolean` | `false` | `true` で実時刻に追従して内部更新（60 秒周期）、`false` で `dateTime` を固定値として使用 |
+| `showSunShadows` | `boolean` | `false` | 太陽 DirectionalLight による地形への影描画を有効化する。GPU 負荷が大きいため既定 OFF |
 
 ### 3.3 API & プロパティ
 
@@ -217,6 +218,14 @@ interface JpmapTerrain {
    */
   get autoSunPosition(): boolean;
   set autoSunPosition(value: boolean);
+
+  /**
+   * 太陽 DirectionalLight による地形への影描画を有効化するフラグ。既定 `false`（OFF）。
+   * `true` のとき `ShadowGenerator` を内部生成し、地形タイル全体を caster / receiver に登録する。
+   * `false` に戻すと `ShadowGenerator` は dispose され、GPU リソースを保持しない。
+   */
+  get showSunShadows(): boolean;
+  set showSunShadows(value: boolean);
 }
 ```
 
@@ -226,6 +235,15 @@ interface JpmapTerrain {
 - `autoSunPosition` を `true` から `false` に切り替えた瞬間、保持していた `dateTime` 値（または `null`）で再計算する。
 - `dispose()` 時に内部タイマーは確実に解放される。
 - ビジュアルテストの決定性が必要な場面（Playwright 等）では、URL クエリ `?dateTime=<ISO8601 with Z>&autoSunPosition=false` を付与し、太陽位置を完全に固定すること。
+
+**`showSunShadows` 仕様 (Issue #39):**
+
+- 既定 `false`（OFF）。OFF 時は `ShadowGenerator` を生成せず、GPU 負荷を発生させない。
+- `true` を set すると `ShadowGenerator`（解像度 1024 / `useBlurExponentialShadowMap` / `darkness=0.4`）を生成し、現時点でアクティブな地形タイルおよび以後追加されるタイルメッシュを caster / receiver として登録する。
+- `false` に戻すと caster/receiver 設定を解除し `ShadowGenerator` を dispose する。
+- 同値の再 set は no-op。`dispose()` 後の set も no-op。
+- `dispose()` 時に `ShadowGenerator` は確実に解放される。
+- URL クエリ `?showSunShadows=true|false` で初期値を制御できる（`true`/`false` 以外の値は無視）。
 
 ### 3.4 型定義
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,22 +59,26 @@ export const resolveLatLon = (
  * @param search `location.search` 等のクエリ文字列（先頭 `?` 任意）
  */
 export const resolveDateTime = (search: string): Date | undefined => {
-    const match = /[?&]dateTime=([^&#]*)/.exec(search);
+    // 先頭 `?` 任意の仕様に合わせ、`(?:^|[?&])` で文字列先頭での `dateTime=` も許容する。
+    const match = /(?:^|[?&])dateTime=([^&#]*)/.exec(search);
     if (!match) return undefined;
+    // ログ汚染対策: 制御文字 (CR/LF/ESC 等) を `?` に置換し、長さも 64 文字に制限する。
+    const sanitize = (value: string): string =>
+        value.replace(/[\r\n\x1B\x00-\x1F\x7F]/g, "?").slice(0, 64);
     let raw: string;
     try {
         // `decodeURIComponent` は `+` をリテラルのまま残すため、`%2B09:00` 形式とも等価になる。
         raw = decodeURIComponent(match[1]);
     } catch {
+        // 不正な `%` シーケンス等のデコード失敗もパース失敗として扱い、警告を出す。
+        console.warn(
+            `[jpmap-terrain demo] invalid dateTime param: ${sanitize(match[1])}`,
+        );
         return undefined;
     }
     const d = new Date(raw);
     if (Number.isNaN(d.getTime())) {
-        // ログ汚染対策: 制御文字 (CR/LF/ESC 等) を `?` に置換し、長さも 64 文字に制限する。
-        const safe = raw
-            .replace(/[\r\n\x1B\x00-\x1F\x7F]/g, "?")
-            .slice(0, 64);
-        console.warn(`[jpmap-terrain demo] invalid dateTime param: ${safe}`);
+        console.warn(`[jpmap-terrain demo] invalid dateTime param: ${sanitize(raw)}`);
         return undefined;
     }
     return d;

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,16 +46,28 @@ export const resolveLatLon = (
     parseLatLonFromUrl(url) ?? undefined;
 
 /**
- * `?dateTime=` クエリ文字列から太陽位置計算用の日時を解決する (Issue #35)。
- * - ISO 8601（`Z` 等のタイムゾーン指定を含む形式を推奨）を受け付ける。
+ * `?dateTime=` クエリ文字列から太陽位置計算用の日時を解決する (Issue #35, #143)。
+ * - ISO 8601 を受け付ける。`Z` に加えてローカルタイムオフセット (`+09:00`, `-05:00` 等) も
+ *   `Z` と等価に解釈する。
  * - 未指定 / パース失敗時は `undefined` を返し、デモ起動時の `opts` には含めない（既存挙動維持）。
  * - パース失敗は `console.warn` のみ。例外は投げない（silent ignore ポリシー）。
+ *
+ * 実装メモ: `URLSearchParams` は仕様により `+` を空白にデコードするため、
+ * `+09:00` 等のオフセット表記が壊れる。これを避けるため正規表現で raw 値を抽出し、
+ * `decodeURIComponent` で復元する (Issue #143)。
  *
  * @param search `location.search` 等のクエリ文字列（先頭 `?` 任意）
  */
 export const resolveDateTime = (search: string): Date | undefined => {
-    const raw = new URLSearchParams(search).get("dateTime");
-    if (raw === null) return undefined;
+    const match = /[?&]dateTime=([^&#]*)/.exec(search);
+    if (!match) return undefined;
+    let raw: string;
+    try {
+        // `decodeURIComponent` は `+` をリテラルのまま残すため、`%2B09:00` 形式とも等価になる。
+        raw = decodeURIComponent(match[1]);
+    } catch {
+        return undefined;
+    }
     const d = new Date(raw);
     if (Number.isNaN(d.getTime())) {
         // ログ汚染対策: 制御文字 (CR/LF/ESC 等) を `?` に置換し、長さも 64 文字に制限する。
@@ -81,6 +93,19 @@ export const resolveAutoSunPosition = (
     return undefined;
 };
 
+/**
+ * `?showSunShadows=` クエリ文字列から太陽影描画フラグを解決する (Issue #39)。
+ * - `"true"` / `"false"` のみを許容し、それ以外は `undefined`（既定 OFF を維持）。
+ */
+export const resolveShowSunShadows = (
+    search: string,
+): boolean | undefined => {
+    const raw = new URLSearchParams(search).get("showSunShadows");
+    if (raw === "true") return true;
+    if (raw === "false") return false;
+    return undefined;
+};
+
 const start = async (): Promise<void> => {
     const mount = document.getElementById(DEMO_MOUNT_ID);
     if (!mount) {
@@ -90,11 +115,13 @@ const start = async (): Promise<void> => {
     const latLon = resolveLatLon(location.href);
     const dateTime = resolveDateTime(location.search);
     const autoSunPosition = resolveAutoSunPosition(location.search);
+    const showSunShadows = resolveShowSunShadows(location.search);
     const opts: JpmapTerrainOptions = {
         ...(engine ? { engine } : {}),
         ...(latLon ?? {}),
         ...(dateTime !== undefined ? { dateTime } : {}),
         ...(autoSunPosition !== undefined ? { autoSunPosition } : {}),
+        ...(showSunShadows !== undefined ? { showSunShadows } : {}),
     };
     const viewer = await JpmapTerrain.create(mount, opts);
 

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -56,6 +56,9 @@ export class JpmapTerrain {
     /** auto モード中、最後に内部反映した実時刻。`dateTime` getter が返す値 */
     private _autoLastAppliedDate: Date | null = null;
 
+    /** 太陽 DirectionalLight 影描画 (Issue #39)。既定 OFF */
+    private _showSunShadows: boolean;
+
     private _canvas: HTMLCanvasElement | null = null;
     private _engine: AbstractEngine | null = null;
     private _scene: Scene | null = null;
@@ -84,6 +87,8 @@ export class JpmapTerrain {
         this._dateTime = JpmapTerrain._sanitizeDateTimeOption(options.dateTime);
         this._autoSunPosition =
             options.autoSunPosition ?? JPMAP_TERRAIN_DEFAULTS.autoSunPosition;
+        this._showSunShadows =
+            options.showSunShadows ?? JPMAP_TERRAIN_DEFAULTS.showSunShadows;
     }
 
     /**
@@ -186,6 +191,10 @@ export class JpmapTerrain {
                         this._tickSunTimer();
                     } else {
                         controller.setSunState(this._dateTime);
+                    }
+                    // 太陽影 (Issue #39)。既定 OFF のため通常は no-op。
+                    if (this._showSunShadows) {
+                        controller.setSunShadows(true);
                     }
                 },
             });
@@ -493,6 +502,25 @@ export class JpmapTerrain {
             // 保持されていた `_dateTime`（または null）で再計算
             this._controller?.setSunState(this._dateTime);
         }
+    }
+
+    /**
+     * 太陽 DirectionalLight による地形への影描画の有効/無効 (Issue #39)。
+     *
+     * - `true`: `ShadowGenerator` を生成し、地形タイル全体を caster / receiver に登録する。
+     * - `false`（既定）: `ShadowGenerator` を生成しない / 既存があれば dispose する。
+     * - 同値再 set は no-op。`dispose()` 後の set も no-op。
+     *
+     * GPU 負荷が比較的大きいため、必要時のみ ON にすることを推奨する。
+     */
+    public get showSunShadows(): boolean {
+        return this._showSunShadows;
+    }
+    public set showSunShadows(value: boolean) {
+        if (this._disposed) return;
+        if (this._showSunShadows === value) return;
+        this._showSunShadows = value;
+        this._controller?.setSunShadows(value);
     }
 
     /** 60 秒周期で `new Date()` を太陽計算に流し込むタイマーを開始する */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -40,6 +40,13 @@ export interface JpmapTerrainOptions {
      * `false`（既定）: `dateTime` を固定値として使用する。
      */
     autoSunPosition?: boolean;
+    /**
+     * 太陽 DirectionalLight による地形への影描画を有効にする (Issue #39)。
+     * 既定は `false`（OFF）。`true` のとき `ShadowGenerator` を生成し、
+     * 既存タイルおよび以後追加されるタイルメッシュを caster / receiver として登録する。
+     * GPU 負荷が大きいため、必要時のみ有効化することを推奨する。
+     */
+    showSunShadows?: boolean;
 }
 
 /**
@@ -75,6 +82,7 @@ export const JPMAP_TERRAIN_DEFAULTS = {
     mapType: "standard" as MapType,
     dateTime: null as Date | null,
     autoSunPosition: false as boolean,
+    showSunShadows: false as boolean,
 } as const;
 
 /**

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -1068,8 +1068,11 @@ export class DefaultScene implements CreateSceneClass {
         };
         const enableSunShadows = (): void => {
             if (shadowGenerator) return;
+            // 構築後の設定で例外が発生しても catch で確実に dispose できるよう、
+            // ローカル変数 `sg` を生成直後に `shadowGenerator` へ代入する。
+            const sg = new ShadowGenerator(1024, sunLight);
+            shadowGenerator = sg;
             try {
-                const sg = new ShadowGenerator(1024, sunLight);
                 // フィルタ選定: `useBlurExponentialShadowMap` は内部で BlurPostProcess を
                 // 利用するが、WebGPU 経路で `infiniteDistance` のメッシュ（太陽メッシュ等）
                 // と相互作用して表示が破綻するケースが確認されたため、PostProcess を伴わない
@@ -1077,7 +1080,6 @@ export class DefaultScene implements CreateSceneClass {
                 sg.usePercentageCloserFiltering = true;
                 sg.bias = 0.0001;
                 sg.setDarkness(0.4);
-                shadowGenerator = sg;
                 tileManager.setShadowHooks(shadowHooks);
                 tileManager.forEachActiveMesh((mesh) => {
                     sg.addShadowCaster(mesh);
@@ -1088,10 +1090,8 @@ export class DefaultScene implements CreateSceneClass {
                     "[JpmapTerrain] failed to enable sun shadows:",
                     err,
                 );
-                if (shadowGenerator) {
-                    shadowGenerator.dispose();
-                    shadowGenerator = null;
-                }
+                shadowGenerator = null;
+                sg.dispose();
                 tileManager.setShadowHooks(null);
             }
         };

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -4,6 +4,9 @@ import { Matrix, Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { Color3 } from "@babylonjs/core/Maths/math.color";
 import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight";
 import { DirectionalLight } from "@babylonjs/core/Lights/directionalLight";
+import { ShadowGenerator } from "@babylonjs/core/Lights/Shadows/shadowGenerator";
+import "@babylonjs/core/Lights/Shadows/shadowGeneratorSceneComponent";
+import type { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { CreateSphere } from "@babylonjs/core/Meshes/Builders/sphereBuilder";
 import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
 import { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
@@ -121,6 +124,18 @@ export interface DefaultSceneController {
     setSunState(dateTime: Date | null): void;
 
     /**
+     * 太陽 DirectionalLight による地形への影描画を有効/無効化する (Issue #39)。
+     *
+     * - `true`: `ShadowGenerator` を生成し、`tileManager` 経由でアクティブな全タイルおよび
+     *   以後 `meshPool.acquire` されるメッシュを caster / receiver として登録する。
+     *   既定 OFF のため、有効化はこのメソッド経由でのみ行う。
+     * - `false`: 登録済みフックを解除し、現在アクティブなメッシュから caster/receiver 設定を
+     *   外したうえで `ShadowGenerator` を `dispose` する（GPU リソースを保持し続けない）。
+     * - 同値再呼び出しは no-op（idempotent）。
+     */
+    setSunShadows(enabled: boolean): void;
+
+    /**
      * `JpmapTerrain.dispose()` から呼ばれる UI クリーンアップ (T7 / Issue #121)。
      *
      * `controlPanel` が `document.body` に追加した UI 要素 (コンパス / ズームボタンコンテナ / 地図切替) を
@@ -226,6 +241,10 @@ export class DefaultScene implements CreateSceneClass {
         sunMesh.material = sunMaterial;
         sunMesh.isPickable = false;
         sunMesh.infiniteDistance = true;
+        // `infiniteDistance` はビュー変換のみカメラ追従させるため、
+        // フラスタムカリングは元の world 座標で行われる。遠方にある太陽メッシュが
+        // カリングされて描画されないのを防ぐため、常時アクティブ化する。
+        sunMesh.alwaysSelectAsActiveMesh = true;
         sunMesh.setEnabled(false);
 
         // 初期位置（options > デフォルト 東京駅付近）
@@ -1010,6 +1029,84 @@ export class DefaultScene implements CreateSceneClass {
         // 適用すべき日時」を都度受け取って描画反映する役割に閉じる。
         let currentSunDateTime: Date | null = null;
         const fallbackSunDate = new Date(SUN_FALLBACK_DATETIME_ISO);
+
+        // ---- 太陽影 (Issue #39) ----
+        // 既定 OFF。ON 化されたときのみ ShadowGenerator を生成し、`tileManager` 経由で
+        // 既存タイル / 以後追加されるタイルメッシュへ caster/receiver を反映する。
+        let shadowGenerator: ShadowGenerator | null = null;
+        // ShadowGenerator の DirectionalLight orthographic frustum 範囲。
+        // camera.upperRadiusLimit (= CAMERA_UPPER_RADIUS, 75km) を基準に固定し、
+        // autoCalcShadowZBounds の毎フレームコストと WebGPU 不安定要因を避ける。
+        const SHADOW_FRUSTUM_RADIUS = CAMERA_UPPER_RADIUS;
+        const updateShadowFrustum = (sunDir: Vector3): void => {
+            if (!shadowGenerator) return;
+            // light.position = camera.target - sunDir * D（光源を地表上空へ移動）
+            sunLight.position.set(
+                camera.target.x - sunDir.x * SHADOW_FRUSTUM_RADIUS,
+                camera.target.y - sunDir.y * SHADOW_FRUSTUM_RADIUS,
+                camera.target.z - sunDir.z * SHADOW_FRUSTUM_RADIUS,
+            );
+            sunLight.shadowMinZ = 1;
+            sunLight.shadowMaxZ = SHADOW_FRUSTUM_RADIUS * 2;
+            sunLight.orthoLeft = -SHADOW_FRUSTUM_RADIUS;
+            sunLight.orthoRight = SHADOW_FRUSTUM_RADIUS;
+            sunLight.orthoTop = SHADOW_FRUSTUM_RADIUS;
+            sunLight.orthoBottom = -SHADOW_FRUSTUM_RADIUS;
+            sunLight.autoCalcShadowZBounds = false;
+        };
+        const shadowHooks = {
+            onAcquire: (mesh: Mesh): void => {
+                if (!shadowGenerator) return;
+                shadowGenerator.addShadowCaster(mesh);
+                mesh.receiveShadows = true;
+            },
+            onRelease: (mesh: Mesh): void => {
+                if (!shadowGenerator) return;
+                shadowGenerator.removeShadowCaster(mesh);
+                mesh.receiveShadows = false;
+            },
+        };
+        const enableSunShadows = (): void => {
+            if (shadowGenerator) return;
+            try {
+                const sg = new ShadowGenerator(1024, sunLight);
+                // フィルタ選定: `useBlurExponentialShadowMap` は内部で BlurPostProcess を
+                // 利用するが、WebGPU 経路で `infiniteDistance` のメッシュ（太陽メッシュ等）
+                // と相互作用して表示が破綻するケースが確認されたため、PostProcess を伴わない
+                // PCF (Percentage Closer Filtering) を採用する。WebGL2/WebGPU 双方で安定。
+                sg.usePercentageCloserFiltering = true;
+                sg.bias = 0.0001;
+                sg.setDarkness(0.4);
+                shadowGenerator = sg;
+                tileManager.setShadowHooks(shadowHooks);
+                tileManager.forEachActiveMesh((mesh) => {
+                    sg.addShadowCaster(mesh);
+                    mesh.receiveShadows = true;
+                });
+            } catch (err) {
+                console.warn(
+                    "[JpmapTerrain] failed to enable sun shadows:",
+                    err,
+                );
+                if (shadowGenerator) {
+                    shadowGenerator.dispose();
+                    shadowGenerator = null;
+                }
+                tileManager.setShadowHooks(null);
+            }
+        };
+        const disableSunShadows = (): void => {
+            if (!shadowGenerator) return;
+            tileManager.setShadowHooks(null);
+            const sg = shadowGenerator;
+            tileManager.forEachActiveMesh((mesh) => {
+                sg.removeShadowCaster(mesh);
+                mesh.receiveShadows = false;
+            });
+            sg.dispose();
+            shadowGenerator = null;
+        };
+
         const applySunStateForCurrent = (): void => {
             const dateForCalc = currentSunDateTime ?? fallbackSunDate;
             // 念のため Invalid Date のセーフガード（呼び出し側で `null` 同等に倒す）
@@ -1047,6 +1144,11 @@ export class DefaultScene implements CreateSceneClass {
             // 指向性ライト方向 = 太陽から地表向き = -sunDir
             sunLight.direction = state.sunDir.scale(-1);
             sunLight.intensity = state.dayFactor;
+            // 影フラスタムは光源方向に追従して更新する (Issue #39)。
+            // ShadowGenerator 未生成（OFF）時は no-op。
+            if (shadowGenerator) {
+                updateShadowFrustum(state.sunDir);
+            }
             // 環境光は夜でも完全な暗黒にならないようベース値 + 昼比例
             hemiLight.intensity = 0.2 + 0.8 * state.dayFactor;
             // 太陽メッシュ位置: カメラターゲット + sunDir * (camera.maxZ * 0.5)
@@ -1104,7 +1206,20 @@ export class DefaultScene implements CreateSceneClass {
                 currentSunDateTime = dateTime;
                 applySunStateForCurrent();
             },
+            setSunShadows: (enabled) => {
+                // 同値再呼び出しは no-op
+                if (enabled === (shadowGenerator !== null)) return;
+                if (enabled) {
+                    enableSunShadows();
+                    // フラスタムを現在の太陽方向で 1 回再センタリング
+                    applySunStateForCurrent();
+                } else {
+                    disableSunShadows();
+                }
+            },
             dispose: () => {
+                // ShadowGenerator が残っていれば確実に解放する (Issue #39)。
+                disableSunShadows();
                 // controlPanel は document.body に各 UI を直接 append しているため、
                 // ここで親要素から取り除く (T7 / Issue #121)。
                 // - compass / mapToggle は単独要素

--- a/src/terrain/meshPool.ts
+++ b/src/terrain/meshPool.ts
@@ -6,12 +6,33 @@ import { CreateGround } from "@babylonjs/core/Meshes/Builders/groundBuilder";
 import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
 import { Color3 } from "@babylonjs/core/Maths/math.color";
 
+/**
+ * 太陽影描画 (Issue #39) のための caster / receiver 設定フック。
+ *
+ * `MeshPool.acquire` 直後と `release` 直前に呼ばれる。`ShadowGenerator` の
+ * `addShadowCaster` / `removeShadowCaster` と `mesh.receiveShadows` の切替を集約する。
+ */
+export interface ShadowHooks {
+    /** メッシュがアクティブ化された直後に呼ばれる（caster 登録 + receiveShadows=true） */
+    onAcquire(mesh: Mesh): void;
+    /** メッシュがプールへ戻される直前に呼ばれる（caster 解除 + receiveShadows=false） */
+    onRelease(mesh: Mesh): void;
+}
+
 export interface MeshPool {
     acquire(): Mesh;
     release(mesh: Mesh): void;
     dispose(): void;
     readonly activeCount: number;
     readonly pooledCount: number;
+    /**
+     * 影 caster / receiver 設定フックを差し替える (Issue #39)。
+     * `null` を渡すとフック解除。設定済みフックは差し替え時には自動解除されないため、
+     * 既存メッシュへの一括反映は呼び出し側で {@link MeshPool.forEachActive} を併用する。
+     */
+    setShadowHooks(hooks: ShadowHooks | null): void;
+    /** 現在アクティブな（acquire 中の）全メッシュを列挙する。OFF→ON 切替時の一括適用用途 */
+    forEachActive(cb: (mesh: Mesh) => void): void;
 }
 
 export interface MeshPoolOptions {
@@ -26,6 +47,7 @@ export const createMeshPool = (opts: MeshPoolOptions): MeshPool => {
     const { scene, subdivisions, tileSize } = opts;
     const pool: Mesh[] = [];
     const active = new Set<Mesh>();
+    let shadowHooks: ShadowHooks | null = null;
 
     const createNewMesh = (): Mesh => {
         const id = meshSeq++;
@@ -51,11 +73,13 @@ export const createMeshPool = (opts: MeshPoolOptions): MeshPool => {
             const mesh = pool.pop() ?? createNewMesh();
             mesh.setEnabled(true);
             active.add(mesh);
+            shadowHooks?.onAcquire(mesh);
             return mesh;
         },
 
         release(mesh: Mesh): void {
             if (!active.has(mesh)) return;
+            shadowHooks?.onRelease(mesh);
             active.delete(mesh);
             mesh.setEnabled(false);
             // テクスチャを解放
@@ -68,6 +92,7 @@ export const createMeshPool = (opts: MeshPoolOptions): MeshPool => {
         },
 
         dispose(): void {
+            shadowHooks = null;
             for (const mesh of active) {
                 mesh.dispose(false, true);
             }
@@ -84,6 +109,16 @@ export const createMeshPool = (opts: MeshPoolOptions): MeshPool => {
 
         get pooledCount(): number {
             return pool.length;
+        },
+
+        setShadowHooks(hooks: ShadowHooks | null): void {
+            shadowHooks = hooks;
+        },
+
+        forEachActive(cb: (mesh: Mesh) => void): void {
+            for (const mesh of active) {
+                cb(mesh);
+            }
         },
     };
 };

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -14,7 +14,7 @@ import { Plane } from "@babylonjs/core/Maths/math.plane";
 import { TileCoord, TileKey, toTileKey, tileOffsetToWorld, convertTileZoom, computeSubTileOffset } from "./tileTypes";
 import { computeQuadtreeTiles, FrustumPlane, LodTileEntry } from "./visibleTiles";
 import { createTileCache, TileCache } from "./tileCache";
-import { createMeshPool, MeshPool } from "./meshPool";
+import { createMeshPool, MeshPool, ShadowHooks } from "./meshPool";
 import {
     TILE_SIZE,
     toTileXY,
@@ -60,6 +60,10 @@ export interface TileManager {
     queryElevationAtWorld(wx: number, wz: number): number | null;
     /** メッシュ頂点の標高が更新されたときに呼ばれるコールバック */
     onTerrainUpdated: (() => void) | null;
+    /** 太陽影 (Issue #39) caster/receiver フックを設定する。`null` で解除 */
+    setShadowHooks(hooks: ShadowHooks | null): void;
+    /** 現在アクティブな全タイルメッシュを列挙する（Issue #39 ON/OFF 切替用） */
+    forEachActiveMesh(cb: (mesh: Mesh) => void): void;
 }
 
 interface ActiveTile {
@@ -777,6 +781,14 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         },
         get onTerrainUpdated(): (() => void) | null {
             return terrainUpdatedCallback;
+        },
+
+        setShadowHooks(hooks: ShadowHooks | null): void {
+            meshPool.setShadowHooks(hooks);
+        },
+
+        forEachActiveMesh(cb: (mesh: Mesh) => void): void {
+            meshPool.forEachActive(cb);
         },
     };
 };

--- a/tests/index.unit.spec.ts
+++ b/tests/index.unit.spec.ts
@@ -142,6 +142,23 @@ describe("resolveDateTime (Issue #35)", () => {
         expect(result).toBeInstanceOf(Date);
         expect(result?.toISOString()).toBe("2025-04-24T20:13:00.000Z");
     });
+
+    it("先頭 `?` を省略しても dateTime を解釈する (PR #144 review)", () => {
+        const result = resolveDateTime("dateTime=2025-06-21T03:00:00Z");
+        expect(result).toBeInstanceOf(Date);
+        expect(result?.toISOString()).toBe("2025-06-21T03:00:00.000Z");
+    });
+
+    it("不正な `%` エンコードは undefined を返し、警告を出す (PR #144 review)", () => {
+        const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            // `%ZZ` は decodeURIComponent で URIError を投げる不正シーケンス
+            expect(resolveDateTime("?dateTime=%ZZ")).toBeUndefined();
+            expect(warn).toHaveBeenCalledTimes(1);
+        } finally {
+            warn.mockRestore();
+        }
+    });
 });
 
 describe("resolveAutoSunPosition (Issue #35)", () => {

--- a/tests/index.unit.spec.ts
+++ b/tests/index.unit.spec.ts
@@ -18,6 +18,7 @@ import {
     resolveLatLon,
     resolveDateTime,
     resolveAutoSunPosition,
+    resolveShowSunShadows,
 } from "../src/index";
 
 describe("resolveEngine", () => {
@@ -109,6 +110,38 @@ describe("resolveDateTime (Issue #35)", () => {
             warn.mockRestore();
         }
     });
+
+    it("?dateTime=<ISO with +09:00 offset> → UTC 等価値の Date を返す (Issue #143)", () => {
+        const result = resolveDateTime(
+            "?dateTime=2025-04-25T05:13:00+09:00",
+        );
+        expect(result).toBeInstanceOf(Date);
+        expect(result?.toISOString()).toBe("2025-04-24T20:13:00.000Z");
+    });
+
+    it("?dateTime=<ISO with -05:00 offset> → 負オフセットも正しく解釈する (Issue #143)", () => {
+        const result = resolveDateTime(
+            "?dateTime=2025-04-25T05:13:00-05:00",
+        );
+        expect(result).toBeInstanceOf(Date);
+        expect(result?.toISOString()).toBe("2025-04-25T10:13:00.000Z");
+    });
+
+    it("?dateTime=<percent-encoded +09:00> も同値で解釈する (Issue #143)", () => {
+        const result = resolveDateTime(
+            "?dateTime=2025-04-25T05:13:00%2B09:00",
+        );
+        expect(result).toBeInstanceOf(Date);
+        expect(result?.toISOString()).toBe("2025-04-24T20:13:00.000Z");
+    });
+
+    it("複数パラメータ混在時も dateTime のみ正しく抽出する (Issue #143)", () => {
+        const result = resolveDateTime(
+            "?engine=webgpu&dateTime=2025-04-25T05:13:00+09:00&autoSunPosition=false",
+        );
+        expect(result).toBeInstanceOf(Date);
+        expect(result?.toISOString()).toBe("2025-04-24T20:13:00.000Z");
+    });
 });
 
 describe("resolveAutoSunPosition (Issue #35)", () => {
@@ -125,5 +158,22 @@ describe("resolveAutoSunPosition (Issue #35)", () => {
         expect(resolveAutoSunPosition("?autoSunPosition=")).toBeUndefined();
         expect(resolveAutoSunPosition("?autoSunPosition=1")).toBeUndefined();
         expect(resolveAutoSunPosition("?autoSunPosition=TRUE")).toBeUndefined();
+    });
+});
+
+describe("resolveShowSunShadows (Issue #39)", () => {
+    it("?showSunShadows=true → true", () => {
+        expect(resolveShowSunShadows("?showSunShadows=true")).toBe(true);
+    });
+
+    it("?showSunShadows=false → false", () => {
+        expect(resolveShowSunShadows("?showSunShadows=false")).toBe(false);
+    });
+
+    it("未指定 / 不正値 → undefined", () => {
+        expect(resolveShowSunShadows("")).toBeUndefined();
+        expect(resolveShowSunShadows("?showSunShadows=")).toBeUndefined();
+        expect(resolveShowSunShadows("?showSunShadows=1")).toBeUndefined();
+        expect(resolveShowSunShadows("?showSunShadows=TRUE")).toBeUndefined();
     });
 });

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -89,6 +89,8 @@ jest.unstable_mockModule("../src/scenes/default", () => {
     let controllerDisposeCount = 0;
     // Issue #35: setSunState 呼び出し履歴を保持する。
     const sunStateCalls: Array<{ dateTime: Date | null }> = [];
+    // Issue #39: setSunShadows 呼び出し履歴を保持する。
+    const sunShadowsCalls: boolean[] = [];
     // #136: scene.onBeforeRenderObservable のテスト用簡易実装。
     // jpmapTerrain.ts は `add(callback)` の戻り値を `Observer` として保持し、
     // dispose 時に `remove(observer)` する。テストからは `__triggerSceneRender` で
@@ -219,6 +221,9 @@ jest.unstable_mockModule("../src/scenes/default", () => {
                         // テスト用: 受信を記録するだけで Babylon 描画は伴わない
                         sunStateCalls.push({ dateTime: _dateTime });
                     },
+                    setSunShadows: (enabled: boolean) => {
+                        sunShadowsCalls.push(enabled);
+                    },
                     dispose: () => {
                         controllerDisposeCount++;
                     },
@@ -267,6 +272,10 @@ jest.unstable_mockModule("../src/scenes/default", () => {
         __resetSunStateCalls: (): void => {
             sunStateCalls.length = 0;
         },
+        __getSunShadowsCalls: (): boolean[] => [...sunShadowsCalls],
+        __resetSunShadowsCalls: (): void => {
+            sunShadowsCalls.length = 0;
+        },
         __triggerSceneRender: (): void => triggerSceneRender(),
     };
 });
@@ -292,6 +301,8 @@ const sceneMockModule = (await import("../src/scenes/default")) as unknown as {
     __resetControllerDisposeCount: () => void;
     __getSunStateCalls: () => Array<{ dateTime: Date | null }>;
     __resetSunStateCalls: () => void;
+    __getSunShadowsCalls: () => boolean[];
+    __resetSunShadowsCalls: () => void;
     __triggerSceneRender: () => void;
 };
 
@@ -1192,6 +1203,61 @@ describe("JpmapTerrain (skeleton)", () => {
             } finally {
                 jest.useRealTimers();
             }
+        });
+    });
+
+    describe("sun shadows (Issue #39)", () => {
+        beforeEach(() => {
+            sceneMockModule.__resetSunShadowsCalls();
+        });
+
+        it("既定値は false。初期化時に setSunShadows(true) は呼ばれない", async () => {
+            const viewer = await create(createMountElement());
+            expect(viewer.showSunShadows).toBe(false);
+            expect(sceneMockModule.__getSunShadowsCalls()).toEqual([]);
+        });
+
+        it("options.showSunShadows=true で初期化すると setSunShadows(true) が 1 回呼ばれる", async () => {
+            const viewer = await create(createMountElement(), {
+                showSunShadows: true,
+            });
+            expect(viewer.showSunShadows).toBe(true);
+            expect(sceneMockModule.__getSunShadowsCalls()).toEqual([true]);
+        });
+
+        it("setter で値を切り替えると controller.setSunShadows が呼ばれる", async () => {
+            const viewer = await create(createMountElement());
+            sceneMockModule.__resetSunShadowsCalls();
+
+            viewer.showSunShadows = true;
+            expect(sceneMockModule.__getSunShadowsCalls()).toEqual([true]);
+
+            viewer.showSunShadows = false;
+            expect(sceneMockModule.__getSunShadowsCalls()).toEqual([
+                true,
+                false,
+            ]);
+        });
+
+        it("同値の再 set は controller.setSunShadows を呼ばない", async () => {
+            const viewer = await create(createMountElement());
+            sceneMockModule.__resetSunShadowsCalls();
+            viewer.showSunShadows = false; // 既定 false への再 set
+            expect(sceneMockModule.__getSunShadowsCalls()).toEqual([]);
+
+            viewer.showSunShadows = true;
+            sceneMockModule.__resetSunShadowsCalls();
+            viewer.showSunShadows = true; // 再 set
+            expect(sceneMockModule.__getSunShadowsCalls()).toEqual([]);
+        });
+
+        it("dispose 後の setter は no-op", async () => {
+            const viewer = await create(createMountElement());
+            viewer.dispose();
+            sceneMockModule.__resetSunShadowsCalls();
+            viewer.showSunShadows = true;
+            expect(viewer.showSunShadows).toBe(false);
+            expect(sceneMockModule.__getSunShadowsCalls()).toEqual([]);
         });
     });
 });

--- a/tests/meshPool.unit.spec.ts
+++ b/tests/meshPool.unit.spec.ts
@@ -109,4 +109,60 @@ describe("createMeshPool", () => {
         expect(mesh1.dispose).toHaveBeenCalled();
         expect(mesh2.dispose).toHaveBeenCalled();
     });
+
+    it("setShadowHooks 設定後の acquire/release でフックが呼ばれる (Issue #39)", () => {
+        const pool = createMeshPool({
+            scene: mockScene,
+            subdivisions: 128,
+            tileSize: 100,
+        });
+        const onAcquire = jest.fn();
+        const onRelease = jest.fn();
+        pool.setShadowHooks({ onAcquire, onRelease });
+
+        const mesh = pool.acquire();
+        expect(onAcquire).toHaveBeenCalledTimes(1);
+        expect(onAcquire).toHaveBeenCalledWith(mesh);
+        expect(onRelease).not.toHaveBeenCalled();
+
+        pool.release(mesh);
+        expect(onRelease).toHaveBeenCalledTimes(1);
+        expect(onRelease).toHaveBeenCalledWith(mesh);
+    });
+
+    it("setShadowHooks(null) 後はフックが呼ばれない (Issue #39)", () => {
+        const pool = createMeshPool({
+            scene: mockScene,
+            subdivisions: 128,
+            tileSize: 100,
+        });
+        const onAcquire = jest.fn();
+        const onRelease = jest.fn();
+        pool.setShadowHooks({ onAcquire, onRelease });
+        pool.setShadowHooks(null);
+
+        const mesh = pool.acquire();
+        pool.release(mesh);
+        expect(onAcquire).not.toHaveBeenCalled();
+        expect(onRelease).not.toHaveBeenCalled();
+    });
+
+    it("forEachActive はアクティブなメッシュのみ列挙する (Issue #39)", () => {
+        const pool = createMeshPool({
+            scene: mockScene,
+            subdivisions: 128,
+            tileSize: 100,
+        });
+        const m1 = pool.acquire();
+        const m2 = pool.acquire();
+        const m3 = pool.acquire();
+        pool.release(m2);
+
+        const visited: unknown[] = [];
+        pool.forEachActive((mesh) => visited.push(mesh));
+        expect(visited).toHaveLength(2);
+        expect(visited).toContain(m1);
+        expect(visited).toContain(m3);
+        expect(visited).not.toContain(m2);
+    });
 });


### PR DESCRIPTION
## 概要
- Issue #39: 太陽による陰影表示 API (`showSunShadows`) を追加（既定 OFF）
- 既存バグ修正: 太陽メッシュがフラスタムカリングで除外され表示されない問題 (`alwaysSelectAsActiveMesh = true`)
- Issue #143: URL `?dateTime=` がローカルタイムオフセット (`+09:00` 等) を受理できないバグを修正

## 主要変更
### API (#39)
- `JpmapTerrainOptions.showSunShadows?: boolean` (default `false`)
- `JpmapTerrain` インスタンスに getter/setter
- URL パラメータ `?showSunShadows=true|false`
- spec/package.md §3.3.5 を更新

### URL 時刻解決 (#143)
- `resolveDateTime` を `URLSearchParams` から正規表現＋`decodeURIComponent` 方式へ置換
- `+09:00` / `-05:00` / `%2B` 形式 / 複数パラメータ混在のテストを追加

### 既存バグ修正
- `sun-mesh` に `alwaysSelectAsActiveMesh = true` を設定（`infiniteDistance` メッシュがカリングで除外されるのを防止）

## ゲート
- ESLint: ✅
- typecheck: ✅
- unit tests: 353/353 ✅
- visual regression: 12/12 ✅

Closes #39
Closes #143
