### PR TITLE
feat(url): add mapType query param and onMapTypeChange API (#149)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,14 +79,15 @@ npm start
 
 `webgpu` 指定時に未対応ブラウザの場合は WebGL2 にフォールバックします。
 
-## URL フォーマット（緯度経度・エンジン指定）
+## URL フォーマット（緯度経度・エンジン・地図種類指定）
 
-開発デモエントリ（`src/index.ts`）は、Google Maps 互換のパス形式 `/@緯度,経度` と `engine` クエリパラメータをサポートします。ここで説明するのは開発デモ用 URL の仕様であり、npm パッケージの公開 API（`EngineType` は `"webgpu" | "webgl2"`）とは別です。
+開発デモエントリ（`src/index.ts`）は、Google Maps 互換のパス形式 `/@緯度,経度` と `engine` / `mapType` クエリパラメータをサポートします。ここで説明するのは開発デモ用 URL の仕様であり、npm パッケージの公開 API（`EngineType` は `"webgpu" | "webgl2"`、`MapType` は `"standard" | "photo"`）とは別です。
 
-- 形式: `http://localhost:8080/@<lat>,<lon>?engine=<webgpu|webgl|webgl2>`（`webgl` は URL クエリでのみ後方互換として受け付け、内部的に `webgl2` に正規化）
+- 形式: `http://localhost:8080/@<lat>,<lon>?engine=<webgpu|webgl|webgl2>&mapType=<standard|photo>`（`webgl` は URL クエリでのみ後方互換として受け付け、内部的に `webgl2` に正規化）
 - 例:
   - `http://localhost:8080/@35.681236,139.767125?engine=webgpu`（東京駅・WebGPU）
   - `http://localhost:8080/@35.3606,138.7274?engine=webgl2`（富士山・WebGL2）
+  - `http://localhost:8080/@35.681236,139.767125?engine=webgpu&mapType=photo`（東京駅・航空写真）
 
 ### `engine` パラメータ
 
@@ -96,6 +97,12 @@ npm start
 - `webgl` は URL クエリでのみ後方互換として受け付けられる別名で、内部的に `webgl2` に正規化されます
 - 省略時は自動選択（WebGPU 利用可能なら WebGPU、未対応なら WebGL2 にフォールバック）
 - npm パッケージの公開 API で指定できる `engine` は `"webgpu" | "webgl2"` です
+
+### `mapType` パラメータ
+
+- `standard`（標準地図）/ `photo`（航空写真）を指定できます（大小文字無視で受理、書き戻しは小文字）
+- 省略・不正値・URL 解析失敗時は `standard` にフォールバックします
+- 地図切替ボタン操作 / `viewer.mapType = ...` のいずれでも、URL のクエリ `?mapType=` が `history.replaceState` で更新されます（パス・他クエリ・ハッシュは保持）
 
 ### 緯度経度の扱い
 

--- a/spec/package.md
+++ b/spec/package.md
@@ -198,7 +198,41 @@ const unsubscribe = viewer.onCameraChange((e) => {
 unsubscribe();
 ```
 
-#### 3.3.5 太陽位置（時間による明るさ変化）
+#### 3.3.5 mapType 変化イベント (Issue #149)
+
+地図種類（`mapType`）の変化を購読する。`onCameraChange` と対称な API。
+
+```typescript
+interface JpmapTerrain {
+  /**
+   * mapType 変化リスナーを登録する。
+   *
+   * @param listener mapType 変化を受け取るリスナー
+   * @returns 登録解除関数（unsubscribe）
+   */
+  onMapTypeChange(listener: MapTypeChangeListener): () => void;
+}
+```
+
+**仕様:**
+
+- 戻り値は登録解除関数。呼び出すと当該リスナーのみが解除される。
+- **発火条件**: `mapType` が実際に変化したタイミングのみ通知する（同値の再 set は通知しない）。UI の地図切替ボタン操作・プログラム経由の `viewer.mapType = ...` の双方で発火する。
+- **初回登録時は即時発火しない**（変化があった次回以降のみ）。
+- 同一リスナーを複数回登録した場合は登録回数だけ呼ばれる。
+- リスナーが throw した場合でも、内部で例外を捕捉して `console.error` でログ出力し、他リスナーの処理は継続する。
+- `dispose()` 後に `onMapTypeChange` を呼び出した場合は登録されず、no-op の unsubscribe 関数を返す。
+
+**利用例:**
+
+```typescript
+const unsubscribe = viewer.onMapTypeChange((mapType) => {
+  console.log(`mapType changed: ${mapType}`);
+});
+unsubscribe();
+```
+
+#### 3.3.6 太陽位置（時間による明るさ変化）
 
 `dateTime` / `autoSunPosition` は **get / set 両対応**。set すると即座にライト・Skybox・太陽メッシュへ反映される。
 
@@ -245,6 +279,13 @@ interface JpmapTerrain {
 - `dispose()` 時に `ShadowGenerator` は確実に解放される。
 - URL クエリ `?showSunShadows=true|false` で初期値を制御できる（`true`/`false` 以外の値は無視）。
 
+**`mapType` URL クエリ仕様 (Issue #149):**
+
+- URL クエリ `?mapType=standard|photo` で初期値を上書きできる（デモ層）。
+- 値は大小文字無視で受理する（例: `?mapType=Photo` も `"photo"` として解釈）。書き戻し時は小文字に正規化する。
+- 不正値・欠落・URL 解析失敗時は `JPMAP_TERRAIN_DEFAULTS.mapType`（= `"standard"`）にフォールバックする（例外は投げない）。
+- `viewer.mapType` の変化（UI 切替ボタン / プログラム set）は `onMapTypeChange` 経由でデモ層が `history.replaceState` により URL の `?mapType=` を更新する。パス（`/@lat,lon[,...]`）と他クエリ（`engine`, `dateTime` 等）・ハッシュは保持される。
+
 ### 3.4 型定義
 
 `CameraChangeEvent` および `CameraChangeListener` は、`jpmap-terrain` から import 可能である（パッケージエントリで re-export 済み）。
@@ -261,10 +302,18 @@ interface CameraChangeEvent {
 
 /** `JpmapTerrain.onCameraChange` リスナー */
 type CameraChangeListener = (event: CameraChangeEvent) => void;
+
+/** `JpmapTerrain.onMapTypeChange` リスナー (Issue #149) */
+type MapTypeChangeListener = (mapType: MapType) => void;
 ```
 
 ```typescript
-import type { CameraChangeEvent, CameraChangeListener } from "jpmap-terrain";
+import type {
+  CameraChangeEvent,
+  CameraChangeListener,
+  MapType,
+  MapTypeChangeListener,
+} from "jpmap-terrain";
 ```
 
 ### 3.5 利用例

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,8 @@ import { showToast } from "./terrain/controlPanel";
 import {
     parseCameraStateFromUrl,
     createUrlUpdater,
+    parseMapTypeFromUrl,
+    updateMapTypeInUrl,
     type CameraUrlState,
 } from "./terrain/urlState";
 
@@ -135,12 +137,14 @@ const start = async (): Promise<void> => {
     const dateTime = resolveDateTime(location.search);
     const autoSunPosition = resolveAutoSunPosition(location.search);
     const showSunShadows = resolveShowSunShadows(location.search);
+    const mapType = parseMapTypeFromUrl(location.href);
     const opts: JpmapTerrainOptions = {
         ...(engine ? { engine } : {}),
         ...(cameraState ?? {}),
         ...(dateTime !== undefined ? { dateTime } : {}),
         ...(autoSunPosition !== undefined ? { autoSunPosition } : {}),
         ...(showSunShadows !== undefined ? { showSunShadows } : {}),
+        ...(mapType !== null ? { mapType } : {}),
     };
     const viewer = await JpmapTerrain.create(mount, opts);
 
@@ -155,6 +159,11 @@ const start = async (): Promise<void> => {
             tilt: event.tilt,
         }),
     );
+
+    // URL 同期: mapType 変化のたびに `?mapType=` を反映する (Issue #149)。
+    viewer.onMapTypeChange((next) => updateMapTypeInUrl(next));
+    // 起動完了直後に一度書き込み、`?mapType=Photo` のような大小混在の値を小文字に揃える。
+    updateMapTypeInUrl(viewer.mapType);
 
     // 開発/テストビルドでのみデバッグ用に内部状態を露出する。
     // （Playwright の `window.scene.isReady()` 等が依存しているため）

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -14,4 +14,5 @@ export type {
     FlyToOptions,
     JpmapTerrainOptions,
     MapType,
+    MapTypeChangeListener,
 } from "./lib/types";

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -23,6 +23,7 @@ import {
     JPMAP_TERRAIN_DEFAULTS,
     JpmapTerrainOptions,
     MapType,
+    MapTypeChangeListener,
     SUN_AUTO_UPDATE_INTERVAL_MS,
 } from "./types";
 
@@ -74,6 +75,8 @@ export class JpmapTerrain {
     private _cameraObserver: Observer<Scene> | null = null;
     /** 直近にリスナー通知した値のスナップショット（初回は null） */
     private _lastCameraSnapshot: CameraChangeEvent | null = null;
+    /** `onMapTypeChange` で登録されたリスナー一覧 (Issue #149) */
+    private _mapTypeListeners: MapTypeChangeListener[] = [];
 
     private constructor(mountElement: HTMLElement, options: JpmapTerrainOptions) {
         this.mountElement = mountElement;
@@ -161,6 +164,7 @@ export class JpmapTerrain {
                 azimuth: this._azimuth,
                 tilt: this._tilt,
                 mapType: this._mapType,
+                onMapTypeChange: (next) => this._handleMapTypeChange(next),
                 onReady: (controller) => {
                     this._controller = controller;
                     // T6: 初期表示状態を controller に反映する
@@ -461,6 +465,55 @@ export class JpmapTerrain {
         this._controller?.setMapType(value);
     }
 
+    /**
+     * `mapType` が変化した際に呼ばれるリスナーを登録する (Issue #149)。
+     *
+     * - `onCameraChange` と対称な API。
+     * - UI ボタン操作・`mapType` setter のいずれの経路でも、値が変化したフレームのみ通知する。
+     * - 同値再 set では通知しない。
+     * - 戻り値の関数で登録解除（複数回呼んでも安全）。
+     * - リスナーが throw しても他リスナーへ伝播し、`console.error` で握りつぶす。
+     * - `dispose()` 後の呼び出しは何もせず、no-op の unsubscribe を返す。
+     *
+     * @param listener `mapType` 変化を受け取るリスナー
+     * @returns 登録解除関数
+     */
+    public onMapTypeChange(listener: MapTypeChangeListener): () => void {
+        if (this._disposed) {
+            return () => {
+                /* no-op: viewer is already disposed */
+            };
+        }
+        this._mapTypeListeners.push(listener);
+        let removed = false;
+        return (): void => {
+            if (removed) return;
+            removed = true;
+            const idx = this._mapTypeListeners.indexOf(listener);
+            if (idx !== -1) {
+                this._mapTypeListeners.splice(idx, 1);
+            }
+        };
+    }
+
+    /**
+     * controller から伝播される `mapType` 変化を受け取り、
+     * 内部状態の更新と登録リスナーへの通知を行う (Issue #149)。
+     * controller 側で同値再 set はフィルタ済みのため、ここでは無条件に通知する。
+     */
+    private _handleMapTypeChange(next: MapType): void {
+        if (this._disposed) return;
+        this._mapType = next;
+        const listeners = this._mapTypeListeners.slice();
+        for (const listener of listeners) {
+            try {
+                listener(next);
+            } catch (err) {
+                console.error("[JpmapTerrain] onMapTypeChange listener threw:", err);
+            }
+        }
+    }
+
     // ---- 太陽位置 (spec §3.3.5 / Issue #35) ----
 
     /**
@@ -652,6 +705,7 @@ export class JpmapTerrain {
         this._cameraObserver = null;
         this._cameraListeners = [];
         this._lastCameraSnapshot = null;
+        this._mapTypeListeners = [];
         if (this._resizeObserver) {
             this._resizeObserver.disconnect();
             this._resizeObserver = null;

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -514,7 +514,7 @@ export class JpmapTerrain {
         }
     }
 
-    // ---- 太陽位置 (spec §3.3.5 / Issue #35) ----
+    // ---- 太陽位置 (spec §3.3.6 / Issue #35) ----
 
     /**
      * 太陽位置計算に使う日時を取得する。

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -113,3 +113,9 @@ export interface CameraChangeEvent {
 
 /** `JpmapTerrain.onCameraChange` リスナー */
 export type CameraChangeListener = (event: CameraChangeEvent) => void;
+
+/**
+ * `JpmapTerrain.onMapTypeChange` リスナー (Issue #149)。
+ * `mapType` が実際に変化したタイミングのみ呼ばれる。
+ */
+export type MapTypeChangeListener = (mapType: MapType) => void;

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -166,6 +166,14 @@ export interface DefaultSceneInitOptions {
     /** 地図種類（T6 で配線） */
     mapType?: "standard" | "photo";
     /**
+     * `mapType` が実際に変化した際に呼ばれるコールバック (Issue #149)。
+     *
+     * - `controller.setMapType` 経由・UI ボタンクリック経由のいずれの変化でも発火する。
+     * - 起動時の初期値設定では発火しない（呼び出し側との重複通知防止）。
+     * - 同値再 set では発火しない。
+     */
+    onMapTypeChange?: (mapType: "standard" | "photo") => void;
+    /**
      * シーン構築完了時に外部操作用コントローラを受け取るコールバック (T5)。
      * `JpmapTerrain` の get/set/flyTo はこのコントローラ経由でカメラ・位置を更新する。
      */
@@ -929,16 +937,24 @@ export class DefaultScene implements CreateSceneClass {
             );
         };
         // 初期 mapType がオプション指定されていれば反映する (T6)。
+        // 初期反映は onMapTypeChange を発火させない（呼び出し側との重複通知防止 / Issue #149）。
         if (options?.mapType) {
             const initialInternal =
                 options.mapType === "standard" ? "std" : "photo";
             tileManager.setMapType(initialInternal);
             updateMapToggleLabel(initialInternal);
         }
-        ui.mapToggle.addEventListener("click", () => {
-            const next = tileManager.mapType === "std" ? "photo" : "std";
+        // mapType の値が実際に変化した場合のみ onMapTypeChange を発火する共通ヘルパ (Issue #149)。
+        const applyMapTypeChange = (next: "std" | "photo"): void => {
+            const prev = tileManager.mapType;
+            if (prev === next) return;
             tileManager.setMapType(next);
             updateMapToggleLabel(next);
+            options?.onMapTypeChange?.(next === "std" ? "standard" : "photo");
+        };
+        ui.mapToggle.addEventListener("click", () => {
+            const next = tileManager.mapType === "std" ? "photo" : "std";
+            applyMapTypeChange(next);
         });
 
         // カメラ-地形衝突回避: 地面にめり込まないよう radius を補正してストップ
@@ -1187,8 +1203,7 @@ export class DefaultScene implements CreateSceneClass {
                 tileManager.mapType === "std" ? "standard" : "photo",
             setMapType: (value) => {
                 const internal = value === "standard" ? "std" : "photo";
-                tileManager.setMapType(internal);
-                updateMapToggleLabel(internal);
+                applyMapTypeChange(internal);
             },
             setUiVisibility: createUiVisibilityController({
                 compass: ui.compass,

--- a/src/terrain/urlState.ts
+++ b/src/terrain/urlState.ts
@@ -234,7 +234,8 @@ export const withMapTypeInUrl = (url: string, mapType: MapType): string => {
 
 /**
  * `history.replaceState` で現在の URL に `?mapType=<value>` を反映する (Issue #149)。
- * パス・他クエリ・ハッシュは保持する。`window` / `history` が未定義な環境（jsdom 等）では何もしない。
+ * パス・他クエリ・ハッシュは保持する。`window` / `history` が未定義な環境
+ *（Node.js / SSR など、ブラウザグローバルが存在しない実行環境）では何もしない。
  */
 export const updateMapTypeInUrl = (mapType: MapType): void => {
     if (typeof window === "undefined" || typeof window.history === "undefined") {

--- a/src/terrain/urlState.ts
+++ b/src/terrain/urlState.ts
@@ -2,6 +2,7 @@
 
 import { clamp, JAPAN_BOUNDS } from "./gsiTile";
 import { JPMAP_TERRAIN_DEFAULTS } from "../lib/types";
+import type { MapType } from "../lib/types";
 
 export interface LatLon {
     lat: number;
@@ -188,4 +189,57 @@ export const createUrlUpdater = (
             history.replaceState(null, "", path + search);
         }, debounceMs);
     };
+};
+
+// ---- mapType クエリ (Issue #149) ----
+
+/** `?mapType=` のクエリキー名 */
+export const MAP_TYPE_QUERY_KEY = "mapType";
+
+const MAP_TYPE_VALUES: ReadonlyArray<MapType> = ["standard", "photo"];
+
+const isMapType = (value: string): value is MapType =>
+    (MAP_TYPE_VALUES as ReadonlyArray<string>).includes(value);
+
+/**
+ * URL から `?mapType=standard|photo` を読み取る (Issue #149)。
+ *
+ * - 大小文字無視（`Standard`, `PHOTO` も可）。書き出しは小文字。
+ * - 不正値・欠落・URL 解析失敗時は `null` を返す。
+ */
+export const parseMapTypeFromUrl = (url: string): MapType | null => {
+    try {
+        const parsed = new URL(url, "http://localhost");
+        const raw = parsed.searchParams.get(MAP_TYPE_QUERY_KEY);
+        if (raw === null) return null;
+        const normalized = raw.toLowerCase();
+        return isMapType(normalized) ? normalized : null;
+    } catch {
+        return null;
+    }
+};
+
+/**
+ * 入力 URL のクエリ部に `mapType=<value>` をマージして返す純粋関数 (Issue #149)。
+ *
+ * - パス・他クエリ（例 `?engine=`）・ハッシュは保持する。
+ * - 既存の `mapType` パラメータは上書きする。
+ * - 戻り値は `pathname + search + hash` のみ（`new URL` の dummy origin は除去）。
+ */
+export const withMapTypeInUrl = (url: string, mapType: MapType): string => {
+    const parsed = new URL(url, "http://localhost");
+    parsed.searchParams.set(MAP_TYPE_QUERY_KEY, mapType);
+    return parsed.pathname + parsed.search + parsed.hash;
+};
+
+/**
+ * `history.replaceState` で現在の URL に `?mapType=<value>` を反映する (Issue #149)。
+ * パス・他クエリ・ハッシュは保持する。`window` / `history` が未定義な環境（jsdom 等）では何もしない。
+ */
+export const updateMapTypeInUrl = (mapType: MapType): void => {
+    if (typeof window === "undefined" || typeof window.history === "undefined") {
+        return;
+    }
+    const next = withMapTypeInUrl(window.location.href, mapType);
+    window.history.replaceState(null, "", next);
 };

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -163,6 +163,7 @@ jest.unstable_mockModule("../src/scenes/default", () => {
                     azimuth?: number;
                     tilt?: number;
                     mapType?: "standard" | "photo";
+                    onMapTypeChange?: (mapType: "standard" | "photo") => void;
                     onReady?: (controller: unknown) => void;
                 },
             ) => {
@@ -211,8 +212,12 @@ jest.unstable_mockModule("../src/scenes/default", () => {
                     ) => applyView(values, options?.refreshTerrain ?? true),
                     getMapType: () => lastMapType,
                     setMapType: (value: "standard" | "photo") => {
+                        const prev = lastMapType;
                         lastMapType = value;
                         setMapTypeCalls.push(value);
+                        if (prev !== value) {
+                            opts?.onMapTypeChange?.(value);
+                        }
                     },
                     setUiVisibility: (target: UiTarget, visible: boolean) => {
                         uiVisibility[target] = visible;
@@ -1030,6 +1035,123 @@ describe("JpmapTerrain (skeleton)", () => {
             sceneMockModule.__triggerSceneRender();
 
             expect(listener).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("onMapTypeChange (Issue #149)", () => {
+        beforeEach(() => {
+            sceneMockModule.__resetSetMapTypeCalls();
+            sceneMockModule.__setLastMapType("standard");
+        });
+
+        it("初回登録時には即時発火しない", async () => {
+            const viewer = await create(createMountElement());
+            const listener = jest.fn();
+            viewer.onMapTypeChange(listener);
+            expect(listener).not.toHaveBeenCalled();
+        });
+
+        it("mapType setter で値が変化したらリスナーが呼ばれる", async () => {
+            const viewer = await create(createMountElement());
+            const listener = jest.fn();
+            viewer.onMapTypeChange(listener);
+
+            viewer.mapType = "photo";
+
+            expect(listener).toHaveBeenCalledTimes(1);
+            expect(listener).toHaveBeenCalledWith("photo");
+        });
+
+        it("同値再 set では発火しない", async () => {
+            const viewer = await create(createMountElement());
+            const listener = jest.fn();
+            viewer.onMapTypeChange(listener);
+
+            viewer.mapType = "standard"; // 既定値と同値
+            viewer.mapType = "photo";
+            viewer.mapType = "photo"; // 同値再 set
+
+            expect(listener).toHaveBeenCalledTimes(1);
+            expect(listener).toHaveBeenCalledWith("photo");
+        });
+
+        it("unsubscribe 後は呼ばれず、複数回呼んでも安全", async () => {
+            const viewer = await create(createMountElement());
+            const listener = jest.fn();
+            const unsubscribe = viewer.onMapTypeChange(listener);
+
+            viewer.mapType = "photo";
+            expect(listener).toHaveBeenCalledTimes(1);
+
+            unsubscribe();
+            unsubscribe(); // 多重呼び出しでも例外にならない
+            viewer.mapType = "standard";
+
+            expect(listener).toHaveBeenCalledTimes(1);
+        });
+
+        it("複数リスナーを登録すると全て呼ばれる", async () => {
+            const viewer = await create(createMountElement());
+            const a = jest.fn();
+            const b = jest.fn();
+            viewer.onMapTypeChange(a);
+            viewer.onMapTypeChange(b);
+
+            viewer.mapType = "photo";
+
+            expect(a).toHaveBeenCalledTimes(1);
+            expect(b).toHaveBeenCalledTimes(1);
+        });
+
+        it("リスナーが throw しても他リスナーへの伝播が継続する", async () => {
+            const viewer = await create(createMountElement());
+            const errorSpy = jest
+                .spyOn(console, "error")
+                .mockImplementation(() => {});
+            const failing = jest.fn(() => {
+                throw new Error("listener failure");
+            });
+            const ok = jest.fn();
+            viewer.onMapTypeChange(failing);
+            viewer.onMapTypeChange(ok);
+
+            viewer.mapType = "photo";
+
+            expect(failing).toHaveBeenCalledTimes(1);
+            expect(ok).toHaveBeenCalledTimes(1);
+            expect(errorSpy).toHaveBeenCalled();
+
+            errorSpy.mockRestore();
+        });
+
+        it("dispose 後の onMapTypeChange は no-op の unsubscribe を返す", async () => {
+            const viewer = await create(createMountElement());
+            viewer.dispose();
+
+            const listener = jest.fn();
+            const unsubscribe = viewer.onMapTypeChange(listener);
+
+            expect(typeof unsubscribe).toBe("function");
+            expect(() => unsubscribe()).not.toThrow();
+            expect(listener).not.toHaveBeenCalled();
+        });
+
+        it("初期 options.mapType の反映では発火しない", async () => {
+            // create 時に listener はまだ登録されていないため発火対象にはなり得ないが、
+            // 念のため「初期化直後にリスナーを付け、その後の操作で初めて発火する」ことを確認する。
+            const viewer = await create(createMountElement(), {
+                mapType: "photo",
+            });
+            const listener = jest.fn();
+            viewer.onMapTypeChange(listener);
+
+            // 初期 photo に同値再 set → 発火しない
+            viewer.mapType = "photo";
+            expect(listener).not.toHaveBeenCalled();
+
+            viewer.mapType = "standard";
+            expect(listener).toHaveBeenCalledTimes(1);
+            expect(listener).toHaveBeenCalledWith("standard");
         });
     });
 

--- a/tests/urlState.unit.spec.ts
+++ b/tests/urlState.unit.spec.ts
@@ -9,6 +9,10 @@ import {
     normalizeAzimuth,
     CAMERA_URL_DEFAULTS,
     CAMERA_URL_LIMITS,
+    MAP_TYPE_QUERY_KEY,
+    parseMapTypeFromUrl,
+    withMapTypeInUrl,
+    updateMapTypeInUrl,
 } from "../src/terrain/urlState";
 
 describe("urlState", () => {
@@ -383,6 +387,161 @@ describe("urlState", () => {
             expect(
                 toAtPath({ lat: 35.0, lon: 139.0, altitude: 3000 })
             ).toBe("/@35.000000,139.000000,3000,0.00,45.00");
+        });
+    });
+
+    describe("parseMapTypeFromUrl (Issue #149)", () => {
+        it("?mapType=standard を読み取る", () => {
+            expect(parseMapTypeFromUrl("http://localhost/?mapType=standard")).toBe(
+                "standard"
+            );
+        });
+
+        it("?mapType=photo を読み取る", () => {
+            expect(parseMapTypeFromUrl("http://localhost/?mapType=photo")).toBe(
+                "photo"
+            );
+        });
+
+        it("大小文字混在も許容して小文字へ正規化する", () => {
+            expect(parseMapTypeFromUrl("http://localhost/?mapType=Photo")).toBe(
+                "photo"
+            );
+            expect(parseMapTypeFromUrl("http://localhost/?mapType=STANDARD")).toBe(
+                "standard"
+            );
+        });
+
+        it("空値は null を返す", () => {
+            expect(parseMapTypeFromUrl("http://localhost/?mapType=")).toBeNull();
+        });
+
+        it("不正値は null を返す", () => {
+            expect(parseMapTypeFromUrl("http://localhost/?mapType=satellite")).toBeNull();
+        });
+
+        it("欠落は null を返す", () => {
+            expect(parseMapTypeFromUrl("http://localhost/")).toBeNull();
+        });
+
+        it("不正 URL は null を返す", () => {
+            expect(parseMapTypeFromUrl("not a url")).toBeNull();
+        });
+
+        it("MAP_TYPE_QUERY_KEY が 'mapType' であること", () => {
+            expect(MAP_TYPE_QUERY_KEY).toBe("mapType");
+        });
+    });
+
+    describe("withMapTypeInUrl (Issue #149)", () => {
+        it("既存クエリ (engine 等) を保持して mapType を追記する", () => {
+            const result = withMapTypeInUrl(
+                "http://localhost/?engine=webgl",
+                "photo"
+            );
+            expect(result).toBe("/?engine=webgl&mapType=photo");
+        });
+
+        it("ハッシュを保持する", () => {
+            const result = withMapTypeInUrl(
+                "http://localhost/path#section",
+                "standard"
+            );
+            expect(result).toBe("/path?mapType=standard#section");
+        });
+
+        it("既存の mapType は上書きする", () => {
+            const result = withMapTypeInUrl(
+                "http://localhost/?mapType=standard",
+                "photo"
+            );
+            expect(result).toBe("/?mapType=photo");
+        });
+
+        it("パス（@lat,lon 形式含む）を保持する", () => {
+            const result = withMapTypeInUrl(
+                "http://localhost/@35.681236,139.767125",
+                "photo"
+            );
+            expect(result).toBe("/@35.681236,139.767125?mapType=photo");
+        });
+    });
+
+    describe("parseMapTypeFromUrl(withMapTypeInUrl(...)) ラウンドトリップ", () => {
+        it.each(["standard", "photo"] as const)(
+            "%s を再パースして同値が得られる",
+            (value) => {
+                const next = withMapTypeInUrl(
+                    "http://localhost/?engine=webgl",
+                    value
+                );
+                expect(parseMapTypeFromUrl(`http://localhost${next}`)).toBe(value);
+            }
+        );
+    });
+
+    describe("updateMapTypeInUrl (Issue #149)", () => {
+        const originalWindow = (globalThis as { window?: unknown }).window;
+
+        afterEach(() => {
+            if (originalWindow === undefined) {
+                delete (globalThis as { window?: unknown }).window;
+            } else {
+                (globalThis as { window?: unknown }).window = originalWindow;
+            }
+        });
+
+        it("history.replaceState を呼び、?mapType=<value> を含む URL を渡す", () => {
+            const replaceSpy = jest.fn();
+            (globalThis as { window?: unknown }).window = {
+                history: { replaceState: replaceSpy },
+                location: { href: "http://localhost/?engine=webgl" },
+            };
+
+            updateMapTypeInUrl("photo");
+
+            expect(replaceSpy).toHaveBeenCalledTimes(1);
+            const args = replaceSpy.mock.calls[0];
+            expect(args[0]).toBeNull();
+            expect(args[1]).toBe("");
+            expect(args[2]).toBe("/?engine=webgl&mapType=photo");
+        });
+
+        it("既存の mapType を上書きする", () => {
+            const replaceSpy = jest.fn();
+            (globalThis as { window?: unknown }).window = {
+                history: { replaceState: replaceSpy },
+                location: { href: "http://localhost/?mapType=standard" },
+            };
+
+            updateMapTypeInUrl("photo");
+
+            expect(replaceSpy).toHaveBeenCalledWith(
+                null,
+                "",
+                "/?mapType=photo"
+            );
+        });
+
+        it("typeof window が undefined の環境では何もしない", () => {
+            delete (globalThis as { window?: unknown }).window;
+            // 例外を投げないことだけ確認
+            expect(() => updateMapTypeInUrl("photo")).not.toThrow();
+        });
+    });
+
+    describe("既存 parseCameraStateFromUrl への mapType の影響なし (Issue #149)", () => {
+        it("?mapType=photo が混入してもカメラ状態は解析される", () => {
+            const result = parseCameraStateFromUrl(
+                "http://localhost/@35.681236,139.767125,1500,90,60?mapType=photo"
+            );
+            expect(result).toEqual({
+                lat: 35.681236,
+                lon: 139.767125,
+                altitude: 1500,
+                azimuth: 90,
+                tilt: 60,
+            });
         });
     });
 });


### PR DESCRIPTION
Closes #149

## 概要
URL クエリ `?mapType=standard|photo` を追加し、共有 URL から地図種類を復元できるようにする。あわせて公開 API `JpmapTerrain.onMapTypeChange` を新設。

## 変更内容
- `src/terrain/urlState.ts`: `parseMapTypeFromUrl` / `withMapTypeInUrl` / `updateMapTypeInUrl` を追加
- `src/lib/types.ts`: `MapTypeChangeListener` 追加
- `src/lib/jpmapTerrain.ts`: `onMapTypeChange()` 公開 API 追加
- `src/scenes/default.ts`: controller 経由の mapType 変化フック注入
- `src/index.ts`: 起動時 `?mapType=` 読み取り、変化時に URL 書き戻し
- `src/lib.ts`: `MapTypeChangeListener` を re-export
- テスト追加: `tests/urlState.unit.spec.ts`, `tests/jpmapTerrain.unit.spec.ts`
- ドキュメント更新: `README.md`, `spec/package.md`

## 仕様
- クエリキー: `mapType`、値: `standard|photo`（大小無視で受理、書き出しは小文字）
- 不正値・欠落・URL 解析失敗時は `JPMAP_TERRAIN_DEFAULTS.mapType`（= `standard`）にフォールバック
- 既存 `/@lat,lon[,...]` パスは変更なし（後方互換完全維持）
- `onMapTypeChange` は `onCameraChange` と対称（同値再 set 非通知 / throw 継続 / dispose 後 no-op）

## 影響範囲
- 公開 API: `JpmapTerrain.onMapTypeChange` 追加、`MapTypeChangeListener` 型追加
- デモ URL 仕様: `?mapType=` クエリ追加
- ドキュメント: README.md / spec/package.md §3.3.5 / §3.4

## 検証
- `npm run lint`: 成功
- `npm run typecheck`: 成功
- `npm run test:unit`: 成功（19 suites / 397 tests）

Parent: #33