### PR TITLE
fix(demos): use absolute publicPath so @-path URLs reload correctly (#157)

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,7 @@ import { defineConfig, devices } from '@playwright/test';
  */
 export default defineConfig({
   testDir: './tests',
-  testMatch: 'validation.spec.ts',
+  testMatch: ['validation.spec.ts', 'atPathReload.spec.ts'],
   /* Maximum time one test can run for. */
   timeout: 120 * 1000,
   expect: {

--- a/tests/atPathReload.spec.ts
+++ b/tests/atPathReload.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Issue #157: `/viewer/@...` および `/timelapse/@...` のデモ識別子付きパスで
+ * 直接アクセス（リロード相当）した際に、HtmlWebpackPlugin が inject する script 等が
+ * 相対パスで解決されて 404 になる回帰を防止する E2E テスト。
+ *
+ * - `/js/` 配下のレスポンスが全て成功 (response.ok()) であること
+ * - `<canvas>` が表示され、サイズがゼロでないこと（= 起動した）
+ * を確認する。スナップショット比較は flaky 回避のため行わない。
+ */
+
+const targets: { name: string; url: string }[] = [
+    {
+        name: "viewer @-path reload",
+        url: "/viewer/@35.681236,139.767125",
+    },
+    {
+        name: "timelapse @-path reload",
+        url: "/timelapse/@35.681236,139.767125",
+    },
+];
+
+for (const target of targets) {
+    test(`${target.name} loads scripts and renders canvas`, async ({ page }) => {
+        const failedJsResponses: { url: string; status: number }[] = [];
+        page.on("response", (response) => {
+            const url = response.url();
+            if (url.includes("/js/") && !response.ok()) {
+                failedJsResponses.push({ url, status: response.status() });
+            }
+        });
+
+        await page.goto(target.url);
+        await page.waitForLoadState("domcontentloaded");
+
+        const canvas = page.locator("canvas").first();
+        await expect(canvas).toBeVisible({ timeout: 30000 });
+
+        const box = await canvas.boundingBox();
+        expect(box).not.toBeNull();
+        expect(box!.width).toBeGreaterThan(0);
+        expect(box!.height).toBeGreaterThan(0);
+
+        expect(failedJsResponses).toEqual([]);
+    });
+}

--- a/tests/atPathReload.spec.ts
+++ b/tests/atPathReload.spec.ts
@@ -42,6 +42,21 @@ for (const target of targets) {
         expect(box!.width).toBeGreaterThan(0);
         expect(box!.height).toBeGreaterThan(0);
 
+        // シーン起動完了を待つ（`src/demos/{viewer,timelapse}/index.ts` で
+        // NODE_ENV!=='production' 時に `window.scene` を公開している）。
+        // `failedJsResponses` を判定する前に、遅延チャンクや初期タイル取得が
+        // 出揃うまで待機することでレースを防ぐ (Issue #157 PR レビュー対応)。
+        await page.waitForFunction(
+            () => {
+                const w = window as unknown as {
+                    scene?: { isReady: () => boolean };
+                };
+                return !!w.scene && w.scene.isReady();
+            },
+            { timeout: 30000 },
+        );
+        await page.waitForLoadState("networkidle", { timeout: 30000 });
+
         expect(failedJsResponses).toEqual([]);
     });
 }

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -47,6 +47,9 @@ module.exports = {
         filename: "js/[name].js",
         path: path.resolve("./dist/"),
         chunkFilename: "js/[name].[contenthash].js",
+        // `/viewer/@...` などのデモ識別子付きパスでリロードされた場合でも、
+        // HtmlWebpackPlugin が inject する script 等を絶対パス基準で解決させる (Issue #157)。
+        publicPath: "/",
     },
     resolve: {
         extensions: [".ts", ".js"],

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -25,7 +25,6 @@ module.exports = merge(common, {
                 { from: /^\/timelapse\.html(?:\/?@.*)?\/?$/, to: '/timelapse.html' },
             ],
         },
-        // publicPath: '/',
         open: false,
         // host: '0.0.0.0', // enable to access from other devices on the network
         // https: true // enable when HTTPS is needed (like in WebXR)

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -2,6 +2,7 @@ const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
 const path = require('path');
 const fs = require('fs');
+const { demoAtPathRewrites } = require('./webpack.rewrites.js');
 
 // App directory
 const appDirectory = fs.realpathSync(process.cwd());
@@ -17,13 +18,8 @@ module.exports = merge(common, {
             disableDotRule: true,
             // デモ識別子付きパス（/viewer/@..., /timelapse/@...）を該当HTMLにrewrite (Issue #155)
             // Google Maps 互換のため `/<demo>/@lat,lon,...` 形式を採用。
-            // パース側は `.html` 付きの旧形式 URL も許容しているため、rewrite も両形式・末尾スラッシュ任意で対応する。
-            rewrites: [
-                { from: /^\/viewer(?:\/@.*)?\/?$/, to: '/viewer.html' },
-                { from: /^\/viewer\.html(?:\/?@.*)?\/?$/, to: '/viewer.html' },
-                { from: /^\/timelapse(?:\/@.*)?\/?$/, to: '/timelapse.html' },
-                { from: /^\/timelapse\.html(?:\/?@.*)?\/?$/, to: '/timelapse.html' },
-            ],
+            // rewrite 定義は dev / E2E (webpack.tests.js) で共有 (Issue #157)。
+            rewrites: demoAtPathRewrites,
         },
         open: false,
         // host: '0.0.0.0', // enable to access from other devices on the network

--- a/webpack.rewrites.js
+++ b/webpack.rewrites.js
@@ -1,0 +1,16 @@
+/**
+ * webpack-dev-server 用 historyApiFallback.rewrites の共有定義 (Issue #157)。
+ * dev (`webpack.dev.js`) と E2E テスト (`webpack.tests.js`) で同一の
+ * SPA fallback ルーティングを使うために単一ソース化している。
+ *
+ * デモ識別子付きパス（/viewer/@..., /timelapse/@...）と、`.html` 付きの
+ * 旧形式 URL も許容する（パース側 `src/terrain/urlState.ts` の挙動に合わせる）。
+ */
+module.exports = {
+    demoAtPathRewrites: [
+        { from: /^\/viewer(?:\/@.*)?\/?$/, to: '/viewer.html' },
+        { from: /^\/viewer\.html(?:\/?@.*)?\/?$/, to: '/viewer.html' },
+        { from: /^\/timelapse(?:\/@.*)?\/?$/, to: '/timelapse.html' },
+        { from: /^\/timelapse\.html(?:\/?@.*)?\/?$/, to: '/timelapse.html' },
+    ],
+};

--- a/webpack.tests.js
+++ b/webpack.tests.js
@@ -2,6 +2,7 @@ const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
 const path = require('path');
 const fs = require('fs');
+const { demoAtPathRewrites } = require('./webpack.rewrites.js');
 
 // App directory
 const appDirectory = fs.realpathSync(process.cwd());
@@ -14,14 +15,9 @@ module.exports = merge(common, {
         compress: true,
         historyApiFallback: {
             disableDotRule: true,
-            // デモ識別子付きパス（/viewer/@..., /timelapse/@...）を該当HTMLにrewrite (Issue #157)
-            // dev-server と同じ挙動を E2E テスト用サーバでも再現する。
-            rewrites: [
-                { from: /^\/viewer(?:\/@.*)?\/?$/, to: '/viewer.html' },
-                { from: /^\/viewer\.html(?:\/?@.*)?\/?$/, to: '/viewer.html' },
-                { from: /^\/timelapse(?:\/@.*)?\/?$/, to: '/timelapse.html' },
-                { from: /^\/timelapse\.html(?:\/?@.*)?\/?$/, to: '/timelapse.html' },
-            ],
+            // デモ識別子付きパス（/viewer/@..., /timelapse/@...）を該当HTMLにrewrite (Issue #157)。
+            // dev / E2E で同一定義を共有することで両者の乖離を防ぐ。
+            rewrites: demoAtPathRewrites,
         },
         webSocketServer: false
     },

--- a/webpack.tests.js
+++ b/webpack.tests.js
@@ -5,13 +5,24 @@ const fs = require('fs');
 
 // App directory
 const appDirectory = fs.realpathSync(process.cwd());
- 
+
 module.exports = merge(common, {
     mode: 'development',
     devtool: 'inline-source-map',
     devServer: {
         static: path.resolve(appDirectory, "public"),
         compress: true,
+        historyApiFallback: {
+            disableDotRule: true,
+            // デモ識別子付きパス（/viewer/@..., /timelapse/@...）を該当HTMLにrewrite (Issue #157)
+            // dev-server と同じ挙動を E2E テスト用サーバでも再現する。
+            rewrites: [
+                { from: /^\/viewer(?:\/@.*)?\/?$/, to: '/viewer.html' },
+                { from: /^\/viewer\.html(?:\/?@.*)?\/?$/, to: '/viewer.html' },
+                { from: /^\/timelapse(?:\/@.*)?\/?$/, to: '/timelapse.html' },
+                { from: /^\/timelapse\.html(?:\/?@.*)?\/?$/, to: '/timelapse.html' },
+            ],
+        },
         webSocketServer: false
     },
 });


### PR DESCRIPTION
<!-- Copilot Code Review: Follow .github/copilot-instructions.md. -->
<!-- Copilot Code Review: Follow AGENTS.md. -->
<!-- Copilot Code Review: Write all review comments in Japanese. -->

## 概要

`/viewer/@lat,lon,...` および `/timelapse/@lat,lon,...` 形式の URL でブラウザをリロードすると 3D シーンが起動しないバグを修正する。`HtmlWebpackPlugin` が相対パスで `<script src="js/...">` を inject していたため、`historyApiFallback` で `viewer.html` / `timelapse.html` に rewrite された際にブラウザが `/viewer/@.../js/...` を要求し 404 となっていた。`output.publicPath = "/"` を指定して絶対パス化することで解消する。

## 関連 Issue

Closes #157

Parent: #33

## 変更内容

- `webpack.common.js` の `output` に `publicPath: "/"` を追加（HtmlWebpackPlugin が inject するスクリプトを絶対パス化）
- `webpack.dev.js` の死コメント `// publicPath: '/',` を削除
- `webpack.tests.js` の `devServer` に `historyApiFallback.rewrites` を追加（dev と同一定義）。Playwright サーバ上でも実利用と同じルーティング挙動を再現
- `tests/atPathReload.spec.ts` を新規追加。`/viewer/@...` / `/timelapse/@...` の直接アクセスで `/js/` の 404 が発生せず `<canvas>` が表示・サイズ非ゼロであることを検証（スナップショット比較なしで flaky 回避）
- `playwright.config.ts` の `testMatch` を配列化し、新規 spec を含めて実行対象に追加

## 動作確認方法

1. `npm start` で開発サーバを起動する
2. ブラウザで `http://localhost:8080/viewer.html` を開き、カメラを操作して URL が `/viewer/@lat,lon,altitude,azimuth,tilt` 形式になるまで待つ
3. ブラウザリロード（⌘R / F5）を実行し、3D シーンが正常に再表示されることを確認
4. 同様の手順を `/timelapse.html` でも確認
5. DevTools Network タブで `js/babylonBundle.js` 等が `http://localhost:8080/js/...` の絶対パスで取得され `200` であることを確認

## 確認事項

- [x] Copilot レビューを日本語で実施し、指摘を修正した（Reviewer approve、blocker なし）
- [x] `npm run test:visuals:update` は毎回実行していない
- [x] 画面表示の意図した変更がある場合のみ、開発者がスナップショットを更新した（描画結果に影響なし、既存スナップショット変更なし）

## 検証結果

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test:unit` ✅ 23 suites / 436 tests
- `npm run test:visuals` ✅ 14 tests（既存 12 + 新規 2）
