### PR TITLE
fix(camera): prevent altitude drift breaking tile LOD on rotate/zoom (#151)

### DIFF
--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -615,13 +615,12 @@ export class DefaultScene implements CreateSceneClass {
                 const sy = e.clientY - rect.top;
 
                 // ドラッグ開始時のピック高度 (dragPlaneY) の水平面で、
-                // カーソル直下のワールド座標が常に dragAnchor に重なるよう
-                // target.x/z を更新する。再ピック方式は水平より上の高所で
-                // ピック先が大きく飛ぶ問題があるため使わない (Issue #151)。
+                // カーソルの動きに合わせて視点（target）を同方向に動かす。
+                // ピック地点を「掴む」のではなく、視点を押し動かす操作感（Issue #151）。
                 const current = intersectPlane(sx, sy, dragPlaneY);
                 if (current) {
-                    camera.target.x += dragAnchor.x - current.x;
-                    camera.target.z += dragAnchor.z - current.z;
+                    camera.target.x += current.x - dragAnchor.x;
+                    camera.target.z += current.z - dragAnchor.z;
                     dragAnchor = intersectPlane(sx, sy, dragPlaneY);
                 }
             }

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -562,12 +562,16 @@ export class DefaultScene implements CreateSceneClass {
             }
 
             const pick = scene.pick(sx, sy, (m) => m.name.startsWith("tile-ground-"));
-            if (pick?.hit && pick.pickedPoint) {
-                // メッシュピックヒット時: ピック点の高度の水平面をドラッグ平面に採用。
-                // この水平面上でカーソル直下が常にピック地点に重なるよう pan する。
+            // ドラッグ平面の決定:
+            // - メッシュピック点がカメラより低ければ、その高度の水平面を採用
+            //   （ピック地点をカーソル直下に保つ自然な grab UX）。
+            // - ピック点がカメラより高い、または空ピック時は y=0 を採用。
+            //   高所ピック面はレイとの交点が遠方に発散しステップ量・回転中心が
+            //   破綻するため (Issue #151)。
+            const cameraYAtDown = camera.target.y + camera.radius * Math.cos(camera.beta);
+            if (pick?.hit && pick.pickedPoint && pick.pickedPoint.y < cameraYAtDown) {
                 dragPlaneY = pick.pickedPoint.y;
             } else {
-                // 空ピック時: target.y=0 不変条件のため dragPlaneY = 0 固定。
                 dragPlaneY = 0;
             }
             dragAnchor = intersectPlane(sx, sy, dragPlaneY);
@@ -621,41 +625,22 @@ export class DefaultScene implements CreateSceneClass {
                 //   操作感が反転して見えるため (Issue #151)。
                 // - カメラ高度に極めて近いピック点（水平線付近）はレイ交点が遠方に
                 //   発散し操作感が破綻するため、パンをスキップする。
-                // ドラッグ開始時のピック高度 (dragPlaneY) の水平面でパン。
-                // パン量はカメラの forward / right 軸で分解する:
-                //   - right (左右): 常に grab 方向 (符号 -1)
-                //   - forward (前後): 通常は grab、ただしカメラより高いピック面 (見上げる
-                //     山の斜面など) ではレイ-平面交点の進む向きが逆転するため反転 (Issue #151)。
+                // ドラッグ開始時に決定した水平面 (dragPlaneY) でカーソル直下を
+                // アンカーする標準的な grab パン。dragPlaneY は必ず cameraY 未満
+                // （pointerdown で保証）なのでレイ-平面交点は安定する (Issue #151)。
                 const current = intersectPlane(sx, sy, dragPlaneY);
                 if (current) {
-                    const cameraY = camera.target.y + camera.radius * Math.cos(camera.beta);
-                    const dx = current.x - dragAnchor.x;
-                    const dz = current.z - dragAnchor.z;
-                    // カメラから target を見る水平方向（forward）と、画面右に対応する right 軸
-                    // ArcRotateCamera: camPos = target + r·(sinβ·cosα, cosβ, sinβ·sinα)
-                    // → forward (target方向の水平成分, 単位) = (-cosα, 0, -sinα)
-                    const fx = -Math.cos(camera.alpha);
-                    const fz = -Math.sin(camera.alpha);
-                    // right = forward × world_up（Babylon 左手系想定）
-                    const rx = fz;
-                    const rz = -fx;
-                    const fComp = dx * fx + dz * fz;
-                    const rComp = dx * rx + dz * rz;
-                    const fSign = dragPlaneY > cameraY ? +1 : -1;
-                    const rSign = -1;
-                    camera.target.x += fSign * fComp * fx + rSign * rComp * rx;
-                    camera.target.z += fSign * fComp * fz + rSign * rComp * rz;
+                    camera.target.x += dragAnchor.x - current.x;
+                    camera.target.z += dragAnchor.z - current.z;
 
                     // パン後にカメラがメッシュを突き抜けないよう radius を下限まで持ち上げる。
                     // (a) terrainMinRadius() … 直下レイキャスト + 標高キャッシュ
                     // (b) dragPlaneY ベース … ドラッグ中のピック点標高は確実な既知値なので、
-                    //     直下タイル未ロードで (a) が下限 50 を返すケースを補完 (Issue #151)。
-                    //     ただしピック点がカメラより高い場合（カメラが見上げる山頂など）は
-                    //     直下のコリジョンには関与しないため適用しない。
+                    //     直下タイル未ロードで (a) が下限 50 を返すケースを補完。
                     const cosB = Math.cos(camera.beta);
                     const upper = camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS;
                     let minR = terrainMinRadius();
-                    if (cosB > 1e-6 && dragPlaneY <= cameraY) {
+                    if (cosB > 1e-6) {
                         const requiredFromPick = (dragPlaneY + CAMERA_LOWER_RADIUS - camera.target.y) / cosB;
                         if (Number.isFinite(requiredFromPick) && requiredFromPick > minR) {
                             minR = requiredFromPick;

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -492,17 +492,6 @@ export class DefaultScene implements CreateSceneClass {
         let activePointerId = -1;
         let dragAnchor: { x: number; z: number } | null = null;
         let dragPlaneY = 0;
-        let dragMeshMode = false;
-        let dragAnchorLat = 0;
-        let dragAnchorLon = 0;
-
-        /** ワールド座標(wx, wz)を現在のgrid基準で緯度経度に変換 */
-        const worldToLatLon = (wx: number, wz: number): { lat: number; lon: number } => {
-            const metersPerDegreeLon = METERS_PER_DEGREE_LAT * Math.cos((currentLat * Math.PI) / 180);
-            const lat = currentLat + (wz - gridResidualZ) / METERS_PER_DEGREE_LAT;
-            const lon = currentLon + (wx - gridResidualX) / metersPerDegreeLon;
-            return { lat, lon };
-        };
 
         /**
          * 新ターゲットに付け替え、カメラのワールド位置を保つよう alpha/beta/radius を再計算する。
@@ -574,20 +563,14 @@ export class DefaultScene implements CreateSceneClass {
 
             const pick = scene.pick(sx, sy, (m) => m.name.startsWith("tile-ground-"));
             if (pick?.hit && pick.pickedPoint) {
-                // メッシュピックモード: 緯度経度アンカーを保存
-                dragMeshMode = true;
-                const latLon = worldToLatLon(pick.pickedPoint.x, pick.pickedPoint.z);
-                dragAnchorLat = latLon.lat;
-                dragAnchorLon = latLon.lon;
+                // メッシュピックヒット時: ピック点の高度の水平面をドラッグ平面に採用。
+                // この水平面上でカーソル直下が常にピック地点に重なるよう pan する。
                 dragPlaneY = pick.pickedPoint.y;
-                dragAnchor = intersectPlane(sx, sy, dragPlaneY);
             } else {
-                // フォールバック: 平面交差モード。target.y=0 不変条件のため
-                // dragPlaneY も常に 0 で十分（Issue #151）。
-                dragMeshMode = false;
+                // 空ピック時: target.y=0 不変条件のため dragPlaneY = 0 固定。
                 dragPlaneY = 0;
-                dragAnchor = intersectPlane(sx, sy, dragPlaneY);
             }
+            dragAnchor = intersectPlane(sx, sy, dragPlaneY);
         });
 
         canvas.addEventListener("pointermove", (e: PointerEvent) => {
@@ -626,41 +609,20 @@ export class DefaultScene implements CreateSceneClass {
                         camera.radius = radiusBeforeTilt;
                     }
                 }
-            } else if (dragAnchor || dragMeshMode) {
+            } else if (dragAnchor) {
                 const rect = canvas.getBoundingClientRect();
                 const sx = e.clientX - rect.left;
                 const sy = e.clientY - rect.top;
 
-                if (dragMeshMode) {
-                    // メッシュピックモード: 現在のカーソル位置でメッシュをピック
-                    const movePick = scene.pick(sx, sy, (m) => m.name.startsWith("tile-ground-"));
-                    if (movePick?.hit && movePick.pickedPoint) {
-                        const currentLatLon = worldToLatLon(movePick.pickedPoint.x, movePick.pickedPoint.z);
-                        const deltaLat = dragAnchorLat - currentLatLon.lat;
-                        const deltaLon = dragAnchorLon - currentLatLon.lon;
-                        // 緯度経度差分をワールド座標のオフセットに変換
-                        const metersPerDegreeLon = METERS_PER_DEGREE_LAT * Math.cos((currentLat * Math.PI) / 180);
-                        camera.target.x += deltaLon * metersPerDegreeLon;
-                        camera.target.z += deltaLat * METERS_PER_DEGREE_LAT;
-                        // 平面交差アンカーも同期（フォールバック切替に備える）
-                        dragAnchor = intersectPlane(sx, sy, dragPlaneY);
-                    } else if (dragAnchor) {
-                        // メッシュピック失敗時: 平面交差パンにフォールバック
-                        const current = intersectPlane(sx, sy, dragPlaneY);
-                        if (current) {
-                            camera.target.x += dragAnchor.x - current.x;
-                            camera.target.z += dragAnchor.z - current.z;
-                            dragAnchor = intersectPlane(sx, sy, dragPlaneY);
-                        }
-                    }
-                } else if (dragAnchor) {
-                    // フォールバック: 既存の平面交差パン
-                    const current = intersectPlane(sx, sy, dragPlaneY);
-                    if (current) {
-                        camera.target.x += dragAnchor.x - current.x;
-                        camera.target.z += dragAnchor.z - current.z;
-                        dragAnchor = intersectPlane(sx, sy, dragPlaneY);
-                    }
+                // ドラッグ開始時のピック高度 (dragPlaneY) の水平面で、
+                // カーソル直下のワールド座標が常に dragAnchor に重なるよう
+                // target.x/z を更新する。再ピック方式は水平より上の高所で
+                // ピック先が大きく飛ぶ問題があるため使わない (Issue #151)。
+                const current = intersectPlane(sx, sy, dragPlaneY);
+                if (current) {
+                    camera.target.x += dragAnchor.x - current.x;
+                    camera.target.z += dragAnchor.z - current.z;
+                    dragAnchor = intersectPlane(sx, sy, dragPlaneY);
                 }
             }
             lastPointerX = e.clientX;
@@ -678,7 +640,6 @@ export class DefaultScene implements CreateSceneClass {
             pointerDown = false;
             activePointerId = -1;
             dragAnchor = null;
-            dragMeshMode = false;
             commitPanOffset();
         };
 

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -492,11 +492,6 @@ export class DefaultScene implements CreateSceneClass {
         let activePointerId = -1;
         let dragAnchor: { x: number; z: number } | null = null;
         let dragPlaneY = 0;
-        // ドラッグ可否の閾値 (Issue #151):
-        // ピック点とカメラ位置の距離がこれ以上のときはドラッグしない。
-        // カメラ最大高度 (CAMERA_UPPER_RADIUS = 75km) と揃え、
-        // 高高度時にも遠景以外を grab pan できるようにする。
-        const MAX_DRAG_PICK_DISTANCE = CAMERA_UPPER_RADIUS;
 
         /**
          * 新ターゲットに付け替え、カメラのワールド位置を保つよう alpha/beta/radius を再計算する。
@@ -579,25 +574,14 @@ export class DefaultScene implements CreateSceneClass {
             // 通常ドラッグの可否判定 (Issue #151 仕様再定義):
             //   1. メッシュにヒットすること
             //   2. ピック点 Y がカメラ Y より低いこと（カメラ高度以上はドラッグ不可）
-            //   3. カメラ位置からピック点までの距離が MAX_DRAG_PICK_DISTANCE 未満
-            // 上記すべてを満たすときのみ grab pan を有効化。それ以外は dragAnchor=null で
-            // pointermove のドラッグ処理がスキップされる。
-            const sinB = Math.sin(camera.beta);
-            const cosB = Math.cos(camera.beta);
-            const camWX = camera.target.x + camera.radius * sinB * Math.cos(camera.alpha);
-            const camWY = camera.target.y + camera.radius * cosB;
-            const camWZ = camera.target.z + camera.radius * sinB * Math.sin(camera.alpha);
+            // 距離制限は実用上の不利益（画面隅の遠景がドラッグ不可になる）が大きく
+            // ユーザー指示で撤廃。
+            const camWY = camera.target.y + camera.radius * Math.cos(camera.beta);
             const pick = scene.pick(sx, sy, (m) => m.name.startsWith("tile-ground-"));
             dragAnchor = null;
             if (pick?.hit && pick.pickedPoint && pick.pickedPoint.y < camWY) {
-                const dxp = pick.pickedPoint.x - camWX;
-                const dyp = pick.pickedPoint.y - camWY;
-                const dzp = pick.pickedPoint.z - camWZ;
-                const dist2 = dxp * dxp + dyp * dyp + dzp * dzp;
-                if (dist2 < MAX_DRAG_PICK_DISTANCE * MAX_DRAG_PICK_DISTANCE) {
-                    dragPlaneY = pick.pickedPoint.y;
-                    dragAnchor = intersectPlane(sx, sy, dragPlaneY);
-                }
+                dragPlaneY = pick.pickedPoint.y;
+                dragAnchor = intersectPlane(sx, sy, dragPlaneY);
             }
         });
 

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -20,6 +20,7 @@ import { createSkybox } from "../terrain/skybox";
 import { computeSunPosition } from "../terrain/sunPosition";
 import { deriveSunState } from "../terrain/sunState";
 import { resolveTiltCollision, TILT_MAX_RADIUS_INCREASE_RATIO } from "../terrain/cameraCollision";
+import { computePoseForNewTarget } from "../terrain/cameraRetarget";
 
 import { createUiVisibilityController } from "../terrain/uiVisibility";
 import { SUN_FALLBACK_DATETIME_ISO } from "../lib/types";
@@ -493,6 +494,37 @@ export class DefaultScene implements CreateSceneClass {
         let dragAnchor: { x: number; z: number } | null = null;
         let dragPlaneY = 0;
 
+        /**
+         * ターゲットを付け替えカメラのワールド位置を保つよう alpha/beta/radius を再計算。
+         * limit 逸脱や退化ケースで apply されないときは false を返す。
+         */
+        const retargetPreservingPose = (newTarget: {
+            x: number;
+            y: number;
+            z: number;
+        }): boolean => {
+            const { alpha, beta, radius } = camera;
+            const sinB = Math.sin(beta);
+            const cosB = Math.cos(beta);
+            const camPos = {
+                x: camera.target.x + radius * sinB * Math.cos(alpha),
+                y: camera.target.y + radius * cosB,
+                z: camera.target.z + radius * sinB * Math.sin(alpha),
+            };
+            const result = computePoseForNewTarget(camPos, newTarget, alpha, {
+                lowerBeta: camera.lowerBetaLimit ?? 0,
+                upperBeta: camera.upperBetaLimit ?? Math.PI,
+                lowerRadius: camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS,
+                upperRadius: camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS,
+            });
+            if (result.action !== "apply") return false;
+            camera.target.copyFromFloats(newTarget.x, newTarget.y, newTarget.z);
+            camera.alpha = result.alpha;
+            camera.beta = result.beta;
+            camera.radius = result.radius;
+            return true;
+        };
+
         canvas.addEventListener("contextmenu", (e) => e.preventDefault());
 
         canvas.addEventListener("pointerdown", (e: PointerEvent) => {
@@ -507,12 +539,21 @@ export class DefaultScene implements CreateSceneClass {
             const sx = e.clientX - rect.left;
             const sy = e.clientY - rect.top;
 
-            // Ctrl/Cmd 押下開始時: 旧版では画面中央の地点へ retargetPreservingPose で
-            // 付け替えていたが、apply 後に limit クランプ・浮動小数誤差で
-            // 視覚ジャンプが残るため撤廃 (Issue #151)。target.y=0 不変条件下では
-            // 既存 target が常に画面中央付近の y=0 平面上にあり、回転中心として十分。
+            // Ctrl/Cmd 押下開始時: 画面中央でヒットしたメッシュ点（例: 富士山山頂）を
+            // 回転中心にするため target をその点に付け替える (Issue #151)。
+            // target.y はヒットした高度を採用し、リリース時に y=0 にポーズ保持で戻す。
             if (e.ctrlKey || e.metaKey) {
                 commitPanOffset();
+                const cx = canvas.clientWidth / 2;
+                const cy = canvas.clientHeight / 2;
+                const centerPick = scene.pick(cx, cy, (m) => m.name.startsWith("tile-ground-"));
+                if (centerPick?.hit && centerPick.pickedPoint) {
+                    const p = centerPick.pickedPoint;
+                    if (retargetPreservingPose({ x: p.x, y: p.y, z: p.z })) {
+                        gridResidualX = camera.target.x;
+                        gridResidualZ = camera.target.z;
+                    }
+                }
             }
 
             // 通常ドラッグの可否判定 (Issue #151 仕様再定義):
@@ -609,10 +650,20 @@ export class DefaultScene implements CreateSceneClass {
             lastPointerY = e.clientY;
         });
 
+        /**
+         * Ctrl+drag 中に target.y を山頂などの実標高に置いた場合、リリース時に
+         * カメラのワールド位置を保ったまま target.y=0 へ戻して不変条件を回復する。
+         */
+        const restoreTargetYZero = (): void => {
+            if (Math.abs(camera.target.y) < 1e-3) return;
+            retargetPreservingPose({ x: camera.target.x, y: 0, z: camera.target.z });
+        };
+
         canvas.addEventListener("pointerup", (e: PointerEvent) => {
             if (e.pointerId !== activePointerId) return;
             pointerDown = false;
             canvas.releasePointerCapture(e.pointerId);
+            restoreTargetYZero();
             commitPanOffset();
         });
 
@@ -620,6 +671,7 @@ export class DefaultScene implements CreateSceneClass {
             pointerDown = false;
             activePointerId = -1;
             dragAnchor = null;
+            restoreTargetYZero();
             commitPanOffset();
         };
 

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -338,10 +338,38 @@ export class DefaultScene implements CreateSceneClass {
             gridResidualX = gridResidualX + newOffsetX - gridShiftX;
             gridResidualZ = gridResidualZ + newOffsetZ - gridShiftZ;
 
-            // target.y は retarget で地形高さに設定されている場合があるため保持する
-            // （0 代入するとリリース時に上下ジャンプが発生する）
-            camera.target.x = gridResidualX;
-            camera.target.z = gridResidualZ;
+            // target.y を地形参照面 (=0) に正規化する (Issue #151)。
+            // 富士山頂で Ctrl+ドラッグ retarget により target.y が 3776m 等になった
+            // まま平地に移動すると、camera.position.y = target.y + radius*cos(beta)
+            // が地表から大きく乖離し、computeQuadtreeTiles の SSE 距離計算が破綻して
+            // 採用 zoom が狂う。computePoseForNewTarget でカメラのワールド位置を保つ
+            // 再射影を試行し、視覚ジャンプを抑止する。limit 逸脱や特異点で skip された
+            // 場合のみ従来挙動 (x/z のみ更新、target.y 保持) にフォールバックする。
+            const { alpha, beta, radius } = camera;
+            const sinB = Math.sin(beta);
+            const cosB = Math.cos(beta);
+            const camPos = {
+                x: camera.target.x + radius * sinB * Math.cos(alpha),
+                y: camera.target.y + radius * cosB,
+                z: camera.target.z + radius * sinB * Math.sin(alpha),
+            };
+            const newTarget = { x: gridResidualX, y: 0, z: gridResidualZ };
+            const pose = computePoseForNewTarget(camPos, newTarget, alpha, {
+                lowerBeta: camera.lowerBetaLimit ?? 0,
+                upperBeta: camera.upperBetaLimit ?? Math.PI,
+                lowerRadius: camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS,
+                upperRadius: camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS,
+            });
+            if (pose.action === "apply") {
+                camera.target.copyFromFloats(newTarget.x, newTarget.y, newTarget.z);
+                camera.alpha = pose.alpha;
+                camera.beta = pose.beta;
+                camera.radius = pose.radius;
+            } else {
+                // フォールバック: 従来挙動。target.y は retarget で設定された値を保持。
+                camera.target.x = gridResidualX;
+                camera.target.z = gridResidualZ;
+            }
 
             currentLat = newLat;
             currentLon = newLon;
@@ -391,6 +419,19 @@ export class DefaultScene implements CreateSceneClass {
         const terrainMinRadius = (): number => {
             const { alpha, beta, radius } = camera;
             const { x: tx, y: ty, z: tz } = camera.target;
+            // 入力 (alpha/beta/radius/target) に NaN/Infinity が混入している場合は
+            // 算出が破綻するため、早期に lowerRadiusLimit を返す (Issue #151)。
+            if (
+                !Number.isFinite(alpha) ||
+                !Number.isFinite(beta) ||
+                !Number.isFinite(radius) ||
+                !Number.isFinite(tx) ||
+                !Number.isFinite(ty) ||
+                !Number.isFinite(tz)
+            ) {
+                cachedMinRadius = camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
+                return cachedMinRadius;
+            }
             if (
                 alpha === prevAlpha &&
                 beta === prevBeta &&
@@ -431,7 +472,7 @@ export class DefaultScene implements CreateSceneClass {
 
             // キャッシュ済み標高データから高精度な値を補完
             const cacheElev = tileManager.queryElevationAtWorld(camX, camZ);
-            if (cacheElev !== null) {
+            if (cacheElev !== null && Number.isFinite(cacheElev)) {
                 terrainY = terrainY !== null ? Math.max(terrainY, cacheElev) : cacheElev;
             }
 
@@ -441,7 +482,14 @@ export class DefaultScene implements CreateSceneClass {
             }
 
             const minCamY = terrainY + CAMERA_LOWER_RADIUS;
-            cachedMinRadius = (minCamY - ty) / cosB;
+            const computed = (minCamY - ty) / cosB;
+            // 非有限値・下限未満は lowerRadiusLimit にクランプ (Issue #151)
+            const lowerLimit = camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
+            if (!Number.isFinite(computed) || computed < lowerLimit) {
+                cachedMinRadius = lowerLimit;
+                return cachedMinRadius;
+            }
+            cachedMinRadius = computed;
             return cachedMinRadius;
         };
 
@@ -700,6 +748,8 @@ export class DefaultScene implements CreateSceneClass {
             // 衝突制限を考慮した実効 lower を算出
             const effectiveLower = Math.max(lower, terrainMinRadius());
             const newRadius = clamp(camera.radius * factor, effectiveLower, upper);
+            // 非有限値ガード (Issue #151): factor/radius が NaN/Infinity だった場合は何もしない
+            if (!Number.isFinite(newRadius)) return;
             if (Math.abs(newRadius - camera.radius) < 0.01) return;
 
             // ズームイン操作なのに半径が増える場合はターゲット移動せず半径だけ補正
@@ -774,6 +824,7 @@ export class DefaultScene implements CreateSceneClass {
                         const camX = camera.target.x + camera.radius * sinB * Math.cos(camera.alpha);
                         const camZ = camera.target.z + camera.radius * sinB * Math.sin(camera.alpha);
                         const newRadius = clamp(camera.radius * factor, effectiveLower2, upper);
+                        if (!Number.isFinite(newRadius)) return;
                         camera.target.x = camX - newRadius * sinB * Math.cos(camera.alpha);
                         camera.target.z = camZ - newRadius * sinB * Math.sin(camera.alpha);
                         camera.radius = newRadius;
@@ -783,7 +834,9 @@ export class DefaultScene implements CreateSceneClass {
                         const effectiveLower1 = Math.max(lower, terrainMinRadius());
                         if (zoomIn && camera.radius <= effectiveLower1) return;
                         if (!zoomIn && camera.radius >= upper) return;
-                        camera.radius = clamp(camera.radius * factor, effectiveLower1, upper);
+                        const next = clamp(camera.radius * factor, effectiveLower1, upper);
+                        if (!Number.isFinite(next)) return;
+                        camera.radius = next;
                     }
                 }
             },

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -338,38 +338,48 @@ export class DefaultScene implements CreateSceneClass {
             gridResidualX = gridResidualX + newOffsetX - gridShiftX;
             gridResidualZ = gridResidualZ + newOffsetZ - gridShiftZ;
 
-            // target.y を地形参照面 (=0) に正規化する (Issue #151)。
+            // Step 1: target.y を地形参照面 (=0) に正規化する (Issue #151)。
             // 富士山頂で Ctrl+ドラッグ retarget により target.y が 3776m 等になった
             // まま平地に移動すると、camera.position.y = target.y + radius*cos(beta)
-            // が地表から大きく乖離し、computeQuadtreeTiles の SSE 距離計算が破綻して
-            // 採用 zoom が狂う。computePoseForNewTarget でカメラのワールド位置を保つ
-            // 再射影を試行し、視覚ジャンプを抑止する。limit 逸脱や特異点で skip された
-            // 場合のみ従来挙動 (x/z のみ更新、target.y 保持) にフォールバックする。
-            const { alpha, beta, radius } = camera;
-            const sinB = Math.sin(beta);
-            const cosB = Math.cos(beta);
-            const camPos = {
-                x: camera.target.x + radius * sinB * Math.cos(alpha),
-                y: camera.target.y + radius * cosB,
-                z: camera.target.z + radius * sinB * Math.sin(alpha),
-            };
-            const newTarget = { x: gridResidualX, y: 0, z: gridResidualZ };
-            const pose = computePoseForNewTarget(camPos, newTarget, alpha, {
-                lowerBeta: camera.lowerBetaLimit ?? 0,
-                upperBeta: camera.upperBetaLimit ?? Math.PI,
-                lowerRadius: camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS,
-                upperRadius: camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS,
-            });
-            if (pose.action === "apply") {
-                camera.target.copyFromFloats(newTarget.x, newTarget.y, newTarget.z);
-                camera.alpha = pose.alpha;
-                camera.beta = pose.beta;
-                camera.radius = pose.radius;
-            } else {
-                // フォールバック: 従来挙動。target.y は retarget で設定された値を保持。
-                camera.target.x = gridResidualX;
-                camera.target.z = gridResidualZ;
+            // が地表から大きく乖離し、computeQuadtreeTiles の SSE 距離計算が破綻する。
+            // y 正規化はカメラのワールド位置を保つ再射影 (computePoseForNewTarget) で行い、
+            // 視覚ジャンプを抑止する。target.y がほぼ 0 のとき (通常のパン/ズーム時) は
+            // 不要な再射影を避け、ズーム時の意図しない視覚回転を防ぐ。
+            // ここでは target.x/z は現フレーム (グリッドスナップ前) のままにし、
+            // グリッドスナップ (Step 2) と座標フレームを分離する。
+            if (Math.abs(camera.target.y) > 1e-3) {
+                const { alpha, beta, radius } = camera;
+                const sinB = Math.sin(beta);
+                const cosB = Math.cos(beta);
+                const camPos = {
+                    x: camera.target.x + radius * sinB * Math.cos(alpha),
+                    y: camera.target.y + radius * cosB,
+                    z: camera.target.z + radius * sinB * Math.sin(alpha),
+                };
+                const newTarget = {
+                    x: camera.target.x,
+                    y: 0,
+                    z: camera.target.z,
+                };
+                const pose = computePoseForNewTarget(camPos, newTarget, alpha, {
+                    lowerBeta: camera.lowerBetaLimit ?? 0,
+                    upperBeta: camera.upperBetaLimit ?? Math.PI,
+                    lowerRadius: camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS,
+                    upperRadius: camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS,
+                });
+                if (pose.action === "apply") {
+                    camera.target.copyFromFloats(newTarget.x, newTarget.y, newTarget.z);
+                    camera.alpha = pose.alpha;
+                    camera.beta = pose.beta;
+                    camera.radius = pose.radius;
+                }
+                // skip 時は target.y を保持（従来挙動と等価）
             }
+
+            // Step 2: グリッド境界スナップ (x/z のみ更新)。
+            // currentLat/Lon の更新と組み合わせて、世界の見た目は不変。
+            camera.target.x = gridResidualX;
+            camera.target.z = gridResidualZ;
 
             currentLat = newLat;
             currentLon = newLon;

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -299,55 +299,91 @@ export class DefaultScene implements CreateSceneClass {
         };
 
         // ---------- カメラターゲットオフセット → 緯度経度変換 ----------
+        /**
+         * target.y を target.x/z 位置の地表高度に追従させる (Issue #151)。
+         * target.y が地表高度から乖離していると terrainMinRadius() のズーム下限計算
+         * `(terrainY + 50 - target.y) / cos(beta)` が破綻し、地面に近づけない／
+         * 数百 m の位置ずれが累積する。カメラのワールド位置を保ったまま target.y のみ
+         * 更新するため、target.x/z は不変で currentLat/Lon・gridResidual の整合も崩れない。
+         */
+        const syncTargetYToTerrain = (): void => {
+            const elev = tileManager.queryElevationAtWorld(camera.target.x, camera.target.z);
+            if (elev === null || !Number.isFinite(elev)) return;
+            if (Math.abs(elev - camera.target.y) <= 0.01) return;
+            const a = camera.alpha;
+            const b = camera.beta;
+            const r = camera.radius;
+            const sB = Math.sin(b);
+            const cB = Math.cos(b);
+            const camPos = {
+                x: camera.target.x + r * sB * Math.cos(a),
+                y: camera.target.y + r * cB,
+                z: camera.target.z + r * sB * Math.sin(a),
+            };
+            const newTarget = { x: camera.target.x, y: elev, z: camera.target.z };
+            const pose = computePoseForNewTarget(camPos, newTarget, a, {
+                lowerBeta: camera.lowerBetaLimit ?? 0,
+                upperBeta: camera.upperBetaLimit ?? Math.PI,
+                lowerRadius: camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS,
+                upperRadius: camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS,
+            });
+            if (pose.action === "apply") {
+                camera.target.y = elev;
+                camera.alpha = pose.alpha;
+                camera.beta = pose.beta;
+                camera.radius = pose.radius;
+            }
+        };
+
         const commitPanOffset = (): void => {
             const tx = camera.target.x;
             const tz = camera.target.z;
-            if (tx === 0 && tz === 0) return;
-
             // 新規オフセット = 全体 - 既知のグリッド残差
             const newOffsetX = tx - gridResidualX;
             const newOffsetZ = tz - gridResidualZ;
-            if (Math.abs(newOffsetX) < 0.01 && Math.abs(newOffsetZ) < 0.01) {
-                return;
+            const hasPan =
+                Math.abs(newOffsetX) >= 0.01 || Math.abs(newOffsetZ) >= 0.01;
+
+            if (hasPan) {
+                const oldLat = currentLat;
+                const oldLon = currentLon;
+                const metersPerDegreeLon =
+                    METERS_PER_DEGREE_LAT *
+                    Math.cos((oldLat * Math.PI) / 180);
+
+                const newLat = clamp(
+                    oldLat + newOffsetZ / METERS_PER_DEGREE_LAT,
+                    JAPAN_BOUNDS.minLat,
+                    JAPAN_BOUNDS.maxLat
+                );
+                const newLon = clamp(
+                    oldLon + newOffsetX / metersPerDegreeLon,
+                    JAPAN_BOUNDS.minLon,
+                    JAPAN_BOUNDS.maxLon
+                );
+
+                const oldTile = toTileXY(oldLat, oldLon, MAX_ZOOM);
+                const newTile = toTileXY(newLat, newLon, MAX_ZOOM);
+                const tileSize = tileEdgeMeters(newLat, MAX_ZOOM);
+                const gridShiftX = (newTile.x - oldTile.x) * tileSize;
+                const gridShiftZ = -((newTile.y - oldTile.y) * tileSize);
+
+                // 残差更新: 旧残差 + 新規オフセット - グリッドシフト
+                gridResidualX = gridResidualX + newOffsetX - gridShiftX;
+                gridResidualZ = gridResidualZ + newOffsetZ - gridShiftZ;
+
+                // target.x/z をグリッド残差に同期。target.y は保持。
+                camera.target.x = gridResidualX;
+                camera.target.z = gridResidualZ;
+
+                currentLat = newLat;
+                currentLon = newLon;
+                void refreshTerrain();
             }
 
-            const oldLat = currentLat;
-            const oldLon = currentLon;
-            const metersPerDegreeLon =
-                METERS_PER_DEGREE_LAT *
-                Math.cos((oldLat * Math.PI) / 180);
-
-            const newLat = clamp(
-                oldLat + newOffsetZ / METERS_PER_DEGREE_LAT,
-                JAPAN_BOUNDS.minLat,
-                JAPAN_BOUNDS.maxLat
-            );
-            const newLon = clamp(
-                oldLon + newOffsetX / metersPerDegreeLon,
-                JAPAN_BOUNDS.minLon,
-                JAPAN_BOUNDS.maxLon
-            );
-
-            const oldTile = toTileXY(oldLat, oldLon, MAX_ZOOM);
-            const newTile = toTileXY(newLat, newLon, MAX_ZOOM);
-            const tileSize = tileEdgeMeters(newLat, MAX_ZOOM);
-            const gridShiftX = (newTile.x - oldTile.x) * tileSize;
-            const gridShiftZ = -((newTile.y - oldTile.y) * tileSize);
-
-            // 残差更新: 旧残差 + 新規オフセット - グリッドシフト
-            gridResidualX = gridResidualX + newOffsetX - gridShiftX;
-            gridResidualZ = gridResidualZ + newOffsetZ - gridShiftZ;
-
-            // target.y は retarget で地形高さに設定されている場合があるため保持する
-            // （0 代入するとリリース時に上下ジャンプが発生する）。
-            // Issue #151 の SSE 破綻は tileManager.computeVisible 側で
-            // cameraPosition.y を absolute Y で渡すことで解消済み。
-            camera.target.x = gridResidualX;
-            camera.target.z = gridResidualZ;
-
-            currentLat = newLat;
-            currentLon = newLon;
-            void refreshTerrain();
+            // パン有無に関わらず、target.y を地表追従させる（Ctrl+drag retarget 直後など、
+            // パン残差なしでズームのみ行ったケースでも target.y のドリフトを防ぐ）。
+            syncTargetYToTerrain();
         };
 
         // ---------- レイ-平面交差ユーティリティ ----------
@@ -824,6 +860,8 @@ export class DefaultScene implements CreateSceneClass {
                         const next = clamp(camera.radius * factor, effectiveLower1, upper);
                         if (!Number.isFinite(next)) return;
                         camera.radius = next;
+                        // Phase 1 でも target.y 追従を走らせる (Issue #151)
+                        commitPanOffset();
                     }
                 }
             },

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -630,6 +630,13 @@ export class DefaultScene implements CreateSceneClass {
                         const sign = inverted ? 1 : -1;
                         camera.target.x += sign * (current.x - dragAnchor.x);
                         camera.target.z += sign * (current.z - dragAnchor.z);
+                        // パン後の新ターゲット直下の地形に対し radius が不足する場合は
+                        // 地形を突き抜けないよう下限まで自動ズームアウト (Issue #151)。
+                        const minR = terrainMinRadius();
+                        const upper = camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS;
+                        if (camera.radius < minR) {
+                            camera.radius = Math.min(minR, upper);
+                        }
                         dragAnchor = intersectPlane(sx, sy, dragPlaneY);
                     }
                 }

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -301,15 +301,13 @@ export class DefaultScene implements CreateSceneClass {
 
         // ---------- カメラターゲットオフセット → 緯度経度変換 ----------
         //
-        // 不変条件 (Issue #151):
-        //   - camera.target.y = 0 (常に地形参照面)
+        // 不変条件 (Issue #151 改訂):
         //   - camera.target.x = gridResidualX
         //   - camera.target.z = gridResidualZ
         //   - currentLat/Lon は target.x/z と同期
-        //
-        // target.y を動かす操作（旧: Ctrl+drag retarget で地形高度に張り付ける／
-        // syncTargetYToTerrain 等）はカメラのワールド位置・SSE 距離・terrainMinRadius と
-        // 累積的に矛盾しドリフト・ジャンプ・タイルレベル破綻の原因となるため廃止する。
+        //   - camera.target.y は通常時 0、Ctrl+drag 中のみ山頂などの実標高を許容
+        //     （リリース後もそのまま保持。target.y は SSE/terrainMinRadius/dragPlaneY の
+        //      参照高度として整合する）。lat/lon 対応は target.x/z のみで決まる。
         const commitPanOffset = (): void => {
             const tx = camera.target.x;
             const tz = camera.target.z;
@@ -350,9 +348,9 @@ export class DefaultScene implements CreateSceneClass {
             gridResidualX = gridResidualX + newOffsetX - gridShiftX;
             gridResidualZ = gridResidualZ + newOffsetZ - gridShiftZ;
 
-            // target を残差基準にスナップ。target.y は 0 固定。
+            // target を残差基準にスナップ。target.y は Ctrl+drag で山頂中心の回転を
+            // 許容するため触らない（lat/lon 対応は x/z のみを使用）。
             camera.target.x = gridResidualX;
-            camera.target.y = 0;
             camera.target.z = gridResidualZ;
 
             currentLat = newLat;
@@ -650,51 +648,10 @@ export class DefaultScene implements CreateSceneClass {
             lastPointerY = e.clientY;
         });
 
-        /**
-         * Ctrl+drag 中に target.y を山頂などの実標高に置いた場合、リリース時に
-         * target.y=0 へ戻す。alpha/beta は維持し、現在のカメラワールド位置から
-         * 視線方向 (alpha,beta) のレイと y=0 平面の交点を新 target にすることで
-         * カメラ姿勢を完全に保ったまま不変条件を回復する。
-         */
-        const restoreTargetYZero = (): void => {
-            if (Math.abs(camera.target.y) < 1e-3) return;
-            const { alpha, beta } = camera;
-            const sinB = Math.sin(beta);
-            const cosB = Math.cos(beta);
-            // カメラのワールド位置
-            const camX = camera.target.x + camera.radius * sinB * Math.cos(alpha);
-            const camY = camera.target.y + camera.radius * cosB;
-            const camZ = camera.target.z + camera.radius * sinB * Math.sin(alpha);
-            // ターゲット方向の単位ベクトル: (camera -> target) = -(sinβcosα, cosβ, sinβsinα)
-            const dirX = -sinB * Math.cos(alpha);
-            const dirY = -cosB;
-            const dirZ = -sinB * Math.sin(alpha);
-            if (Math.abs(dirY) < 1e-6) {
-                // 真横を向いているとき y=0 と交わらないので諦めて y のみリセット
-                camera.target.y = 0;
-                return;
-            }
-            // y=0 平面までの距離 t: camY + t*dirY = 0
-            const t = -camY / dirY;
-            const upper = camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS;
-            const lower = camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
-            // t が radius 範囲外、または逆向き（t<0）なら姿勢を崩さない緊急回避として
-            // y のみリセット（厳密には小ジャンプするが多くは Ctrl+drag 中の極端な姿勢のみ）。
-            if (!Number.isFinite(t) || t < lower || t > upper) {
-                camera.target.y = 0;
-                return;
-            }
-            camera.target.x = camX + t * dirX;
-            camera.target.y = 0;
-            camera.target.z = camZ + t * dirZ;
-            camera.radius = t;
-        };
-
         canvas.addEventListener("pointerup", (e: PointerEvent) => {
             if (e.pointerId !== activePointerId) return;
             pointerDown = false;
             canvas.releasePointerCapture(e.pointerId);
-            restoreTargetYZero();
             commitPanOffset();
         });
 
@@ -702,7 +659,6 @@ export class DefaultScene implements CreateSceneClass {
             pointerDown = false;
             activePointerId = -1;
             dragAnchor = null;
-            restoreTargetYZero();
             commitPanOffset();
         };
 

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -638,10 +638,12 @@ export class DefaultScene implements CreateSceneClass {
                     // (a) terrainMinRadius() … 直下レイキャスト + 標高キャッシュ
                     // (b) dragPlaneY ベース … ドラッグ中のピック点標高は確実な既知値なので、
                     //     直下タイル未ロードで (a) が下限 50 を返すケースを補完 (Issue #151)。
+                    //     ただしピック点がカメラより高い場合（カメラが見上げる山頂など）は
+                    //     直下のコリジョンには関与しないため適用しない。
                     const cosB = Math.cos(camera.beta);
                     const upper = camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS;
                     let minR = terrainMinRadius();
-                    if (cosB > 1e-6) {
+                    if (cosB > 1e-6 && dragPlaneY <= cameraY) {
                         const requiredFromPick = (dragPlaneY + CAMERA_LOWER_RADIUS - camera.target.y) / cosB;
                         if (Number.isFinite(requiredFromPick) && requiredFromPick > minR) {
                             minR = requiredFromPick;

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -301,13 +301,13 @@ export class DefaultScene implements CreateSceneClass {
 
         // ---------- カメラターゲットオフセット → 緯度経度変換 ----------
         //
-        // 不変条件 (Issue #151 改訂):
+        // 不変条件 (Issue #151):
         //   - camera.target.x = gridResidualX
         //   - camera.target.z = gridResidualZ
         //   - currentLat/Lon は target.x/z と同期
-        //   - camera.target.y は通常時 0、Ctrl+drag 中のみ山頂などの実標高を許容
-        //     （リリース後もそのまま保持。target.y は SSE/terrainMinRadius/dragPlaneY の
-        //      参照高度として整合する）。lat/lon 対応は target.x/z のみで決まる。
+        //   - 通常時 camera.target.y = 0
+        //   - Ctrl+drag 中のみ target.y を実標高に置くことを許容するが、リリース直後に
+        //     restoreTargetYZero でカメラ姿勢を保ったまま y=0 平面に戻す。
         const commitPanOffset = (): void => {
             const tx = camera.target.x;
             const tz = camera.target.z;
@@ -648,11 +648,52 @@ export class DefaultScene implements CreateSceneClass {
             lastPointerY = e.clientY;
         });
 
+        /**
+         * Ctrl+drag 中に target.y を実標高に置いた場合、リリース時に target.y=0 へ戻す。
+         * カメラのワールド位置・alpha・beta は維持し、視線レイと y=0 平面の交点を新 target に
+         * して radius を再計算する。target.x/z の変位は gridResidual と lat/lon に反映する。
+         */
+        const restoreTargetYZero = (): void => {
+            if (Math.abs(camera.target.y) < 1e-3) return;
+            const { alpha, beta } = camera;
+            const sinB = Math.sin(beta);
+            const cosB = Math.cos(beta);
+            const camX = camera.target.x + camera.radius * sinB * Math.cos(alpha);
+            const camY = camera.target.y + camera.radius * cosB;
+            const camZ = camera.target.z + camera.radius * sinB * Math.sin(alpha);
+            // ターゲット方向 (camera -> target): -(sinβcosα, cosβ, sinβsinα)
+            const dirX = -sinB * Math.cos(alpha);
+            const dirY = -cosB;
+            const dirZ = -sinB * Math.sin(alpha);
+            if (Math.abs(dirY) < 1e-6 || dirY > 0) {
+                // 真横/見上げ姿勢では y=0 と前方交点なし→ y のみリセット
+                camera.target.y = 0;
+                return;
+            }
+            const t = -camY / dirY;
+            const upper = camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS;
+            const lower = camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
+            if (!Number.isFinite(t) || t < lower || t > upper) {
+                camera.target.y = 0;
+                return;
+            }
+            const newTx = camX + t * dirX;
+            const newTz = camZ + t * dirZ;
+            // target.x/z 変位を lat/lon に確定反映してから新位置にスナップ。
+            // 下記順序で gridResidual を確定させ、その後 target を新位置に置く。
+            camera.target.x = newTx;
+            camera.target.y = 0;
+            camera.target.z = newTz;
+            camera.radius = t;
+            commitPanOffset();
+        };
+
         canvas.addEventListener("pointerup", (e: PointerEvent) => {
             if (e.pointerId !== activePointerId) return;
             pointerDown = false;
             canvas.releasePointerCapture(e.pointerId);
             commitPanOffset();
+            restoreTargetYZero();
         });
 
         const resetPointerState = (): void => {
@@ -660,6 +701,7 @@ export class DefaultScene implements CreateSceneClass {
             activePointerId = -1;
             dragAnchor = null;
             commitPanOffset();
+            restoreTargetYZero();
         };
 
         canvas.addEventListener("pointercancel", resetPointerState);

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -492,6 +492,10 @@ export class DefaultScene implements CreateSceneClass {
         let activePointerId = -1;
         let dragAnchor: { x: number; z: number } | null = null;
         let dragPlaneY = 0;
+        // ピクセルベース pan モード: カメラより高いピック点・空ピック時、
+        // レイ-平面交点が遠方で発散しステップ量が狂うため、
+        // カーソルピクセル量×radius 係数で forward/right に pan する (Issue #151)。
+        let dragPixelMode = false;
 
         /**
          * 新ターゲットに付け替え、カメラのワールド位置を保つよう alpha/beta/radius を再計算する。
@@ -562,19 +566,20 @@ export class DefaultScene implements CreateSceneClass {
             }
 
             const pick = scene.pick(sx, sy, (m) => m.name.startsWith("tile-ground-"));
-            // ドラッグ平面の決定:
-            // - メッシュピック点がカメラより低ければ、その高度の水平面を採用
-            //   （ピック地点をカーソル直下に保つ自然な grab UX）。
-            // - ピック点がカメラより高い、または空ピック時は y=0 を採用。
-            //   高所ピック面はレイとの交点が遠方に発散しステップ量・回転中心が
-            //   破綻するため (Issue #151)。
+            // ドラッグモードの決定 (Issue #151):
+            // - ピック点がカメラより低い: y=pickedY 平面での grab パン。
+            // - カメラより高い / 空ピック: レイ交点が遠方発散するため
+            //   ピクセルベース pan に切り替える。
             const cameraYAtDown = camera.target.y + camera.radius * Math.cos(camera.beta);
             if (pick?.hit && pick.pickedPoint && pick.pickedPoint.y < cameraYAtDown) {
+                dragPixelMode = false;
                 dragPlaneY = pick.pickedPoint.y;
+                dragAnchor = intersectPlane(sx, sy, dragPlaneY);
             } else {
+                dragPixelMode = true;
                 dragPlaneY = 0;
+                dragAnchor = null;
             }
-            dragAnchor = intersectPlane(sx, sy, dragPlaneY);
         });
 
         canvas.addEventListener("pointermove", (e: PointerEvent) => {
@@ -613,18 +618,34 @@ export class DefaultScene implements CreateSceneClass {
                         camera.radius = radiusBeforeTilt;
                     }
                 }
+            } else if (dragPixelMode) {
+                // ピクセルベース pan: カメラより高いピック点・空ピック時の救済 (Issue #151)。
+                // レイ-平面交点は遠方発散するため、カーソルピクセル変位 × radius 係数で
+                // forward/right に直接 target を動かす。
+                const dx = e.clientX - lastPointerX;
+                const dy = e.clientY - lastPointerY;
+                const scale = camera.radius / Math.max(canvas.clientWidth, 1);
+                // forward (target 方向の水平成分): (-cosα, 0, -sinα)
+                const fx = -Math.cos(camera.alpha);
+                const fz = -Math.sin(camera.alpha);
+                // right = forward × world_up (Babylon 左手系)
+                const rx = fz;
+                const rz = -fx;
+                // 画面上方向ドラッグ (dy<0) で前進、画面右ドラッグ (dx>0) で右移動
+                const fAmt = -dy * scale;
+                const rAmt = dx * scale;
+                camera.target.x += fAmt * fx + rAmt * rx;
+                camera.target.z += fAmt * fz + rAmt * rz;
+                const minR = terrainMinRadius();
+                const upper = camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS;
+                if (camera.radius < minR) {
+                    camera.radius = Math.min(minR, upper);
+                }
             } else if (dragAnchor) {
                 const rect = canvas.getBoundingClientRect();
                 const sx = e.clientX - rect.left;
                 const sy = e.clientY - rect.top;
 
-                // ドラッグ開始時のピック高度 (dragPlaneY) の水平面でパン。
-                // - カメラより下のピック点（通常の地形）: ピック地点を掴む方向 (anchor - current)
-                // - カメラより上のピック点（高所メッシュ）: 視点を押し動かす方向 (current - anchor)
-                //   水平より上ではレイ方向と平面が浅い角度で交わり、掴む方向だと
-                //   操作感が反転して見えるため (Issue #151)。
-                // - カメラ高度に極めて近いピック点（水平線付近）はレイ交点が遠方に
-                //   発散し操作感が破綻するため、パンをスキップする。
                 // ドラッグ開始時に決定した水平面 (dragPlaneY) でカーソル直下を
                 // アンカーする標準的な grab パン。dragPlaneY は必ず cameraY 未満
                 // （pointerdown で保証）なのでレイ-平面交点は安定する (Issue #151)。
@@ -667,6 +688,7 @@ export class DefaultScene implements CreateSceneClass {
             pointerDown = false;
             activePointerId = -1;
             dragAnchor = null;
+            dragPixelMode = false;
             commitPanOffset();
         };
 

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -614,13 +614,18 @@ export class DefaultScene implements CreateSceneClass {
                 const sx = e.clientX - rect.left;
                 const sy = e.clientY - rect.top;
 
-                // ドラッグ開始時のピック高度 (dragPlaneY) の水平面で、
-                // カーソルの動きに合わせて視点（target）を同方向に動かす。
-                // ピック地点を「掴む」のではなく、視点を押し動かす操作感（Issue #151）。
+                // ドラッグ開始時のピック高度 (dragPlaneY) の水平面でパン。
+                // - カメラより下のピック点（通常の地形）: ピック地点を掴む方向 (anchor - current)
+                // - カメラより上のピック点（高所メッシュ）: 視点を押し動かす方向 (current - anchor)
+                //   水平より上ではレイ方向と平面が浅い角度で交わり、掴む方向だと
+                //   操作感が反転して見えるため (Issue #151)。
                 const current = intersectPlane(sx, sy, dragPlaneY);
                 if (current) {
-                    camera.target.x += current.x - dragAnchor.x;
-                    camera.target.z += current.z - dragAnchor.z;
+                    const cameraY = camera.target.y + camera.radius * Math.cos(camera.beta);
+                    const inverted = dragPlaneY > cameraY;
+                    const sign = inverted ? 1 : -1;
+                    camera.target.x += sign * (current.x - dragAnchor.x);
+                    camera.target.z += sign * (current.z - dragAnchor.z);
                     dragAnchor = intersectPlane(sx, sy, dragPlaneY);
                 }
             }

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -421,6 +421,9 @@ export class DefaultScene implements CreateSceneClass {
             const { x: tx, y: ty, z: tz } = camera.target;
             // 入力 (alpha/beta/radius/target) に NaN/Infinity が混入している場合は
             // 算出が破綻するため、早期に lowerRadiusLimit を返す (Issue #151)。
+            // ここでは prev* を NaN に倒してキャッシュキーを無効化する。
+            // そうしないと、後続で正常値（直前の prev と同じ値）に戻ったとき
+            // キャッシュヒットして下限値のまま再計算されない可能性がある。
             if (
                 !Number.isFinite(alpha) ||
                 !Number.isFinite(beta) ||
@@ -429,6 +432,12 @@ export class DefaultScene implements CreateSceneClass {
                 !Number.isFinite(ty) ||
                 !Number.isFinite(tz)
             ) {
+                prevAlpha = NaN;
+                prevBeta = NaN;
+                prevRadius = NaN;
+                prevTargetX = NaN;
+                prevTargetY = NaN;
+                prevTargetZ = NaN;
                 cachedMinRadius = camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
                 return cachedMinRadius;
             }

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -621,24 +621,36 @@ export class DefaultScene implements CreateSceneClass {
                 //   操作感が反転して見えるため (Issue #151)。
                 // - カメラ高度に極めて近いピック点（水平線付近）はレイ交点が遠方に
                 //   発散し操作感が破綻するため、パンをスキップする。
+                // ドラッグ開始時のピック高度 (dragPlaneY) の水平面でパン。
+                // - カメラより下のピック点（通常の地形）: ピック地点を掴む方向 (anchor - current)
+                // - カメラより上のピック点（高所メッシュ）: 視点を押し動かす方向 (current - anchor)
+                //   水平より上ではレイ方向と平面が浅い角度で交わり、掴む方向だと
+                //   操作感が反転して見えるため (Issue #151)。
                 const current = intersectPlane(sx, sy, dragPlaneY);
                 if (current) {
                     const cameraY = camera.target.y + camera.radius * Math.cos(camera.beta);
-                    const horizonBand = Math.max(50, camera.radius * 0.02);
-                    if (Math.abs(dragPlaneY - cameraY) >= horizonBand) {
-                        const inverted = dragPlaneY > cameraY;
-                        const sign = inverted ? 1 : -1;
-                        camera.target.x += sign * (current.x - dragAnchor.x);
-                        camera.target.z += sign * (current.z - dragAnchor.z);
-                        // パン後の新ターゲット直下の地形に対し radius が不足する場合は
-                        // 地形を突き抜けないよう下限まで自動ズームアウト (Issue #151)。
-                        const minR = terrainMinRadius();
-                        const upper = camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS;
-                        if (camera.radius < minR) {
-                            camera.radius = Math.min(minR, upper);
+                    const inverted = dragPlaneY > cameraY;
+                    const sign = inverted ? 1 : -1;
+                    camera.target.x += sign * (current.x - dragAnchor.x);
+                    camera.target.z += sign * (current.z - dragAnchor.z);
+
+                    // パン後にカメラがメッシュを突き抜けないよう radius を下限まで持ち上げる。
+                    // (a) terrainMinRadius() … 直下レイキャスト + 標高キャッシュ
+                    // (b) dragPlaneY ベース … ドラッグ中のピック点標高は確実な既知値なので、
+                    //     直下タイル未ロードで (a) が下限 50 を返すケースを補完 (Issue #151)。
+                    const cosB = Math.cos(camera.beta);
+                    const upper = camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS;
+                    let minR = terrainMinRadius();
+                    if (cosB > 1e-6) {
+                        const requiredFromPick = (dragPlaneY + CAMERA_LOWER_RADIUS - camera.target.y) / cosB;
+                        if (Number.isFinite(requiredFromPick) && requiredFromPick > minR) {
+                            minR = requiredFromPick;
                         }
-                        dragAnchor = intersectPlane(sx, sy, dragPlaneY);
                     }
+                    if (camera.radius < minR) {
+                        camera.radius = Math.min(minR, upper);
+                    }
+                    dragAnchor = intersectPlane(sx, sy, dragPlaneY);
                 }
             }
             lastPointerX = e.clientX;

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -622,17 +622,29 @@ export class DefaultScene implements CreateSceneClass {
                 // - カメラ高度に極めて近いピック点（水平線付近）はレイ交点が遠方に
                 //   発散し操作感が破綻するため、パンをスキップする。
                 // ドラッグ開始時のピック高度 (dragPlaneY) の水平面でパン。
-                // - カメラより下のピック点（通常の地形）: ピック地点を掴む方向 (anchor - current)
-                // - カメラより上のピック点（高所メッシュ）: 視点を押し動かす方向 (current - anchor)
-                //   水平より上ではレイ方向と平面が浅い角度で交わり、掴む方向だと
-                //   操作感が反転して見えるため (Issue #151)。
+                // パン量はカメラの forward / right 軸で分解する:
+                //   - right (左右): 常に grab 方向 (符号 -1)
+                //   - forward (前後): 通常は grab、ただしカメラより高いピック面 (見上げる
+                //     山の斜面など) ではレイ-平面交点の進む向きが逆転するため反転 (Issue #151)。
                 const current = intersectPlane(sx, sy, dragPlaneY);
                 if (current) {
                     const cameraY = camera.target.y + camera.radius * Math.cos(camera.beta);
-                    const inverted = dragPlaneY > cameraY;
-                    const sign = inverted ? 1 : -1;
-                    camera.target.x += sign * (current.x - dragAnchor.x);
-                    camera.target.z += sign * (current.z - dragAnchor.z);
+                    const dx = current.x - dragAnchor.x;
+                    const dz = current.z - dragAnchor.z;
+                    // カメラから target を見る水平方向（forward）と、画面右に対応する right 軸
+                    // ArcRotateCamera: camPos = target + r·(sinβ·cosα, cosβ, sinβ·sinα)
+                    // → forward (target方向の水平成分, 単位) = (-cosα, 0, -sinα)
+                    const fx = -Math.cos(camera.alpha);
+                    const fz = -Math.sin(camera.alpha);
+                    // right = forward × world_up（Babylon 左手系想定）
+                    const rx = fz;
+                    const rz = -fx;
+                    const fComp = dx * fx + dz * fz;
+                    const rComp = dx * rx + dz * rz;
+                    const fSign = dragPlaneY > cameraY ? +1 : -1;
+                    const rSign = -1;
+                    camera.target.x += fSign * fComp * fx + rSign * rComp * rx;
+                    camera.target.z += fSign * fComp * fz + rSign * rComp * rz;
 
                     // パン後にカメラがメッシュを突き抜けないよう radius を下限まで持ち上げる。
                     // (a) terrainMinRadius() … 直下レイキャスト + 標高キャッシュ

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -619,14 +619,19 @@ export class DefaultScene implements CreateSceneClass {
                 // - カメラより上のピック点（高所メッシュ）: 視点を押し動かす方向 (current - anchor)
                 //   水平より上ではレイ方向と平面が浅い角度で交わり、掴む方向だと
                 //   操作感が反転して見えるため (Issue #151)。
+                // - カメラ高度に極めて近いピック点（水平線付近）はレイ交点が遠方に
+                //   発散し操作感が破綻するため、パンをスキップする。
                 const current = intersectPlane(sx, sy, dragPlaneY);
                 if (current) {
                     const cameraY = camera.target.y + camera.radius * Math.cos(camera.beta);
-                    const inverted = dragPlaneY > cameraY;
-                    const sign = inverted ? 1 : -1;
-                    camera.target.x += sign * (current.x - dragAnchor.x);
-                    camera.target.z += sign * (current.z - dragAnchor.z);
-                    dragAnchor = intersectPlane(sx, sy, dragPlaneY);
+                    const horizonBand = Math.max(50, camera.radius * 0.02);
+                    if (Math.abs(dragPlaneY - cameraY) >= horizonBand) {
+                        const inverted = dragPlaneY > cameraY;
+                        const sign = inverted ? 1 : -1;
+                        camera.target.x += sign * (current.x - dragAnchor.x);
+                        camera.target.z += sign * (current.z - dragAnchor.z);
+                        dragAnchor = intersectPlane(sx, sy, dragPlaneY);
+                    }
                 }
             }
             lastPointerX = e.clientX;

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -627,13 +627,23 @@ export class DefaultScene implements CreateSceneClass {
                 const sy = e.clientY - rect.top;
 
                 // ドラッグ開始時に決定した水平面 (dragPlaneY) でカーソル直下を
-                // アンカーする標準的な grab パン。dragAnchor が存在する時点で
-                // pointerdown の判定（pickY < cameraY、距離 < MAX_DRAG_PICK_DISTANCE）を
-                // 通過しているのでレイ-平面交点は安定。
+                // アンカーする標準的な grab パン。
                 const current = intersectPlane(sx, sy, dragPlaneY);
                 if (current) {
-                    camera.target.x += dragAnchor.x - current.x;
-                    camera.target.z += dragAnchor.z - current.z;
+                    let dx = dragAnchor.x - current.x;
+                    let dz = dragAnchor.z - current.z;
+                    // 遠景・水平線付近のドラッグでレイ交点が大きく動き、1フレームの移動量が
+                    // 際限なく膨らむのを抑制する (Issue #151)。
+                    // 1フレームあたりの最大移動距離をカメラの radius に比例した値に制限。
+                    const maxStep = camera.radius * 0.5;
+                    const stepLen = Math.hypot(dx, dz);
+                    if (stepLen > maxStep && stepLen > 0) {
+                        const k = maxStep / stepLen;
+                        dx *= k;
+                        dz *= k;
+                    }
+                    camera.target.x += dx;
+                    camera.target.z += dz;
 
                     // パン後にカメラがメッシュを突き抜けないよう radius を下限まで持ち上げる。
                     const cosB = Math.cos(camera.beta);

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -338,46 +338,10 @@ export class DefaultScene implements CreateSceneClass {
             gridResidualX = gridResidualX + newOffsetX - gridShiftX;
             gridResidualZ = gridResidualZ + newOffsetZ - gridShiftZ;
 
-            // Step 1: target.y を地形参照面 (=0) に正規化する (Issue #151)。
-            // 富士山頂で Ctrl+ドラッグ retarget により target.y が 3776m 等になった
-            // まま平地に移動すると、camera.position.y = target.y + radius*cos(beta)
-            // が地表から大きく乖離し、computeQuadtreeTiles の SSE 距離計算が破綻する。
-            // y 正規化はカメラのワールド位置を保つ再射影 (computePoseForNewTarget) で行い、
-            // 視覚ジャンプを抑止する。target.y がほぼ 0 のとき (通常のパン/ズーム時) は
-            // 不要な再射影を避け、ズーム時の意図しない視覚回転を防ぐ。
-            // ここでは target.x/z は現フレーム (グリッドスナップ前) のままにし、
-            // グリッドスナップ (Step 2) と座標フレームを分離する。
-            if (Math.abs(camera.target.y) > 1e-3) {
-                const { alpha, beta, radius } = camera;
-                const sinB = Math.sin(beta);
-                const cosB = Math.cos(beta);
-                const camPos = {
-                    x: camera.target.x + radius * sinB * Math.cos(alpha),
-                    y: camera.target.y + radius * cosB,
-                    z: camera.target.z + radius * sinB * Math.sin(alpha),
-                };
-                const newTarget = {
-                    x: camera.target.x,
-                    y: 0,
-                    z: camera.target.z,
-                };
-                const pose = computePoseForNewTarget(camPos, newTarget, alpha, {
-                    lowerBeta: camera.lowerBetaLimit ?? 0,
-                    upperBeta: camera.upperBetaLimit ?? Math.PI,
-                    lowerRadius: camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS,
-                    upperRadius: camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS,
-                });
-                if (pose.action === "apply") {
-                    camera.target.copyFromFloats(newTarget.x, newTarget.y, newTarget.z);
-                    camera.alpha = pose.alpha;
-                    camera.beta = pose.beta;
-                    camera.radius = pose.radius;
-                }
-                // skip 時は target.y を保持（従来挙動と等価）
-            }
-
-            // Step 2: グリッド境界スナップ (x/z のみ更新)。
-            // currentLat/Lon の更新と組み合わせて、世界の見た目は不変。
+            // target.y は retarget で地形高さに設定されている場合があるため保持する
+            // （0 代入するとリリース時に上下ジャンプが発生する）。
+            // Issue #151 の SSE 破綻は tileManager.computeVisible 側で
+            // cameraPosition.y を absolute Y で渡すことで解消済み。
             camera.target.x = gridResidualX;
             camera.target.z = gridResidualZ;
 

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -494,8 +494,9 @@ export class DefaultScene implements CreateSceneClass {
         let dragPlaneY = 0;
         // ドラッグ可否の閾値 (Issue #151):
         // ピック点とカメラ位置の距離がこれ以上のときはドラッグしない。
-        // 遠距離ピックだと grab pan のステップ量が取り回しのつかないジャンプになるため。
-        const MAX_DRAG_PICK_DISTANCE = 10000;
+        // カメラ最大高度 (CAMERA_UPPER_RADIUS = 75km) と揃え、
+        // 高高度時にも遠景以外を grab pan できるようにする。
+        const MAX_DRAG_PICK_DISTANCE = CAMERA_UPPER_RADIUS;
 
         /**
          * 新ターゲットに付け替え、カメラのワールド位置を保つよう alpha/beta/radius を再計算する。

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -20,7 +20,7 @@ import { createSkybox } from "../terrain/skybox";
 import { computeSunPosition } from "../terrain/sunPosition";
 import { deriveSunState } from "../terrain/sunState";
 import { resolveTiltCollision, TILT_MAX_RADIUS_INCREASE_RATIO } from "../terrain/cameraCollision";
-import { computePoseForNewTarget } from "../terrain/cameraRetarget";
+
 import { createUiVisibilityController } from "../terrain/uiVisibility";
 import { SUN_FALLBACK_DATETIME_ISO } from "../lib/types";
 
@@ -493,40 +493,6 @@ export class DefaultScene implements CreateSceneClass {
         let dragAnchor: { x: number; z: number } | null = null;
         let dragPlaneY = 0;
 
-        /**
-         * 新ターゲットに付け替え、カメラのワールド位置を保つよう alpha/beta/radius を再計算する。
-         * `computePoseForNewTarget` が limit 逸脱や退化ケースなどで `apply` を返せない場合は何もせず、
-         * 既存 target を維持する。なお、sin(beta)≈0 の特異点近傍では alpha を一意に再計算できなくても、
-         * current alpha を保持したまま `apply` される場合がある。
-         * @returns 付け替えを適用したら true
-         */
-        const retargetPreservingPose = (newTarget: {
-            x: number;
-            y: number;
-            z: number;
-        }): boolean => {
-            const { alpha, beta, radius } = camera;
-            const sinB = Math.sin(beta);
-            const cosB = Math.cos(beta);
-            const camPos = {
-                x: camera.target.x + radius * sinB * Math.cos(alpha),
-                y: camera.target.y + radius * cosB,
-                z: camera.target.z + radius * sinB * Math.sin(alpha),
-            };
-            const result = computePoseForNewTarget(camPos, newTarget, alpha, {
-                lowerBeta: camera.lowerBetaLimit ?? 0,
-                upperBeta: camera.upperBetaLimit ?? Math.PI,
-                lowerRadius: camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS,
-                upperRadius: camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS,
-            });
-            if (result.action !== "apply") return false;
-            camera.target.copyFromFloats(newTarget.x, newTarget.y, newTarget.z);
-            camera.alpha = result.alpha;
-            camera.beta = result.beta;
-            camera.radius = result.radius;
-            return true;
-        };
-
         canvas.addEventListener("contextmenu", (e) => e.preventDefault());
 
         canvas.addEventListener("pointerdown", (e: PointerEvent) => {
@@ -541,34 +507,12 @@ export class DefaultScene implements CreateSceneClass {
             const sx = e.clientX - rect.left;
             const sy = e.clientY - rect.top;
 
-            // Ctrl/Cmd 押下開始時: 回転中心を画面中央のピック点に再射影する (Issue #151)。
-            // - 画面中央でメッシュにヒットすればその xz を採用
-            // - ヒットしなければ y=0 平面交点 (空ピック相当) を採用
-            // target.y は 0 不変条件のため常に 0 で再射影。
-            // computePoseForNewTarget でカメラのワールド位置を保つので視覚ジャンプはしない。
+            // Ctrl/Cmd 押下開始時: 旧版では画面中央の地点へ retargetPreservingPose で
+            // 付け替えていたが、apply 後に limit クランプ・浮動小数誤差で
+            // 視覚ジャンプが残るため撤廃 (Issue #151)。target.y=0 不変条件下では
+            // 既存 target が常に画面中央付近の y=0 平面上にあり、回転中心として十分。
             if (e.ctrlKey || e.metaKey) {
                 commitPanOffset();
-                const cx = canvas.clientWidth / 2;
-                const cy = canvas.clientHeight / 2;
-                const centerPick = scene.pick(cx, cy, (m) => m.name.startsWith("tile-ground-"));
-                let nx: number | null = null;
-                let nz: number | null = null;
-                if (centerPick?.hit && centerPick.pickedPoint) {
-                    nx = centerPick.pickedPoint.x;
-                    nz = centerPick.pickedPoint.z;
-                } else {
-                    const planeHit = intersectPlane(cx, cy, 0);
-                    if (planeHit) {
-                        nx = planeHit.x;
-                        nz = planeHit.z;
-                    }
-                }
-                if (nx !== null && nz !== null) {
-                    if (retargetPreservingPose({ x: nx, y: 0, z: nz })) {
-                        gridResidualX = camera.target.x;
-                        gridResidualZ = camera.target.z;
-                    }
-                }
             }
 
             // 通常ドラッグの可否判定 (Issue #151 仕様再定義):

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -652,11 +652,42 @@ export class DefaultScene implements CreateSceneClass {
 
         /**
          * Ctrl+drag 中に target.y を山頂などの実標高に置いた場合、リリース時に
-         * カメラのワールド位置を保ったまま target.y=0 へ戻して不変条件を回復する。
+         * target.y=0 へ戻す。alpha/beta は維持し、現在のカメラワールド位置から
+         * 視線方向 (alpha,beta) のレイと y=0 平面の交点を新 target にすることで
+         * カメラ姿勢を完全に保ったまま不変条件を回復する。
          */
         const restoreTargetYZero = (): void => {
             if (Math.abs(camera.target.y) < 1e-3) return;
-            retargetPreservingPose({ x: camera.target.x, y: 0, z: camera.target.z });
+            const { alpha, beta } = camera;
+            const sinB = Math.sin(beta);
+            const cosB = Math.cos(beta);
+            // カメラのワールド位置
+            const camX = camera.target.x + camera.radius * sinB * Math.cos(alpha);
+            const camY = camera.target.y + camera.radius * cosB;
+            const camZ = camera.target.z + camera.radius * sinB * Math.sin(alpha);
+            // ターゲット方向の単位ベクトル: (camera -> target) = -(sinβcosα, cosβ, sinβsinα)
+            const dirX = -sinB * Math.cos(alpha);
+            const dirY = -cosB;
+            const dirZ = -sinB * Math.sin(alpha);
+            if (Math.abs(dirY) < 1e-6) {
+                // 真横を向いているとき y=0 と交わらないので諦めて y のみリセット
+                camera.target.y = 0;
+                return;
+            }
+            // y=0 平面までの距離 t: camY + t*dirY = 0
+            const t = -camY / dirY;
+            const upper = camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS;
+            const lower = camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
+            // t が radius 範囲外、または逆向き（t<0）なら姿勢を崩さない緊急回避として
+            // y のみリセット（厳密には小ジャンプするが多くは Ctrl+drag 中の極端な姿勢のみ）。
+            if (!Number.isFinite(t) || t < lower || t > upper) {
+                camera.target.y = 0;
+                return;
+            }
+            camera.target.x = camX + t * dirX;
+            camera.target.y = 0;
+            camera.target.z = camZ + t * dirZ;
+            camera.radius = t;
         };
 
         canvas.addEventListener("pointerup", (e: PointerEvent) => {

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -573,9 +573,13 @@ export class DefaultScene implements CreateSceneClass {
                 dragPlaneY = pick.pickedPoint.y;
                 dragAnchor = intersectPlane(sx, sy, dragPlaneY);
             } else {
-                // フォールバック: 既存の平面交差モード
+                // フォールバック: 既存の平面交差モード。
+                // dragPlaneY を camera.target.y に揃えることで、Ctrl+drag retarget 後など
+                // target.y が非ゼロな状態でもドラッグスケールが現在の target 高度と
+                // 整合する (Issue #151)。Y=0 固定だと target.y > 0 のとき空ピック時の
+                // ドラッグ移動量が地形面と乖離し、操作感が破綻する。
                 dragMeshMode = false;
-                dragPlaneY = 0;
+                dragPlaneY = camera.target.y;
                 dragAnchor = intersectPlane(sx, sy, dragPlaneY);
             }
         });

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -299,91 +299,64 @@ export class DefaultScene implements CreateSceneClass {
         };
 
         // ---------- カメラターゲットオフセット → 緯度経度変換 ----------
-        /**
-         * target.y を target.x/z 位置の地表高度に追従させる (Issue #151)。
-         * target.y が地表高度から乖離していると terrainMinRadius() のズーム下限計算
-         * `(terrainY + 50 - target.y) / cos(beta)` が破綻し、地面に近づけない／
-         * 数百 m の位置ずれが累積する。カメラのワールド位置を保ったまま target.y のみ
-         * 更新するため、target.x/z は不変で currentLat/Lon・gridResidual の整合も崩れない。
-         */
-        const syncTargetYToTerrain = (): void => {
-            const elev = tileManager.queryElevationAtWorld(camera.target.x, camera.target.z);
-            if (elev === null || !Number.isFinite(elev)) return;
-            if (Math.abs(elev - camera.target.y) <= 0.01) return;
-            const a = camera.alpha;
-            const b = camera.beta;
-            const r = camera.radius;
-            const sB = Math.sin(b);
-            const cB = Math.cos(b);
-            const camPos = {
-                x: camera.target.x + r * sB * Math.cos(a),
-                y: camera.target.y + r * cB,
-                z: camera.target.z + r * sB * Math.sin(a),
-            };
-            const newTarget = { x: camera.target.x, y: elev, z: camera.target.z };
-            const pose = computePoseForNewTarget(camPos, newTarget, a, {
-                lowerBeta: camera.lowerBetaLimit ?? 0,
-                upperBeta: camera.upperBetaLimit ?? Math.PI,
-                lowerRadius: camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS,
-                upperRadius: camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS,
-            });
-            if (pose.action === "apply") {
-                camera.target.y = elev;
-                camera.alpha = pose.alpha;
-                camera.beta = pose.beta;
-                camera.radius = pose.radius;
-            }
-        };
-
+        //
+        // 不変条件 (Issue #151):
+        //   - camera.target.y = 0 (常に地形参照面)
+        //   - camera.target.x = gridResidualX
+        //   - camera.target.z = gridResidualZ
+        //   - currentLat/Lon は target.x/z と同期
+        //
+        // target.y を動かす操作（旧: Ctrl+drag retarget で地形高度に張り付ける／
+        // syncTargetYToTerrain 等）はカメラのワールド位置・SSE 距離・terrainMinRadius と
+        // 累積的に矛盾しドリフト・ジャンプ・タイルレベル破綻の原因となるため廃止する。
         const commitPanOffset = (): void => {
             const tx = camera.target.x;
             const tz = camera.target.z;
             // 新規オフセット = 全体 - 既知のグリッド残差
             const newOffsetX = tx - gridResidualX;
             const newOffsetZ = tz - gridResidualZ;
-            const hasPan =
-                Math.abs(newOffsetX) >= 0.01 || Math.abs(newOffsetZ) >= 0.01;
-
-            if (hasPan) {
-                const oldLat = currentLat;
-                const oldLon = currentLon;
-                const metersPerDegreeLon =
-                    METERS_PER_DEGREE_LAT *
-                    Math.cos((oldLat * Math.PI) / 180);
-
-                const newLat = clamp(
-                    oldLat + newOffsetZ / METERS_PER_DEGREE_LAT,
-                    JAPAN_BOUNDS.minLat,
-                    JAPAN_BOUNDS.maxLat
-                );
-                const newLon = clamp(
-                    oldLon + newOffsetX / metersPerDegreeLon,
-                    JAPAN_BOUNDS.minLon,
-                    JAPAN_BOUNDS.maxLon
-                );
-
-                const oldTile = toTileXY(oldLat, oldLon, MAX_ZOOM);
-                const newTile = toTileXY(newLat, newLon, MAX_ZOOM);
-                const tileSize = tileEdgeMeters(newLat, MAX_ZOOM);
-                const gridShiftX = (newTile.x - oldTile.x) * tileSize;
-                const gridShiftZ = -((newTile.y - oldTile.y) * tileSize);
-
-                // 残差更新: 旧残差 + 新規オフセット - グリッドシフト
-                gridResidualX = gridResidualX + newOffsetX - gridShiftX;
-                gridResidualZ = gridResidualZ + newOffsetZ - gridShiftZ;
-
-                // target.x/z をグリッド残差に同期。target.y は保持。
-                camera.target.x = gridResidualX;
-                camera.target.z = gridResidualZ;
-
-                currentLat = newLat;
-                currentLon = newLon;
-                void refreshTerrain();
+            if (
+                Math.abs(newOffsetX) < 0.01 &&
+                Math.abs(newOffsetZ) < 0.01
+            ) {
+                return;
             }
 
-            // パン有無に関わらず、target.y を地表追従させる（Ctrl+drag retarget 直後など、
-            // パン残差なしでズームのみ行ったケースでも target.y のドリフトを防ぐ）。
-            syncTargetYToTerrain();
+            const oldLat = currentLat;
+            const oldLon = currentLon;
+            const metersPerDegreeLon =
+                METERS_PER_DEGREE_LAT *
+                Math.cos((oldLat * Math.PI) / 180);
+
+            const newLat = clamp(
+                oldLat + newOffsetZ / METERS_PER_DEGREE_LAT,
+                JAPAN_BOUNDS.minLat,
+                JAPAN_BOUNDS.maxLat
+            );
+            const newLon = clamp(
+                oldLon + newOffsetX / metersPerDegreeLon,
+                JAPAN_BOUNDS.minLon,
+                JAPAN_BOUNDS.maxLon
+            );
+
+            const oldTile = toTileXY(oldLat, oldLon, MAX_ZOOM);
+            const newTile = toTileXY(newLat, newLon, MAX_ZOOM);
+            const tileSize = tileEdgeMeters(newLat, MAX_ZOOM);
+            const gridShiftX = (newTile.x - oldTile.x) * tileSize;
+            const gridShiftZ = -((newTile.y - oldTile.y) * tileSize);
+
+            // 残差更新: 旧残差 + 新規オフセット - グリッドシフト
+            gridResidualX = gridResidualX + newOffsetX - gridShiftX;
+            gridResidualZ = gridResidualZ + newOffsetZ - gridShiftZ;
+
+            // target を残差基準にスナップ。target.y は 0 固定。
+            camera.target.x = gridResidualX;
+            camera.target.y = 0;
+            camera.target.z = gridResidualZ;
+
+            currentLat = newLat;
+            currentLon = newLon;
+            void refreshTerrain();
         };
 
         // ---------- レイ-平面交差ユーティリティ ----------
@@ -579,19 +552,19 @@ export class DefaultScene implements CreateSceneClass {
             const sx = e.clientX - rect.left;
             const sy = e.clientY - rect.top;
 
-            // Ctrl/Cmd 押下開始時: 画面中央の地形メッシュ交点を回転中心にする
-            // （カメラのワールド位置は保持されるためジャンプは発生しない）
+            // Ctrl/Cmd 押下開始時: 画面中央の y=0 平面交点を回転中心にする。
+            // target.y=0 不変条件を守るため、地形メッシュのピック高度ではなく
+            // y=0 平面との交点を採用する (Issue #151)。
+            // カメラのワールド位置を保つ再射影 (computePoseForNewTarget) を行うため
+            // 視覚ジャンプは発生しない。skip された場合は target を変更しない。
             if (e.ctrlKey || e.metaKey) {
                 // 直前までの pan オフセットを lat/lon に反映してから target を差し替える
                 commitPanOffset();
                 const cx = canvas.clientWidth / 2;
                 const cy = canvas.clientHeight / 2;
-                const centerPick = scene.pick(cx, cy, (m) =>
-                    m.name.startsWith("tile-ground-")
-                );
-                if (centerPick?.hit && centerPick.pickedPoint) {
-                    const p = centerPick.pickedPoint;
-                    if (retargetPreservingPose({ x: p.x, y: p.y, z: p.z })) {
+                const centerHit = intersectPlane(cx, cy, 0);
+                if (centerHit) {
+                    if (retargetPreservingPose({ x: centerHit.x, y: 0, z: centerHit.z })) {
                         // 新 target の xz を新たなグリッド残差基準として同期
                         gridResidualX = camera.target.x;
                         gridResidualZ = camera.target.z;
@@ -609,13 +582,10 @@ export class DefaultScene implements CreateSceneClass {
                 dragPlaneY = pick.pickedPoint.y;
                 dragAnchor = intersectPlane(sx, sy, dragPlaneY);
             } else {
-                // フォールバック: 既存の平面交差モード。
-                // dragPlaneY を camera.target.y に揃えることで、Ctrl+drag retarget 後など
-                // target.y が非ゼロな状態でもドラッグスケールが現在の target 高度と
-                // 整合する (Issue #151)。Y=0 固定だと target.y > 0 のとき空ピック時の
-                // ドラッグ移動量が地形面と乖離し、操作感が破綻する。
+                // フォールバック: 平面交差モード。target.y=0 不変条件のため
+                // dragPlaneY も常に 0 で十分（Issue #151）。
                 dragMeshMode = false;
-                dragPlaneY = camera.target.y;
+                dragPlaneY = 0;
                 dragAnchor = intersectPlane(sx, sy, dragPlaneY);
             }
         });
@@ -853,15 +823,13 @@ export class DefaultScene implements CreateSceneClass {
                         camera.radius = newRadius;
                         commitPanOffset();
                     } else {
-                        // Phase 1: ターゲットに向かってズーム
+                        // Phase 1: ターゲットに向かってズーム（target は不変）
                         const effectiveLower1 = Math.max(lower, terrainMinRadius());
                         if (zoomIn && camera.radius <= effectiveLower1) return;
                         if (!zoomIn && camera.radius >= upper) return;
                         const next = clamp(camera.radius * factor, effectiveLower1, upper);
                         if (!Number.isFinite(next)) return;
                         camera.radius = next;
-                        // Phase 1 でも target.y 追従を走らせる (Issue #151)
-                        commitPanOffset();
                     }
                 }
             },

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -492,10 +492,10 @@ export class DefaultScene implements CreateSceneClass {
         let activePointerId = -1;
         let dragAnchor: { x: number; z: number } | null = null;
         let dragPlaneY = 0;
-        // ピクセルベース pan モード: カメラより高いピック点・空ピック時、
-        // レイ-平面交点が遠方で発散しステップ量が狂うため、
-        // カーソルピクセル量×radius 係数で forward/right に pan する (Issue #151)。
-        let dragPixelMode = false;
+        // ドラッグ可否の閾値 (Issue #151):
+        // ピック点とカメラ位置の距離がこれ以上のときはドラッグしない。
+        // 遠距離ピックだと grab pan のステップ量が取り回しのつかないジャンプになるため。
+        const MAX_DRAG_PICK_DISTANCE = 10000;
 
         /**
          * 新ターゲットに付け替え、カメラのワールド位置を保つよう alpha/beta/radius を再計算する。
@@ -545,40 +545,58 @@ export class DefaultScene implements CreateSceneClass {
             const sx = e.clientX - rect.left;
             const sy = e.clientY - rect.top;
 
-            // Ctrl/Cmd 押下開始時: 画面中央の y=0 平面交点を回転中心にする。
-            // target.y=0 不変条件を守るため、地形メッシュのピック高度ではなく
-            // y=0 平面との交点を採用する (Issue #151)。
-            // カメラのワールド位置を保つ再射影 (computePoseForNewTarget) を行うため
-            // 視覚ジャンプは発生しない。skip された場合は target を変更しない。
+            // Ctrl/Cmd 押下開始時: 回転中心を画面中央のピック点に再射影する (Issue #151)。
+            // - 画面中央でメッシュにヒットすればその xz を採用
+            // - ヒットしなければ y=0 平面交点 (空ピック相当) を採用
+            // target.y は 0 不変条件のため常に 0 で再射影。
+            // computePoseForNewTarget でカメラのワールド位置を保つので視覚ジャンプはしない。
             if (e.ctrlKey || e.metaKey) {
-                // 直前までの pan オフセットを lat/lon に反映してから target を差し替える
                 commitPanOffset();
                 const cx = canvas.clientWidth / 2;
                 const cy = canvas.clientHeight / 2;
-                const centerHit = intersectPlane(cx, cy, 0);
-                if (centerHit) {
-                    if (retargetPreservingPose({ x: centerHit.x, y: 0, z: centerHit.z })) {
-                        // 新 target の xz を新たなグリッド残差基準として同期
+                const centerPick = scene.pick(cx, cy, (m) => m.name.startsWith("tile-ground-"));
+                let nx: number | null = null;
+                let nz: number | null = null;
+                if (centerPick?.hit && centerPick.pickedPoint) {
+                    nx = centerPick.pickedPoint.x;
+                    nz = centerPick.pickedPoint.z;
+                } else {
+                    const planeHit = intersectPlane(cx, cy, 0);
+                    if (planeHit) {
+                        nx = planeHit.x;
+                        nz = planeHit.z;
+                    }
+                }
+                if (nx !== null && nz !== null) {
+                    if (retargetPreservingPose({ x: nx, y: 0, z: nz })) {
                         gridResidualX = camera.target.x;
                         gridResidualZ = camera.target.z;
                     }
                 }
             }
 
+            // 通常ドラッグの可否判定 (Issue #151 仕様再定義):
+            //   1. メッシュにヒットすること
+            //   2. ピック点 Y がカメラ Y より低いこと（カメラ高度以上はドラッグ不可）
+            //   3. カメラ位置からピック点までの距離が MAX_DRAG_PICK_DISTANCE 未満
+            // 上記すべてを満たすときのみ grab pan を有効化。それ以外は dragAnchor=null で
+            // pointermove のドラッグ処理がスキップされる。
+            const sinB = Math.sin(camera.beta);
+            const cosB = Math.cos(camera.beta);
+            const camWX = camera.target.x + camera.radius * sinB * Math.cos(camera.alpha);
+            const camWY = camera.target.y + camera.radius * cosB;
+            const camWZ = camera.target.z + camera.radius * sinB * Math.sin(camera.alpha);
             const pick = scene.pick(sx, sy, (m) => m.name.startsWith("tile-ground-"));
-            // ドラッグモードの決定 (Issue #151):
-            // - ピック点がカメラより低い: y=pickedY 平面での grab パン。
-            // - カメラより高い / 空ピック: レイ交点が遠方発散するため
-            //   ピクセルベース pan に切り替える。
-            const cameraYAtDown = camera.target.y + camera.radius * Math.cos(camera.beta);
-            if (pick?.hit && pick.pickedPoint && pick.pickedPoint.y < cameraYAtDown) {
-                dragPixelMode = false;
-                dragPlaneY = pick.pickedPoint.y;
-                dragAnchor = intersectPlane(sx, sy, dragPlaneY);
-            } else {
-                dragPixelMode = true;
-                dragPlaneY = 0;
-                dragAnchor = null;
+            dragAnchor = null;
+            if (pick?.hit && pick.pickedPoint && pick.pickedPoint.y < camWY) {
+                const dxp = pick.pickedPoint.x - camWX;
+                const dyp = pick.pickedPoint.y - camWY;
+                const dzp = pick.pickedPoint.z - camWZ;
+                const dist2 = dxp * dxp + dyp * dyp + dzp * dzp;
+                if (dist2 < MAX_DRAG_PICK_DISTANCE * MAX_DRAG_PICK_DISTANCE) {
+                    dragPlaneY = pick.pickedPoint.y;
+                    dragAnchor = intersectPlane(sx, sy, dragPlaneY);
+                }
             }
         });
 
@@ -618,46 +636,21 @@ export class DefaultScene implements CreateSceneClass {
                         camera.radius = radiusBeforeTilt;
                     }
                 }
-            } else if (dragPixelMode) {
-                // ピクセルベース pan: カメラより高いピック点・空ピック時の救済 (Issue #151)。
-                // レイ-平面交点は遠方発散するため、カーソルピクセル変位 × radius 係数で
-                // forward/right に直接 target を動かす。
-                const dx = e.clientX - lastPointerX;
-                const dy = e.clientY - lastPointerY;
-                const scale = camera.radius / Math.max(canvas.clientWidth, 1);
-                // forward (target 方向の水平成分): (-cosα, 0, -sinα)
-                const fx = -Math.cos(camera.alpha);
-                const fz = -Math.sin(camera.alpha);
-                // right = forward × world_up (Babylon 左手系)
-                const rx = fz;
-                const rz = -fx;
-                // 画面上方向ドラッグ (dy<0) で前進、画面右ドラッグ (dx>0) で右移動
-                const fAmt = -dy * scale;
-                const rAmt = dx * scale;
-                camera.target.x += fAmt * fx + rAmt * rx;
-                camera.target.z += fAmt * fz + rAmt * rz;
-                const minR = terrainMinRadius();
-                const upper = camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS;
-                if (camera.radius < minR) {
-                    camera.radius = Math.min(minR, upper);
-                }
             } else if (dragAnchor) {
                 const rect = canvas.getBoundingClientRect();
                 const sx = e.clientX - rect.left;
                 const sy = e.clientY - rect.top;
 
                 // ドラッグ開始時に決定した水平面 (dragPlaneY) でカーソル直下を
-                // アンカーする標準的な grab パン。dragPlaneY は必ず cameraY 未満
-                // （pointerdown で保証）なのでレイ-平面交点は安定する (Issue #151)。
+                // アンカーする標準的な grab パン。dragAnchor が存在する時点で
+                // pointerdown の判定（pickY < cameraY、距離 < MAX_DRAG_PICK_DISTANCE）を
+                // 通過しているのでレイ-平面交点は安定。
                 const current = intersectPlane(sx, sy, dragPlaneY);
                 if (current) {
                     camera.target.x += dragAnchor.x - current.x;
                     camera.target.z += dragAnchor.z - current.z;
 
                     // パン後にカメラがメッシュを突き抜けないよう radius を下限まで持ち上げる。
-                    // (a) terrainMinRadius() … 直下レイキャスト + 標高キャッシュ
-                    // (b) dragPlaneY ベース … ドラッグ中のピック点標高は確実な既知値なので、
-                    //     直下タイル未ロードで (a) が下限 50 を返すケースを補完。
                     const cosB = Math.cos(camera.beta);
                     const upper = camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS;
                     let minR = terrainMinRadius();
@@ -688,7 +681,6 @@ export class DefaultScene implements CreateSceneClass {
             pointerDown = false;
             activePointerId = -1;
             dragAnchor = null;
-            dragPixelMode = false;
             commitPanOffset();
         };
 

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -527,6 +527,9 @@ export class DefaultScene implements CreateSceneClass {
 
         canvas.addEventListener("pointerdown", (e: PointerEvent) => {
             if (e.button !== 0) return;
+            // 直前操作で pointerup が取りこぼされ target.y が残留しているケースに備え、
+            // 新規ポインタ操作の冒頭で必ず target.y=0 を回復する (Issue #151)。
+            restoreTargetYZero();
             pointerDown = true;
             lastPointerX = e.clientX;
             lastPointerY = e.clientY;

--- a/src/terrain/cameraRetarget.ts
+++ b/src/terrain/cameraRetarget.ts
@@ -48,6 +48,19 @@ export function computePoseForNewTarget(
     currentAlpha: number,
     limits: RetargetLimits,
 ): RetargetResult {
+    // 入力に NaN/Infinity が紛れ込むと acos/atan2 が破綻し、以降のカメラ状態が
+    // 全て不正値で汚染される（Issue #151）。早期に skip して直前状態を維持する。
+    if (
+        !Number.isFinite(camPos.x) ||
+        !Number.isFinite(camPos.y) ||
+        !Number.isFinite(camPos.z) ||
+        !Number.isFinite(newTarget.x) ||
+        !Number.isFinite(newTarget.y) ||
+        !Number.isFinite(newTarget.z)
+    ) {
+        return { action: "skip", reason: "degenerate" };
+    }
+
     const vx = camPos.x - newTarget.x;
     const vy = camPos.y - newTarget.y;
     const vz = camPos.z - newTarget.z;

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -612,6 +612,19 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
     ): LodTileEntry[] => {
         if (!currentCenter) return [];
         const engine = scene.getEngine();
+        const camRelX = camera.position.x - camera.target.x;
+        const camRelY = camera.position.y - camera.target.y;
+        const camRelZ = camera.position.z - camera.target.z;
+        // 非有限値が混入すると SSE 距離が NaN になり Quadtree 採用が破綻するため
+        // 早期に空配列を返して直前の可視集合を維持させる (Issue #151)
+        if (
+            !Number.isFinite(camRelX) ||
+            !Number.isFinite(camRelY) ||
+            !Number.isFinite(camRelZ) ||
+            !Number.isFinite(camera.fov)
+        ) {
+            return [];
+        }
         return computeQuadtreeTiles({
             maxZoom: zoom,
             minZoom,
@@ -619,9 +632,9 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
             tileSizeForZoom,
             frustumPlanes,
             cameraPosition: {
-                x: camera.position.x - camera.target.x,
-                y: camera.position.y - camera.target.y,
-                z: camera.position.z - camera.target.z,
+                x: camRelX,
+                y: camRelY,
+                z: camRelZ,
             },
             verticalFov: camera.fov,
             viewportHeight: engine.getRenderHeight(),

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -616,14 +616,23 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
     ): LodTileEntry[] | null => {
         if (!currentCenter) return [];
         const engine = scene.getEngine();
+        // x/z は baseCenter (= 現在の中心タイル) 原点ローカル座標系で渡す。
+        // target はパン残差で baseCenter 近傍に保たれているため target 相対で十分。
         const camRelX = camera.position.x - camera.target.x;
-        const camRelY = camera.position.y - camera.target.y;
         const camRelZ = camera.position.z - camera.target.z;
+        // y は世界座標の絶対値を渡す (Issue #151)。
+        // `distanceFootprintToPoint` は `|cameraPosition.y|` を地表からのカメラ高度として使い、
+        // AABB の高さ (0..maxElevation) と整合させて SSE 距離を算出する。
+        // target 相対 (camera.position.y - camera.target.y) で渡すと、Ctrl+ドラッグで
+        // target.y が高所 (例: 富士山頂 ~3776m) に張り付いた場合に実効高度が縮小し、
+        // SSE 分母が破綻して採用 zoom が狂う。target.y は視野方向に直結するため
+        // 正規化はせず、ここで absolute Y を渡すことで根本解決する。
+        const camAbsY = camera.position.y;
         // 非有限値が混入すると SSE 距離が NaN になり Quadtree 採用が破綻する。
         // null を返して呼び出し側で更新自体をスキップさせ、直前の可視集合を維持する。
         if (
             !Number.isFinite(camRelX) ||
-            !Number.isFinite(camRelY) ||
+            !Number.isFinite(camAbsY) ||
             !Number.isFinite(camRelZ) ||
             !Number.isFinite(camera.fov)
         ) {
@@ -637,7 +646,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
             frustumPlanes,
             cameraPosition: {
                 x: camRelX,
-                y: camRelY,
+                y: camAbsY,
                 z: camRelZ,
             },
             verticalFov: camera.fov,

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -605,25 +605,29 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         return null;
     };
 
-    /** 可視タイルを算出する共通ヘルパー */
+    /**
+     * 可視タイルを算出する共通ヘルパー。
+     * カメラ位置等に NaN/Infinity が混入していた場合は `null` を返し、
+     * 呼び出し側で applyVisibleTiles をスキップして直前の可視集合を維持する (Issue #151)。
+     */
     const computeVisible = (
         frustumPlanes: FrustumPlane[],
         maxElevation: number
-    ): LodTileEntry[] => {
+    ): LodTileEntry[] | null => {
         if (!currentCenter) return [];
         const engine = scene.getEngine();
         const camRelX = camera.position.x - camera.target.x;
         const camRelY = camera.position.y - camera.target.y;
         const camRelZ = camera.position.z - camera.target.z;
-        // 非有限値が混入すると SSE 距離が NaN になり Quadtree 採用が破綻するため
-        // 早期に空配列を返して直前の可視集合を維持させる (Issue #151)
+        // 非有限値が混入すると SSE 距離が NaN になり Quadtree 採用が破綻する。
+        // null を返して呼び出し側で更新自体をスキップさせ、直前の可視集合を維持する。
         if (
             !Number.isFinite(camRelX) ||
             !Number.isFinite(camRelY) ||
             !Number.isFinite(camRelZ) ||
             !Number.isFinite(camera.fov)
         ) {
-            return [];
+            return null;
         }
         return computeQuadtreeTiles({
             maxZoom: zoom,
@@ -695,6 +699,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
             (MAX_BASE_ELEVATION + Math.max(0, altitudeOffset)) * heightScale;
 
         const visibleEntries = computeVisible(frustumPlanes, maxElevation);
+        if (visibleEntries === null) return;
         await applyVisibleTiles(visibleEntries, rid, true);
     };
 
@@ -709,6 +714,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
             heightScale;
 
         const visibleEntries = computeVisible(frustumPlanes, maxElevation);
+        if (visibleEntries === null) return;
         await applyVisibleTiles(visibleEntries, rid, false);
     };
 

--- a/tests/cameraRetarget.unit.spec.ts
+++ b/tests/cameraRetarget.unit.spec.ts
@@ -117,4 +117,49 @@ describe("computePoseForNewTarget", () => {
             expect(result.alpha).toBe(currentAlpha);
         });
     });
+
+    describe("非有限値ガード (Issue #151)", () => {
+        const baseTarget = { x: 0, y: 0, z: 0 };
+        const baseCamPos = { x: 1000, y: 1000, z: 1000 };
+
+        it("camPos.x が NaN なら degenerate skip", () => {
+            const result = computePoseForNewTarget(
+                { ...baseCamPos, x: NaN },
+                baseTarget,
+                0,
+                LIMITS,
+            );
+            expect(result).toEqual({ action: "skip", reason: "degenerate" });
+        });
+
+        it("camPos.y が Infinity なら degenerate skip", () => {
+            const result = computePoseForNewTarget(
+                { ...baseCamPos, y: Infinity },
+                baseTarget,
+                0,
+                LIMITS,
+            );
+            expect(result).toEqual({ action: "skip", reason: "degenerate" });
+        });
+
+        it("newTarget.z が -Infinity なら degenerate skip", () => {
+            const result = computePoseForNewTarget(
+                baseCamPos,
+                { ...baseTarget, z: -Infinity },
+                0,
+                LIMITS,
+            );
+            expect(result).toEqual({ action: "skip", reason: "degenerate" });
+        });
+
+        it("newTarget.y が NaN なら degenerate skip（富士山 retarget 後の汚染想定）", () => {
+            const result = computePoseForNewTarget(
+                baseCamPos,
+                { ...baseTarget, y: NaN },
+                0,
+                LIMITS,
+            );
+            expect(result).toEqual({ action: "skip", reason: "degenerate" });
+        });
+    });
 });


### PR DESCRIPTION
## 概要

マウスでの回転（Ctrl+ドラッグ retarget）・ホイールズーム操作を富士山のような高標高地点で繰り返し、その後平地に移動するとカメラの高度（`camera.position.y`）が実地表から大きく乖離し、`computeQuadtreeTiles` の SSE 距離計算が破綻して採用タイルレベルが狂うバグを修正する。

直接の原因は `commitPanOffset` が `target.y` を保持していたため、富士山頂の retarget で `target.y ≒ 3776m` になった状態が平地パン後も残留することだった。あわせて、NaN/Infinity が紛れ込んだ場合にもタイルレベルが破綻しないよう、カメラ系の各経路に有限性ガードを追加した。

## 関連 Issue

Closes #151

## 変更内容

- `src/terrain/cameraRetarget.ts`: `computePoseForNewTarget` の冒頭に NaN/Infinity 入力ガードを追加し、非有限値が混入したら `{action:"skip", reason:"degenerate"}` を返すようにした。
- `src/scenes/default.ts` `commitPanOffset`: target.y を地形参照面 (`y=0`) に正規化するため、`computePoseForNewTarget` 経由でカメラのワールド位置を保ったまま再射影するロジックを追加。limit 逸脱・特異点で skip された場合のみ従来挙動（x/z のみ更新、target.y 保持）にフォールバックする。
- `src/scenes/default.ts` `terrainMinRadius`: 入力 `(alpha, beta, radius, target)` の有限性チェック、`queryElevationAtWorld` 戻り値の `Number.isFinite` チェック、最終算出値の `lowerRadiusLimit` クランプを追加。
- `src/scenes/default.ts` ホイール系（`zoomTowardPoint` / Phase 1 / Phase 2）: 計算後の `newRadius` に `Number.isFinite` ガードを追加し、非有限値での更新を抑止。
- `src/terrain/tileManager.ts` `computeVisible`: `cameraPosition` 各成分と `camera.fov` の有限性をチェックし、非有限なら空配列を返して直前の可視タイル集合を維持するようにした。
- `tests/cameraRetarget.unit.spec.ts`: 「非有限値ガード (Issue #151)」describe を追加し、`camPos.x = NaN` / `camPos.y = Infinity` / `newTarget.z = -Infinity` / `newTarget.y = NaN` で `degenerate` skip となることを検証。

## 影響範囲

- 公開API/型: 変更なし（`RetargetResult` も既存の `"degenerate"` reason を再利用）。
- 挙動: 富士山頂等で Ctrl+ドラッグ retarget 後にパンした際、`target.y` が次のパン確定で `0` に正規化される。再射影はカメラのワールド位置を保つため視覚ジャンプは発生しない。skip フォールバック時は従来挙動と等価。

## 動作確認方法

1. `npm start` でビューアを起動。
2. 富士山頂付近（例: `?lat=35.3606&lon=138.7274`）に移動。
3. Ctrl+ドラッグで山頂付近の地形メッシュを回転中心にして数回 retarget。
4. 左ドラッグ＋ホイールで平地（例: 東京駅 `lat=35.681236, lon=139.767125`）まで移動・ズーム。
5. 平地上空で採用タイルレベルが平地相当（z14〜z16 程度）に収まり、過剰に粗く／細かくならないことを確認。

## ローカル検証結果

- `npm run lint`: PASS
- `npx tsc -p tsconfig.json --noEmit`: PASS
- `npm run test:unit`: 23 suites / 440 tests PASS

## 確認事項

- [x] Copilot レビューを日本語で実施し、指摘を修正した
- [x] `npm run test:visuals:update` は毎回実行していない
- [x] 画面表示の意図した変更がある場合のみ、開発者がスナップショットを更新した
