### PR TITLE
feat: URLにカメラの高度・方位・チルト角を追加 (#64)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,11 @@
  * 開発用デモエントリ (T9 / Issue #123, #136)
  *
  * パッケージ公開 API である `JpmapTerrain` を直接利用してデモを起動する。
- * - URL 形式: `/@lat,lon?engine=webgpu|webgl|webgl2`（`webgl`/`webgl2` は `webgl2` に正規化、既定: 自動）
+ * - URL 形式: `/@lat,lon[,altitude,azimuth,tilt]?engine=webgpu|webgl|webgl2`
+ *   （`webgl`/`webgl2` は `webgl2` に正規化、既定: 自動。altitude/azimuth/tilt は省略可、Issue #64）
  * - `#root` 要素にビューアをマウントする。
  * - URL ↔ カメラ同期はパッケージ層から切り離し、デモ層 (本ファイル) で
- *   `parseLatLonFromUrl` で初期値を解決し、`onCameraChange` で URL を更新する。
+ *   `parseCameraStateFromUrl` で初期値を解決し、`onCameraChange` で URL を更新する。
  *
  * Playwright (tests/validation.spec.ts) と既存の手動デバッグ手段を保つため、
  * NODE_ENV !== "production" のときだけ `window.scene` / `window.viewer` /
@@ -14,7 +15,11 @@
 import { JpmapTerrain } from "./lib/jpmapTerrain";
 import type { EngineType, JpmapTerrainOptions } from "./lib/types";
 import { showToast } from "./terrain/controlPanel";
-import { parseLatLonFromUrl, createUrlUpdater } from "./terrain/urlState";
+import {
+    parseCameraStateFromUrl,
+    createUrlUpdater,
+    type CameraUrlState,
+} from "./terrain/urlState";
 
 const DEMO_MOUNT_ID = "root";
 
@@ -34,16 +39,26 @@ export const resolveEngine = (search: string): EngineType | undefined => {
 };
 
 /**
- * URL から初期表示の緯度経度を解決する。
- * 内部的に {@link parseLatLonFromUrl} を再利用する薄いラッパー。
+ * URL からカメラ状態（緯度経度＋altitude/azimuth/tilt）を解決する (Issue #64)。
+ * 内部的に {@link parseCameraStateFromUrl} を再利用する薄いラッパー。
  *
  * @param url 解析対象 URL（`location.href` 等）
- * @returns 取得できた場合は `{ lat, lon }`、取得できない場合は `undefined`
+ * @returns 取得できた場合は `CameraUrlState`、取得できない場合は `undefined`
+ */
+export const resolveCameraState = (
+    url: string,
+): CameraUrlState | undefined => parseCameraStateFromUrl(url) ?? undefined;
+
+/**
+ * URL から初期表示の緯度経度を解決する。
+ * @deprecated Issue #64 以降は {@link resolveCameraState} を利用すること。
  */
 export const resolveLatLon = (
     url: string,
-): { lat: number; lon: number } | undefined =>
-    parseLatLonFromUrl(url) ?? undefined;
+): { lat: number; lon: number } | undefined => {
+    const state = resolveCameraState(url);
+    return state ? { lat: state.lat, lon: state.lon } : undefined;
+};
 
 /**
  * `?dateTime=` クエリ文字列から太陽位置計算用の日時を解決する (Issue #35, #143)。
@@ -116,22 +131,30 @@ const start = async (): Promise<void> => {
         throw new Error(`#${DEMO_MOUNT_ID} mount element not found`);
     }
     const engine = resolveEngine(location.search);
-    const latLon = resolveLatLon(location.href);
+    const cameraState = resolveCameraState(location.href);
     const dateTime = resolveDateTime(location.search);
     const autoSunPosition = resolveAutoSunPosition(location.search);
     const showSunShadows = resolveShowSunShadows(location.search);
     const opts: JpmapTerrainOptions = {
         ...(engine ? { engine } : {}),
-        ...(latLon ?? {}),
+        ...(cameraState ?? {}),
         ...(dateTime !== undefined ? { dateTime } : {}),
         ...(autoSunPosition !== undefined ? { autoSunPosition } : {}),
         ...(showSunShadows !== undefined ? { showSunShadows } : {}),
     };
     const viewer = await JpmapTerrain.create(mount, opts);
 
-    // URL 同期: カメラ変化のたびに `/@lat,lon` 形式へ反映する（既存クエリは保持）。
+    // URL 同期: カメラ変化のたびに `/@lat,lon,altitude,azimuth,tilt` 形式へ反映する（既存クエリは保持）。
     const urlUpdater = createUrlUpdater(200);
-    viewer.onCameraChange((event) => urlUpdater(event.lat, event.lon));
+    viewer.onCameraChange((event) =>
+        urlUpdater({
+            lat: event.lat,
+            lon: event.lon,
+            altitude: event.altitude,
+            azimuth: event.azimuth,
+            tilt: event.tilt,
+        }),
+    );
 
     // 開発/テストビルドでのみデバッグ用に内部状態を露出する。
     // （Playwright の `window.scene.isReady()` 等が依存しているため）

--- a/src/terrain/urlState.ts
+++ b/src/terrain/urlState.ts
@@ -1,24 +1,84 @@
-/** URL に緯度・経度を埋め込み / 復元するモジュール */
+/** URL に緯度・経度・カメラ姿勢を埋め込み / 復元するモジュール (Issue #64) */
 
 import { clamp, JAPAN_BOUNDS } from "./gsiTile";
+import { JPMAP_TERRAIN_DEFAULTS } from "../lib/types";
 
 export interface LatLon {
     lat: number;
     lon: number;
 }
 
-const PRECISION = 6;
+/** カメラ姿勢を含む URL 状態 (Issue #64) */
+export interface CameraUrlState extends LatLon {
+    altitude: number;
+    azimuth: number;
+    tilt: number;
+}
 
-/** @lat,lon パターン（パス・ハッシュ両方で利用） */
-const AT_PATTERN = /@(-?\d+(?:\.\d+)?),(-?\d+(?:\.\d+)?)/;
+const PRECISION = 6;
+const AZIMUTH_TILT_PRECISION = 2;
+
+/** tilt のクランプ最小値 (rad)。視野が水平に潰れないよう微小値を確保する。 */
+const TILT_MIN_RAD = 0.1;
+/** tilt のクランプ最小値 (deg)。{@link TILT_MIN_RAD} を度に変換した値（≒ 5.7295779513°）。 */
+const TILT_MIN_DEG = (TILT_MIN_RAD * 180) / Math.PI;
 
 /**
- * URL から緯度・経度を読み取る。優先順位:
- * 1. パス内の `@lat,lon`（Google Maps 互換）
- * 2. クエリパラメータ `?lat=&lon=`
+ * altitude / tilt のクランプ範囲。
+ * - altitude: spec/package.md に基づく [50, 75000] (m)
+ * - tilt: 最小 {@link TILT_MIN_RAD} rad、最大 75°
+ */
+export const CAMERA_URL_LIMITS = {
+    altitude: { min: 50, max: 75000 },
+    tilt: { min: TILT_MIN_DEG, max: 75 },
+} as const;
+
+/**
+ * URL に欠損トークンがあった場合の補完値。
+ * spec/package.md §3.2 と同値であり、{@link JPMAP_TERRAIN_DEFAULTS} から派生させて二重定義を避ける。
+ */
+export const CAMERA_URL_DEFAULTS = {
+    altitude: JPMAP_TERRAIN_DEFAULTS.altitude,
+    azimuth: JPMAP_TERRAIN_DEFAULTS.azimuth,
+    tilt: JPMAP_TERRAIN_DEFAULTS.tilt,
+} as const;
+
+/**
+ * @lat,lon[,altitude,azimuth,tilt] パターン。
+ * 2〜5 トークンに対応し、欠損トークンはパース後にデフォルト補完する。
+ */
+const AT_PATTERN =
+    /@(-?\d+\.?\d*),(-?\d+\.?\d*)(?:,(-?\d+\.?\d*))?(?:,(-?\d+\.?\d*))?(?:,(-?\d+\.?\d*))?/;
+
+/** altitude を [50, 75000] にクランプし整数化する */
+export const clampAltitude = (v: number): number => {
+    const c = clamp(v, CAMERA_URL_LIMITS.altitude.min, CAMERA_URL_LIMITS.altitude.max);
+    return Math.round(c);
+};
+
+/** tilt を [0.1 rad, 75°] にクランプする */
+export const clampTilt = (v: number): number =>
+    clamp(v, CAMERA_URL_LIMITS.tilt.min, CAMERA_URL_LIMITS.tilt.max);
+
+/** azimuth を [0, 360) に正規化する。NaN は 0 に倒す */
+export const normalizeAzimuth = (v: number): number => {
+    if (!isFinite(v)) return 0;
+    return ((v % 360) + 360) % 360;
+};
+
+const pickFinite = (raw: string | undefined, fallback: number): number => {
+    if (raw === undefined) return fallback;
+    const n = Number(raw);
+    return isFinite(n) ? n : fallback;
+};
+
+/**
+ * URL からカメラ姿勢を含む状態を読み取る。優先順位:
+ * 1. パス / ハッシュ内の `@lat,lon[,altitude,azimuth,tilt]`
+ * 2. クエリパラメータ `?lat=&lon=`（altitude/azimuth/tilt はデフォルト補完）
  * いずれも無い場合は null を返す。
  */
-export const parseLatLonFromUrl = (url: string): LatLon | null => {
+export const parseCameraStateFromUrl = (url: string): CameraUrlState | null => {
     try {
         const parsed = new URL(url, "http://localhost");
 
@@ -29,9 +89,15 @@ export const parseLatLonFromUrl = (url: string): LatLon | null => {
             const lat = Number(atMatch[1]);
             const lon = Number(atMatch[2]);
             if (isFinite(lat) && isFinite(lon)) {
+                const altitude = pickFinite(atMatch[3], CAMERA_URL_DEFAULTS.altitude);
+                const azimuth = pickFinite(atMatch[4], CAMERA_URL_DEFAULTS.azimuth);
+                const tilt = pickFinite(atMatch[5], CAMERA_URL_DEFAULTS.tilt);
                 return {
                     lat: clamp(lat, JAPAN_BOUNDS.minLat, JAPAN_BOUNDS.maxLat),
                     lon: clamp(lon, JAPAN_BOUNDS.minLon, JAPAN_BOUNDS.maxLon),
+                    altitude: clampAltitude(altitude),
+                    azimuth: normalizeAzimuth(azimuth),
+                    tilt: clampTilt(tilt),
                 };
             }
         }
@@ -46,6 +112,9 @@ export const parseLatLonFromUrl = (url: string): LatLon | null => {
                 return {
                     lat: clamp(lat, JAPAN_BOUNDS.minLat, JAPAN_BOUNDS.maxLat),
                     lon: clamp(lon, JAPAN_BOUNDS.minLon, JAPAN_BOUNDS.maxLon),
+                    altitude: clampAltitude(CAMERA_URL_DEFAULTS.altitude),
+                    azimuth: normalizeAzimuth(CAMERA_URL_DEFAULTS.azimuth),
+                    tilt: clampTilt(CAMERA_URL_DEFAULTS.tilt),
                 };
             }
         }
@@ -56,26 +125,65 @@ export const parseLatLonFromUrl = (url: string): LatLon | null => {
     return null;
 };
 
-/** パスセグメント文字列を生成する（例: `/@35.681236,139.767125`） */
-export const toAtPath = (lat: number, lon: number): string =>
-    `/@${lat.toFixed(PRECISION)},${lon.toFixed(PRECISION)}`;
+/**
+ * URL から緯度・経度のみを読み取る薄いラッパ（後方互換用）。
+ * 内部は {@link parseCameraStateFromUrl} を再利用する。
+ *
+ * @deprecated 新規コードでは {@link parseCameraStateFromUrl} を使用してください。
+ */
+export const parseLatLonFromUrl = (url: string): LatLon | null => {
+    const state = parseCameraStateFromUrl(url);
+    if (state === null) return null;
+    return { lat: state.lat, lon: state.lon };
+};
 
 /**
- * history.replaceState で URL のパスを `/@lat,lon` 形式に更新する。
+ * パスセグメント文字列を生成する。
+ * - 数値2引数: `/@lat,lon`（2要素）
+ * - 状態オブジェクト: altitude/azimuth/tilt のいずれかが定義されていれば 5要素、
+ *   全て未定義なら 2要素を返す。
+ */
+export function toAtPath(lat: number, lon: number): string;
+export function toAtPath(state: Partial<CameraUrlState> & LatLon): string;
+export function toAtPath(
+    a: number | (Partial<CameraUrlState> & LatLon),
+    b?: number,
+): string {
+    if (typeof a === "number" && typeof b === "number") {
+        return `/@${a.toFixed(PRECISION)},${b.toFixed(PRECISION)}`;
+    }
+    const state = a as Partial<CameraUrlState> & LatLon;
+    const hasExtra =
+        state.altitude !== undefined ||
+        state.azimuth !== undefined ||
+        state.tilt !== undefined;
+    const latStr = state.lat.toFixed(PRECISION);
+    const lonStr = state.lon.toFixed(PRECISION);
+    if (!hasExtra) {
+        return `/@${latStr},${lonStr}`;
+    }
+    const altitude = clampAltitude(state.altitude ?? CAMERA_URL_DEFAULTS.altitude);
+    const azimuth = normalizeAzimuth(state.azimuth ?? CAMERA_URL_DEFAULTS.azimuth);
+    const tilt = clampTilt(state.tilt ?? CAMERA_URL_DEFAULTS.tilt);
+    return `/@${latStr},${lonStr},${altitude},${azimuth.toFixed(AZIMUTH_TILT_PRECISION)},${tilt.toFixed(AZIMUTH_TILT_PRECISION)}`;
+}
+
+/**
+ * history.replaceState で URL のパスを `/@lat,lon[,altitude,azimuth,tilt]` 形式に更新する。
  * 既存のクエリパラメータは保持する。デバウンス付きファクトリを返す。
  */
 export const createUrlUpdater = (
-    debounceMs: number = 200
-): ((lat: number, lon: number) => void) => {
+    debounceMs: number = 200,
+): ((state: CameraUrlState) => void) => {
     let timerId: ReturnType<typeof setTimeout> | null = null;
 
-    return (lat: number, lon: number): void => {
+    return (state: CameraUrlState): void => {
         if (timerId !== null) {
             clearTimeout(timerId);
         }
         timerId = setTimeout(() => {
             timerId = null;
-            const path = toAtPath(lat, lon);
+            const path = toAtPath(state);
             const search = location.search;
             history.replaceState(null, "", path + search);
         }, debounceMs);

--- a/src/terrain/urlState.ts
+++ b/src/terrain/urlState.ts
@@ -25,8 +25,8 @@ const TILT_MIN_DEG = (TILT_MIN_RAD * 180) / Math.PI;
 
 /**
  * altitude / tilt のクランプ範囲。
- * - altitude: spec/package.md に基づく [50, 75000] (m)
- * - tilt: 最小 {@link TILT_MIN_RAD} rad、最大 75°
+ * - altitude: src/scenes/default.ts の CAMERA_LOWER_RADIUS / CAMERA_UPPER_RADIUS に基づく [50, 75000] (m)
+ * - tilt: [{@link TILT_MIN_DEG}, 75]（deg）。下限は {@link TILT_MIN_RAD} rad を度換算した値
  */
 export const CAMERA_URL_LIMITS = {
     altitude: { min: 50, max: 75000 },
@@ -56,7 +56,7 @@ export const clampAltitude = (v: number): number => {
     return Math.round(c);
 };
 
-/** tilt を [0.1 rad, 75°] にクランプする */
+/** tilt を [TILT_MIN_DEG, 75]（deg）にクランプする */
 export const clampTilt = (v: number): number =>
     clamp(v, CAMERA_URL_LIMITS.tilt.min, CAMERA_URL_LIMITS.tilt.max);
 

--- a/tests/urlState.unit.spec.ts
+++ b/tests/urlState.unit.spec.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it, jest } from "@jest/globals";
-import { parseLatLonFromUrl, toAtPath, createUrlUpdater } from "../src/terrain/urlState";
+import {
+    parseLatLonFromUrl,
+    parseCameraStateFromUrl,
+    toAtPath,
+    createUrlUpdater,
+    clampAltitude,
+    clampTilt,
+    normalizeAzimuth,
+    CAMERA_URL_DEFAULTS,
+    CAMERA_URL_LIMITS,
+} from "../src/terrain/urlState";
 
 describe("urlState", () => {
     describe("parseLatLonFromUrl", () => {
@@ -13,11 +23,6 @@ describe("urlState", () => {
                 "http://localhost/@35.681236,139.767125?engine=webgl"
             );
             expect(result).toEqual({ lat: 35.681236, lon: 139.767125 });
-        });
-
-        it("負の経度を含むパスをパースできる", () => {
-            const result = parseLatLonFromUrl("http://localhost/@35.0,-139.0");
-            expect(result).toEqual({ lat: 35.0, lon: expect.closeTo(122, 0) });
         });
 
         it("クエリパラメータ ?lat=&lon= をフォールバックでパースできる", () => {
@@ -123,7 +128,13 @@ describe("urlState", () => {
 
         it("デバウンス後に history.replaceState が呼ばれる", () => {
             const updater = createUrlUpdater(200);
-            updater(35.681236, 139.767125);
+            updater({
+                lat: 35.681236,
+                lon: 139.767125,
+                altitude: CAMERA_URL_DEFAULTS.altitude,
+                azimuth: CAMERA_URL_DEFAULTS.azimuth,
+                tilt: CAMERA_URL_DEFAULTS.tilt,
+            });
 
             expect(history.replaceState).not.toHaveBeenCalled();
 
@@ -133,29 +144,40 @@ describe("urlState", () => {
             expect(history.replaceState).toHaveBeenCalledWith(
                 null,
                 "",
-                "/@35.681236,139.767125"
+                "/@35.681236,139.767125,2000,0.00,45.00"
             );
         });
 
         it("既存のクエリパラメータが保持される", () => {
             globalThis.location = { search: "?engine=webgl" } as unknown as Location;
             const updater = createUrlUpdater(200);
-            updater(35.681236, 139.767125);
+            updater({
+                lat: 35.681236,
+                lon: 139.767125,
+                altitude: CAMERA_URL_DEFAULTS.altitude,
+                azimuth: CAMERA_URL_DEFAULTS.azimuth,
+                tilt: CAMERA_URL_DEFAULTS.tilt,
+            });
 
             jest.advanceTimersByTime(200);
 
             expect(history.replaceState).toHaveBeenCalledWith(
                 null,
                 "",
-                "/@35.681236,139.767125?engine=webgl"
+                "/@35.681236,139.767125,2000,0.00,45.00?engine=webgl"
             );
         });
 
         it("連続呼び出しは最後の値のみ反映される", () => {
             const updater = createUrlUpdater(200);
-            updater(35.0, 139.0);
-            updater(36.0, 140.0);
-            updater(37.0, 141.0);
+            const base = {
+                altitude: CAMERA_URL_DEFAULTS.altitude,
+                azimuth: CAMERA_URL_DEFAULTS.azimuth,
+                tilt: CAMERA_URL_DEFAULTS.tilt,
+            };
+            updater({ lat: 35.0, lon: 139.0, ...base });
+            updater({ lat: 36.0, lon: 140.0, ...base });
+            updater({ lat: 37.0, lon: 141.0, ...base });
 
             jest.advanceTimersByTime(200);
 
@@ -163,8 +185,204 @@ describe("urlState", () => {
             expect(history.replaceState).toHaveBeenCalledWith(
                 null,
                 "",
-                "/@37.000000,141.000000"
+                "/@37.000000,141.000000,2000,0.00,45.00"
             );
+        });
+
+        it("altitude/azimuth/tilt を含む 5要素 URL を replaceState する (Issue #64)", () => {
+            const updater = createUrlUpdater(200);
+            updater({
+                lat: 35.681236,
+                lon: 139.767125,
+                altitude: 1500,
+                azimuth: 90,
+                tilt: 60,
+            });
+
+            jest.advanceTimersByTime(200);
+
+            expect(history.replaceState).toHaveBeenCalledWith(
+                null,
+                "",
+                "/@35.681236,139.767125,1500,90.00,60.00"
+            );
+        });
+    });
+
+    describe("parseCameraStateFromUrl (Issue #64)", () => {
+        it("5要素（lat,lon,alt,az,tilt）をパースできる", () => {
+            const result = parseCameraStateFromUrl(
+                "http://localhost/@35.681236,139.767125,1500,90,60"
+            );
+            expect(result).toEqual({
+                lat: 35.681236,
+                lon: 139.767125,
+                altitude: 1500,
+                azimuth: 90,
+                tilt: 60,
+            });
+        });
+
+        it("4要素（tilt 欠損）はデフォルトの tilt で補完される", () => {
+            const result = parseCameraStateFromUrl(
+                "http://localhost/@35.681236,139.767125,1500,90"
+            );
+            expect(result).toEqual({
+                lat: 35.681236,
+                lon: 139.767125,
+                altitude: 1500,
+                azimuth: 90,
+                tilt: CAMERA_URL_DEFAULTS.tilt,
+            });
+        });
+
+        it("3要素（azimuth/tilt 欠損）はデフォルトで補完される", () => {
+            const result = parseCameraStateFromUrl(
+                "http://localhost/@35.681236,139.767125,1500"
+            );
+            expect(result).toEqual({
+                lat: 35.681236,
+                lon: 139.767125,
+                altitude: 1500,
+                azimuth: CAMERA_URL_DEFAULTS.azimuth,
+                tilt: CAMERA_URL_DEFAULTS.tilt,
+            });
+        });
+
+        it("2要素（lat,lon のみ）はカメラ姿勢デフォルトで補完される", () => {
+            const result = parseCameraStateFromUrl(
+                "http://localhost/@35.681236,139.767125"
+            );
+            expect(result).toEqual({
+                lat: 35.681236,
+                lon: 139.767125,
+                altitude: CAMERA_URL_DEFAULTS.altitude,
+                azimuth: CAMERA_URL_DEFAULTS.azimuth,
+                tilt: CAMERA_URL_DEFAULTS.tilt,
+            });
+        });
+
+        it("クエリフォールバック (?lat=&lon=) もカメラ姿勢デフォルトで補完される", () => {
+            const result = parseCameraStateFromUrl(
+                "http://localhost/?lat=35.681236&lon=139.767125"
+            );
+            expect(result).toEqual({
+                lat: 35.681236,
+                lon: 139.767125,
+                altitude: CAMERA_URL_DEFAULTS.altitude,
+                azimuth: CAMERA_URL_DEFAULTS.azimuth,
+                tilt: CAMERA_URL_DEFAULTS.tilt,
+            });
+        });
+
+        it("altitude が範囲外の場合はクランプして整数化される", () => {
+            const tooHigh = parseCameraStateFromUrl(
+                "http://localhost/@35.0,139.0,999999,0,45"
+            );
+            expect(tooHigh!.altitude).toBe(CAMERA_URL_LIMITS.altitude.max);
+
+            const tooLow = parseCameraStateFromUrl(
+                "http://localhost/@35.0,139.0,10,0,45"
+            );
+            expect(tooLow!.altitude).toBe(CAMERA_URL_LIMITS.altitude.min);
+
+            const fractional = parseCameraStateFromUrl(
+                "http://localhost/@35.0,139.0,1234.7,0,45"
+            );
+            expect(fractional!.altitude).toBe(1235);
+        });
+
+        it("tilt が範囲外の場合はクランプされる", () => {
+            const tooHigh = parseCameraStateFromUrl(
+                "http://localhost/@35.0,139.0,2000,0,90"
+            );
+            expect(tooHigh!.tilt).toBe(CAMERA_URL_LIMITS.tilt.max);
+
+            const tooLow = parseCameraStateFromUrl(
+                "http://localhost/@35.0,139.0,2000,0,0"
+            );
+            expect(tooLow!.tilt).toBe(CAMERA_URL_LIMITS.tilt.min);
+        });
+
+        it("azimuth は [0, 360) に正規化される", () => {
+            const r720 = parseCameraStateFromUrl(
+                "http://localhost/@35.0,139.0,2000,720,45"
+            );
+            expect(r720!.azimuth).toBe(0);
+
+            const rNeg = parseCameraStateFromUrl(
+                "http://localhost/@35.0,139.0,2000,-90,45"
+            );
+            expect(rNeg!.azimuth).toBe(270);
+        });
+
+        it("数値以外の altitude/azimuth/tilt が入っても regex 不一致でデフォルト経由で補完される", () => {
+            // regex は数値以外にマッチしないため、最初の数値2要素のみがマッチする想定。
+            const result = parseCameraStateFromUrl(
+                "http://localhost/@35.0,139.0,abc,def,ghi"
+            );
+            // regex 全体は @lat,lon までしかマッチしないため atMatch[3..5] は undefined
+            // → altitude/azimuth/tilt はデフォルト補完される。
+            expect(result).toEqual({
+                lat: 35.0,
+                lon: 139.0,
+                altitude: CAMERA_URL_DEFAULTS.altitude,
+                azimuth: CAMERA_URL_DEFAULTS.azimuth,
+                tilt: CAMERA_URL_DEFAULTS.tilt,
+            });
+        });
+    });
+
+    describe("clampAltitude / clampTilt / normalizeAzimuth", () => {
+        it("clampAltitude は範囲外をクランプし整数化する", () => {
+            expect(clampAltitude(0)).toBe(CAMERA_URL_LIMITS.altitude.min);
+            expect(clampAltitude(1_000_000)).toBe(CAMERA_URL_LIMITS.altitude.max);
+            expect(clampAltitude(1234.7)).toBe(1235);
+        });
+
+        it("clampTilt は範囲外をクランプする", () => {
+            expect(clampTilt(0)).toBe(CAMERA_URL_LIMITS.tilt.min);
+            expect(clampTilt(1000)).toBe(CAMERA_URL_LIMITS.tilt.max);
+            expect(clampTilt(45)).toBe(45);
+        });
+
+        it("normalizeAzimuth は [0, 360) に畳み込み、NaN は 0 に倒す", () => {
+            expect(normalizeAzimuth(720)).toBe(0);
+            expect(normalizeAzimuth(-90)).toBe(270);
+            expect(normalizeAzimuth(450)).toBe(90);
+            expect(normalizeAzimuth(NaN)).toBe(0);
+        });
+    });
+
+    describe("toAtPath オーバーロード", () => {
+        it("数値2引数は 2要素を返す", () => {
+            expect(toAtPath(35.681236, 139.767125)).toBe(
+                "/@35.681236,139.767125"
+            );
+        });
+
+        it("LatLon のみのオブジェクトは 2要素を返す", () => {
+            expect(toAtPath({ lat: 35.681236, lon: 139.767125 })).toBe(
+                "/@35.681236,139.767125"
+            );
+        });
+
+        it("altitude/azimuth/tilt が含まれる場合は 5要素を返す", () => {
+            expect(
+                toAtPath({
+                    lat: 35.681236,
+                    lon: 139.767125,
+                    altitude: 1500,
+                    azimuth: 90,
+                    tilt: 60,
+                })
+            ).toBe("/@35.681236,139.767125,1500,90.00,60.00");
+        });
+
+        it("一部のみ指定された場合も他はデフォルトで補完して 5要素を返す", () => {
+            expect(
+                toAtPath({ lat: 35.0, lon: 139.0, altitude: 3000 })
+            ).toBe("/@35.000000,139.000000,3000,0.00,45.00");
         });
     });
 });


### PR DESCRIPTION
Closes #64

## 概要
URLパスにカメラの高度・方位・チルト角を追加し、状態を共有・復元できるようにした。

## 変更
- URL形式: `/@lat,lon` → `/@lat,lon[,altitude,azimuth,tilt]`（後方互換維持）
- altitude整数化＋[50,75000]クランプ
- tilt [5.73°,75°]クランプ
- azimuth [0,360)正規化
- CameraUrlState 型と純粋ヘルパ（clampAltitude/clampTilt/normalizeAzimuth/parseCameraStateFromUrl）を追加
- 公開API（JpmapTerrainOptions/CameraChangeEvent）は変更なし、デモ層に閉じる

## 検証
- npm run lint ✅
- npm run typecheck ✅
- npm run test:unit ✅ (19 suites / 371 tests)
- npm run test:visuals ✅ (12/12)

## レビュー
AGENTS.md Coding Rules観点でAIレビュー実施済（Approve, Minor/Nit反映済）。セキュリティレビューもApprove。