### PR TITLE
fix(demo): preserve demo path prefix in URL and link portal without .html (#155)

### DIFF
--- a/src/demos/portal/index.ts
+++ b/src/demos/portal/index.ts
@@ -22,13 +22,13 @@ const DEMO_LIST: readonly DemoEntry[] = [
         title: "3D 地形ビューア",
         description:
             "地理院タイルの標高データから 3D 地形を表示する基本デモ。緯度経度・カメラ向き・地図種別を URL で指定できます。",
-        href: "viewer.html",
+        href: "viewer",
     },
     {
         title: "タイムラプス（太陽の動きと陰影）",
         description:
             "24 時間を 1 分に圧縮して太陽位置・陰影をアニメーションし、アナログ時計で同期表示するショーケース。",
-        href: "timelapse.html",
+        href: "timelapse",
     },
 ];
 

--- a/src/demos/timelapse/index.ts
+++ b/src/demos/timelapse/index.ts
@@ -23,6 +23,7 @@ import type { EngineType, JpmapTerrainOptions } from "../../lib/types";
 import {
     parseCameraStateFromUrl,
     parseMapTypeFromUrl,
+    createUrlUpdater,
 } from "../../terrain/urlState";
 import { mountClock } from "./clockOverlay";
 import {
@@ -73,6 +74,19 @@ const start = async (): Promise<void> => {
     };
 
     const viewer = await JpmapTerrain.create(mount, opts);
+
+    // URL 同期: カメラ変化のたびに `/<demo>@lat,lon,altitude,azimuth,tilt` 形式へ反映する (Issue #155)。
+    // 既存クエリ（?engine=, ?start=, ?speed= など）は `createUrlUpdater` 内で保持される。
+    const urlUpdater = createUrlUpdater(200);
+    viewer.onCameraChange((event) =>
+        urlUpdater({
+            lat: event.lat,
+            lon: event.lon,
+            altitude: event.altitude,
+            azimuth: event.azimuth,
+            tilt: event.tilt,
+        }),
+    );
 
     // 時計オーバーレイをマウント。
     const clockSvg = document.getElementById(CLOCK_ELEMENT_ID);

--- a/src/terrain/urlState.ts
+++ b/src/terrain/urlState.ts
@@ -166,9 +166,9 @@ export const extractDemoPathPrefix = (pathname: string): string => {
  * - 状態オブジェクト: altitude/azimuth/tilt のいずれかが定義されていれば 5要素、
  *   全て未定義なら 2要素を返す。
  *
- * `prefix` を渡すと `${prefix}@lat,lon,...` 形式になる (Issue #155)。
- * 例: `prefix="/viewer"` → `/viewer@lat,lon,...`
- * `prefix=""` のときのみ先頭にスラッシュを付与し `/@lat,lon,...` とする。
+ * `prefix` を渡すと `${prefix}/@lat,lon,...` 形式になる (Issue #155)。
+ * 例: `prefix="/viewer"` → `/viewer/@lat,lon,...`（Google Maps 互換のフォーマット）
+ * `prefix=""` のときは `/@lat,lon,...`。
  */
 export function toAtPath(lat: number, lon: number, prefix?: string): string;
 export function toAtPath(
@@ -180,8 +180,7 @@ export function toAtPath(
     b?: number | string,
     c?: string,
 ): string {
-    const buildHead = (prefix: string): string =>
-        prefix === "" ? "/@" : `${prefix}@`;
+    const buildHead = (prefix: string): string => `${prefix}/@`;
     if (typeof a === "number" && typeof b === "number") {
         const prefix = c ?? "";
         return `${buildHead(prefix)}${a.toFixed(PRECISION)},${b.toFixed(PRECISION)}`;
@@ -205,8 +204,8 @@ export function toAtPath(
 }
 
 /**
- * history.replaceState で URL のパスを `${prefix}@lat,lon[,altitude,azimuth,tilt]` 形式に更新する。
- * `prefix` が空のときは `/@lat,lon,...`、`/viewer` 等のときは `/viewer@lat,lon,...` を出力する。
+ * history.replaceState で URL のパスを `${prefix}/@lat,lon[,altitude,azimuth,tilt]` 形式に更新する。
+ * `prefix` が空のときは `/@lat,lon,...`、`/viewer` 等のときは `/viewer/@lat,lon,...`（Google Maps 互換）を出力する。
  * 現在の pathname からデモ識別子（例: `/viewer`, `/timelapse`）を抽出して保持し、
  * `.html` 拡張子は剥がして正規化する (Issue #155)。既存のクエリパラメータは保持する。
  * デバウンス付きファクトリを返す。

--- a/src/terrain/urlState.ts
+++ b/src/terrain/urlState.ts
@@ -139,21 +139,56 @@ export const parseLatLonFromUrl = (url: string): LatLon | null => {
 };
 
 /**
+ * 現在の pathname から `@lat,lon,...` セグメント以降を取り除き、
+ * デモを識別するプレフィクス（例: `''`, `/viewer`, `/timelapse`）を返す (Issue #155)。
+ *
+ * - 末尾の `.html` は剥がして拡張子なしに正規化する。
+ * - 末尾スラッシュは取り除く（`/` は `''` を返す）。
+ * - 想定外の深いパス（`/foo/bar`）はそのまま返し、呼び出し元で `${prefix}@...` を構築する。
+ */
+export const extractDemoPathPrefix = (pathname: string): string => {
+    const atIndex = pathname.indexOf("@");
+    let base = atIndex >= 0 ? pathname.slice(0, atIndex) : pathname;
+    // 末尾スラッシュを除去（`/` は空文字に倒す）
+    if (base.endsWith("/")) {
+        base = base.slice(0, -1);
+    }
+    // 末尾 `.html` を剥がす
+    if (base.endsWith(".html")) {
+        base = base.slice(0, -".html".length);
+    }
+    return base;
+};
+
+/**
  * パスセグメント文字列を生成する。
  * - 数値2引数: `/@lat,lon`（2要素）
  * - 状態オブジェクト: altitude/azimuth/tilt のいずれかが定義されていれば 5要素、
  *   全て未定義なら 2要素を返す。
+ *
+ * `prefix` を渡すと `${prefix}@lat,lon,...` 形式になる (Issue #155)。
+ * 例: `prefix="/viewer"` → `/viewer@lat,lon,...`
+ * `prefix=""` のときのみ先頭にスラッシュを付与し `/@lat,lon,...` とする。
  */
-export function toAtPath(lat: number, lon: number): string;
-export function toAtPath(state: Partial<CameraUrlState> & LatLon): string;
+export function toAtPath(lat: number, lon: number, prefix?: string): string;
+export function toAtPath(
+    state: Partial<CameraUrlState> & LatLon,
+    prefix?: string,
+): string;
 export function toAtPath(
     a: number | (Partial<CameraUrlState> & LatLon),
-    b?: number,
+    b?: number | string,
+    c?: string,
 ): string {
+    const buildHead = (prefix: string): string =>
+        prefix === "" ? "/@" : `${prefix}@`;
     if (typeof a === "number" && typeof b === "number") {
-        return `/@${a.toFixed(PRECISION)},${b.toFixed(PRECISION)}`;
+        const prefix = c ?? "";
+        return `${buildHead(prefix)}${a.toFixed(PRECISION)},${b.toFixed(PRECISION)}`;
     }
     const state = a as Partial<CameraUrlState> & LatLon;
+    const prefix = (typeof b === "string" ? b : undefined) ?? "";
+    const head = buildHead(prefix);
     const hasExtra =
         state.altitude !== undefined ||
         state.azimuth !== undefined ||
@@ -161,17 +196,19 @@ export function toAtPath(
     const latStr = state.lat.toFixed(PRECISION);
     const lonStr = state.lon.toFixed(PRECISION);
     if (!hasExtra) {
-        return `/@${latStr},${lonStr}`;
+        return `${head}${latStr},${lonStr}`;
     }
     const altitude = clampAltitude(state.altitude ?? CAMERA_URL_DEFAULTS.altitude);
     const azimuth = normalizeAzimuth(state.azimuth ?? CAMERA_URL_DEFAULTS.azimuth);
     const tilt = clampTilt(state.tilt ?? CAMERA_URL_DEFAULTS.tilt);
-    return `/@${latStr},${lonStr},${altitude},${azimuth.toFixed(AZIMUTH_TILT_PRECISION)},${tilt.toFixed(AZIMUTH_TILT_PRECISION)}`;
+    return `${head}${latStr},${lonStr},${altitude},${azimuth.toFixed(AZIMUTH_TILT_PRECISION)},${tilt.toFixed(AZIMUTH_TILT_PRECISION)}`;
 }
 
 /**
- * history.replaceState で URL のパスを `/@lat,lon[,altitude,azimuth,tilt]` 形式に更新する。
- * 既存のクエリパラメータは保持する。デバウンス付きファクトリを返す。
+ * history.replaceState で URL のパスを `${prefix}/@lat,lon[,altitude,azimuth,tilt]` 形式に更新する。
+ * 現在の pathname からデモ識別子（例: `/viewer`, `/timelapse`）を抽出して保持し、
+ * `.html` 拡張子は剥がして正規化する (Issue #155)。既存のクエリパラメータは保持する。
+ * デバウンス付きファクトリを返す。
  */
 export const createUrlUpdater = (
     debounceMs: number = 200,
@@ -184,7 +221,8 @@ export const createUrlUpdater = (
         }
         timerId = setTimeout(() => {
             timerId = null;
-            const path = toAtPath(state);
+            const prefix = extractDemoPathPrefix(location.pathname);
+            const path = toAtPath(state, prefix);
             const search = location.search;
             history.replaceState(null, "", path + search);
         }, debounceMs);

--- a/src/terrain/urlState.ts
+++ b/src/terrain/urlState.ts
@@ -205,7 +205,8 @@ export function toAtPath(
 }
 
 /**
- * history.replaceState で URL のパスを `${prefix}/@lat,lon[,altitude,azimuth,tilt]` 形式に更新する。
+ * history.replaceState で URL のパスを `${prefix}@lat,lon[,altitude,azimuth,tilt]` 形式に更新する。
+ * `prefix` が空のときは `/@lat,lon,...`、`/viewer` 等のときは `/viewer@lat,lon,...` を出力する。
  * 現在の pathname からデモ識別子（例: `/viewer`, `/timelapse`）を抽出して保持し、
  * `.html` 拡張子は剥がして正規化する (Issue #155)。既存のクエリパラメータは保持する。
  * デバウンス付きファクトリを返す。

--- a/tests/portal.unit.spec.ts
+++ b/tests/portal.unit.spec.ts
@@ -11,8 +11,8 @@ import { buildPortalHtml } from "../src/demos/portal/index";
 describe("buildPortalHtml", () => {
     it("デフォルトで viewer/timelapse へのリンクを含む", () => {
         const html = buildPortalHtml();
-        expect(html).toContain('href="viewer.html"');
-        expect(html).toContain('href="timelapse.html"');
+        expect(html).toContain('href="viewer"');
+        expect(html).toContain('href="timelapse"');
         expect(html).toContain("<h1>");
     });
 

--- a/tests/urlState.unit.spec.ts
+++ b/tests/urlState.unit.spec.ts
@@ -227,7 +227,7 @@ describe("urlState", () => {
             expect(history.replaceState).toHaveBeenCalledWith(
                 null,
                 "",
-                "/viewer@35.681236,139.767125,2000,0.00,45.00"
+                "/viewer/@35.681236,139.767125,2000,0.00,45.00"
             );
         });
 
@@ -245,13 +245,13 @@ describe("urlState", () => {
             expect(history.replaceState).toHaveBeenCalledWith(
                 null,
                 "",
-                "/viewer@35.000000,139.000000,2000,0.00,45.00"
+                "/viewer/@35.000000,139.000000,2000,0.00,45.00"
             );
         });
 
         it("pathname に既に `@lat,lon` が含まれる場合は新しい値で置き換える (Issue #155)", () => {
             globalThis.location = {
-                pathname: "/timelapse@10.0,20.0,1000,0,30",
+                pathname: "/timelapse/@10.0,20.0,1000,0,30",
                 search: "?speed=60",
             } as unknown as Location;
             const updater = createUrlUpdater(200);
@@ -266,7 +266,7 @@ describe("urlState", () => {
             expect(history.replaceState).toHaveBeenCalledWith(
                 null,
                 "",
-                "/timelapse@35.000000,139.000000,1500,90.00,60.00?speed=60"
+                "/timelapse/@35.000000,139.000000,1500,90.00,60.00?speed=60"
             );
         });
     });
@@ -284,8 +284,8 @@ describe("urlState", () => {
             expect(extractDemoPathPrefix("/viewer.html")).toBe("/viewer");
         });
 
-        it("`/timelapse@lat,lon,...` は `/timelapse` を返す", () => {
-            expect(extractDemoPathPrefix("/timelapse@35.0,139.0,1500,0,45")).toBe("/timelapse");
+        it("`/timelapse/@lat,lon,...` は `/timelapse` を返す", () => {
+            expect(extractDemoPathPrefix("/timelapse/@35.0,139.0,1500,0,45")).toBe("/timelapse");
         });
 
         it("`/viewer.html@lat,lon` も `.html` を剥がして `/viewer` を返す", () => {

--- a/tests/urlState.unit.spec.ts
+++ b/tests/urlState.unit.spec.ts
@@ -7,6 +7,7 @@ import {
     clampAltitude,
     clampTilt,
     normalizeAzimuth,
+    extractDemoPathPrefix,
     CAMERA_URL_DEFAULTS,
     CAMERA_URL_LIMITS,
     MAP_TYPE_QUERY_KEY,
@@ -121,7 +122,7 @@ describe("urlState", () => {
         beforeEach(() => {
             jest.useFakeTimers();
             globalThis.history = { replaceState: jest.fn() } as unknown as History;
-            globalThis.location = { search: "" } as unknown as Location;
+            globalThis.location = { pathname: "/", search: "" } as unknown as Location;
         });
 
         afterEach(() => {
@@ -153,7 +154,7 @@ describe("urlState", () => {
         });
 
         it("既存のクエリパラメータが保持される", () => {
-            globalThis.location = { search: "?engine=webgl" } as unknown as Location;
+            globalThis.location = { pathname: "/", search: "?engine=webgl" } as unknown as Location;
             const updater = createUrlUpdater(200);
             updater({
                 lat: 35.681236,
@@ -210,6 +211,85 @@ describe("urlState", () => {
                 "",
                 "/@35.681236,139.767125,1500,90.00,60.00"
             );
+        });
+
+        it("pathname にデモ識別子（/viewer）が含まれる場合は保持される (Issue #155)", () => {
+            globalThis.location = { pathname: "/viewer", search: "" } as unknown as Location;
+            const updater = createUrlUpdater(200);
+            updater({
+                lat: 35.681236,
+                lon: 139.767125,
+                altitude: CAMERA_URL_DEFAULTS.altitude,
+                azimuth: CAMERA_URL_DEFAULTS.azimuth,
+                tilt: CAMERA_URL_DEFAULTS.tilt,
+            });
+            jest.advanceTimersByTime(200);
+            expect(history.replaceState).toHaveBeenCalledWith(
+                null,
+                "",
+                "/viewer@35.681236,139.767125,2000,0.00,45.00"
+            );
+        });
+
+        it("pathname に `.html` 付きデモ識別子がある場合は剥がして書き戻す (Issue #155)", () => {
+            globalThis.location = { pathname: "/viewer.html", search: "" } as unknown as Location;
+            const updater = createUrlUpdater(200);
+            updater({
+                lat: 35.0,
+                lon: 139.0,
+                altitude: CAMERA_URL_DEFAULTS.altitude,
+                azimuth: CAMERA_URL_DEFAULTS.azimuth,
+                tilt: CAMERA_URL_DEFAULTS.tilt,
+            });
+            jest.advanceTimersByTime(200);
+            expect(history.replaceState).toHaveBeenCalledWith(
+                null,
+                "",
+                "/viewer@35.000000,139.000000,2000,0.00,45.00"
+            );
+        });
+
+        it("pathname に既に `@lat,lon` が含まれる場合は新しい値で置き換える (Issue #155)", () => {
+            globalThis.location = {
+                pathname: "/timelapse@10.0,20.0,1000,0,30",
+                search: "?speed=60",
+            } as unknown as Location;
+            const updater = createUrlUpdater(200);
+            updater({
+                lat: 35.0,
+                lon: 139.0,
+                altitude: 1500,
+                azimuth: 90,
+                tilt: 60,
+            });
+            jest.advanceTimersByTime(200);
+            expect(history.replaceState).toHaveBeenCalledWith(
+                null,
+                "",
+                "/timelapse@35.000000,139.000000,1500,90.00,60.00?speed=60"
+            );
+        });
+    });
+
+    describe("extractDemoPathPrefix (Issue #155)", () => {
+        it("ルート pathname は空文字を返す", () => {
+            expect(extractDemoPathPrefix("/")).toBe("");
+        });
+
+        it("`/viewer` はそのまま返す", () => {
+            expect(extractDemoPathPrefix("/viewer")).toBe("/viewer");
+        });
+
+        it("`/viewer.html` は `.html` を剥がす", () => {
+            expect(extractDemoPathPrefix("/viewer.html")).toBe("/viewer");
+        });
+
+        it("`/timelapse@lat,lon,...` は `/timelapse` を返す", () => {
+            expect(extractDemoPathPrefix("/timelapse@35.0,139.0,1500,0,45")).toBe("/timelapse");
+        });
+
+        it("`/viewer.html@lat,lon` も `.html` を剥がして `/viewer` を返す", () => {
+            expect(extractDemoPathPrefix("/viewer.html@35.0,139.0")).toBe("/viewer");
         });
     });
 

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -15,13 +15,14 @@ module.exports = merge(common, {
         hot: true,
         historyApiFallback: {
             disableDotRule: true,
-            // デモ識別子付きパス（/viewer@..., /timelapse@...）を該当HTMLにrewrite (Issue #155)
+            // デモ識別子付きパス（/viewer/@..., /timelapse/@...）を該当HTMLにrewrite (Issue #155)
+            // Google Maps 互換のため `/<demo>/@lat,lon,...` 形式を採用。
             // パース側は `.html` 付きの旧形式 URL も許容しているため、rewrite も両形式・末尾スラッシュ任意で対応する。
             rewrites: [
-                { from: /^\/viewer(?:@.*)?\/?$/, to: '/viewer.html' },
-                { from: /^\/viewer\.html(?:@.*)?\/?$/, to: '/viewer.html' },
-                { from: /^\/timelapse(?:@.*)?\/?$/, to: '/timelapse.html' },
-                { from: /^\/timelapse\.html(?:@.*)?\/?$/, to: '/timelapse.html' },
+                { from: /^\/viewer(?:\/@.*)?\/?$/, to: '/viewer.html' },
+                { from: /^\/viewer\.html(?:\/?@.*)?\/?$/, to: '/viewer.html' },
+                { from: /^\/timelapse(?:\/@.*)?\/?$/, to: '/timelapse.html' },
+                { from: /^\/timelapse\.html(?:\/?@.*)?\/?$/, to: '/timelapse.html' },
             ],
         },
         // publicPath: '/',

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -16,9 +16,12 @@ module.exports = merge(common, {
         historyApiFallback: {
             disableDotRule: true,
             // デモ識別子付きパス（/viewer@..., /timelapse@...）を該当HTMLにrewrite (Issue #155)
+            // パース側は `.html` 付きの旧形式 URL も許容しているため、rewrite も両形式・末尾スラッシュ任意で対応する。
             rewrites: [
-                { from: /^\/viewer(?:@.*)?$/, to: '/viewer.html' },
-                { from: /^\/timelapse(?:@.*)?$/, to: '/timelapse.html' },
+                { from: /^\/viewer(?:@.*)?\/?$/, to: '/viewer.html' },
+                { from: /^\/viewer\.html(?:@.*)?\/?$/, to: '/viewer.html' },
+                { from: /^\/timelapse(?:@.*)?\/?$/, to: '/timelapse.html' },
+                { from: /^\/timelapse\.html(?:@.*)?\/?$/, to: '/timelapse.html' },
             ],
         },
         // publicPath: '/',

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -15,6 +15,11 @@ module.exports = merge(common, {
         hot: true,
         historyApiFallback: {
             disableDotRule: true,
+            // デモ識別子付きパス（/viewer@..., /timelapse@...）を該当HTMLにrewrite (Issue #155)
+            rewrites: [
+                { from: /^\/viewer(?:@.*)?$/, to: '/viewer.html' },
+                { from: /^\/timelapse(?:@.*)?$/, to: '/timelapse.html' },
+            ],
         },
         // publicPath: '/',
         open: false,


### PR DESCRIPTION
## 概要

デモページ（viewer / timelapse）の URL がカメラ操作（ドラッグ等）で `/@lat,lon,...` に上書きされ、リロードするとデモを特定できずポータルへフォールバックしてしまう不具合を修正する。あわせて、timelapse でも viewer と同等にカメラ姿勢を URL に反映できるようにし、ポータルからのリンクを拡張子なし（`/viewer`, `/timelapse`）に統一する。

URL 形式は **Google Maps 互換** の `/<demo>/@lat,lon,altitude,azimuth,tilt` を採用する（例: `http://localhost:8080/viewer/@35.681236,139.767125,2000,0.00,45.00`）。

## 関連 Issue

Closes #155

## 変更内容

- `src/terrain/urlState.ts`
  - `extractDemoPathPrefix` を追加し、現在の pathname から `@...` 以降と末尾スラッシュ・`.html` を除いたデモ識別子（`''` / `/viewer` / `/timelapse`）を抽出
  - `toAtPath` に `prefix` 引数を追加。`${prefix}/@lat,lon,...` を出力する（Google Maps 互換）
  - `createUrlUpdater` を「現在の pathname のデモ識別子を保持して書き戻す」挙動に変更（既存クエリは引き続き保持）
- `webpack.dev.js`
  - `historyApiFallback.rewrites` を追加し、`/viewer(/@.*)?` → `/viewer.html`、`/timelapse(/@.*)?` → `/timelapse.html` を解決（`.html` 付き旧形式も併せて許容）
- `src/demos/timelapse/index.ts`
  - `createUrlUpdater` を組み込み、`onCameraChange` で URL にカメラ姿勢を反映
- `src/demos/portal/index.ts`
  - ポータルからのリンクを `viewer.html` / `timelapse.html` から `viewer` / `timelapse` に変更
- テスト
  - `tests/urlState.unit.spec.ts`: プレフィクス保持・`.html` 正規化・既存 `@...` 置換・`extractDemoPathPrefix` のケースを追加
  - `tests/portal.unit.spec.ts`: 期待値を新リンク形式に更新

## 動作確認方法

1. `npm start` で dev サーバを起動
2. `http://localhost:8080/` にアクセスし、ポータルから「3D 地形ビューア」を開く
3. URL が `/viewer` で始まることを確認
4. 視点をドラッグして動かし、URL が `/viewer/@lat,lon,altitude,azimuth,tilt` の形式で更新されることを確認（Google Maps 互換）
5. ブラウザをリロードしてもそのまま 3D ビューアが表示されることを確認（ポータルへ戻らない）
6. 同様に「タイムラプス」も `/timelapse/@...` で URL 同期・リロード復元できることを確認
7. `?mapType=photo` 等のクエリを付与した状態で操作し、クエリが保持されることを確認

### 自動テスト

- `npm run lint`
- `npm run typecheck`
- `npm run test:unit`（436/436 成功）

## 影響範囲

- フロントエンドのデモ（viewer / timelapse / portal）
- dev サーバの routing（`historyApiFallback`）
- 公開ライブラリ層（`src/lib/**`）には変更なし

## 互換性 / 既知の事項

- 旧形式の URL（`/@lat,lon,...`）は引き続きパース可能（後方互換）。書き出し時のみ新形式に正規化される
- 本番（静的ホスティング）での `/viewer` ルーティングは別途対応が必要（本 PR では dev サーバのみ対応）

## 確認事項

- [x] Copilot レビューを日本語で実施し、指摘を修正した
- [x] `npm run test:visuals:update` は毎回実行していない
- [x] 画面表示の意図した変更がある場合のみ、開発者がスナップショットを更新した（本 PR は URL 仕様変更のみで Visual に影響なし）
