### PR TITLE
fix(timelapse): タイムラプスの戻るボタンでポータルへ戻れない不具合を修正 (#163)

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,7 @@ import { defineConfig, devices } from '@playwright/test';
  */
 export default defineConfig({
   testDir: './tests',
-  testMatch: ['validation.spec.ts', 'atPathReload.spec.ts'],
+  testMatch: ['validation.spec.ts', 'atPathReload.spec.ts', 'timelapseBackLink.spec.ts'],
   /* Maximum time one test can run for. */
   timeout: 120 * 1000,
   expect: {

--- a/public/timelapse.html
+++ b/public/timelapse.html
@@ -84,7 +84,7 @@
 <body>
   <div id="root">
     <div id="timelapse-overlay">
-      <a class="back-link" href="./">← デモ一覧へ</a>
+      <a class="back-link" href="/">← デモ一覧へ</a>
       <div id="timelapse-clock-area">
         <svg
           id="timelapse-clock"

--- a/tests/timelapseBackLink.spec.ts
+++ b/tests/timelapseBackLink.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Issue #163: タイムラプスデモの戻るリンクからポータルへ戻れない不具合の回帰防止。
+ *
+ * Issue #155 で URL が `/timelapse/@lat,lon,...` 形式に書き換えられるようになった結果、
+ * 相対パス `href="./"` は `/timelapse/` に解決され、webpack の historyApiFallback rewrite で
+ * 再びタイムラプス HTML へフォールバックされてしまっていた。
+ * 戻るリンクは絶対パス `/` を指し、ポータル (`<ul class="demos">`) へ遷移すること。
+ */
+test("timelapse back-link navigates to portal even after URL is rewritten to /timelapse/@...", async ({ page }) => {
+    await page.goto("/timelapse/@35.681236,139.767125");
+    await page.waitForLoadState("domcontentloaded");
+
+    const backLink = page.locator(".back-link");
+    await expect(backLink).toBeVisible();
+    await expect(backLink).toHaveAttribute("href", "/");
+
+    await backLink.click();
+    await page.waitForLoadState("domcontentloaded");
+
+    await expect(page.locator("ul.demos")).toBeVisible({ timeout: 10000 });
+    expect(new URL(page.url()).pathname).toBe("/");
+});


### PR DESCRIPTION
Closes #163

## 変更内容
- public/timelapse.html: 戻るリンクを `href="./"` → `href="/"` に変更
- tests/timelapseBackLink.spec.ts: 回帰防止 E2E を追加
- playwright.config.ts: testMatch に新テストを追加

## 原因
Issue #155 で URL が `/timelapse/@lat,lon,...` 形式に書き換えられるようになった結果、相対パス `./` が `/timelapse/` に解決され、webpack の `historyApiFallback` rewrite で再度 `timelapse.html` にフォールバックされていた。絶対パス `/` に変更し URL 状態に依存しないようにする。

## 影響範囲
- タイムラプスデモのオーバーレイ UI のみ。viewer / portal は影響なし。
- 本番デプロイ環境ではホスティング側で historyApiFallback 相当の rewrite を併せて用意する前提（既存）。

## 検証
- npm run lint: PASS
- npm run typecheck: PASS
- npm run test:unit: 428 PASS
- npm run test:visuals: 15 PASS（追加分含む）