### PR TITLE
fix(scenes): refresh tiles on engine resize (#150)

### DIFF
--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -14,6 +14,7 @@ import { Ray } from "@babylonjs/core/Culling/ray";
 import { CreateSceneClass } from "../createScene";
 import { clamp, toTileXY, tileEdgeMeters, JAPAN_BOUNDS } from "../terrain/gsiTile";
 import { createControlPanel, snapScale, formatScale, showToast } from "../terrain/controlPanel";
+import { attachResizeRefresh } from "../terrain/resizeRefresh";
 import { createTileManager } from "../terrain/tileManager";
 import { createSkybox } from "../terrain/skybox";
 import { computeSunPosition } from "../terrain/sunPosition";
@@ -845,24 +846,9 @@ export class DefaultScene implements CreateSceneClass {
         // タイルが取得・描画されない。`tileManager.applyVisibleTiles` は不要解放と
         // 新規ロードの差分処理のみ行うため、ここから refreshTerrain を呼んでも
         // 既存タイルは保持され、ちらつきは発生しない。
-        // 連続リサイズで何度も refresh が走らないよう短い debounce を挟む。
-        const RESIZE_REFRESH_DEBOUNCE_MS = 100;
-        let resizeRefreshTimer: ReturnType<typeof setTimeout> | null = null;
-        engine.onResizeObservable.add(() => {
-            if (resizeRefreshTimer !== null) {
-                clearTimeout(resizeRefreshTimer);
-            }
-            resizeRefreshTimer = setTimeout(() => {
-                resizeRefreshTimer = null;
-                void refreshTerrain();
-            }, RESIZE_REFRESH_DEBOUNCE_MS);
-        });
-        scene.onDisposeObservable.add(() => {
-            if (resizeRefreshTimer !== null) {
-                clearTimeout(resizeRefreshTimer);
-                resizeRefreshTimer = null;
-            }
-        });
+        // 購読解除・保留中タイマーのクリアは attachResizeRefresh が
+        // scene.onDisposeObservable 経由で自動的に行う (PR #153 レビュー指摘対応)。
+        attachResizeRefresh(engine, scene, () => refreshTerrain());
 
         // 方位磁針: 北向き・真下にスムーズアニメーション
         ui.compass.style.cursor = "pointer";

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -839,6 +839,31 @@ export class DefaultScene implements CreateSceneClass {
         engine.onResizeObservable.add(updateScaleBar);
         updateScaleBar();
 
+        // ウィンドウ/canvas のリサイズ時に可視タイル集合を再計算する (Issue #150)。
+        // 可視タイル更新は通常 camera.onViewMatrixChangedObservable をトリガに走るが、
+        // リサイズ単独ではビュー行列が変わらないため発火せず、新たに視野へ入った領域の
+        // タイルが取得・描画されない。`tileManager.applyVisibleTiles` は不要解放と
+        // 新規ロードの差分処理のみ行うため、ここから refreshTerrain を呼んでも
+        // 既存タイルは保持され、ちらつきは発生しない。
+        // 連続リサイズで何度も refresh が走らないよう短い debounce を挟む。
+        const RESIZE_REFRESH_DEBOUNCE_MS = 100;
+        let resizeRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+        engine.onResizeObservable.add(() => {
+            if (resizeRefreshTimer !== null) {
+                clearTimeout(resizeRefreshTimer);
+            }
+            resizeRefreshTimer = setTimeout(() => {
+                resizeRefreshTimer = null;
+                void refreshTerrain();
+            }, RESIZE_REFRESH_DEBOUNCE_MS);
+        });
+        scene.onDisposeObservable.add(() => {
+            if (resizeRefreshTimer !== null) {
+                clearTimeout(resizeRefreshTimer);
+                resizeRefreshTimer = null;
+            }
+        });
+
         // 方位磁針: 北向き・真下にスムーズアニメーション
         ui.compass.style.cursor = "pointer";
         const resetCompassView = (): void => {

--- a/src/terrain/resizeRefresh.ts
+++ b/src/terrain/resizeRefresh.ts
@@ -1,0 +1,86 @@
+/**
+ * リサイズに伴うタイル再描画ヘルパ (Issue #150)
+ *
+ * Babylon.js の `engine.onResizeObservable` は canvas のリサイズで発火するが、
+ * カメラのビュー行列は変化しないため `tileManager` 側の可視タイル更新
+ * (`camera.onViewMatrixChangedObservable` 起点) が走らない。これにより、
+ * ウィンドウ拡大時に新たに視野へ入った領域のタイルが取得・描画されない問題が発生する。
+ *
+ * 本ヘルパは engine のリサイズイベントを購読し、短い debounce を挟んだうえで
+ * 与えられた `refresh` を呼ぶ。`tileManager.applyVisibleTiles` 側が差分更新
+ * (不要解放＋新規ロード) のため、既存タイルは保持されちらつかない。
+ *
+ * Scene の dispose 時には Observer 解除と保留中タイマーのクリアを行い、
+ * 破棄済みリソースへの参照やタイマーリークを防ぐ (PR #153 レビュー指摘対応)。
+ */
+
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { Observer } from "@babylonjs/core/Misc/observable";
+import type { Scene } from "@babylonjs/core/scene";
+
+/** debounce のデフォルト値 (ms)。連続リサイズで refresh が頻発しない値。 */
+export const DEFAULT_RESIZE_REFRESH_DEBOUNCE_MS = 100;
+
+export interface AttachResizeRefreshOptions {
+    /** debounce 時間 (ms)。省略時は {@link DEFAULT_RESIZE_REFRESH_DEBOUNCE_MS}。 */
+    readonly debounceMs?: number;
+}
+
+export interface AttachResizeRefreshHandle {
+    /** 購読解除と保留中タイマーのクリアを行う。複数回呼んでも安全。 */
+    dispose(): void;
+}
+
+/**
+ * `engine.onResizeObservable` を購読し、debounce 付きで `refresh` を呼ぶ。
+ * `scene.onDisposeObservable` で自動的に dispose も登録する。
+ *
+ * @param engine 対象の Babylon.js Engine
+ * @param scene 対象の Scene。dispose 検知に利用する。
+ * @param refresh リサイズ後に呼びたい処理 (通常は `refreshTerrain`)。
+ * @param options debounce 時間など。
+ * @returns 手動 dispose 用のハンドル。
+ */
+export function attachResizeRefresh(
+    engine: Pick<AbstractEngine, "onResizeObservable">,
+    scene: Pick<Scene, "onDisposeObservable">,
+    refresh: () => void | Promise<void>,
+    options?: AttachResizeRefreshOptions,
+): AttachResizeRefreshHandle {
+    const debounceMs = options?.debounceMs ?? DEFAULT_RESIZE_REFRESH_DEBOUNCE_MS;
+
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let disposed = false;
+
+    const observer: Observer<AbstractEngine> | null = engine.onResizeObservable.add(
+        () => {
+            if (disposed) return;
+            if (timer !== null) {
+                clearTimeout(timer);
+            }
+            timer = setTimeout(() => {
+                timer = null;
+                if (disposed) return;
+                void refresh();
+            }, debounceMs);
+        },
+    );
+
+    const dispose = (): void => {
+        if (disposed) return;
+        disposed = true;
+        if (timer !== null) {
+            clearTimeout(timer);
+            timer = null;
+        }
+        if (observer) {
+            engine.onResizeObservable.remove(observer);
+        }
+    };
+
+    scene.onDisposeObservable.add(() => {
+        dispose();
+    });
+
+    return { dispose };
+}

--- a/tests/resizeRefresh.unit.spec.ts
+++ b/tests/resizeRefresh.unit.spec.ts
@@ -1,0 +1,179 @@
+/**
+ * `attachResizeRefresh` のユニットテスト (Issue #150 / PR #153)
+ *
+ * - リサイズ通知が debounce されて 1 回だけ refresh を呼ぶ
+ * - dispose / scene.dispose で Observer 解除と保留タイマーのクリアが行われる
+ */
+
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+
+import {
+    attachResizeRefresh,
+    DEFAULT_RESIZE_REFRESH_DEBOUNCE_MS,
+} from "../src/terrain/resizeRefresh";
+
+type Listener = () => void;
+
+interface FakeObservable {
+    listeners: Listener[];
+    add: jest.Mock<(cb: Listener) => Listener>;
+    remove: jest.Mock<(cb: Listener) => boolean>;
+    /** テスト用: 登録済み listener を全て呼ぶ */
+    notify: () => void;
+}
+
+const createFakeObservable = (): FakeObservable => {
+    const listeners: Listener[] = [];
+    const obs: FakeObservable = {
+        listeners,
+        add: jest.fn((cb: Listener) => {
+            listeners.push(cb);
+            return cb;
+        }),
+        remove: jest.fn((cb: Listener) => {
+            const idx = listeners.indexOf(cb);
+            if (idx >= 0) {
+                listeners.splice(idx, 1);
+                return true;
+            }
+            return false;
+        }),
+        notify: () => {
+            for (const cb of [...listeners]) cb();
+        },
+    };
+    return obs;
+};
+
+describe("attachResizeRefresh", () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+        jest.clearAllMocks();
+    });
+
+    it("デフォルト debounce 後に refresh が 1 回呼ばれる", () => {
+        const onResize = createFakeObservable();
+        const onDispose = createFakeObservable();
+        const refresh = jest.fn<() => void>();
+
+        attachResizeRefresh(
+            { onResizeObservable: onResize } as never,
+            { onDisposeObservable: onDispose } as never,
+            refresh,
+        );
+
+        onResize.notify();
+        expect(refresh).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(DEFAULT_RESIZE_REFRESH_DEBOUNCE_MS);
+        expect(refresh).toHaveBeenCalledTimes(1);
+    });
+
+    it("連続リサイズは debounce され、最後の発火から debounceMs 後に 1 回だけ呼ばれる", () => {
+        const onResize = createFakeObservable();
+        const onDispose = createFakeObservable();
+        const refresh = jest.fn<() => void>();
+
+        attachResizeRefresh(
+            { onResizeObservable: onResize } as never,
+            { onDisposeObservable: onDispose } as never,
+            refresh,
+            { debounceMs: 50 },
+        );
+
+        onResize.notify();
+        jest.advanceTimersByTime(30);
+        onResize.notify();
+        jest.advanceTimersByTime(30);
+        onResize.notify();
+
+        // ここまでは debounce 内で再スケジュールされるため呼ばれていない
+        expect(refresh).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(50);
+        expect(refresh).toHaveBeenCalledTimes(1);
+    });
+
+    it("dispose 後はリサイズが来ても refresh が呼ばれず、Observer も解除される", () => {
+        const onResize = createFakeObservable();
+        const onDispose = createFakeObservable();
+        const refresh = jest.fn<() => void>();
+
+        const handle = attachResizeRefresh(
+            { onResizeObservable: onResize } as never,
+            { onDisposeObservable: onDispose } as never,
+            refresh,
+        );
+
+        handle.dispose();
+
+        expect(onResize.remove).toHaveBeenCalledTimes(1);
+        expect(onResize.listeners.length).toBe(0);
+
+        onResize.notify();
+        jest.advanceTimersByTime(DEFAULT_RESIZE_REFRESH_DEBOUNCE_MS);
+        expect(refresh).not.toHaveBeenCalled();
+    });
+
+    it("保留中タイマーは dispose でキャンセルされる", () => {
+        const onResize = createFakeObservable();
+        const onDispose = createFakeObservable();
+        const refresh = jest.fn<() => void>();
+
+        const handle = attachResizeRefresh(
+            { onResizeObservable: onResize } as never,
+            { onDisposeObservable: onDispose } as never,
+            refresh,
+        );
+
+        onResize.notify();
+        // debounce 経過前に dispose
+        handle.dispose();
+        jest.advanceTimersByTime(DEFAULT_RESIZE_REFRESH_DEBOUNCE_MS * 2);
+
+        expect(refresh).not.toHaveBeenCalled();
+    });
+
+    it("scene.onDisposeObservable 発火で自動的に dispose される", () => {
+        const onResize = createFakeObservable();
+        const onDispose = createFakeObservable();
+        const refresh = jest.fn<() => void>();
+
+        attachResizeRefresh(
+            { onResizeObservable: onResize } as never,
+            { onDisposeObservable: onDispose } as never,
+            refresh,
+        );
+
+        // scene dispose 通知
+        onDispose.notify();
+
+        expect(onResize.remove).toHaveBeenCalledTimes(1);
+
+        onResize.notify();
+        jest.advanceTimersByTime(DEFAULT_RESIZE_REFRESH_DEBOUNCE_MS);
+        expect(refresh).not.toHaveBeenCalled();
+    });
+
+    it("dispose を複数回呼んでも安全（remove は 1 回のみ）", () => {
+        const onResize = createFakeObservable();
+        const onDispose = createFakeObservable();
+        const refresh = jest.fn<() => void>();
+
+        const handle = attachResizeRefresh(
+            { onResizeObservable: onResize } as never,
+            { onDisposeObservable: onDispose } as never,
+            refresh,
+        );
+
+        handle.dispose();
+        handle.dispose();
+        onDispose.notify();
+
+        expect(onResize.remove).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
Closes #150

## 概要
ウィンドウ拡大時に新たに視野へ入った領域のタイルが取得・描画されない不具合を修正。

## 原因
可視タイル再計算は `camera.onViewMatrixChangedObservable` でのみ起動しており、リサイズではビュー行列が変化しないため発火しなかった。

## 修正
`src/scenes/default.ts` の `engine.onResizeObservable` に `refreshTerrain()` を 100ms debounce 付きで登録。`tileManager.applyVisibleTiles` は不要解放＋新規ロードの差分処理のため、既存タイルは保持されちらつかない。`scene.onDisposeObservable` でタイマーを解放。

## 影響範囲
- src/scenes/default.ts のみ
- 公開API/型/既定値の変更なし

## 検証
- npm run lint: ✅
- npm run typecheck: ✅
- npm run test:unit: ✅ (397/397)
- ブラウザ実機（Chrome/Firefox/Safari）でリサイズ拡大時のタイル追加描画とちらつき無しを確認