### PR TITLE
feat(terrain): stitch cross-level tile edges near camera (#161)

### DIFF
--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -24,7 +24,8 @@ import {
     MapType,
     fillInvalidPixels,
 } from "./gsiTile";
-import { stitchTileEdges, stitchTileEdgesCrossLevel, CoarseEdgeNeighbor } from "./tileStitching";
+import { stitchTileEdges, stitchTileEdgesCrossLevel } from "./tileStitching";
+import type { CoarseEdgeNeighbor } from "./tileStitching";
 
 export interface TileManagerOptions {
     scene: Scene;
@@ -597,7 +598,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         stitchTileEdges(stitched, neighbors, TILE_SIZE);
 
         // 異 zoom 隣接（粗タイル）と縫い合わせ。カメラ近傍タイルのみ対象。
-        // 遠方タイルは隙間が視認しにくい一方、毎フレーム再計算されるため負荷を抑える。
+        // 遠方タイルは隙間が視認しにくいため、タイル再適用時の計算コストを抑える目的で対象外にする。
         const tileSize = tileSizeForZoom(coord.zoom);
         if (isTileNearCamera(coord, tileSize)) {
             const coarse = getCoarseEdgeNeighbors(coord);

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -24,7 +24,7 @@ import {
     MapType,
     fillInvalidPixels,
 } from "./gsiTile";
-import { stitchTileEdges } from "./tileStitching";
+import { stitchTileEdges, stitchTileEdgesCrossLevel, CoarseEdgeNeighbor } from "./tileStitching";
 
 export interface TileManagerOptions {
     scene: Scene;
@@ -79,6 +79,12 @@ const DEFAULT_CACHE_CAPACITY = 192;
 const DEFAULT_DEBOUNCE_MS = 200;
 /** Frustum 判定用の基準最大標高 (m) — 富士山 3776m + マージン */
 const MAX_BASE_ELEVATION = 4000;
+/**
+ * クロスレベル縫い合わせを適用する「カメラ近傍」判定の距離係数。
+ * タイル中心とカメラの 3D 距離が `tileSize × NEAR_DISTANCE_TILES_FACTOR` 以下なら近傍とみなす。
+ * 値が大きいほど縫い合わせ対象が広がる。遠方タイルは隙間が視認しにくいため、近傍のみに限定する。
+ */
+const NEAR_DISTANCE_TILES_FACTOR = 3;
 
 /** 頂点Y座標を標高値で更新 */
 const applyElevation = (
@@ -492,6 +498,85 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         };
     };
 
+    /**
+     * カメラがタイル中心に近いか判定する。
+     * タイル中心（XZ 平面上）とカメラ（target 原点ローカル）との 3D 距離が
+     * `tileSize × NEAR_DISTANCE_TILES_FACTOR` 以下なら true。
+     * クロスレベル縫い合わせを近傍に限定するために用いる。
+     */
+    const isTileNearCamera = (coord: TileCoord, tileSize: number): boolean => {
+        if (!currentCenter) return false;
+        const center = convertTileZoom(currentCenter, coord.zoom);
+        const { fracX, fracY } = computeSubTileOffset(currentCenter, coord.zoom);
+        const dx = coord.x - center.x;
+        const dy = coord.y - center.y;
+        const { wx, wz } = tileOffsetToWorld(dx - fracX, dy - fracY, tileSize);
+        // camera position は target 原点ローカル。タイル中心は y=0 平面。
+        const cx = camera.position.x - camera.target.x;
+        const cy = camera.position.y - camera.target.y;
+        const cz = camera.position.z - camera.target.z;
+        const ex = wx - cx;
+        const ez = wz - cz;
+        const dist = Math.sqrt(ex * ex + cy * cy + ez * ez);
+        return dist <= tileSize * NEAR_DISTANCE_TILES_FACTOR;
+    };
+
+    /**
+     * target タイルの 4 辺それぞれについて、辺を共有する粗 zoom のアクティブタイルを
+     * 1 つだけ選んで返す（同じ辺で複数候補があれば最も細かい粗 zoom を採用）。
+     * 同 zoom の隣接タイルが存在する場合はその辺は対象外（同 zoom の縫い合わせに任せる）。
+     */
+    const getCoarseEdgeNeighbors = (coord: TileCoord): CoarseEdgeNeighbor[] => {
+        const result: CoarseEdgeNeighbor[] = [];
+        const { zoom: z, x, y } = coord;
+        const dirs = [
+            { dir: "top" as const, ndx: 0, ndy: -1 },
+            { dir: "bottom" as const, ndx: 0, ndy: 1 },
+            { dir: "left" as const, ndx: -1, ndy: 0 },
+            { dir: "right" as const, ndx: 1, ndy: 0 },
+        ];
+        for (const d of dirs) {
+            // 同 zoom 隣接が存在すればクロスレベル不要
+            const sameZoomKey = toTileKey({ zoom: z, x: x + d.ndx, y: y + d.ndy });
+            if (activeTiles.has(sameZoomKey)) continue;
+
+            // 粗 zoom を z-1 から minZoom まで降順で探索（細かい粗 zoom を優先）
+            for (let zp = z - 1; zp >= minZoom; zp--) {
+                const diff = z - zp;
+                const scale = 1 << diff;
+                const subX = x & (scale - 1);
+                const subY = y & (scale - 1);
+                // target の辺が親タイルの境界辺と一致する条件
+                let onParentEdge: boolean;
+                switch (d.dir) {
+                    case "top": onParentEdge = subY === 0; break;
+                    case "bottom": onParentEdge = subY === scale - 1; break;
+                    case "left": onParentEdge = subX === 0; break;
+                    case "right": onParentEdge = subX === scale - 1; break;
+                }
+                if (!onParentEdge) continue;
+
+                const px = x >> diff;
+                const py = y >> diff;
+                const ncx = px + d.ndx;
+                const ncy = py + d.ndy;
+                const nKey = toTileKey({ zoom: zp, x: ncx, y: ncy });
+                if (!activeTiles.has(nKey)) continue;
+                const entry = cache.get(nKey);
+                if (!entry) continue;
+                result.push({
+                    elevation: entry.elevation,
+                    direction: d.dir,
+                    subX,
+                    subY,
+                    scale,
+                });
+                break;
+            }
+        }
+        return result;
+    };
+
     /** タイルの標高データをステッチ＋NaN埋めしてメッシュに適用 */
     const applyStitchedElevation = (
         mesh: Mesh,
@@ -507,9 +592,19 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         // 標高データのコピーを作成（キャッシュの元データを保持するため）
         const stitched = new Float32Array(elevation);
 
-        // 隣接タイルと辺を縫い合わせ
+        // 隣接タイルと辺を縫い合わせ（同 zoom）
         const neighbors = getNeighborElevations(coord);
         stitchTileEdges(stitched, neighbors, TILE_SIZE);
+
+        // 異 zoom 隣接（粗タイル）と縫い合わせ。カメラ近傍タイルのみ対象。
+        // 遠方タイルは隙間が視認しにくい一方、毎フレーム再計算されるため負荷を抑える。
+        const tileSize = tileSizeForZoom(coord.zoom);
+        if (isTileNearCamera(coord, tileSize)) {
+            const coarse = getCoarseEdgeNeighbors(coord);
+            if (coarse.length > 0) {
+                stitchTileEdgesCrossLevel(stitched, coarse, TILE_SIZE);
+            }
+        }
 
         // NaN を埋める
         fillInvalidPixels(stitched, TILE_SIZE, TILE_SIZE);
@@ -549,6 +644,29 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
             if (!activeTiles.has(neighborKey)) continue;
             pendingRestitch.add(neighborKey);
         }
+
+        // クロスレベル: coord（粗タイル/同 zoom 問わず）の辺を共有する細タイルを再ステッチ。
+        // coord が粗タイルなら、隣接する細タイルがそのスナップ先として coord を参照しうる。
+        // coord が細タイルなら、隣接する更に細い別 zoom タイルへの影響は限定的だが、
+        // 自身の cross-level スナップは applyStitchedElevation で初回適用済み。
+        for (const [k, t] of activeTiles) {
+            if (t.coord.zoom <= z) continue;
+            const diff = t.coord.zoom - z;
+            const scale = 1 << diff;
+            const tpx = t.coord.x >> diff;
+            const tpy = t.coord.y >> diff;
+            const tsubX = t.coord.x & (scale - 1);
+            const tsubY = t.coord.y & (scale - 1);
+            // 細タイル t が coord と辺を共有する条件
+            const adjTop = tpx === x && tpy === y - 1 && tsubY === scale - 1; // t の上に coord
+            const adjBottom = tpx === x && tpy === y + 1 && tsubY === 0; // t の下に coord
+            const adjLeft = tpx === x - 1 && tpy === y && tsubX === scale - 1;
+            const adjRight = tpx === x + 1 && tpy === y && tsubX === 0;
+            if (adjTop || adjBottom || adjLeft || adjRight) {
+                pendingRestitch.add(k);
+            }
+        }
+
         if (restitchRafId === null) {
             restitchRafId = requestAnimationFrame(flushRestitch);
         }

--- a/src/terrain/tileStitching.ts
+++ b/src/terrain/tileStitching.ts
@@ -146,8 +146,10 @@ export interface CoarseEdgeNeighbor {
  *   in-place に上書きする（粗タイル側は変更しない）。
  * - これにより細タイルが粗タイルにスナップされ、T-junction 隙間を解消する。
  * - NaN は補間から除外。両端が NaN の場合はそのピクセルを変更しない。
- * - 角は辺の端点として処理される。同一角に複数方向の隣接情報が指定された場合は
- *   呼び出し順に上書きされるため、安定化のため呼び出し側で順序を一定にすること。
+ * - 角ピクセルは上書きしない。同 zoom 隣接タイルが角を共有する場合に、
+ *   隣接細タイル同士で異なる粗サンプル位置にスナップされて角値が不一致となる
+ *   （= 同 zoom タイル間に新たな亀裂が生じる）のを防ぐため、角は
+ *   `stitchTileEdges`（同 zoom）の処理結果をそのまま保持する。
  */
 export const stitchTileEdgesCrossLevel = (
     target: Float32Array,
@@ -155,11 +157,12 @@ export const stitchTileEdgesCrossLevel = (
     tileSize: number,
 ): void => {
     const last = tileSize - 1;
-    if (last <= 0) return;
+    if (last <= 1) return; // 角しかないサイズでは何もしない
 
     for (const n of coarseNeighbors) {
         const subSize = tileSize / n.scale; // 粗タイル内で target が占めるピクセル幅
-        for (let i = 0; i <= last; i++) {
+        // 角ピクセル (i=0, i=last) は除外し、辺の内側のみを上書きする。
+        for (let i = 1; i < last; i++) {
             const u = i / last; // 0..1（target 辺方向）
             // 粗タイルの対応辺上での位置（連続値）
             const along =

--- a/src/terrain/tileStitching.ts
+++ b/src/terrain/tileStitching.ts
@@ -124,3 +124,92 @@ export const stitchTileEdges = (
         if (!Number.isNaN(avg)) target[last * tileSize + last] = avg;
     }
 };
+
+/** クロスレベル縫い合わせで参照する粗タイル隣接情報 */
+export interface CoarseEdgeNeighbor {
+    /** 粗タイルの標高データ（target と同じ tileSize 解像度） */
+    elevation: Float32Array;
+    /** target から見た粗タイルの方向 */
+    direction: "top" | "bottom" | "left" | "right";
+    /** target が属する親タイル内でのサブ位置 X（0..scale-1） */
+    subX: number;
+    /** target が属する親タイル内でのサブ位置 Y（0..scale-1） */
+    subY: number;
+    /** 親 1 辺あたりの target タイル数（= 2^(targetZoom - coarseZoom)） */
+    scale: number;
+}
+
+/**
+ * 異 zoom 隣接（粗タイル）と target タイルの境界辺を縫い合わせる。
+ *
+ * - target（細タイル）の境界辺の各ピクセルを、粗タイル対応辺の線形補間値で
+ *   in-place に上書きする（粗タイル側は変更しない）。
+ * - これにより細タイルが粗タイルにスナップされ、T-junction 隙間を解消する。
+ * - NaN は補間から除外。両端が NaN の場合はそのピクセルを変更しない。
+ * - 角は辺の端点として処理される。同一角に複数方向の隣接情報が指定された場合は
+ *   呼び出し順に上書きされるため、安定化のため呼び出し側で順序を一定にすること。
+ */
+export const stitchTileEdgesCrossLevel = (
+    target: Float32Array,
+    coarseNeighbors: readonly CoarseEdgeNeighbor[],
+    tileSize: number,
+): void => {
+    const last = tileSize - 1;
+    if (last <= 0) return;
+
+    for (const n of coarseNeighbors) {
+        const subSize = tileSize / n.scale; // 粗タイル内で target が占めるピクセル幅
+        for (let i = 0; i <= last; i++) {
+            const u = i / last; // 0..1（target 辺方向）
+            // 粗タイルの対応辺上での位置（連続値）
+            const along =
+                n.direction === "top" || n.direction === "bottom"
+                    ? n.subX * subSize + u * (subSize - 1)
+                    : n.subY * subSize + u * (subSize - 1);
+            const lo = Math.max(0, Math.min(last, Math.floor(along)));
+            const hi = Math.max(0, Math.min(last, lo + 1));
+            const t = along - lo;
+
+            let coarseIdxLo: number;
+            let coarseIdxHi: number;
+            let targetIdx: number;
+            switch (n.direction) {
+                case "top":
+                    // target row=0 ↔ coarse row=last
+                    coarseIdxLo = last * tileSize + lo;
+                    coarseIdxHi = last * tileSize + hi;
+                    targetIdx = i;
+                    break;
+                case "bottom":
+                    // target row=last ↔ coarse row=0
+                    coarseIdxLo = lo;
+                    coarseIdxHi = hi;
+                    targetIdx = last * tileSize + i;
+                    break;
+                case "left":
+                    // target col=0 ↔ coarse col=last
+                    coarseIdxLo = lo * tileSize + last;
+                    coarseIdxHi = hi * tileSize + last;
+                    targetIdx = i * tileSize;
+                    break;
+                case "right":
+                    // target col=last ↔ coarse col=0
+                    coarseIdxLo = lo * tileSize;
+                    coarseIdxHi = hi * tileSize;
+                    targetIdx = i * tileSize + last;
+                    break;
+            }
+
+            const a = n.elevation[coarseIdxLo];
+            const b = n.elevation[coarseIdxHi];
+            let v: number;
+            const aNaN = Number.isNaN(a);
+            const bNaN = Number.isNaN(b);
+            if (aNaN && bNaN) continue;
+            else if (aNaN) v = b;
+            else if (bNaN) v = a;
+            else v = a * (1 - t) + b * t;
+            target[targetIdx] = v;
+        }
+    }
+};

--- a/tests/tileStitching.unit.spec.ts
+++ b/tests/tileStitching.unit.spec.ts
@@ -2,8 +2,10 @@ import { describe, it, expect } from "@jest/globals";
 import {
     nanMean,
     stitchTileEdges,
-    StitchNeighbors,
     stitchTileEdgesCrossLevel,
+} from "../src/terrain/tileStitching";
+import type {
+    StitchNeighbors,
     CoarseEdgeNeighbor,
 } from "../src/terrain/tileStitching";
 
@@ -246,7 +248,7 @@ describe("stitchTileEdgesCrossLevel", () => {
         expect(target).toEqual(copy);
     });
 
-    it("上辺: 粗タイル一定値で target 上辺がスナップされる", () => {
+    it("上辺: 粗タイル一定値で target 上辺がスナップされる（角除く）", () => {
         const target = fill(S, 10);
         const coarse = fill(S, 50);
         // scale=2, subX=0, subY=0 → target は粗タイルの左上の子
@@ -258,14 +260,17 @@ describe("stitchTileEdgesCrossLevel", () => {
             scale: 2,
         };
         stitchTileEdgesCrossLevel(target, [neighbor], S);
-        // 粗タイルが一定値なので target 上辺は全て 50 にスナップ
-        for (let i = 0; i < S; i++) expect(target[i]).toBe(50);
+        // 粗タイルが一定値なので target 上辺の辺内部は 50 にスナップ
+        for (let i = 1; i < S - 1; i++) expect(target[i]).toBe(50);
+        // 角は変えない（同 zoom ステッチの結果を保持）
+        expect(target[0]).toBe(10);
+        expect(target[S - 1]).toBe(10);
         // 内部は変わらない
         expect(target[S]).toBe(10);
         expect(target[S + 1]).toBe(10);
     });
 
-    it("下辺: 粗タイルの上辺の対応区間にスナップされる", () => {
+    it("下辺: 粗タイルの上辺の対応区間にスナップされる（角除く）", () => {
         const target = fill(S, 10);
         const coarse = fill(S, 30);
         const neighbor: CoarseEdgeNeighbor = {
@@ -277,10 +282,13 @@ describe("stitchTileEdgesCrossLevel", () => {
         };
         stitchTileEdgesCrossLevel(target, [neighbor], S);
         const lastRow = (S - 1) * S;
-        for (let i = 0; i < S; i++) expect(target[lastRow + i]).toBe(30);
+        for (let i = 1; i < S - 1; i++) expect(target[lastRow + i]).toBe(30);
+        // 角は変えない
+        expect(target[lastRow]).toBe(10);
+        expect(target[lastRow + (S - 1)]).toBe(10);
     });
 
-    it("左辺と右辺: 一定値の粗タイルにスナップされる", () => {
+    it("左辺と右辺: 一定値の粗タイルにスナップされる（角除く）", () => {
         const target = fill(S, 10);
         const coarseL = fill(S, 70);
         const coarseR = fill(S, 80);
@@ -289,10 +297,15 @@ describe("stitchTileEdgesCrossLevel", () => {
             { elevation: coarseR, direction: "right", subX: 1, subY: 0, scale: 2 },
         ];
         stitchTileEdgesCrossLevel(target, neighbors, S);
-        for (let r = 0; r < S; r++) {
+        for (let r = 1; r < S - 1; r++) {
             expect(target[r * S]).toBe(70);
             expect(target[r * S + (S - 1)]).toBe(80);
         }
+        // 角は変えない
+        expect(target[0]).toBe(10);
+        expect(target[(S - 1) * S]).toBe(10);
+        expect(target[S - 1]).toBe(10);
+        expect(target[(S - 1) * S + (S - 1)]).toBe(10);
     });
 
     it("粗タイルの値が辺方向に勾配を持つ場合、線形補間で間の値になる", () => {
@@ -315,10 +328,14 @@ describe("stitchTileEdgesCrossLevel", () => {
             scale: 2,
         };
         stitchTileEdgesCrossLevel(target, [neighbor], S);
-        for (let i = 0; i < S; i++) {
+        // 角除く i=1..S-2 で期待値 = u*3 (u=i/(S-1))
+        for (let i = 1; i < S - 1; i++) {
             const expected = (i / (S - 1)) * 3;
             expect(target[i]).toBeCloseTo(expected, 6);
         }
+        // 角は変えない
+        expect(target[0]).toBe(100);
+        expect(target[S - 1]).toBe(100);
     });
 
     it("粗タイル両端 NaN の場合は target を変更しない", () => {
@@ -332,13 +349,16 @@ describe("stitchTileEdgesCrossLevel", () => {
             scale: 2,
         };
         stitchTileEdgesCrossLevel(target, [neighbor], S);
-        for (let i = 0; i < S; i++) expect(target[i]).toBe(99);
+        for (let i = 1; i < S - 1; i++) expect(target[i]).toBe(99);
+        // 角は元より変わらない
+        expect(target[0]).toBe(99);
+        expect(target[S - 1]).toBe(99);
     });
 
     it("粗タイル片側 NaN なら有効値で埋める", () => {
-        // 粗タイル下辺 col=0 のみ 50、他は NaN
+        // 粗タイル下辺 col=1 のみ 50、他は NaN
         const coarse = fillNaN(S);
-        coarse[(S - 1) * S + 0] = 50;
+        coarse[(S - 1) * S + 1] = 50;
         const target = fill(S, 10);
         const neighbor: CoarseEdgeNeighbor = {
             elevation: coarse,
@@ -348,11 +368,11 @@ describe("stitchTileEdgesCrossLevel", () => {
             scale: 2,
         };
         stitchTileEdgesCrossLevel(target, [neighbor], S);
-        // i=0: a=coarse[last,0]=50, b=coarse[last,1]=NaN → 50 にスナップ
-        expect(target[0]).toBe(50);
+        // i=1: along=3/(S-1)≈0.43 → lo=0(NaN), hi=1(50) → 50 にスナップ
+        expect(target[1]).toBe(50);
     });
 
-    it("scale=4: subSize=2 でも適切な範囲を参照する", () => {
+    it("scale=4: subSize=2 でも適切な範囲を参照する（角除く）", () => {
         const SS = 8;
         // 粗タイル下辺 col=4..6 範囲（subX=2, scale=4 → along base = 2*2=4）が値 7、その他 0
         const coarse = new Float32Array(SS * SS);
@@ -366,8 +386,11 @@ describe("stitchTileEdgesCrossLevel", () => {
             scale: 4,
         };
         stitchTileEdgesCrossLevel(target, [neighbor], SS);
-        // i=0: along=4 → coarse[last,4]=7 ・i=last(7): along=4+1=5 → coarse[last,5]=7
-        expect(target[0]).toBe(7);
-        expect(target[SS - 1]).toBe(7);
+        // i=1..SS-2 の辺内部は粗タイル col=4..5 近傍に補間されて 7 付近
+        // （伝達関数より、その区間はすべて 7 にスナップ）
+        for (let i = 1; i < SS - 1; i++) expect(target[i]).toBe(7);
+        // 角は変わらない
+        expect(target[0]).toBe(0);
+        expect(target[SS - 1]).toBe(0);
     });
 });

--- a/tests/tileStitching.unit.spec.ts
+++ b/tests/tileStitching.unit.spec.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "@jest/globals";
-import { nanMean, stitchTileEdges, StitchNeighbors } from "../src/terrain/tileStitching";
+import {
+    nanMean,
+    stitchTileEdges,
+    StitchNeighbors,
+    stitchTileEdgesCrossLevel,
+    CoarseEdgeNeighbor,
+} from "../src/terrain/tileStitching";
 
 // --- nanMean ---
 
@@ -225,5 +231,143 @@ describe("stitchTileEdges", () => {
         expect(target[1 * SIZE + 255]).toBe(150);
         // 内部は変わらない
         expect(target[1 * SIZE + 254]).toBe(100);
+    });
+});
+
+// --- stitchTileEdgesCrossLevel ---
+
+describe("stitchTileEdgesCrossLevel", () => {
+    const S = 8; // サブタイル領域 (subSize) を 4 に保てる適度なサイズ
+
+    it("隣接が空なら何も変わらない", () => {
+        const target = fill(S, 10);
+        const copy = new Float32Array(target);
+        stitchTileEdgesCrossLevel(target, [], S);
+        expect(target).toEqual(copy);
+    });
+
+    it("上辺: 粗タイル一定値で target 上辺がスナップされる", () => {
+        const target = fill(S, 10);
+        const coarse = fill(S, 50);
+        // scale=2, subX=0, subY=0 → target は粗タイルの左上の子
+        const neighbor: CoarseEdgeNeighbor = {
+            elevation: coarse,
+            direction: "top",
+            subX: 0,
+            subY: 0,
+            scale: 2,
+        };
+        stitchTileEdgesCrossLevel(target, [neighbor], S);
+        // 粗タイルが一定値なので target 上辺は全て 50 にスナップ
+        for (let i = 0; i < S; i++) expect(target[i]).toBe(50);
+        // 内部は変わらない
+        expect(target[S]).toBe(10);
+        expect(target[S + 1]).toBe(10);
+    });
+
+    it("下辺: 粗タイルの上辺の対応区間にスナップされる", () => {
+        const target = fill(S, 10);
+        const coarse = fill(S, 30);
+        const neighbor: CoarseEdgeNeighbor = {
+            elevation: coarse,
+            direction: "bottom",
+            subX: 1,
+            subY: 1,
+            scale: 2,
+        };
+        stitchTileEdgesCrossLevel(target, [neighbor], S);
+        const lastRow = (S - 1) * S;
+        for (let i = 0; i < S; i++) expect(target[lastRow + i]).toBe(30);
+    });
+
+    it("左辺と右辺: 一定値の粗タイルにスナップされる", () => {
+        const target = fill(S, 10);
+        const coarseL = fill(S, 70);
+        const coarseR = fill(S, 80);
+        const neighbors: CoarseEdgeNeighbor[] = [
+            { elevation: coarseL, direction: "left", subX: 0, subY: 0, scale: 2 },
+            { elevation: coarseR, direction: "right", subX: 1, subY: 0, scale: 2 },
+        ];
+        stitchTileEdgesCrossLevel(target, neighbors, S);
+        for (let r = 0; r < S; r++) {
+            expect(target[r * S]).toBe(70);
+            expect(target[r * S + (S - 1)]).toBe(80);
+        }
+    });
+
+    it("粗タイルの値が辺方向に勾配を持つ場合、線形補間で間の値になる", () => {
+        // 粗タイル下辺 (row=last) を col 方向に 0..S-1 の勾配にする
+        const coarse = new Float32Array(S * S);
+        for (let r = 0; r < S; r++) {
+            for (let c = 0; c < S; c++) {
+                coarse[r * S + c] = r === S - 1 ? c : 0;
+            }
+        }
+        const target = fill(S, 100);
+        // scale=2, subX=0 → target 上辺は粗タイル下辺の col=0..3 範囲を読む。
+        // along = 0*4 + u*(4-1) = u*3, u = i/(S-1)。
+        // 補間値は連続値で along（NaN なし両端有効なので a*(1-t)+b*t = along）。
+        const neighbor: CoarseEdgeNeighbor = {
+            elevation: coarse,
+            direction: "top",
+            subX: 0,
+            subY: 0,
+            scale: 2,
+        };
+        stitchTileEdgesCrossLevel(target, [neighbor], S);
+        for (let i = 0; i < S; i++) {
+            const expected = (i / (S - 1)) * 3;
+            expect(target[i]).toBeCloseTo(expected, 6);
+        }
+    });
+
+    it("粗タイル両端 NaN の場合は target を変更しない", () => {
+        const coarse = fillNaN(S);
+        const target = fill(S, 99);
+        const neighbor: CoarseEdgeNeighbor = {
+            elevation: coarse,
+            direction: "top",
+            subX: 0,
+            subY: 0,
+            scale: 2,
+        };
+        stitchTileEdgesCrossLevel(target, [neighbor], S);
+        for (let i = 0; i < S; i++) expect(target[i]).toBe(99);
+    });
+
+    it("粗タイル片側 NaN なら有効値で埋める", () => {
+        // 粗タイル下辺 col=0 のみ 50、他は NaN
+        const coarse = fillNaN(S);
+        coarse[(S - 1) * S + 0] = 50;
+        const target = fill(S, 10);
+        const neighbor: CoarseEdgeNeighbor = {
+            elevation: coarse,
+            direction: "top",
+            subX: 0,
+            subY: 0,
+            scale: 2,
+        };
+        stitchTileEdgesCrossLevel(target, [neighbor], S);
+        // i=0: a=coarse[last,0]=50, b=coarse[last,1]=NaN → 50 にスナップ
+        expect(target[0]).toBe(50);
+    });
+
+    it("scale=4: subSize=2 でも適切な範囲を参照する", () => {
+        const SS = 8;
+        // 粗タイル下辺 col=4..6 範囲（subX=2, scale=4 → along base = 2*2=4）が値 7、その他 0
+        const coarse = new Float32Array(SS * SS);
+        for (let c = 4; c <= 6; c++) coarse[(SS - 1) * SS + c] = 7;
+        const target = fill(SS, 0);
+        const neighbor: CoarseEdgeNeighbor = {
+            elevation: coarse,
+            direction: "top",
+            subX: 2,
+            subY: 0,
+            scale: 4,
+        };
+        stitchTileEdgesCrossLevel(target, [neighbor], SS);
+        // i=0: along=4 → coarse[last,4]=7 ・i=last(7): along=4+1=5 → coarse[last,5]=7
+        expect(target[0]).toBe(7);
+        expect(target[SS - 1]).toBe(7);
     });
 });


### PR DESCRIPTION
Closes #161

## 概要
異なる zoom の隣接タイル間の継ぎ目隙間（T-junction）を、カメラ近傍タイルに限定して縫い合わせる。

## 変更点
- `stitchTileEdgesCrossLevel`: 細タイル境界辺を粗タイル対応辺の線形補間値にスナップ（粗側不変、NaN 安全）
- tileManager: カメラ近傍判定（tileSize × 3）+ 4辺それぞれで最も細かい粗 zoom 隣接を選択
- `restitchNeighbors` を異 zoom にも拡張（粗タイル更新時に細タイル側を再ステッチ）
- 単体テスト 7 ケース追加
- Visual snapshot 更新（Compass reset 2 件: WebGL2 / WebGPU）

## 検証
- `npm run lint` / `npm run typecheck` / `npm run test:unit` (436 tests) PASS
- `npm run test:visuals` (14 tests) PASS