### PR TITLE
feat(marker): add basic marker API with CRUD and enable/disable (#167)

### DIFF
--- a/spec/package.md
+++ b/spec/package.md
@@ -305,15 +305,15 @@ interface MarkerOptions {
   icon?: { url: string; width?: number; height?: number };
   text?: {
     value: string;          // "\n" で改行
-    fontSize?: number;      // 1 行のおおよそのワールド m 高さ (default 16)
+    fontSize?: number;      // フォントサイズ(px) (default 18)
     color?: string;         // CSS color (default "#000000")
     backgroundColor?: string; // CSS color (default "transparent")
     lineHeight?: number;    // 倍率 (default 1.2)
   };
   line?: {
-    color?: string;  // default "#000000"
-    width?: number;  // m (default 8)
-    height?: number; // m (default 500)
+    color?: string;  // CSS color (default "#000000")
+    width?: number;  // m (default 4)
+    height?: number; // m (default 500)。動的高さ計算が無効な場合のフォールバック値
   };
   enabled?: boolean; // default true
 }
@@ -323,7 +323,11 @@ interface MarkerOptions {
 
 - `icon` と `text` は **少なくとも片方が必須**。両方指定時は **上=text、下=icon** の順で線の上にスタックする。
 - ビルボードは `BILLBOARDMODE_ALL` でカメラ常時追従。`renderingGroupId = 1` で最前面に描画する。
-- 表示位置の高さは「タイル表面の標高 + `line.height`」。標高未取得地点では描画を保留し、対応するタイルロード後（`onTerrainUpdated`）に自動で表示する（例外は投げない）。
+- 表示位置の高さは **「タイル表面の標高 + 線の高さ」**。線の高さはカメラ距離・仰角から
+  動的に算出される値（`radius * 0.1 * clamp(sin(beta), 0.3, 1)` を 100m–10000m にクランプ）を採用し、
+  カメラ距離が変わってもスクリーン上で安定した長さに見えるようにする。`line.height` は
+  動的計算が利用できないテスト/フォールバック時の基準値として保持する。
+  標高未取得地点では描画を保留し、対応するタイルロード後（`onTerrainUpdated`）に自動で表示する（例外は投げない）。
 - `icon.url` は `http(s):` / `data:image/...` / 相対パスのみ許可。`javascript:` 等のスキームは Error。
 - `lat`/`lon` が JAPAN_BOUNDS 外、`MarkerOptions` 不正属性の場合は Error。
 - `addMarker` の戻り値および `getMarker` は read-only スナップショット（更新は必ず `updateMarker` 経由）。

--- a/spec/package.md
+++ b/spec/package.md
@@ -305,15 +305,15 @@ interface MarkerOptions {
   icon?: { url: string; width?: number; height?: number };
   text?: {
     value: string;          // "\n" で改行
-    fontSize?: number;      // px (default 14)
+    fontSize?: number;      // 1 行のおおよそのワールド m 高さ (default 60)
     color?: string;         // CSS color (default "#ffffff")
     backgroundColor?: string; // CSS color (default "rgba(0,0,0,0.6)")
     lineHeight?: number;    // 倍率 (default 1.2)
   };
   line?: {
     color?: string;  // default "#ffffff"
-    width?: number;  // m (default 1.5)
-    height?: number; // m (default 200)
+    width?: number;  // m (default 20)
+    height?: number; // m (default 500)
   };
   enabled?: boolean; // default true
 }

--- a/spec/package.md
+++ b/spec/package.md
@@ -279,6 +279,57 @@ interface JpmapTerrain {
 - `dispose()` 時に `ShadowGenerator` は確実に解放される。
 - URL クエリ `?showSunShadows=true|false` で初期値を制御できる（`true`/`false` 以外の値は無視）。
 
+#### 3.3.7 マーカー (Issue #167)
+
+任意地点に、地表から垂直に伸びる線とその先のビルボード（アイコン＋改行テキスト）を表示する機能。
+
+```typescript
+interface JpmapTerrain {
+  /** マーカー追加。同 id 重複は throw、icon/text 双方未指定は throw。 */
+  addMarker(id: string, options: MarkerOptions): MarkerHandle;
+  /** 取得。未存在は null */
+  getMarker(id: string): MarkerHandle | null;
+  /** 部分更新。未存在は throw */
+  updateMarker(id: string, partial: MarkerUpdate): MarkerHandle;
+  /** 削除。未存在は no-op + warn */
+  removeMarker(id: string): void;
+  /** enabled の薄いショートカット */
+  setMarkerEnabled(id: string, enabled: boolean): void;
+  /** 全 id を生成順で返す */
+  listMarkers(): readonly string[];
+}
+
+interface MarkerOptions {
+  lat: number;
+  lon: number;
+  icon?: { url: string; width?: number; height?: number };
+  text?: {
+    value: string;          // "\n" で改行
+    fontSize?: number;      // px (default 14)
+    color?: string;         // CSS color (default "#ffffff")
+    backgroundColor?: string; // CSS color (default "rgba(0,0,0,0.6)")
+    lineHeight?: number;    // 倍率 (default 1.2)
+  };
+  line?: {
+    color?: string;  // default "#ffffff"
+    width?: number;  // m (default 1.5)
+    height?: number; // m (default 200)
+  };
+  enabled?: boolean; // default true
+}
+```
+
+**仕様:**
+
+- `icon` と `text` は **少なくとも片方が必須**。両方指定時は **上=text、下=icon** の順で線の上にスタックする。
+- ビルボードは `BILLBOARDMODE_ALL` でカメラ常時追従。`renderingGroupId = 1` で最前面に描画する。
+- 表示位置の高さは「タイル表面の標高 + `line.height`」。標高未取得地点では描画を保留し、対応するタイルロード後（`onTerrainUpdated`）に自動で表示する（例外は投げない）。
+- `icon.url` は `http(s):` / `data:image/...` / 相対パスのみ許可。`javascript:` 等のスキームは Error。
+- `lat`/`lon` が JAPAN_BOUNDS 外、`MarkerOptions` 不正属性の場合は Error。
+- `addMarker` の戻り値および `getMarker` は read-only スナップショット（更新は必ず `updateMarker` 経由）。
+- `dispose()` で全マーカーリソース（Mesh / Material / Texture）を解放する。
+- マーカーは別機能（タイムラプス等）から内部的に利用可能。
+
 **`mapType` URL クエリ仕様 (Issue #149):**
 
 - URL クエリ `?mapType=standard|photo` で初期値を上書きできる（デモ層）。
@@ -357,36 +408,11 @@ import type {
 
 ### 4.2 追加 API
 
+§3.3.7 でマーカー基本機能（CRUD + enable/disable）が正式仕様化された (Issue #167)。
+本節では、後日実装予定の **3D モデル配置** のみ残す。
+
 ```typescript
 interface JpmapTerrain {
-  // --- マーカー ---
-  /** 任意地点に画像マーカーを追加する */
-  addImageMarker(id: string, options: {
-    lat: number;
-    lon: number;
-    imageUrl: string;
-    width?: number;
-    height?: number;
-  }): void;
-  /** マーカーの表示・非表示を切り替える */
-  setMarkerVisible(id: string, visible: boolean): void;
-  /** マーカーを削除する */
-  removeMarker(id: string): void;
-
-  // --- テキストラベル ---
-  /** 任意地点にテキストラベルを追加する */
-  addLabel(id: string, options: {
-    lat: number;
-    lon: number;
-    text: string;
-    fontSize?: number;
-    color?: string;
-  }): void;
-  /** ラベルの表示・非表示を切り替える */
-  setLabelVisible(id: string, visible: boolean): void;
-  /** ラベルを削除する */
-  removeLabel(id: string): void;
-
   // --- 3Dモデル ---
   /** 任意地点に3Dモデルを配置する */
   addModel(id: string, options: {
@@ -403,6 +429,7 @@ interface JpmapTerrain {
 }
 ```
 
+> マーカー（旧 `addImageMarker` / `addLabel`）は §3.3.7 の `addMarker` に統合された (Issue #167)。
 > 日時 (`dateTime` / `autoSunPosition`) は §3.3.5 で正式仕様化済み。
 
 ## 5. パッケージ構成

--- a/spec/package.md
+++ b/spec/package.md
@@ -305,14 +305,14 @@ interface MarkerOptions {
   icon?: { url: string; width?: number; height?: number };
   text?: {
     value: string;          // "\n" で改行
-    fontSize?: number;      // 1 行のおおよそのワールド m 高さ (default 60)
-    color?: string;         // CSS color (default "#ffffff")
-    backgroundColor?: string; // CSS color (default "rgba(0,0,0,0.6)")
+    fontSize?: number;      // 1 行のおおよそのワールド m 高さ (default 16)
+    color?: string;         // CSS color (default "#000000")
+    backgroundColor?: string; // CSS color (default "transparent")
     lineHeight?: number;    // 倍率 (default 1.2)
   };
   line?: {
-    color?: string;  // default "#ffffff"
-    width?: number;  // m (default 20)
+    color?: string;  // default "#000000"
+    width?: number;  // m (default 8)
     height?: number; // m (default 500)
   };
   enabled?: boolean; // default true

--- a/src/demos/viewer/index.ts
+++ b/src/demos/viewer/index.ts
@@ -169,9 +169,9 @@ const start = async (): Promise<void> => {
     // マーカーはカメラ距離に応じてスクリーン空間サイズが一定になるよう自動スケールされる。
     // アイコンは赤いピン形状の SVG をインラインの data URL で渡す。
     const PIN_ICON_URL =
-        "data:image/svg+xml;utf8," +
+        "data:image/svg+xml," +
         encodeURIComponent(
-            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">' +
+            '<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">' +
                 '<path d="M32 2C20 2 10 12 10 24c0 14 22 38 22 38s22-24 22-38C54 12 44 2 32 2z" ' +
                 'fill="#e53935" stroke="#ffffff" stroke-width="3" stroke-linejoin="round"/>' +
                 '<circle cx="32" cy="24" r="8" fill="#ffffff"/>' +

--- a/src/demos/viewer/index.ts
+++ b/src/demos/viewer/index.ts
@@ -166,21 +166,22 @@ const start = async (): Promise<void> => {
     updateMapTypeInUrl(viewer.mapType);
 
     // デモ用マーカー: 東京駅・皇居・都庁 (Issue #167)
+    // fontSize はワールド m 相当の値になっており、高度 2000m で表示したときに読めるサイズを与える。
     try {
         viewer.addMarker("tokyo-station", {
             lat: 35.681236,
             lon: 139.767125,
-            text: { value: "東京駅", fontSize: 16 },
+            text: { value: "東京駅", fontSize: 80 },
         });
         viewer.addMarker("imperial-palace", {
             lat: 35.685175,
             lon: 139.7528,
-            text: { value: "皇居", fontSize: 16 },
+            text: { value: "皇居", fontSize: 80 },
         });
         viewer.addMarker("tokyo-metropolitan-government", {
             lat: 35.6896,
             lon: 139.6917,
-            text: { value: "東京都庁\n(新宿)", fontSize: 16 },
+            text: { value: "東京都庁\n(新宿)", fontSize: 80 },
         });
     } catch (err) {
         console.warn("[jpmap-terrain demo] failed to add demo markers:", err);

--- a/src/demos/viewer/index.ts
+++ b/src/demos/viewer/index.ts
@@ -166,22 +166,22 @@ const start = async (): Promise<void> => {
     updateMapTypeInUrl(viewer.mapType);
 
     // デモ用マーカー: 東京駅・皇居・都庁 (Issue #167)
-    // fontSize はワールド m 相当の値になっており、高度 2000m で表示したときに読めるサイズを与える。
+    // マーカーはカメラ距離に応じてスクリーン空間サイズが一定になるよう自動スケールされる。
     try {
         viewer.addMarker("tokyo-station", {
             lat: 35.681236,
             lon: 139.767125,
-            text: { value: "東京駅", fontSize: 80 },
+            text: { value: "東京駅" },
         });
         viewer.addMarker("imperial-palace", {
             lat: 35.685175,
             lon: 139.7528,
-            text: { value: "皇居", fontSize: 80 },
+            text: { value: "皇居" },
         });
         viewer.addMarker("tokyo-metropolitan-government", {
             lat: 35.6896,
             lon: 139.6917,
-            text: { value: "東京都庁\n(新宿)", fontSize: 80 },
+            text: { value: "東京都庁\n(新宿)" },
         });
     } catch (err) {
         console.warn("[jpmap-terrain demo] failed to add demo markers:", err);

--- a/src/demos/viewer/index.ts
+++ b/src/demos/viewer/index.ts
@@ -165,6 +165,27 @@ const start = async (): Promise<void> => {
     // 起動完了直後に一度書き込み、`?mapType=Photo` のような大小混在の値を小文字に揃える。
     updateMapTypeInUrl(viewer.mapType);
 
+    // デモ用マーカー: 東京駅・皇居・都庁 (Issue #167)
+    try {
+        viewer.addMarker("tokyo-station", {
+            lat: 35.681236,
+            lon: 139.767125,
+            text: { value: "東京駅", fontSize: 16 },
+        });
+        viewer.addMarker("imperial-palace", {
+            lat: 35.685175,
+            lon: 139.7528,
+            text: { value: "皇居", fontSize: 16 },
+        });
+        viewer.addMarker("tokyo-metropolitan-government", {
+            lat: 35.6896,
+            lon: 139.6917,
+            text: { value: "東京都庁\n(新宿)", fontSize: 16 },
+        });
+    } catch (err) {
+        console.warn("[jpmap-terrain demo] failed to add demo markers:", err);
+    }
+
     // 開発/テストビルドでのみデバッグ用に内部状態を露出する。
     // （Playwright の `window.scene.isReady()` 等が依存しているため）
     // `__debugScene` は @internal 扱いの公式デバッグアクセサ（spec/package.md には未記載）。

--- a/src/demos/viewer/index.ts
+++ b/src/demos/viewer/index.ts
@@ -167,18 +167,38 @@ const start = async (): Promise<void> => {
 
     // デモ用マーカー: 東京駅・皇居・都庁 (Issue #167)
     // マーカーはカメラ距離に応じてスクリーン空間サイズが一定になるよう自動スケールされる。
-    // アイコンは赤いピン形状の SVG を base64 化した data URL で渡す（Babylon Texture が確実に読める形式）。
-    const PIN_SVG =
-        '<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">' +
-        '<path d="M32 2C20 2 10 12 10 24c0 14 22 38 22 38s22-24 22-38C54 12 44 2 32 2z" ' +
-        'fill="#e53935" stroke="#ffffff" stroke-width="3" stroke-linejoin="round"/>' +
-        '<circle cx="32" cy="24" r="8" fill="#ffffff"/>' +
-        "</svg>";
-    const PIN_ICON_URL =
-        "data:image/svg+xml;base64," +
-        (typeof btoa === "function"
-            ? btoa(PIN_SVG)
-            : Buffer.from(PIN_SVG, "utf-8").toString("base64"));
+    // アイコン: WebGPU の ImageBitmap デコーダは SVG を扱えないため、
+    // Canvas API で赤いピンを描画して PNG data URL に変換する。
+    const buildPinIconUrl = (): string => {
+        const size = 64;
+        const c = document.createElement("canvas");
+        c.width = size;
+        c.height = size;
+        const ctx = c.getContext("2d");
+        if (!ctx) return "";
+        ctx.clearRect(0, 0, size, size);
+        // ピン本体
+        ctx.beginPath();
+        ctx.moveTo(32, 2);
+        ctx.bezierCurveTo(20, 2, 10, 12, 10, 24);
+        ctx.bezierCurveTo(10, 38, 32, 62, 32, 62);
+        ctx.bezierCurveTo(32, 62, 54, 38, 54, 24);
+        ctx.bezierCurveTo(54, 12, 44, 2, 32, 2);
+        ctx.closePath();
+        ctx.fillStyle = "#e53935";
+        ctx.fill();
+        ctx.lineJoin = "round";
+        ctx.lineWidth = 3;
+        ctx.strokeStyle = "#ffffff";
+        ctx.stroke();
+        // 中心の白い円
+        ctx.beginPath();
+        ctx.arc(32, 24, 8, 0, Math.PI * 2);
+        ctx.fillStyle = "#ffffff";
+        ctx.fill();
+        return c.toDataURL("image/png");
+    };
+    const PIN_ICON_URL = buildPinIconUrl();
     try {
         viewer.addMarker("tokyo-station", {
             lat: 35.681236,

--- a/src/demos/viewer/index.ts
+++ b/src/demos/viewer/index.ts
@@ -167,16 +167,18 @@ const start = async (): Promise<void> => {
 
     // デモ用マーカー: 東京駅・皇居・都庁 (Issue #167)
     // マーカーはカメラ距離に応じてスクリーン空間サイズが一定になるよう自動スケールされる。
-    // アイコンは赤いピン形状の SVG をインラインの data URL で渡す。
+    // アイコンは赤いピン形状の SVG を base64 化した data URL で渡す（Babylon Texture が確実に読める形式）。
+    const PIN_SVG =
+        '<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">' +
+        '<path d="M32 2C20 2 10 12 10 24c0 14 22 38 22 38s22-24 22-38C54 12 44 2 32 2z" ' +
+        'fill="#e53935" stroke="#ffffff" stroke-width="3" stroke-linejoin="round"/>' +
+        '<circle cx="32" cy="24" r="8" fill="#ffffff"/>' +
+        "</svg>";
     const PIN_ICON_URL =
-        "data:image/svg+xml," +
-        encodeURIComponent(
-            '<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">' +
-                '<path d="M32 2C20 2 10 12 10 24c0 14 22 38 22 38s22-24 22-38C54 12 44 2 32 2z" ' +
-                'fill="#e53935" stroke="#ffffff" stroke-width="3" stroke-linejoin="round"/>' +
-                '<circle cx="32" cy="24" r="8" fill="#ffffff"/>' +
-                "</svg>",
-        );
+        "data:image/svg+xml;base64," +
+        (typeof btoa === "function"
+            ? btoa(PIN_SVG)
+            : Buffer.from(PIN_SVG, "utf-8").toString("base64"));
     try {
         viewer.addMarker("tokyo-station", {
             lat: 35.681236,

--- a/src/demos/viewer/index.ts
+++ b/src/demos/viewer/index.ts
@@ -167,20 +167,33 @@ const start = async (): Promise<void> => {
 
     // デモ用マーカー: 東京駅・皇居・都庁 (Issue #167)
     // マーカーはカメラ距離に応じてスクリーン空間サイズが一定になるよう自動スケールされる。
+    // アイコンは赤いピン形状の SVG をインラインの data URL で渡す。
+    const PIN_ICON_URL =
+        "data:image/svg+xml;utf8," +
+        encodeURIComponent(
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">' +
+                '<path d="M32 2C20 2 10 12 10 24c0 14 22 38 22 38s22-24 22-38C54 12 44 2 32 2z" ' +
+                'fill="#e53935" stroke="#ffffff" stroke-width="3" stroke-linejoin="round"/>' +
+                '<circle cx="32" cy="24" r="8" fill="#ffffff"/>' +
+                "</svg>",
+        );
     try {
         viewer.addMarker("tokyo-station", {
             lat: 35.681236,
             lon: 139.767125,
+            icon: { url: PIN_ICON_URL },
             text: { value: "東京駅" },
         });
         viewer.addMarker("imperial-palace", {
             lat: 35.685175,
             lon: 139.7528,
+            icon: { url: PIN_ICON_URL },
             text: { value: "皇居" },
         });
         viewer.addMarker("tokyo-metropolitan-government", {
             lat: 35.6896,
             lon: 139.6917,
+            icon: { url: PIN_ICON_URL },
             text: { value: "東京都庁\n(新宿)" },
         });
     } catch (err) {

--- a/src/demos/viewer/index.ts
+++ b/src/demos/viewer/index.ts
@@ -168,8 +168,9 @@ const start = async (): Promise<void> => {
     // デモ用マーカー: 東京駅・皇居・都庁 (Issue #167)
     // マーカーはカメラ距離に応じてスクリーン空間サイズが一定になるよう自動スケールされる。
     // アイコン: WebGPU の ImageBitmap デコーダは SVG を扱えないため、
-    // Canvas API で赤いピンを描画して PNG data URL に変換する。
-    const buildPinIconUrl = (): string => {
+    // Canvas API で「丸 + グリフ」を描画して PNG data URL に変換する。
+    type IconGlyph = "letter-s" | "house" | "building";
+    const buildCircleIconUrl = (glyph: IconGlyph): string => {
         const size = 64;
         const c = document.createElement("canvas");
         c.width = size;
@@ -177,13 +178,9 @@ const start = async (): Promise<void> => {
         const ctx = c.getContext("2d");
         if (!ctx) return "";
         ctx.clearRect(0, 0, size, size);
-        // ピン本体
+        // 円本体（赤地・白縁）
         ctx.beginPath();
-        ctx.moveTo(32, 2);
-        ctx.bezierCurveTo(20, 2, 10, 12, 10, 24);
-        ctx.bezierCurveTo(10, 38, 32, 62, 32, 62);
-        ctx.bezierCurveTo(32, 62, 54, 38, 54, 24);
-        ctx.bezierCurveTo(54, 12, 44, 2, 32, 2);
+        ctx.arc(32, 32, 28, 0, Math.PI * 2);
         ctx.closePath();
         ctx.fillStyle = "#e53935";
         ctx.fill();
@@ -191,31 +188,60 @@ const start = async (): Promise<void> => {
         ctx.lineWidth = 3;
         ctx.strokeStyle = "#ffffff";
         ctx.stroke();
-        // 中心の白い円
-        ctx.beginPath();
-        ctx.arc(32, 24, 8, 0, Math.PI * 2);
+
+        // グリフ（白）
         ctx.fillStyle = "#ffffff";
-        ctx.fill();
+        ctx.strokeStyle = "#ffffff";
+        if (glyph === "letter-s") {
+            // 東京駅: 丸に "S"
+            ctx.font = "bold 38px sans-serif";
+            ctx.textAlign = "center";
+            ctx.textBaseline = "middle";
+            ctx.fillText("S", 32, 34);
+        } else if (glyph === "house") {
+            // 皇居: 丸に家
+            // 屋根 (三角)
+            ctx.beginPath();
+            ctx.moveTo(32, 16);
+            ctx.lineTo(52, 32);
+            ctx.lineTo(12, 32);
+            ctx.closePath();
+            ctx.fill();
+            // 壁 (四角)
+            ctx.fillRect(18, 32, 28, 18);
+            // ドア (赤抜き)
+            ctx.fillStyle = "#e53935";
+            ctx.fillRect(28, 38, 8, 12);
+        } else {
+            // 都庁: 丸にビル (高さ違いの 3 棟)
+            ctx.fillRect(14, 32, 10, 20); // 左 (低)
+            ctx.fillRect(27, 22, 10, 30); // 中央 (高)
+            ctx.fillRect(40, 28, 10, 24); // 右 (中)
+            // 窓 (赤抜き) — 中央棟のみ
+            ctx.fillStyle = "#e53935";
+            ctx.fillRect(30, 26, 4, 4);
+            ctx.fillRect(30, 34, 4, 4);
+            ctx.fillRect(30, 42, 4, 4);
+        }
         return c.toDataURL("image/png");
     };
-    const PIN_ICON_URL = buildPinIconUrl();
     try {
         viewer.addMarker("tokyo-station", {
             lat: 35.681236,
             lon: 139.767125,
-            icon: { url: PIN_ICON_URL },
+            icon: { url: buildCircleIconUrl("letter-s") },
             text: { value: "東京駅" },
         });
         viewer.addMarker("imperial-palace", {
             lat: 35.685175,
             lon: 139.7528,
-            icon: { url: PIN_ICON_URL },
+            icon: { url: buildCircleIconUrl("house") },
             text: { value: "皇居" },
         });
         viewer.addMarker("tokyo-metropolitan-government", {
             lat: 35.6896,
             lon: 139.6917,
-            icon: { url: PIN_ICON_URL },
+            icon: { url: buildCircleIconUrl("building") },
             text: { value: "東京都庁\n(新宿)" },
         });
     } catch (err) {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -15,4 +15,10 @@ export type {
     JpmapTerrainOptions,
     MapType,
     MapTypeChangeListener,
+    MarkerHandle,
+    MarkerIconOptions,
+    MarkerLineOptions,
+    MarkerOptions,
+    MarkerTextOptions,
+    MarkerUpdate,
 } from "./lib/types";

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -24,8 +24,12 @@ import {
     JpmapTerrainOptions,
     MapType,
     MapTypeChangeListener,
+    MarkerHandle,
+    MarkerOptions,
+    MarkerUpdate,
     SUN_AUTO_UPDATE_INTERVAL_MS,
 } from "./types";
+import { createMarkerManager, type MarkerManager } from "../terrain/markerManager";
 
 /**
  * jpmap-terrain ビューア。
@@ -77,6 +81,9 @@ export class JpmapTerrain {
     private _lastCameraSnapshot: CameraChangeEvent | null = null;
     /** `onMapTypeChange` で登録されたリスナー一覧 (Issue #149) */
     private _mapTypeListeners: MapTypeChangeListener[] = [];
+
+    /** マーカー管理 (Issue #167)。`onReady` で初期化される */
+    private _markerManager: MarkerManager | null = null;
 
     private constructor(mountElement: HTMLElement, options: JpmapTerrainOptions) {
         this.mountElement = mountElement;
@@ -200,6 +207,10 @@ export class JpmapTerrain {
                     if (this._showSunShadows) {
                         controller.setSunShadows(true);
                     }
+                    // マーカー (Issue #167)。境界コンテキスト経由で manager を構築する。
+                    this._markerManager = createMarkerManager(
+                        controller.getMarkerContext(),
+                    );
                 },
             });
             this._scene = scene;
@@ -677,6 +688,50 @@ export class JpmapTerrain {
         }
     }
 
+    // ---- マーカー (Issue #167) ----
+
+    private _assertAlive(): void {
+        if (this._disposed) {
+            throw new Error("JpmapTerrain has been disposed");
+        }
+    }
+
+    private _requireMarkerManager(): MarkerManager {
+        if (!this._markerManager) {
+            throw new Error("JpmapTerrain marker manager is not ready yet");
+        }
+        return this._markerManager;
+    }
+
+    public addMarker(id: string, options: MarkerOptions): MarkerHandle {
+        this._assertAlive();
+        return this._requireMarkerManager().add(id, options);
+    }
+
+    public getMarker(id: string): MarkerHandle | null {
+        if (this._disposed || !this._markerManager) return null;
+        return this._markerManager.get(id);
+    }
+
+    public updateMarker(id: string, partial: MarkerUpdate): MarkerHandle {
+        this._assertAlive();
+        return this._requireMarkerManager().update(id, partial);
+    }
+
+    public removeMarker(id: string): void {
+        if (this._disposed || !this._markerManager) return;
+        this._markerManager.remove(id);
+    }
+
+    public setMarkerEnabled(id: string, enabled: boolean): void {
+        this._assertAlive();
+        this._requireMarkerManager().setEnabled(id, enabled);
+    }
+
+    public listMarkers(): readonly string[] {
+        return this._markerManager?.list() ?? [];
+    }
+
     // ---- ライフサイクル (spec §3.3.3) ----
 
     /**
@@ -713,6 +768,15 @@ export class JpmapTerrain {
         if (this._onWindowResize) {
             window.removeEventListener("resize", this._onWindowResize);
             this._onWindowResize = null;
+        }
+        // マーカーマネージャを Scene dispose 前に解放する (Issue #167)。
+        if (this._markerManager) {
+            try {
+                this._markerManager.dispose();
+            } catch (err) {
+                console.error("[JpmapTerrain] markerManager.dispose threw:", err);
+            }
+            this._markerManager = null;
         }
         // controlPanel が body に追加した UI 要素を Scene dispose 前に除去する。
         if (this._controller) {

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -703,6 +703,14 @@ export class JpmapTerrain {
         return this._markerManager;
     }
 
+    /**
+     * dispose 後のマーカー API は次の方針で統一する:
+     * - 戻り値が `MarkerHandle`（非 null）の API（`addMarker` / `updateMarker`）は
+     *   呼び出し側が結果を必ず使うため、明示的に `Error` を投げる。
+     * - 戻り値が void / `MarkerHandle | null` / `readonly string[]` の API
+     *   （`getMarker` / `removeMarker` / `setMarkerEnabled` / `listMarkers`）は
+     *   片付け中のクリーンアップで安全に呼べるよう no-op として扱う。
+     */
     public addMarker(id: string, options: MarkerOptions): MarkerHandle {
         this._assertAlive();
         return this._requireMarkerManager().add(id, options);
@@ -724,11 +732,12 @@ export class JpmapTerrain {
     }
 
     public setMarkerEnabled(id: string, enabled: boolean): void {
-        this._assertAlive();
-        this._requireMarkerManager().setEnabled(id, enabled);
+        if (this._disposed || !this._markerManager) return;
+        this._markerManager.setEnabled(id, enabled);
     }
 
     public listMarkers(): readonly string[] {
+        if (this._disposed) return [];
         return this._markerManager?.list() ?? [];
     }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -183,10 +183,10 @@ export interface MarkerHandle {
 
 export const MARKER_DEFAULTS = {
     enabled: true,
-    line: { color: "#000000", width: 8, height: 500 },
+    line: { color: "#000000", width: 4, height: 500 },
     icon: { width: 200, height: 200 },
     text: {
-        fontSize: 16,
+        fontSize: 36,
         color: "#000000",
         backgroundColor: "transparent",
         lineHeight: 1.2,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -186,7 +186,7 @@ export const MARKER_DEFAULTS = {
     line: { color: "#000000", width: 4, height: 500 },
     icon: { width: 200, height: 200 },
     text: {
-        fontSize: 36,
+        fontSize: 18,
         color: "#000000",
         backgroundColor: "transparent",
         lineHeight: 1.2,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -186,7 +186,7 @@ export const MARKER_DEFAULTS = {
     line: { color: "#000000", width: 8, height: 500 },
     icon: { width: 200, height: 200 },
     text: {
-        fontSize: 60,
+        fontSize: 16,
         color: "#000000",
         backgroundColor: "transparent",
         lineHeight: 1.2,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -184,7 +184,7 @@ export interface MarkerHandle {
 export const MARKER_DEFAULTS = {
     enabled: true,
     line: { color: "#000000", width: 4, height: 500 },
-    icon: { width: 200, height: 200 },
+    icon: { width: 40, height: 40 },
     text: {
         fontSize: 18,
         color: "#000000",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -183,12 +183,12 @@ export interface MarkerHandle {
 
 export const MARKER_DEFAULTS = {
     enabled: true,
-    line: { color: "#ffffff", width: 20, height: 500 },
+    line: { color: "#000000", width: 8, height: 500 },
     icon: { width: 200, height: 200 },
     text: {
         fontSize: 60,
-        color: "#ffffff",
-        backgroundColor: "rgba(0,0,0,0.6)",
+        color: "#000000",
+        backgroundColor: "transparent",
         lineHeight: 1.2,
     },
     textMaxLength: 512,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -183,10 +183,10 @@ export interface MarkerHandle {
 
 export const MARKER_DEFAULTS = {
     enabled: true,
-    line: { color: "#ffffff", width: 1.5, height: 200 },
-    icon: { width: 64, height: 64 },
+    line: { color: "#ffffff", width: 20, height: 500 },
+    icon: { width: 200, height: 200 },
     text: {
-        fontSize: 14,
+        fontSize: 60,
         color: "#ffffff",
         backgroundColor: "rgba(0,0,0,0.6)",
         lineHeight: 1.2,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -119,3 +119,77 @@ export type CameraChangeListener = (event: CameraChangeEvent) => void;
  * `mapType` が実際に変化したタイミングのみ呼ばれる。
  */
 export type MapTypeChangeListener = (mapType: MapType) => void;
+
+// ---- マーカー (Issue #167) ----
+
+export interface MarkerTextOptions {
+    /** テキスト本体。"\n" で複数行。最大 512 chars（超過は console.warn のうえ truncate） */
+    value: string;
+    /** フォントサイズ(px)。default 14 */
+    fontSize?: number;
+    /** CSS color。default "#ffffff" */
+    color?: string;
+    /** 背景色。default "rgba(0,0,0,0.6)"。"transparent" 可 */
+    backgroundColor?: string;
+    /** 行高倍率。default 1.2 */
+    lineHeight?: number;
+}
+
+export interface MarkerIconOptions {
+    /** 画像URL。`javascript:` / `vbscript:` 等は拒否 */
+    url: string;
+    /** 表示幅(world meters)。default 64 */
+    width?: number;
+    /** 表示高(world meters)。default 64 */
+    height?: number;
+}
+
+export interface MarkerLineOptions {
+    /** 線色 CSS。default "#ffffff" */
+    color?: string;
+    /** 線幅(world meters)。default 1.5 */
+    width?: number;
+    /** 線の長さ(地表からビルボード基点)。default 200 */
+    height?: number;
+}
+
+export interface MarkerOptions {
+    lat: number;
+    lon: number;
+    icon?: MarkerIconOptions;
+    text?: MarkerTextOptions;
+    line?: MarkerLineOptions;
+    /** default true */
+    enabled?: boolean;
+}
+
+export type MarkerUpdate = Partial<
+    Pick<MarkerOptions, "icon" | "text" | "line" | "enabled">
+> & {
+    lat?: number;
+    lon?: number;
+};
+
+export interface MarkerHandle {
+    readonly id: string;
+    readonly lat: number;
+    readonly lon: number;
+    readonly enabled: boolean;
+    readonly icon: Readonly<MarkerIconOptions> | null;
+    readonly text: Readonly<MarkerTextOptions> | null;
+    readonly line: Readonly<Required<MarkerLineOptions>>;
+    readonly elevationResolved: boolean;
+}
+
+export const MARKER_DEFAULTS = {
+    enabled: true,
+    line: { color: "#ffffff", width: 1.5, height: 200 },
+    icon: { width: 64, height: 64 },
+    text: {
+        fontSize: 14,
+        color: "#ffffff",
+        backgroundColor: "rgba(0,0,0,0.6)",
+        lineHeight: 1.2,
+    },
+    textMaxLength: 512,
+} as const;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -125,11 +125,11 @@ export type MapTypeChangeListener = (mapType: MapType) => void;
 export interface MarkerTextOptions {
     /** テキスト本体。"\n" で複数行。最大 512 chars（超過は console.warn のうえ truncate） */
     value: string;
-    /** フォントサイズ(px)。default 14 */
+    /** フォントサイズ(px)。default 18 */
     fontSize?: number;
-    /** CSS color。default "#ffffff" */
+    /** CSS color。default "#000000" */
     color?: string;
-    /** 背景色。default "rgba(0,0,0,0.6)"。"transparent" 可 */
+    /** 背景色。default "transparent"（透明）。CSS color を指定可 */
     backgroundColor?: string;
     /** 行高倍率。default 1.2 */
     lineHeight?: number;
@@ -138,18 +138,27 @@ export interface MarkerTextOptions {
 export interface MarkerIconOptions {
     /** 画像URL。`javascript:` / `vbscript:` 等は拒否 */
     url: string;
-    /** 表示幅(world meters)。default 64 */
+    /** 表示幅(world meters)。default 40 */
     width?: number;
-    /** 表示高(world meters)。default 64 */
+    /** 表示高(world meters)。default 40 */
     height?: number;
 }
 
 export interface MarkerLineOptions {
-    /** 線色 CSS。default "#ffffff" */
+    /**
+     * 線色 CSS。default "#000000"。
+     * Canvas `fillStyle` に直接代入されるため CSS で許容される表記
+     * （`#RRGGBB` / `rgb(...)` / `red` 等）が利用可能。
+     */
     color?: string;
-    /** 線幅(world meters)。default 1.5 */
+    /** 線幅(world meters)。default 4 */
     width?: number;
-    /** 線の長さ(地表からビルボード基点)。default 200 */
+    /**
+     * 線の長さ (m)。default 500。
+     * 実装はカメラ距離・仰角に応じた動的高さを優先採用するため、
+     * 通常はカメラ距離が解決できないテスト/フォールバック時の参考値となる
+     * （`spec/package.md §3.3.7` 参照）。
+     */
     height?: number;
 }
 

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -70,8 +70,19 @@ export interface MarkerContext {
         gridResidualX: number;
         gridResidualZ: number;
     };
-    /** 現在のカメラワールド位置。スクリーン空間サイズ一定のスケール計算で利用される */
-    getCameraPosition(): { x: number; y: number; z: number };
+    /**
+     * 現在のカメラ状態。
+     * - position: ワールド位置 (distScale 計算用)
+     * - radius / beta: ArcRotateCamera のレディアスと仰角。
+     *   マーカー高さをカメラ距離・仰角に応じて動的に決めるために使用される。
+     */
+    getCameraPosition(): {
+        x: number;
+        y: number;
+        z: number;
+        radius: number;
+        beta: number;
+    };
 }
 
 /**
@@ -1351,6 +1362,8 @@ export class DefaultScene implements CreateSceneClass {
                     x: camera.globalPosition.x,
                     y: camera.globalPosition.y,
                     z: camera.globalPosition.z,
+                    radius: camera.radius,
+                    beta: camera.beta,
                 }),
             }),
         };

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -70,6 +70,8 @@ export interface MarkerContext {
         gridResidualX: number;
         gridResidualZ: number;
     };
+    /** 現在のカメラワールド位置。スクリーン空間サイズ一定のスケール計算で利用される */
+    getCameraPosition(): { x: number; y: number; z: number };
 }
 
 /**
@@ -1344,6 +1346,11 @@ export class DefaultScene implements CreateSceneClass {
                     lon: currentLon,
                     gridResidualX,
                     gridResidualZ,
+                }),
+                getCameraPosition: () => ({
+                    x: camera.globalPosition.x,
+                    y: camera.globalPosition.y,
+                    z: camera.globalPosition.z,
                 }),
             }),
         };

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -48,7 +48,29 @@ const CAMERA_FAR_CLIP = 400000;
 const SKY_ZOOM_ALTITUDE_THRESHOLD = 1000;
 
 /** 1度の緯度あたりのメートル数（概算） */
-const METERS_PER_DEGREE_LAT = 111320;
+export const METERS_PER_DEGREE_LAT = 111320;
+
+/**
+ * MarkerManager 構築用の境界コンテキスト (Issue #167)。
+ *
+ * `JpmapTerrain` から `getMarkerContext()` で取得し、`createMarkerManager` に渡す。
+ * `DefaultScene` 内部のクロージャ（カメラ位置・grid 残差）を直接参照させず、
+ * 必要な値・関数のみを露出する。
+ */
+export interface MarkerContext {
+    scene: Scene;
+    tileManager: {
+        queryElevationAtWorld(wx: number, wz: number): number | null;
+        /** @returns 既存 onTerrainUpdated を chain で保持しつつ、追加 listener を register する unsubscribe 関数 */
+        subscribeTerrainUpdated(listener: () => void): () => void;
+    };
+    getOrigin(): {
+        lat: number;
+        lon: number;
+        gridResidualX: number;
+        gridResidualZ: number;
+    };
+}
 
 /**
  * `DefaultScene` 経由で外部からカメラ・位置を操作するためのコントローラ (T5 / Issue #119)。
@@ -143,6 +165,9 @@ export interface DefaultSceneController {
      * Scene/Engine の dispose は `JpmapTerrain` 側で行う（このメソッドはあくまで UI 限定）。
      */
     dispose(): void;
+
+    /** @internal MarkerManager 構築用コンテキスト (Issue #167) */
+    getMarkerContext(): MarkerContext;
 }
 
 /**
@@ -998,8 +1023,23 @@ export class DefaultScene implements CreateSceneClass {
         scene.onBeforeRenderObservable.add(clampCameraAboveTerrain);
 
         // メッシュ標高更新時にキャッシュを無効化して即座に再チェック
+        const terrainUpdatedListeners: Array<() => void> = [];
         tileManager.onTerrainUpdated = () => {
             prevAlpha = NaN; // terrainMinRadius のキャッシュを無効化
+            for (const fn of terrainUpdatedListeners.slice()) {
+                try {
+                    fn();
+                } catch (err) {
+                    console.warn("[jpmap-terrain] terrain listener failed:", err);
+                }
+            }
+        };
+        const subscribeTerrainUpdated = (listener: () => void): (() => void) => {
+            terrainUpdatedListeners.push(listener);
+            return () => {
+                const idx = terrainUpdatedListeners.indexOf(listener);
+                if (idx !== -1) terrainUpdatedListeners.splice(idx, 1);
+            };
         };
 
         // カメラ移動時の自動タイル更新
@@ -1292,6 +1332,20 @@ export class DefaultScene implements CreateSceneClass {
                     removeFromParent(ui.scaleBar.attribution);
                 }
             },
+            getMarkerContext: () => ({
+                scene,
+                tileManager: {
+                    queryElevationAtWorld: (wx, wz) =>
+                        tileManager.queryElevationAtWorld(wx, wz),
+                    subscribeTerrainUpdated,
+                },
+                getOrigin: () => ({
+                    lat: currentLat,
+                    lon: currentLon,
+                    gridResidualX,
+                    gridResidualZ,
+                }),
+            }),
         };
         options?.onReady?.(controller);
 

--- a/src/terrain/marker.ts
+++ b/src/terrain/marker.ts
@@ -108,62 +108,68 @@ const resolve = (options: MarkerOptions): ResolvedMarker => ({
 });
 
 interface LineMeshes {
-    outer: Mesh;
-    inner: Mesh;
-    outerMaterial: StandardMaterial;
-    innerMaterial: StandardMaterial;
+    mesh: Mesh;
+    material: StandardMaterial;
+    texture: DynamicTexture;
 }
 
 /**
- * 垂直線をビルボード平面 2 枚 (外側=白縁, 内側=黒コア) で表現する。
+ * 垂直線を 1 枚のビルボード平面 + DynamicTexture で表現する。
  *
- * - `BILLBOARDMODE_Y` により Y 軸回転のみで常にカメラへ正面を向ける。
- * - 高さは applyTransform 時に `dynamicLineHeight` を Y スケールへ流し込む。
- * - 幅は `line.width` をベースとし、X スケールでカメラ距離一定 (distScale) を反映する。
- * - 縁取り幅は内側幅の 50% を片側に確保し、上端も同量だけ延ばして額縁状にする。
+ * - DT に「白い背景に黒コアのインセット矩形」を描き、平面を outerW × outerH に伸ばす。
+ *   結果として常に「黒バー + 白縁取り」になり、別メッシュ重ねによる z-fight が発生しない。
+ * - 縁取りの太さは plane のスケール比例で決まる（applyTransform 側で
+ *   `outerW = innerW + 2*border`、`outerH = lineHeight + border` に設定する）。
  */
 const createLineMesh = (
     scene: Scene,
     id: string,
     line: Required<MarkerLineOptions>,
 ): LineMeshes => {
-    const inner = CreatePlane(
-        `marker-line-inner-${id}`,
+    // 64x64 で十分。NEAREST サンプリングで境界がにじまない。
+    const TEX_W = 64;
+    const TEX_H = 64;
+    const texture = new DynamicTexture(
+        `marker-line-${id}`,
+        { width: TEX_W, height: TEX_H },
+        scene,
+        false,
+    );
+    texture.hasAlpha = true;
+    texture.updateSamplingMode(1); // NEAREST_NEAREST = 1
+    texture.wrapU = 0; // CLAMP_ADDRESSMODE = 0
+    texture.wrapV = 0;
+    const ctx = texture.getContext() as unknown as CanvasRenderingContext2D;
+    ctx.clearRect(0, 0, TEX_W, TEX_H);
+    // 全体を白で塗り、内側を黒（line.color）で塗り潰すことで縁取りを表現。
+    // 横は 25/50/25、縦は plane のアス比で延びるので 25/75 比率で代表しておく
+    // （上端の白縁取りが border 分、底辺は 0）。
+    ctx.fillStyle = "#ffffff";
+    ctx.fillRect(0, 0, TEX_W, TEX_H);
+    ctx.fillStyle = Color3.FromHexString(line.color).toHexString();
+    const xL = Math.floor(TEX_W * 0.25);
+    const xR = Math.ceil(TEX_W * 0.75);
+    const yT = Math.floor(TEX_H * 0.25);
+    ctx.fillRect(xL, yT, xR - xL, TEX_H - yT);
+    texture.update(false);
+
+    const mesh = CreatePlane(
+        `marker-line-${id}`,
         { width: 1, height: 1 },
         scene,
     );
-    inner.billboardMode = AbstractMesh.BILLBOARDMODE_Y;
-    inner.renderingGroupId = RENDERING_GROUP_ID;
-    inner.isPickable = false;
-    const innerMaterial = new StandardMaterial(
-        `marker-line-inner-mat-${id}`,
-        scene,
-    );
-    innerMaterial.emissiveColor = Color3.FromHexString(line.color);
-    innerMaterial.disableLighting = true;
-    innerMaterial.backFaceCulling = false;
-    // 内側を縁取りより手前へ寄せて Z-fight を回避する。
-    innerMaterial.zOffset = -1;
-    inner.material = innerMaterial;
+    mesh.billboardMode = AbstractMesh.BILLBOARDMODE_Y;
+    mesh.renderingGroupId = RENDERING_GROUP_ID;
+    mesh.isPickable = false;
+    const material = new StandardMaterial(`marker-line-mat-${id}`, scene);
+    material.disableLighting = true;
+    material.backFaceCulling = false;
+    material.useAlphaFromDiffuseTexture = true;
+    material.emissiveColor = Color3.White();
+    material.diffuseTexture = texture;
+    mesh.material = material;
 
-    const outer = CreatePlane(
-        `marker-line-outer-${id}`,
-        { width: 1, height: 1 },
-        scene,
-    );
-    outer.billboardMode = AbstractMesh.BILLBOARDMODE_Y;
-    outer.renderingGroupId = RENDERING_GROUP_ID;
-    outer.isPickable = false;
-    const outerMaterial = new StandardMaterial(
-        `marker-line-outer-mat-${id}`,
-        scene,
-    );
-    outerMaterial.emissiveColor = Color3.White();
-    outerMaterial.disableLighting = true;
-    outerMaterial.backFaceCulling = false;
-    outer.material = outerMaterial;
-
-    return { outer, inner, outerMaterial, innerMaterial };
+    return { mesh, material, texture };
 };
 
 interface IconTextMeshes {
@@ -207,6 +213,8 @@ const createIconTextMesh = (
     let strokePx = 0;
     let textWidthPx = 0;
     let textHeightPx = 0;
+    // テキスト下端の内側パディング: アイコンが存在する場合は半分にしてアイコンを近づける。
+    let textBottomPadPx = 0;
     if (text) {
         lines = text.value.split("\n");
         const lineCount = Math.max(lines.length, 1);
@@ -229,8 +237,10 @@ const createIconTextMesh = (
         lineHeightPx = text.fontSize * text.lineHeight;
         const totalTextHeightPx = lineHeightPx * lineCount;
         const innerPad = padPx + strokePx;
+        // アイコンが下に並ぶ場合は底側パディングを半分に詰めて寄せる。
+        textBottomPadPx = icon ? innerPad * 0.5 : innerPad;
         textWidthPx = Math.ceil((maxLineWidth + innerPad * 2) * dpr);
-        textHeightPx = Math.ceil((totalTextHeightPx + innerPad * 2) * dpr);
+        textHeightPx = Math.ceil((totalTextHeightPx + innerPad + textBottomPadPx) * dpr);
     }
 
     // アイコン領域サイズ (px)。icon.width/height は world m なので dpr 換算で px にする。
@@ -396,8 +406,7 @@ export const createMarkerNode = (
 
     const applyVisibility = (): void => {
         const visible = logicalEnabled && elevationResolved;
-        lineMeshes.outer.setEnabled(visible);
-        lineMeshes.inner.setEnabled(visible);
+        lineMeshes.mesh.setEnabled(visible);
         iconTextMeshes?.mesh.setEnabled(visible);
     };
     applyVisibility();
@@ -421,12 +430,9 @@ export const createMarkerNode = (
         const outerW = innerW + border * 2;
         const outerH = lineHeight + border;
 
-        // 内側 (黒コア): 平面 1×1 を innerW × lineHeight にスケールし、底辺を地表に合わせる。
-        lineMeshes.inner.scaling.set(innerW, lineHeight, 1);
-        lineMeshes.inner.position.set(wx, elev + lineHeight / 2, wz);
-        // 外側 (白縁): innerW + 2*border 幅、上端を border 分だけ高くした位置に置く。
-        lineMeshes.outer.scaling.set(outerW, outerH, 1);
-        lineMeshes.outer.position.set(wx, elev + outerH / 2, wz);
+        // 1 枚プレーン: outerW × outerH に伸ばし、底辺を地表に合わせる。
+        lineMeshes.mesh.scaling.set(outerW, outerH, 1);
+        lineMeshes.mesh.position.set(wx, elev + outerH / 2, wz);
 
         // アイコン+テキストの合成プレーン:
         // - 線の先端 (lineTopY) をアイコン中心に合わせる。
@@ -450,10 +456,9 @@ export const createMarkerNode = (
         iconTextMeshes = null;
     };
     const disposeLine = (): void => {
-        lineMeshes.outerMaterial.dispose();
-        lineMeshes.innerMaterial.dispose();
-        lineMeshes.outer.dispose();
-        lineMeshes.inner.dispose();
+        lineMeshes.material.dispose();
+        lineMeshes.texture.dispose();
+        lineMeshes.mesh.dispose();
     };
 
     return {

--- a/src/terrain/marker.ts
+++ b/src/terrain/marker.ts
@@ -277,6 +277,11 @@ const createIconTextMesh = (
 
     // 上半分にテキストを描く
     if (text) {
+        // 1) backgroundColor が "transparent" 以外なら、テキスト領域の背景を塗る。
+        if (text.backgroundColor && text.backgroundColor !== "transparent") {
+            ctx2d.fillStyle = text.backgroundColor;
+            ctx2d.fillRect(0, 0, dtWidth, textHeightPx);
+        }
         ctx2d.font = `${text.fontSize * dpr}px sans-serif`;
         ctx2d.textBaseline = "top";
         ctx2d.textAlign = "center";
@@ -285,7 +290,7 @@ const createIconTextMesh = (
         const innerPad = padPx + strokePx;
         const startY = innerPad * dpr;
         const centerX = dtWidth / 2;
-        // 1) 白の縁取り → 2) 黒の本体
+        // 2) 白の縁取り → 3) テキスト本体
         ctx2d.lineWidth = strokePx * 2 * dpr;
         ctx2d.strokeStyle = "#ffffff";
         for (let i = 0; i < lines.length; i++) {

--- a/src/terrain/marker.ts
+++ b/src/terrain/marker.ts
@@ -1,0 +1,444 @@
+/**
+ * 個別マーカーノード (Issue #167)。
+ *
+ * 地表からの線 (Tube)・アイコン Plane・テキスト Plane の組み合わせで
+ * 1 マーカーを表現する。`MarkerManager` から生成・更新・破棄される。
+ */
+
+import type { Scene } from "@babylonjs/core/scene";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { Color3 } from "@babylonjs/core/Maths/math.color";
+import { CreateTube } from "@babylonjs/core/Meshes/Builders/tubeBuilder";
+import { CreatePlane } from "@babylonjs/core/Meshes/Builders/planeBuilder";
+import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
+import { Texture } from "@babylonjs/core/Materials/Textures/texture";
+import { DynamicTexture } from "@babylonjs/core/Materials/Textures/dynamicTexture";
+import type { Mesh } from "@babylonjs/core/Meshes/mesh";
+import { AbstractMesh } from "@babylonjs/core/Meshes/abstractMesh";
+
+import {
+    MARKER_DEFAULTS,
+    type MarkerHandle,
+    type MarkerIconOptions,
+    type MarkerLineOptions,
+    type MarkerOptions,
+    type MarkerTextOptions,
+    type MarkerUpdate,
+} from "../lib/types";
+
+const ICON_TEXT_GAP_M = 4;
+const RENDERING_GROUP_ID = 1;
+const MAX_DT_SIZE = 1024;
+const TEXT_WORLD_PX_PER_M = 16;
+
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:", "data:"]);
+
+/**
+ * `icon.url` を検証する。`javascript:` / `vbscript:` 等の危険スキームを拒否する。
+ *
+ * - 空文字: 例外
+ * - `scheme:` を含まない（相対パス・絶対パス）: そのまま許可
+ * - `scheme:` を含む: `http(s)` / `data:image/*` のみ許可
+ */
+export const validateIconUrl = (url: string): void => {
+    const trimmed = url.trim();
+    if (!trimmed) throw new Error("addMarker: icon.url is empty");
+    if (!/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return;
+    let parsed: URL;
+    try {
+        parsed = new URL(trimmed);
+    } catch {
+        throw new Error(
+            `addMarker: icon.url is invalid: ${trimmed.slice(0, 64)}`,
+        );
+    }
+    if (!ALLOWED_PROTOCOLS.has(parsed.protocol)) {
+        throw new Error(
+            `addMarker: icon.url has disallowed scheme: ${parsed.protocol}`,
+        );
+    }
+    if (parsed.protocol === "data:" && !/^data:image\//i.test(trimmed)) {
+        throw new Error("addMarker: data URL must be image/*");
+    }
+};
+
+const ceilPow2 = (n: number): number => {
+    if (n <= 1) return 1;
+    return 2 ** Math.ceil(Math.log2(n));
+};
+
+interface ResolvedMarker {
+    enabled: boolean;
+    line: Required<MarkerLineOptions>;
+    icon: Required<MarkerIconOptions> | null;
+    text: Required<MarkerTextOptions> | null;
+}
+
+const resolveLine = (line: MarkerLineOptions | undefined): Required<MarkerLineOptions> => ({
+    color: line?.color ?? MARKER_DEFAULTS.line.color,
+    width: line?.width ?? MARKER_DEFAULTS.line.width,
+    height: line?.height ?? MARKER_DEFAULTS.line.height,
+});
+
+const resolveIcon = (
+    icon: MarkerIconOptions | undefined,
+): Required<MarkerIconOptions> | null => {
+    if (!icon) return null;
+    return {
+        url: icon.url,
+        width: icon.width ?? MARKER_DEFAULTS.icon.width,
+        height: icon.height ?? MARKER_DEFAULTS.icon.height,
+    };
+};
+
+const resolveText = (
+    text: MarkerTextOptions | undefined,
+): Required<MarkerTextOptions> | null => {
+    if (!text) return null;
+    let value = text.value;
+    if (value.length > MARKER_DEFAULTS.textMaxLength) {
+        console.warn(
+            `[jpmap-terrain] marker text exceeds ${MARKER_DEFAULTS.textMaxLength} chars; truncating`,
+        );
+        value = value.slice(0, MARKER_DEFAULTS.textMaxLength);
+    }
+    return {
+        value,
+        fontSize: text.fontSize ?? MARKER_DEFAULTS.text.fontSize,
+        color: text.color ?? MARKER_DEFAULTS.text.color,
+        backgroundColor:
+            text.backgroundColor ?? MARKER_DEFAULTS.text.backgroundColor,
+        lineHeight: text.lineHeight ?? MARKER_DEFAULTS.text.lineHeight,
+    };
+};
+
+const resolve = (options: MarkerOptions): ResolvedMarker => ({
+    enabled: options.enabled ?? MARKER_DEFAULTS.enabled,
+    line: resolveLine(options.line),
+    icon: resolveIcon(options.icon),
+    text: resolveText(options.text),
+});
+
+interface LineMeshes {
+    mesh: Mesh;
+    material: StandardMaterial;
+}
+
+const createLineMesh = (
+    scene: Scene,
+    id: string,
+    line: Required<MarkerLineOptions>,
+): LineMeshes => {
+    const mesh = CreateTube(
+        `marker-line-${id}`,
+        {
+            path: [Vector3.Zero(), new Vector3(0, line.height, 0)],
+            radius: Math.max(line.width / 2, 0.01),
+            tessellation: 8,
+            updatable: false,
+        },
+        scene,
+    );
+    const material = new StandardMaterial(`marker-line-mat-${id}`, scene);
+    material.emissiveColor = Color3.FromHexString(line.color);
+    material.disableLighting = true;
+    mesh.material = material;
+    mesh.renderingGroupId = RENDERING_GROUP_ID;
+    mesh.isPickable = false;
+    return { mesh, material };
+};
+
+interface IconMeshes {
+    mesh: Mesh;
+    material: StandardMaterial;
+    texture: Texture;
+    widthWorld: number;
+    heightWorld: number;
+}
+
+const createIconMesh = (
+    scene: Scene,
+    id: string,
+    icon: Required<MarkerIconOptions>,
+): IconMeshes => {
+    const mesh = CreatePlane(
+        `marker-icon-${id}`,
+        { width: icon.width, height: icon.height },
+        scene,
+    );
+    mesh.billboardMode = AbstractMesh.BILLBOARDMODE_ALL;
+    mesh.renderingGroupId = RENDERING_GROUP_ID;
+    mesh.isPickable = false;
+    const material = new StandardMaterial(`marker-icon-mat-${id}`, scene);
+    material.emissiveColor = Color3.White();
+    material.disableLighting = true;
+    material.useAlphaFromDiffuseTexture = true;
+    const texture = new Texture(icon.url, scene);
+    texture.hasAlpha = true;
+    material.diffuseTexture = texture;
+    mesh.material = material;
+    return {
+        mesh,
+        material,
+        texture,
+        widthWorld: icon.width,
+        heightWorld: icon.height,
+    };
+};
+
+interface TextMeshes {
+    mesh: Mesh;
+    material: StandardMaterial;
+    texture: DynamicTexture;
+    widthWorld: number;
+    heightWorld: number;
+}
+
+const createTextMesh = (
+    scene: Scene,
+    id: string,
+    text: Required<MarkerTextOptions>,
+): TextMeshes => {
+    const lines = text.value.split("\n");
+    const lineCount = Math.max(lines.length, 1);
+    const dpr =
+        typeof globalThis !== "undefined" &&
+        typeof (globalThis as { devicePixelRatio?: number }).devicePixelRatio ===
+            "number"
+            ? Math.max((globalThis as { devicePixelRatio: number }).devicePixelRatio, 1)
+            : 1;
+    const padPx = Math.round(text.fontSize * 0.4);
+    // 暫定 DT を作って measureText で各行の最大幅を計測する
+    const probe = new DynamicTexture(
+        `marker-text-probe-${id}`,
+        { width: 16, height: 16 },
+        scene,
+        false,
+    );
+    const probeCtx = probe.getContext();
+    const fontStr = `${text.fontSize}px sans-serif`;
+    probeCtx.font = fontStr;
+    let maxLineWidth = 0;
+    for (const ln of lines) {
+        const m = probeCtx.measureText(ln === "" ? " " : ln);
+        if (m.width > maxLineWidth) maxLineWidth = m.width;
+    }
+    probe.dispose();
+    const lineHeightPx = text.fontSize * text.lineHeight;
+    const totalTextHeightPx = lineHeightPx * lineCount;
+    const dtWidth = Math.min(
+        MAX_DT_SIZE,
+        ceilPow2(Math.max(1, Math.ceil((maxLineWidth + padPx * 2) * dpr))),
+    );
+    const dtHeight = Math.min(
+        MAX_DT_SIZE,
+        ceilPow2(
+            Math.max(1, Math.ceil((totalTextHeightPx + padPx * 2) * dpr)),
+        ),
+    );
+    const texture = new DynamicTexture(
+        `marker-text-${id}`,
+        { width: dtWidth, height: dtHeight },
+        scene,
+        false,
+    );
+    texture.hasAlpha = true;
+    const ctx = texture.getContext();
+    ctx.clearRect(0, 0, dtWidth, dtHeight);
+    if (text.backgroundColor !== "transparent") {
+        ctx.fillStyle = text.backgroundColor;
+        ctx.fillRect(0, 0, dtWidth, dtHeight);
+    }
+    ctx.font = `${text.fontSize * dpr}px sans-serif`;
+    ctx.fillStyle = text.color;
+    // `ICanvasRenderingContext` に textBaseline が無い（Babylon の最小型定義）ため、
+    // 実体は CanvasRenderingContext2D 互換。安全に as 経由でフィールドを設定する。
+    (ctx as unknown as { textBaseline: CanvasTextBaseline }).textBaseline =
+        "top";
+    for (let i = 0; i < lines.length; i++) {
+        ctx.fillText(
+            lines[i],
+            padPx * dpr,
+            (padPx + i * lineHeightPx) * dpr,
+        );
+    }
+    texture.update(false);
+
+    const widthWorld = (maxLineWidth + padPx * 2) / TEXT_WORLD_PX_PER_M;
+    const heightWorld =
+        (totalTextHeightPx + padPx * 2) / TEXT_WORLD_PX_PER_M;
+    const mesh = CreatePlane(
+        `marker-text-${id}`,
+        { width: widthWorld, height: heightWorld },
+        scene,
+    );
+    mesh.billboardMode = AbstractMesh.BILLBOARDMODE_ALL;
+    mesh.renderingGroupId = RENDERING_GROUP_ID;
+    mesh.isPickable = false;
+    const material = new StandardMaterial(`marker-text-mat-${id}`, scene);
+    material.emissiveColor = Color3.White();
+    material.disableLighting = true;
+    material.useAlphaFromDiffuseTexture = true;
+    material.diffuseTexture = texture;
+    mesh.material = material;
+    return { mesh, material, texture, widthWorld, heightWorld };
+};
+
+export interface MarkerNode {
+    readonly id: string;
+    readonly lat: number;
+    readonly lon: number;
+    applyTransform(wx: number, elev: number, wz: number): void;
+    setEnabledLogical(enabled: boolean): void;
+    setElevationResolved(resolved: boolean): void;
+    update(partial: MarkerUpdate, newLat: number, newLon: number): void;
+    getHandle(): MarkerHandle;
+    dispose(): void;
+}
+
+export interface CreateMarkerNodeDeps {
+    /** 親 manager に lat/lon が変更されたことを通知する（manager 側の Map 整合用ではなく将来拡張） */
+    readonly _placeholder?: never;
+}
+
+export const createMarkerNode = (
+    scene: Scene,
+    id: string,
+    options: MarkerOptions,
+): MarkerNode => {
+    if (!options.icon && !options.text) {
+        throw new Error(
+            `addMarker: at least one of icon/text is required (id="${id}")`,
+        );
+    }
+    if (options.icon) validateIconUrl(options.icon.url);
+
+    let resolved = resolve(options);
+    let lat = options.lat;
+    let lon = options.lon;
+    let logicalEnabled = resolved.enabled;
+    let elevationResolved = false;
+
+    let lineMeshes: LineMeshes = createLineMesh(scene, id, resolved.line);
+    let iconMeshes: IconMeshes | null = resolved.icon
+        ? createIconMesh(scene, id, resolved.icon)
+        : null;
+    let textMeshes: TextMeshes | null = resolved.text
+        ? createTextMesh(scene, id, resolved.text)
+        : null;
+
+    const applyVisibility = (): void => {
+        const visible = logicalEnabled && elevationResolved;
+        lineMeshes.mesh.setEnabled(visible);
+        iconMeshes?.mesh.setEnabled(visible);
+        textMeshes?.mesh.setEnabled(visible);
+    };
+    applyVisibility();
+
+    const applyTransform = (wx: number, elev: number, wz: number): void => {
+        lineMeshes.mesh.position.set(wx, elev, wz);
+        const baseY = elev + resolved.line.height;
+        const iconH = iconMeshes?.heightWorld ?? 0;
+        const textH = textMeshes?.heightWorld ?? 0;
+        if (iconMeshes && textMeshes) {
+            iconMeshes.mesh.position.set(wx, baseY + iconH / 2, wz);
+            textMeshes.mesh.position.set(
+                wx,
+                baseY + iconH + ICON_TEXT_GAP_M + textH / 2,
+                wz,
+            );
+        } else if (iconMeshes) {
+            iconMeshes.mesh.position.set(wx, baseY + iconH / 2, wz);
+        } else if (textMeshes) {
+            textMeshes.mesh.position.set(wx, baseY + textH / 2, wz);
+        }
+    };
+
+    const disposeIcon = (): void => {
+        if (!iconMeshes) return;
+        iconMeshes.texture.dispose();
+        iconMeshes.material.dispose();
+        iconMeshes.mesh.dispose();
+        iconMeshes = null;
+    };
+    const disposeText = (): void => {
+        if (!textMeshes) return;
+        textMeshes.texture.dispose();
+        textMeshes.material.dispose();
+        textMeshes.mesh.dispose();
+        textMeshes = null;
+    };
+    const disposeLine = (): void => {
+        lineMeshes.material.dispose();
+        lineMeshes.mesh.dispose();
+    };
+
+    return {
+        id,
+        get lat() {
+            return lat;
+        },
+        get lon() {
+            return lon;
+        },
+        applyTransform,
+        setEnabledLogical(enabled: boolean): void {
+            logicalEnabled = enabled;
+            applyVisibility();
+        },
+        setElevationResolved(r: boolean): void {
+            elevationResolved = r;
+            applyVisibility();
+        },
+        update(partial: MarkerUpdate, newLat: number, newLon: number): void {
+            lat = newLat;
+            lon = newLon;
+            if (partial.icon !== undefined) validateIconUrl(partial.icon.url);
+            // line 差分 → 再生成
+            if (partial.line !== undefined) {
+                resolved = {
+                    ...resolved,
+                    line: resolveLine(partial.line),
+                };
+                disposeLine();
+                lineMeshes = createLineMesh(scene, id, resolved.line);
+            }
+            if (partial.icon !== undefined) {
+                resolved = { ...resolved, icon: resolveIcon(partial.icon) };
+                disposeIcon();
+                if (resolved.icon) {
+                    iconMeshes = createIconMesh(scene, id, resolved.icon);
+                }
+            }
+            if (partial.text !== undefined) {
+                resolved = { ...resolved, text: resolveText(partial.text) };
+                disposeText();
+                if (resolved.text) {
+                    textMeshes = createTextMesh(scene, id, resolved.text);
+                }
+            }
+            if (partial.enabled !== undefined) {
+                logicalEnabled = partial.enabled;
+                resolved = { ...resolved, enabled: partial.enabled };
+            }
+            applyVisibility();
+        },
+        getHandle(): MarkerHandle {
+            return {
+                id,
+                lat,
+                lon,
+                enabled: logicalEnabled,
+                icon: resolved.icon,
+                text: resolved.text,
+                line: resolved.line,
+                elevationResolved,
+            };
+        },
+        dispose(): void {
+            disposeIcon();
+            disposeText();
+            disposeLine();
+        },
+    };
+};

--- a/src/terrain/marker.ts
+++ b/src/terrain/marker.ts
@@ -116,10 +116,10 @@ interface LineMeshes {
 /**
  * 垂直線を 1 枚のビルボード平面 + DynamicTexture で表現する。
  *
- * - DT に「白い背景に黒コアのインセット矩形」を描き、平面を outerW × outerH に伸ばす。
- *   結果として常に「黒バー + 白縁取り」になり、別メッシュ重ねによる z-fight が発生しない。
+ * - DT に「左右だけ白縁・中央は黒コア」を描き、平面を outerW × lineHeight に伸ばす。
+ *   結果として常に「黒バー + 左右の白縁」になり、別メッシュ重ねによる z-fight が発生しない。
  * - 縁取りの太さは plane のスケール比例で決まる（applyTransform 側で
- *   `outerW = innerW + 2*border`、`outerH = lineHeight + border` に設定する）。
+ *   `outerW = innerW + 2*border` に設定する。上下方向には白縁を持たない）。
  */
 const createLineMesh = (
     scene: Scene,
@@ -141,16 +141,14 @@ const createLineMesh = (
     texture.wrapV = 0;
     const ctx = texture.getContext() as unknown as CanvasRenderingContext2D;
     ctx.clearRect(0, 0, TEX_W, TEX_H);
-    // 全体を白で塗り、内側を黒（line.color）で塗り潰すことで縁取りを表現。
-    // 横は 25/50/25、縦は plane のアス比で延びるので 25/75 比率で代表しておく
-    // （上端の白縁取りが border 分、底辺は 0）。
+    // 左右だけに白縁を残し、上下方向は黒（line.color）が端まで届くようにする。
+    // 横の比率は 25/50/25（左白・中央黒・右白）、縦は全域を黒で塗りつぶす。
     ctx.fillStyle = "#ffffff";
     ctx.fillRect(0, 0, TEX_W, TEX_H);
     ctx.fillStyle = Color3.FromHexString(line.color).toHexString();
     const xL = Math.floor(TEX_W * 0.25);
     const xR = Math.ceil(TEX_W * 0.75);
-    const yT = Math.floor(TEX_H * 0.25);
-    ctx.fillRect(xL, yT, xR - xL, TEX_H - yT);
+    ctx.fillRect(xL, 0, xR - xL, TEX_H);
     texture.update(false);
 
     const mesh = CreatePlane(
@@ -425,14 +423,13 @@ export const createMarkerNode = (
                 : resolved.line.height * distScale;
         // 線の幅は distScale でスクリーン定幅に保つ。
         const innerW = Math.max(resolved.line.width, 0.5) * distScale;
-        // 縁取り幅 (片側) = 内側幅の 50%。上端も同量だけ延ばして額縁状にする。
+        // 縁取り幅 (片側) = 内側幅の 50%。左右だけに白縁を持たせる（上下は地表/アイコンに突き当たるので不要）。
         const border = innerW * 0.5;
         const outerW = innerW + border * 2;
-        const outerH = lineHeight + border;
 
-        // 1 枚プレーン: outerW × outerH に伸ばし、底辺を地表に合わせる。
-        lineMeshes.mesh.scaling.set(outerW, outerH, 1);
-        lineMeshes.mesh.position.set(wx, elev + outerH / 2, wz);
+        // 1 枚プレーン: outerW × lineHeight に伸ばし、底辺を地表に合わせる。
+        lineMeshes.mesh.scaling.set(outerW, lineHeight, 1);
+        lineMeshes.mesh.position.set(wx, elev + lineHeight / 2, wz);
 
         // アイコン+テキストの合成プレーン:
         // - 線の先端 (lineTopY) をアイコン中心に合わせる。

--- a/src/terrain/marker.ts
+++ b/src/terrain/marker.ts
@@ -197,28 +197,36 @@ const createIconMesh = (
     mesh.renderingGroupId = RENDERING_GROUP_ID;
     mesh.isPickable = false;
     const material = new StandardMaterial(`marker-icon-mat-${id}`, scene);
-    material.emissiveColor = Color3.White();
     material.disableLighting = true;
-    material.useAlphaFromDiffuseTexture = true;
-    // テクスチャ読み込みの診断をしやすいよう onError でログを出す。
-    // その他パラメータ: noMipmap=true / invertY=false で SVG データ URL との互換性を上げる。
+    material.backFaceCulling = false;
+    // 初期は白フォールバック。テクスチャ読み込み完了で emissiveTexture / opacityTexture を割り当てる。
+    // disableLighting=true のため diffuseColor は反映されない点に注意（emissiveColor のみ寄与）。
+    material.emissiveColor = Color3.White();
+    // SVG / data URL 互換のため noMipmap=true / invertY=false。
     const texture = new Texture(
         icon.url,
         scene,
         true, // noMipmap
         false, // invertY (SVG / data URL は上下反転しない)
         Texture.TRILINEAR_SAMPLINGMODE,
-        null,
+        () => {
+            // ロード成功時に割り当てる。emissiveTexture でフルブライト表示し、
+            // opacityTexture に同じテクスチャを割り当てて SVG の透明領域を抜く。
+            texture.hasAlpha = true;
+            material.emissiveTexture = texture;
+            material.opacityTexture = texture;
+        },
         (msg, ex) => {
             console.warn(
                 `[jpmap-terrain] marker icon texture load failed: id=${id}`,
                 msg,
                 ex,
             );
+            // ロード失敗時は赤いフォールバックでジオメトリ位置を可視化する。
+            material.emissiveColor = new Color3(1, 0, 0);
         },
     );
     texture.hasAlpha = true;
-    material.diffuseTexture = texture;
     mesh.material = material;
     return {
         mesh,

--- a/src/terrain/marker.ts
+++ b/src/terrain/marker.ts
@@ -141,11 +141,13 @@ const createLineMesh = (
     texture.wrapV = 0;
     const ctx = texture.getContext() as unknown as CanvasRenderingContext2D;
     ctx.clearRect(0, 0, TEX_W, TEX_H);
-    // 左右だけに白縁を残し、上下方向は黒（line.color）が端まで届くようにする。
-    // 横の比率は 25/50/25（左白・中央黒・右白）、縦は全域を黒で塗りつぶす。
+    // 左右だけに白縁を残し、上下方向は line.color が端まで届くようにする。
+    // 横の比率は 25/50/25（左白・中央色・右白）、縦は全域を塗りつぶす。
+    // line.color は CSS で許容される表記（"#RRGGBB" / "rgb(...)" / "red" 等）を
+    // そのまま fillStyle に代入できる。
     ctx.fillStyle = "#ffffff";
     ctx.fillRect(0, 0, TEX_W, TEX_H);
-    ctx.fillStyle = Color3.FromHexString(line.color).toHexString();
+    ctx.fillStyle = line.color;
     const xL = Math.floor(TEX_W * 0.25);
     const xR = Math.ceil(TEX_W * 0.75);
     ctx.fillRect(xL, 0, xR - xL, TEX_H);

--- a/src/terrain/marker.ts
+++ b/src/terrain/marker.ts
@@ -35,9 +35,7 @@ const MAX_DT_SIZE = 1024;
  */
 const TEXT_WORLD_PX_PER_M = 1;
 
-const ALLOWED_PROTOCOLS = new Set(["http:", "https:", "data:"]);
-
-/**
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:", "data:"]);/**
  * `icon.url` を検証する。`javascript:` / `vbscript:` 等の危険スキームを拒否する。
  *
  * - 空文字: 例外
@@ -64,11 +62,6 @@ export const validateIconUrl = (url: string): void => {
     if (parsed.protocol === "data:" && !/^data:image\//i.test(trimmed)) {
         throw new Error("addMarker: data URL must be image/*");
     }
-};
-
-const ceilPow2 = (n: number): number => {
-    if (n <= 1) return 1;
-    return 2 ** Math.ceil(Math.log2(n));
 };
 
 interface ResolvedMarker {
@@ -264,15 +257,15 @@ const createTextMesh = (
     const totalTextHeightPx = lineHeightPx * lineCount;
     // 縁取り分も収まるよう余白に加算する。
     const innerPad = padPx + strokePx;
+    // テクスチャサイズは実サイズと一致させる（pow2 パディングをやめてプレーンとキャンバスの
+    // アスペクトを揃えることで、マーカー間で文字サイズ・縦横比を一定に保つ）。
     const dtWidth = Math.min(
         MAX_DT_SIZE,
-        ceilPow2(Math.max(1, Math.ceil((maxLineWidth + innerPad * 2) * dpr))),
+        Math.max(1, Math.ceil((maxLineWidth + innerPad * 2) * dpr)),
     );
     const dtHeight = Math.min(
         MAX_DT_SIZE,
-        ceilPow2(
-            Math.max(1, Math.ceil((totalTextHeightPx + innerPad * 2) * dpr)),
-        ),
+        Math.max(1, Math.ceil((totalTextHeightPx + innerPad * 2) * dpr)),
     );
     const texture = new DynamicTexture(
         `marker-text-${id}`,
@@ -307,9 +300,10 @@ const createTextMesh = (
     }
     texture.update(false);
 
-    const widthWorld = (maxLineWidth + innerPad * 2) / TEXT_WORLD_PX_PER_M;
-    const heightWorld =
-        (totalTextHeightPx + innerPad * 2) / TEXT_WORLD_PX_PER_M;
+    // プレーンサイズ = キャンバスサイズ / dpr。テクスチャとプレーンのアスペクト・サイズが一致し、
+    // distScale 適用後もスクリーン上の文字サイズがマーカー間で同一になる。
+    const widthWorld = dtWidth / dpr / TEXT_WORLD_PX_PER_M;
+    const heightWorld = dtHeight / dpr / TEXT_WORLD_PX_PER_M;
     const mesh = CreatePlane(
         `marker-text-${id}`,
         { width: widthWorld, height: heightWorld },

--- a/src/terrain/marker.ts
+++ b/src/terrain/marker.ts
@@ -200,7 +200,23 @@ const createIconMesh = (
     material.emissiveColor = Color3.White();
     material.disableLighting = true;
     material.useAlphaFromDiffuseTexture = true;
-    const texture = new Texture(icon.url, scene);
+    // テクスチャ読み込みの診断をしやすいよう onError でログを出す。
+    // その他パラメータ: noMipmap=true / invertY=false で SVG データ URL との互換性を上げる。
+    const texture = new Texture(
+        icon.url,
+        scene,
+        true, // noMipmap
+        false, // invertY (SVG / data URL は上下反転しない)
+        Texture.TRILINEAR_SAMPLINGMODE,
+        null,
+        (msg, ex) => {
+            console.warn(
+                `[jpmap-terrain] marker icon texture load failed: id=${id}`,
+                msg,
+                ex,
+            );
+        },
+    );
     texture.hasAlpha = true;
     material.diffuseTexture = texture;
     mesh.material = material;

--- a/src/terrain/marker.ts
+++ b/src/terrain/marker.ts
@@ -199,23 +199,17 @@ const createIconMesh = (
     const material = new StandardMaterial(`marker-icon-mat-${id}`, scene);
     material.disableLighting = true;
     material.backFaceCulling = false;
-    // 初期は白フォールバック。テクスチャ読み込み完了で emissiveTexture / opacityTexture を割り当てる。
-    // disableLighting=true のため diffuseColor は反映されない点に注意（emissiveColor のみ寄与）。
-    material.emissiveColor = Color3.White();
-    // SVG / data URL 互換のため noMipmap=true / invertY=false。
+    // disableLighting=true により diffuseTexture はそのまま画面に出る（lighting 計算スキップ）。
+    // useAlphaFromDiffuseTexture により SVG の alpha チャンネルで形状を切り抜く。
+    material.useAlphaFromDiffuseTexture = true;
+    material.emissiveColor = Color3.Black();
     const texture = new Texture(
         icon.url,
         scene,
         true, // noMipmap
         false, // invertY (SVG / data URL は上下反転しない)
         Texture.TRILINEAR_SAMPLINGMODE,
-        () => {
-            // ロード成功時に割り当てる。emissiveTexture でフルブライト表示し、
-            // opacityTexture に同じテクスチャを割り当てて SVG の透明領域を抜く。
-            texture.hasAlpha = true;
-            material.emissiveTexture = texture;
-            material.opacityTexture = texture;
-        },
+        undefined,
         (msg, ex) => {
             console.warn(
                 `[jpmap-terrain] marker icon texture load failed: id=${id}`,
@@ -224,9 +218,11 @@ const createIconMesh = (
             );
             // ロード失敗時は赤いフォールバックでジオメトリ位置を可視化する。
             material.emissiveColor = new Color3(1, 0, 0);
+            material.diffuseTexture = null;
         },
     );
     texture.hasAlpha = true;
+    material.diffuseTexture = texture;
     mesh.material = material;
     return {
         mesh,

--- a/src/terrain/marker.ts
+++ b/src/terrain/marker.ts
@@ -6,9 +6,7 @@
  */
 
 import type { Scene } from "@babylonjs/core/scene";
-import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { Color3 } from "@babylonjs/core/Maths/math.color";
-import { CreateTube } from "@babylonjs/core/Meshes/Builders/tubeBuilder";
 import { CreatePlane } from "@babylonjs/core/Meshes/Builders/planeBuilder";
 import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
 import { Texture } from "@babylonjs/core/Materials/Textures/texture";
@@ -133,49 +131,54 @@ interface LineMeshes {
 }
 
 /**
- * 垂直線を 「外側（縁取り色） + 内側（コア色）」の二重チューブで表現する。
- * `line.color` をコア色、縁取りは白固定とし、両者はデフォルトスケール (1) で描画され、
- * 距離一定スケールは mesh.scaling で外部から調整する。
+ * 垂直線をビルボード平面 2 枚 (外側=白縁, 内側=黒コア) で表現する。
+ *
+ * - `BILLBOARDMODE_Y` により Y 軸回転のみで常にカメラへ正面を向ける。
+ * - 高さは applyTransform 時に `dynamicLineHeight` を Y スケールへ流し込む。
+ * - 幅は `line.width` をベースとし、X スケールでカメラ距離一定 (distScale) を反映する。
+ * - 縁取り幅は内側幅の 50% を片側に確保し、上端も同量だけ延ばして額縁状にする。
  */
 const createLineMesh = (
     scene: Scene,
     id: string,
     line: Required<MarkerLineOptions>,
 ): LineMeshes => {
-    const outerRadius = Math.max(line.width / 2, 0.05);
-    // 内側は外側の 50% を目安にし、極端に細いときも最低限見えるようクランプする。
-    const innerRadius = Math.max(outerRadius * 0.5, 0.02);
-    const path = [Vector3.Zero(), new Vector3(0, line.height, 0)];
-    const outer = CreateTube(
-        `marker-line-outer-${id}`,
-        { path, radius: outerRadius, tessellation: 8, updatable: false },
-        scene,
-    );
-    const inner = CreateTube(
+    const inner = CreatePlane(
         `marker-line-inner-${id}`,
-        { path, radius: innerRadius, tessellation: 8, updatable: false },
+        { width: 1, height: 1 },
         scene,
     );
-    const outerMaterial = new StandardMaterial(
-        `marker-line-outer-mat-${id}`,
-        scene,
-    );
-    outerMaterial.emissiveColor = Color3.White();
-    outerMaterial.disableLighting = true;
-    outer.material = outerMaterial;
-    outer.renderingGroupId = RENDERING_GROUP_ID;
-    outer.isPickable = false;
+    inner.billboardMode = AbstractMesh.BILLBOARDMODE_Y;
+    inner.renderingGroupId = RENDERING_GROUP_ID;
+    inner.isPickable = false;
     const innerMaterial = new StandardMaterial(
         `marker-line-inner-mat-${id}`,
         scene,
     );
     innerMaterial.emissiveColor = Color3.FromHexString(line.color);
     innerMaterial.disableLighting = true;
+    innerMaterial.backFaceCulling = false;
+    // 内側を縁取りより手前へ寄せて Z-fight を回避する。
+    innerMaterial.zOffset = -1;
     inner.material = innerMaterial;
-    inner.renderingGroupId = RENDERING_GROUP_ID;
-    inner.isPickable = false;
-    // 内側を手前に描画して艦色体を俺閐させるための Z-fight 選出オフセット。
-    inner.material.zOffset = -1;
+
+    const outer = CreatePlane(
+        `marker-line-outer-${id}`,
+        { width: 1, height: 1 },
+        scene,
+    );
+    outer.billboardMode = AbstractMesh.BILLBOARDMODE_Y;
+    outer.renderingGroupId = RENDERING_GROUP_ID;
+    outer.isPickable = false;
+    const outerMaterial = new StandardMaterial(
+        `marker-line-outer-mat-${id}`,
+        scene,
+    );
+    outerMaterial.emissiveColor = Color3.White();
+    outerMaterial.disableLighting = true;
+    outerMaterial.backFaceCulling = false;
+    outer.material = outerMaterial;
+
     return { outer, inner, outerMaterial, innerMaterial };
 };
 
@@ -329,10 +332,17 @@ export interface MarkerNode {
     readonly lat: number;
     readonly lon: number;
     /**
-     * 位置とスクリーン一定スケールを適用する。
-     * @param distScale カメラ距離に比例したスケール倍率。未指定時は 1。
+     * 位置・スケール・線高さを 1 フレーム分まとめて反映する。
+     * @param distScale カメラ距離に応じたスクリーン一定スケール（幅・アイコン・テキストへ適用）。
+     * @param dynamicLineHeight 線の高さ (m)。`undefined` の場合は `line.height` をそのまま使用する。
      */
-    applyTransform(wx: number, elev: number, wz: number, distScale?: number): void;
+    applyTransform(
+        wx: number,
+        elev: number,
+        wz: number,
+        distScale?: number,
+        dynamicLineHeight?: number,
+    ): void;
     setEnabledLogical(enabled: boolean): void;
     setElevationResolved(resolved: boolean): void;
     update(partial: MarkerUpdate, newLat: number, newLon: number): void;
@@ -385,14 +395,28 @@ export const createMarkerNode = (
         elev: number,
         wz: number,
         distScale = 1,
+        dynamicLineHeight?: number,
     ): void => {
-        // 線: 足元を地表に固定し、Y 軸方向に distScale 倍して伸ばす。
-        // 太さ（X/Z）も distScale で反映させるとカメラ距離に関わらず見た目の太さが一定になる。
-        lineMeshes.outer.position.set(wx, elev, wz);
-        lineMeshes.inner.position.set(wx, elev, wz);
-        lineMeshes.outer.scaling.set(distScale, distScale, distScale);
-        lineMeshes.inner.scaling.set(distScale, distScale, distScale);
-        const baseY = elev + resolved.line.height * distScale;
+        // 線の高さ: 動的指定があればそれを使い、無ければ resolved.line.height (×distScale で screen-constant) にフォールバック。
+        const lineHeight =
+            dynamicLineHeight !== undefined && dynamicLineHeight > 0
+                ? dynamicLineHeight
+                : resolved.line.height * distScale;
+        // 線の幅は distScale でスクリーン定幅に保つ。
+        const innerW = Math.max(resolved.line.width, 0.5) * distScale;
+        // 縁取り幅 (片側) = 内側幅の 50%。上端も同量だけ延ばして額縁状にする。
+        const border = innerW * 0.5;
+        const outerW = innerW + border * 2;
+        const outerH = lineHeight + border;
+
+        // 内側 (黒コア): 平面 1×1 を innerW × lineHeight にスケールし、底辺を地表に合わせる。
+        lineMeshes.inner.scaling.set(innerW, lineHeight, 1);
+        lineMeshes.inner.position.set(wx, elev + lineHeight / 2, wz);
+        // 外側 (白縁): innerW + 2*border 幅、上端を border 分だけ高くした位置に置く。
+        lineMeshes.outer.scaling.set(outerW, outerH, 1);
+        lineMeshes.outer.position.set(wx, elev + outerH / 2, wz);
+
+        const baseY = elev + lineHeight;
         const iconH = (iconMeshes?.heightWorld ?? 0) * distScale;
         const textH = (textMeshes?.heightWorld ?? 0) * distScale;
         const gap = ICON_TEXT_GAP_M * distScale;

--- a/src/terrain/marker.ts
+++ b/src/terrain/marker.ts
@@ -520,14 +520,16 @@ export const createMarkerNode = (
             applyVisibility();
         },
         getHandle(): MarkerHandle {
+            // 利用者が返却オブジェクトを書き換えても内部状態に影響しないよう、
+            // 各 sub-object を浅いコピーして返す（read-only スナップショット）。
             return {
                 id,
                 lat,
                 lon,
                 enabled: logicalEnabled,
-                icon: resolved.icon,
-                text: resolved.text,
-                line: resolved.line,
+                icon: resolved.icon ? { ...resolved.icon } : null,
+                text: resolved.text ? { ...resolved.text } : null,
+                line: { ...resolved.line },
                 elevationResolved,
             };
         },

--- a/src/terrain/marker.ts
+++ b/src/terrain/marker.ts
@@ -207,7 +207,7 @@ const createIconMesh = (
         icon.url,
         scene,
         true, // noMipmap
-        false, // invertY (SVG / data URL は上下反転しない)
+        true, // invertY (PNG/Canvas は UV と Y 軸が逆なので true)
         Texture.TRILINEAR_SAMPLINGMODE,
         undefined,
         (msg, ex) => {

--- a/src/terrain/marker.ts
+++ b/src/terrain/marker.ts
@@ -182,6 +182,12 @@ interface IconTextMeshes {
     iconHeightWorld: number;
     /** プレーン上部に占めるテキスト領域の高さ (world m)。テキスト無しの場合 0。 */
     textHeightWorld: number;
+    /**
+     * dispose 済みフラグ。アイコン画像の非同期ロードが dispose
+     * 後に完了した際、解放済みの texture / mesh にアクセスして例外を
+     * 引き起こさないよう onload コールバックで参照してガードする。
+     */
+    disposed: boolean;
 }
 
 /**
@@ -323,13 +329,27 @@ const createIconTextMesh = (
     material.diffuseTexture = texture;
     mesh.material = material;
 
+    const handle: IconTextMeshes = {
+        mesh,
+        material,
+        texture,
+        widthWorld,
+        heightWorld,
+        iconHeightWorld,
+        textHeightWorld,
+        disposed: false,
+    };
+
     // アイコン画像を非同期にロードして下半分へ描き込む（Canvas で描いた PNG data URL や
     // CORS 許可済み http(s) を想定）。
+    // dispose 後に onload が走った場合は解放済み texture / mesh への誤アクセスを避けるため、
+    // handle.disposed を確認してからガードする。
     if (icon) {
         const img = new Image();
         // クロスオリジン対応: 失敗してもタグ自体は読み込まれるため crossOrigin を試行する。
         img.crossOrigin = "anonymous";
         img.onload = () => {
+            if (handle.disposed) return;
             const dx = (dtWidth - iconWidthPx) / 2;
             const dy = textHeightPx;
             ctx2d.drawImage(img, dx, dy, iconWidthPx, iconHeightPx);
@@ -344,15 +364,7 @@ const createIconTextMesh = (
         img.src = icon.url;
     }
 
-    return {
-        mesh,
-        material,
-        texture,
-        widthWorld,
-        heightWorld,
-        iconHeightWorld,
-        textHeightWorld,
-    };
+    return handle;
 };
 
 export interface MarkerNode {
@@ -454,6 +466,9 @@ export const createMarkerNode = (
 
     const disposeIconText = (): void => {
         if (!iconTextMeshes) return;
+        // 非同期アイコン onload がこの後に走ったときにガードされるよう
+        // 先に disposed フラグを立ててからリソースを解放する。
+        iconTextMeshes.disposed = true;
         iconTextMeshes.texture.dispose();
         iconTextMeshes.material.dispose();
         iconTextMeshes.mesh.dispose();

--- a/src/terrain/marker.ts
+++ b/src/terrain/marker.ts
@@ -126,32 +126,57 @@ const resolve = (options: MarkerOptions): ResolvedMarker => ({
 });
 
 interface LineMeshes {
-    mesh: Mesh;
-    material: StandardMaterial;
+    outer: Mesh;
+    inner: Mesh;
+    outerMaterial: StandardMaterial;
+    innerMaterial: StandardMaterial;
 }
 
+/**
+ * 垂直線を 「外側（縁取り色） + 内側（コア色）」の二重チューブで表現する。
+ * `line.color` をコア色、縁取りは白固定とし、両者はデフォルトスケール (1) で描画され、
+ * 距離一定スケールは mesh.scaling で外部から調整する。
+ */
 const createLineMesh = (
     scene: Scene,
     id: string,
     line: Required<MarkerLineOptions>,
 ): LineMeshes => {
-    const mesh = CreateTube(
-        `marker-line-${id}`,
-        {
-            path: [Vector3.Zero(), new Vector3(0, line.height, 0)],
-            radius: Math.max(line.width / 2, 0.01),
-            tessellation: 8,
-            updatable: false,
-        },
+    const outerRadius = Math.max(line.width / 2, 0.05);
+    // 内側は外側の 50% を目安にし、極端に細いときも最低限見えるようクランプする。
+    const innerRadius = Math.max(outerRadius * 0.5, 0.02);
+    const path = [Vector3.Zero(), new Vector3(0, line.height, 0)];
+    const outer = CreateTube(
+        `marker-line-outer-${id}`,
+        { path, radius: outerRadius, tessellation: 8, updatable: false },
         scene,
     );
-    const material = new StandardMaterial(`marker-line-mat-${id}`, scene);
-    material.emissiveColor = Color3.FromHexString(line.color);
-    material.disableLighting = true;
-    mesh.material = material;
-    mesh.renderingGroupId = RENDERING_GROUP_ID;
-    mesh.isPickable = false;
-    return { mesh, material };
+    const inner = CreateTube(
+        `marker-line-inner-${id}`,
+        { path, radius: innerRadius, tessellation: 8, updatable: false },
+        scene,
+    );
+    const outerMaterial = new StandardMaterial(
+        `marker-line-outer-mat-${id}`,
+        scene,
+    );
+    outerMaterial.emissiveColor = Color3.White();
+    outerMaterial.disableLighting = true;
+    outer.material = outerMaterial;
+    outer.renderingGroupId = RENDERING_GROUP_ID;
+    outer.isPickable = false;
+    const innerMaterial = new StandardMaterial(
+        `marker-line-inner-mat-${id}`,
+        scene,
+    );
+    innerMaterial.emissiveColor = Color3.FromHexString(line.color);
+    innerMaterial.disableLighting = true;
+    inner.material = innerMaterial;
+    inner.renderingGroupId = RENDERING_GROUP_ID;
+    inner.isPickable = false;
+    // 内側を手前に描画して艦色体を俺閐させるための Z-fight 選出オフセット。
+    inner.material.zOffset = -1;
+    return { outer, inner, outerMaterial, innerMaterial };
 };
 
 interface IconMeshes {
@@ -214,6 +239,8 @@ const createTextMesh = (
             ? Math.max((globalThis as { devicePixelRatio: number }).devicePixelRatio, 1)
             : 1;
     const padPx = Math.round(text.fontSize * 0.4);
+    // 縁取り幅 (px)。フォントサイズの ~12% を目安にし、最低 2px を確保する。
+    const strokePx = Math.max(2, Math.round(text.fontSize * 0.12));
     // 暫定 DT を作って measureText で各行の最大幅を計測する
     const probe = new DynamicTexture(
         `marker-text-probe-${id}`,
@@ -232,14 +259,16 @@ const createTextMesh = (
     probe.dispose();
     const lineHeightPx = text.fontSize * text.lineHeight;
     const totalTextHeightPx = lineHeightPx * lineCount;
+    // 縁取り分も収まるよう余白に加算する。
+    const innerPad = padPx + strokePx;
     const dtWidth = Math.min(
         MAX_DT_SIZE,
-        ceilPow2(Math.max(1, Math.ceil((maxLineWidth + padPx * 2) * dpr))),
+        ceilPow2(Math.max(1, Math.ceil((maxLineWidth + innerPad * 2) * dpr))),
     );
     const dtHeight = Math.min(
         MAX_DT_SIZE,
         ceilPow2(
-            Math.max(1, Math.ceil((totalTextHeightPx + padPx * 2) * dpr)),
+            Math.max(1, Math.ceil((totalTextHeightPx + innerPad * 2) * dpr)),
         ),
     );
     const texture = new DynamicTexture(
@@ -249,30 +278,35 @@ const createTextMesh = (
         false,
     );
     texture.hasAlpha = true;
+    // Plane の UV と DynamicTexture canvas の Y 軸を一致させる（上下反転防止）。
+    texture.vScale = -1;
+    texture.vOffset = 1;
     const ctx = texture.getContext();
+    // 背景は描かず透明のままにする（ウィンドウ非表示要件）。
     ctx.clearRect(0, 0, dtWidth, dtHeight);
-    if (text.backgroundColor !== "transparent") {
-        ctx.fillStyle = text.backgroundColor;
-        ctx.fillRect(0, 0, dtWidth, dtHeight);
-    }
-    ctx.font = `${text.fontSize * dpr}px sans-serif`;
-    ctx.fillStyle = text.color;
-    // `ICanvasRenderingContext` に textBaseline が無い（Babylon の最小型定義）ため、
-    // 実体は CanvasRenderingContext2D 互換。安全に as 経由でフィールドを設定する。
-    (ctx as unknown as { textBaseline: CanvasTextBaseline }).textBaseline =
-        "top";
+    const ctx2d = ctx as unknown as CanvasRenderingContext2D;
+    ctx2d.font = `${text.fontSize * dpr}px sans-serif`;
+    ctx2d.textBaseline = "top";
+    ctx2d.textAlign = "center";
+    ctx2d.lineJoin = "round";
+    ctx2d.miterLimit = 2;
+    const centerX = dtWidth / 2;
+    const startY = innerPad * dpr;
+    // 1) 白の縁取りを strokeText で描き、2) その上に黒の本体を fillText する。
+    ctx2d.lineWidth = strokePx * 2 * dpr; // strokeText は中心線基準なので 2 倍
+    ctx2d.strokeStyle = "#ffffff";
     for (let i = 0; i < lines.length; i++) {
-        ctx.fillText(
-            lines[i],
-            padPx * dpr,
-            (padPx + i * lineHeightPx) * dpr,
-        );
+        ctx2d.strokeText(lines[i], centerX, startY + i * lineHeightPx * dpr);
+    }
+    ctx2d.fillStyle = text.color;
+    for (let i = 0; i < lines.length; i++) {
+        ctx2d.fillText(lines[i], centerX, startY + i * lineHeightPx * dpr);
     }
     texture.update(false);
 
-    const widthWorld = (maxLineWidth + padPx * 2) / TEXT_WORLD_PX_PER_M;
+    const widthWorld = (maxLineWidth + innerPad * 2) / TEXT_WORLD_PX_PER_M;
     const heightWorld =
-        (totalTextHeightPx + padPx * 2) / TEXT_WORLD_PX_PER_M;
+        (totalTextHeightPx + innerPad * 2) / TEXT_WORLD_PX_PER_M;
     const mesh = CreatePlane(
         `marker-text-${id}`,
         { width: widthWorld, height: heightWorld },
@@ -294,7 +328,11 @@ export interface MarkerNode {
     readonly id: string;
     readonly lat: number;
     readonly lon: number;
-    applyTransform(wx: number, elev: number, wz: number): void;
+    /**
+     * 位置とスクリーン一定スケールを適用する。
+     * @param distScale カメラ距離に比例したスケール倍率。未指定時は 1。
+     */
+    applyTransform(wx: number, elev: number, wz: number, distScale?: number): void;
     setEnabledLogical(enabled: boolean): void;
     setElevationResolved(resolved: boolean): void;
     update(partial: MarkerUpdate, newLat: number, newLon: number): void;
@@ -335,22 +373,40 @@ export const createMarkerNode = (
 
     const applyVisibility = (): void => {
         const visible = logicalEnabled && elevationResolved;
-        lineMeshes.mesh.setEnabled(visible);
+        lineMeshes.outer.setEnabled(visible);
+        lineMeshes.inner.setEnabled(visible);
         iconMeshes?.mesh.setEnabled(visible);
         textMeshes?.mesh.setEnabled(visible);
     };
     applyVisibility();
 
-    const applyTransform = (wx: number, elev: number, wz: number): void => {
-        lineMeshes.mesh.position.set(wx, elev, wz);
-        const baseY = elev + resolved.line.height;
-        const iconH = iconMeshes?.heightWorld ?? 0;
-        const textH = textMeshes?.heightWorld ?? 0;
+    const applyTransform = (
+        wx: number,
+        elev: number,
+        wz: number,
+        distScale = 1,
+    ): void => {
+        // 線: 足元を地表に固定し、Y 軸方向に distScale 倍して伸ばす。
+        // 太さ（X/Z）も distScale で反映させるとカメラ距離に関わらず見た目の太さが一定になる。
+        lineMeshes.outer.position.set(wx, elev, wz);
+        lineMeshes.inner.position.set(wx, elev, wz);
+        lineMeshes.outer.scaling.set(distScale, distScale, distScale);
+        lineMeshes.inner.scaling.set(distScale, distScale, distScale);
+        const baseY = elev + resolved.line.height * distScale;
+        const iconH = (iconMeshes?.heightWorld ?? 0) * distScale;
+        const textH = (textMeshes?.heightWorld ?? 0) * distScale;
+        const gap = ICON_TEXT_GAP_M * distScale;
+        if (iconMeshes) {
+            iconMeshes.mesh.scaling.set(distScale, distScale, distScale);
+        }
+        if (textMeshes) {
+            textMeshes.mesh.scaling.set(distScale, distScale, distScale);
+        }
         if (iconMeshes && textMeshes) {
             iconMeshes.mesh.position.set(wx, baseY + iconH / 2, wz);
             textMeshes.mesh.position.set(
                 wx,
-                baseY + iconH + ICON_TEXT_GAP_M + textH / 2,
+                baseY + iconH + gap + textH / 2,
                 wz,
             );
         } else if (iconMeshes) {
@@ -375,8 +431,10 @@ export const createMarkerNode = (
         textMeshes = null;
     };
     const disposeLine = (): void => {
-        lineMeshes.material.dispose();
-        lineMeshes.mesh.dispose();
+        lineMeshes.outerMaterial.dispose();
+        lineMeshes.innerMaterial.dispose();
+        lineMeshes.outer.dispose();
+        lineMeshes.inner.dispose();
     };
 
     return {

--- a/src/terrain/marker.ts
+++ b/src/terrain/marker.ts
@@ -9,7 +9,6 @@ import type { Scene } from "@babylonjs/core/scene";
 import { Color3 } from "@babylonjs/core/Maths/math.color";
 import { CreatePlane } from "@babylonjs/core/Meshes/Builders/planeBuilder";
 import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
-import { Texture } from "@babylonjs/core/Materials/Textures/texture";
 import { DynamicTexture } from "@babylonjs/core/Materials/Textures/dynamicTexture";
 import type { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { AbstractMesh } from "@babylonjs/core/Meshes/abstractMesh";
@@ -24,16 +23,8 @@ import {
     type MarkerUpdate,
 } from "../lib/types";
 
-const ICON_TEXT_GAP_M = 4;
 const RENDERING_GROUP_ID = 1;
 const MAX_DT_SIZE = 1024;
-/**
- * `fontSize` (ピクセル表記) を 1ピクセル = N ワールド m として描画プレーンのサイズを決定するための分母。
- *
- * デフォルト表示高度 2000m 付近でもテキストが判読可能なサイズになるよう 1 としている。
- * より小さく見せたい場合は `MarkerOptions.text.fontSize` で調整する。
- */
-const TEXT_WORLD_PX_PER_M = 1;
 
 const ALLOWED_PROTOCOLS = new Set(["http:", "https:", "data:"]);/**
  * `icon.url` を検証する。`javascript:` / `vbscript:` 等の危険スキームを拒否する。
@@ -175,170 +166,178 @@ const createLineMesh = (
     return { outer, inner, outerMaterial, innerMaterial };
 };
 
-interface IconMeshes {
-    mesh: Mesh;
-    material: StandardMaterial;
-    texture: Texture;
-    widthWorld: number;
-    heightWorld: number;
-}
-
-const createIconMesh = (
-    scene: Scene,
-    id: string,
-    icon: Required<MarkerIconOptions>,
-): IconMeshes => {
-    const mesh = CreatePlane(
-        `marker-icon-${id}`,
-        { width: icon.width, height: icon.height },
-        scene,
-    );
-    mesh.billboardMode = AbstractMesh.BILLBOARDMODE_ALL;
-    mesh.renderingGroupId = RENDERING_GROUP_ID;
-    mesh.isPickable = false;
-    const material = new StandardMaterial(`marker-icon-mat-${id}`, scene);
-    material.disableLighting = true;
-    material.backFaceCulling = false;
-    // disableLighting=true により diffuseTexture はそのまま画面に出る（lighting 計算スキップ）。
-    // useAlphaFromDiffuseTexture により SVG の alpha チャンネルで形状を切り抜く。
-    material.useAlphaFromDiffuseTexture = true;
-    material.emissiveColor = Color3.Black();
-    const texture = new Texture(
-        icon.url,
-        scene,
-        true, // noMipmap
-        true, // invertY (PNG/Canvas は UV と Y 軸が逆なので true)
-        Texture.TRILINEAR_SAMPLINGMODE,
-        undefined,
-        (msg, ex) => {
-            console.warn(
-                `[jpmap-terrain] marker icon texture load failed: id=${id}`,
-                msg,
-                ex,
-            );
-            // ロード失敗時は赤いフォールバックでジオメトリ位置を可視化する。
-            material.emissiveColor = new Color3(1, 0, 0);
-            material.diffuseTexture = null;
-        },
-    );
-    texture.hasAlpha = true;
-    material.diffuseTexture = texture;
-    mesh.material = material;
-    return {
-        mesh,
-        material,
-        texture,
-        widthWorld: icon.width,
-        heightWorld: icon.height,
-    };
-};
-
-interface TextMeshes {
+interface IconTextMeshes {
     mesh: Mesh;
     material: StandardMaterial;
     texture: DynamicTexture;
     widthWorld: number;
     heightWorld: number;
+    /** プレーン下部に占めるアイコン領域の高さ (world m)。アイコン無しの場合 0。 */
+    iconHeightWorld: number;
+    /** プレーン上部に占めるテキスト領域の高さ (world m)。テキスト無しの場合 0。 */
+    textHeightWorld: number;
 }
 
-const createTextMesh = (
+/**
+ * アイコン画像とテキストを 1 枚の板ポリ（DynamicTexture）にまとめて描画する。
+ * - 上半分: テキスト（複数行・縁取り付き、中央揃え）
+ * - 下半分: アイコン画像（非同期 Image ロード、ロード完了後に canvas へ drawImage して update）
+ * - 板の幅は max(textWidth, iconWidth) に揃え、両領域とも水平中央に配置する。
+ * - 板の左右はアスペクト維持のためテクスチャと同サイズ（dpr 換算）。
+ */
+const createIconTextMesh = (
     scene: Scene,
     id: string,
-    text: Required<MarkerTextOptions>,
-): TextMeshes => {
-    const lines = text.value.split("\n");
-    const lineCount = Math.max(lines.length, 1);
+    icon: Required<MarkerIconOptions> | null,
+    text: Required<MarkerTextOptions> | null,
+): IconTextMeshes | null => {
+    if (!icon && !text) return null;
+
     const dpr =
         typeof globalThis !== "undefined" &&
         typeof (globalThis as { devicePixelRatio?: number }).devicePixelRatio ===
             "number"
             ? Math.max((globalThis as { devicePixelRatio: number }).devicePixelRatio, 1)
             : 1;
-    const padPx = Math.round(text.fontSize * 0.4);
-    // 縁取り幅 (px)。フォントサイズの ~12% を目安にし、最低 2px を確保する。
-    const strokePx = Math.max(2, Math.round(text.fontSize * 0.12));
-    // 暫定 DT を作って measureText で各行の最大幅を計測する
-    const probe = new DynamicTexture(
-        `marker-text-probe-${id}`,
-        { width: 16, height: 16 },
-        scene,
-        false,
-    );
-    const probeCtx = probe.getContext();
-    const fontStr = `${text.fontSize}px sans-serif`;
-    probeCtx.font = fontStr;
-    let maxLineWidth = 0;
-    for (const ln of lines) {
-        const m = probeCtx.measureText(ln === "" ? " " : ln);
-        if (m.width > maxLineWidth) maxLineWidth = m.width;
+
+    // テキスト領域サイズ (px)
+    let lines: string[] = [];
+    let lineHeightPx = 0;
+    let padPx = 0;
+    let strokePx = 0;
+    let textWidthPx = 0;
+    let textHeightPx = 0;
+    if (text) {
+        lines = text.value.split("\n");
+        const lineCount = Math.max(lines.length, 1);
+        padPx = Math.round(text.fontSize * 0.4);
+        strokePx = Math.max(2, Math.round(text.fontSize * 0.12));
+        const probe = new DynamicTexture(
+            `marker-iconText-probe-${id}`,
+            { width: 16, height: 16 },
+            scene,
+            false,
+        );
+        const probeCtx = probe.getContext();
+        probeCtx.font = `${text.fontSize}px sans-serif`;
+        let maxLineWidth = 0;
+        for (const ln of lines) {
+            const m = probeCtx.measureText(ln === "" ? " " : ln);
+            if (m.width > maxLineWidth) maxLineWidth = m.width;
+        }
+        probe.dispose();
+        lineHeightPx = text.fontSize * text.lineHeight;
+        const totalTextHeightPx = lineHeightPx * lineCount;
+        const innerPad = padPx + strokePx;
+        textWidthPx = Math.ceil((maxLineWidth + innerPad * 2) * dpr);
+        textHeightPx = Math.ceil((totalTextHeightPx + innerPad * 2) * dpr);
     }
-    probe.dispose();
-    const lineHeightPx = text.fontSize * text.lineHeight;
-    const totalTextHeightPx = lineHeightPx * lineCount;
-    // 縁取り分も収まるよう余白に加算する。
-    const innerPad = padPx + strokePx;
-    // テクスチャサイズは実サイズと一致させる（pow2 パディングをやめてプレーンとキャンバスの
-    // アスペクトを揃えることで、マーカー間で文字サイズ・縦横比を一定に保つ）。
+
+    // アイコン領域サイズ (px)。icon.width/height は world m なので dpr 換算で px にする。
+    let iconWidthPx = 0;
+    let iconHeightPx = 0;
+    if (icon) {
+        iconWidthPx = Math.max(1, Math.ceil(icon.width * dpr));
+        iconHeightPx = Math.max(1, Math.ceil(icon.height * dpr));
+    }
+
     const dtWidth = Math.min(
         MAX_DT_SIZE,
-        Math.max(1, Math.ceil((maxLineWidth + innerPad * 2) * dpr)),
+        Math.max(1, Math.max(textWidthPx, iconWidthPx)),
     );
     const dtHeight = Math.min(
         MAX_DT_SIZE,
-        Math.max(1, Math.ceil((totalTextHeightPx + innerPad * 2) * dpr)),
+        Math.max(1, textHeightPx + iconHeightPx),
     );
+
     const texture = new DynamicTexture(
-        `marker-text-${id}`,
+        `marker-iconText-${id}`,
         { width: dtWidth, height: dtHeight },
         scene,
         false,
     );
     texture.hasAlpha = true;
-    // Plane の UV と DynamicTexture canvas の Y 軸を一致させる（上下反転防止）。
+    // Plane の UV と canvas の Y 軸を一致させる（上下反転防止）。
     texture.vScale = -1;
     texture.vOffset = 1;
+
     const ctx = texture.getContext();
-    // 背景は描かず透明のままにする（ウィンドウ非表示要件）。
-    ctx.clearRect(0, 0, dtWidth, dtHeight);
     const ctx2d = ctx as unknown as CanvasRenderingContext2D;
-    ctx2d.font = `${text.fontSize * dpr}px sans-serif`;
-    ctx2d.textBaseline = "top";
-    ctx2d.textAlign = "center";
-    ctx2d.lineJoin = "round";
-    ctx2d.miterLimit = 2;
-    const centerX = dtWidth / 2;
-    const startY = innerPad * dpr;
-    // 1) 白の縁取りを strokeText で描き、2) その上に黒の本体を fillText する。
-    ctx2d.lineWidth = strokePx * 2 * dpr; // strokeText は中心線基準なので 2 倍
-    ctx2d.strokeStyle = "#ffffff";
-    for (let i = 0; i < lines.length; i++) {
-        ctx2d.strokeText(lines[i], centerX, startY + i * lineHeightPx * dpr);
-    }
-    ctx2d.fillStyle = text.color;
-    for (let i = 0; i < lines.length; i++) {
-        ctx2d.fillText(lines[i], centerX, startY + i * lineHeightPx * dpr);
+    ctx2d.clearRect(0, 0, dtWidth, dtHeight);
+
+    // 上半分にテキストを描く
+    if (text) {
+        ctx2d.font = `${text.fontSize * dpr}px sans-serif`;
+        ctx2d.textBaseline = "top";
+        ctx2d.textAlign = "center";
+        ctx2d.lineJoin = "round";
+        ctx2d.miterLimit = 2;
+        const innerPad = padPx + strokePx;
+        const startY = innerPad * dpr;
+        const centerX = dtWidth / 2;
+        // 1) 白の縁取り → 2) 黒の本体
+        ctx2d.lineWidth = strokePx * 2 * dpr;
+        ctx2d.strokeStyle = "#ffffff";
+        for (let i = 0; i < lines.length; i++) {
+            ctx2d.strokeText(lines[i], centerX, startY + i * lineHeightPx * dpr);
+        }
+        ctx2d.fillStyle = text.color;
+        for (let i = 0; i < lines.length; i++) {
+            ctx2d.fillText(lines[i], centerX, startY + i * lineHeightPx * dpr);
+        }
     }
     texture.update(false);
 
-    // プレーンサイズ = キャンバスサイズ / dpr。テクスチャとプレーンのアスペクト・サイズが一致し、
-    // distScale 適用後もスクリーン上の文字サイズがマーカー間で同一になる。
-    const widthWorld = dtWidth / dpr / TEXT_WORLD_PX_PER_M;
-    const heightWorld = dtHeight / dpr / TEXT_WORLD_PX_PER_M;
+    const widthWorld = dtWidth / dpr;
+    const heightWorld = dtHeight / dpr;
+    const iconHeightWorld = iconHeightPx / dpr;
+    const textHeightWorld = textHeightPx / dpr;
+
     const mesh = CreatePlane(
-        `marker-text-${id}`,
+        `marker-iconText-${id}`,
         { width: widthWorld, height: heightWorld },
         scene,
     );
     mesh.billboardMode = AbstractMesh.BILLBOARDMODE_ALL;
     mesh.renderingGroupId = RENDERING_GROUP_ID;
     mesh.isPickable = false;
-    const material = new StandardMaterial(`marker-text-mat-${id}`, scene);
+    const material = new StandardMaterial(`marker-iconText-mat-${id}`, scene);
     material.emissiveColor = Color3.White();
     material.disableLighting = true;
     material.useAlphaFromDiffuseTexture = true;
     material.diffuseTexture = texture;
     mesh.material = material;
-    return { mesh, material, texture, widthWorld, heightWorld };
+
+    // アイコン画像を非同期にロードして下半分へ描き込む（Canvas で描いた PNG data URL や
+    // CORS 許可済み http(s) を想定）。
+    if (icon) {
+        const img = new Image();
+        // クロスオリジン対応: 失敗してもタグ自体は読み込まれるため crossOrigin を試行する。
+        img.crossOrigin = "anonymous";
+        img.onload = () => {
+            const dx = (dtWidth - iconWidthPx) / 2;
+            const dy = textHeightPx;
+            ctx2d.drawImage(img, dx, dy, iconWidthPx, iconHeightPx);
+            texture.update(false);
+        };
+        img.onerror = () => {
+            console.warn(
+                `[jpmap-terrain] marker icon image load failed: id=${id}`,
+                icon.url,
+            );
+        };
+        img.src = icon.url;
+    }
+
+    return {
+        mesh,
+        material,
+        texture,
+        widthWorld,
+        heightWorld,
+        iconHeightWorld,
+        textHeightWorld,
+    };
 };
 
 export interface MarkerNode {
@@ -388,19 +387,18 @@ export const createMarkerNode = (
     let elevationResolved = false;
 
     let lineMeshes: LineMeshes = createLineMesh(scene, id, resolved.line);
-    let iconMeshes: IconMeshes | null = resolved.icon
-        ? createIconMesh(scene, id, resolved.icon)
-        : null;
-    let textMeshes: TextMeshes | null = resolved.text
-        ? createTextMesh(scene, id, resolved.text)
-        : null;
+    let iconTextMeshes: IconTextMeshes | null = createIconTextMesh(
+        scene,
+        id,
+        resolved.icon,
+        resolved.text,
+    );
 
     const applyVisibility = (): void => {
         const visible = logicalEnabled && elevationResolved;
         lineMeshes.outer.setEnabled(visible);
         lineMeshes.inner.setEnabled(visible);
-        iconMeshes?.mesh.setEnabled(visible);
-        textMeshes?.mesh.setEnabled(visible);
+        iconTextMeshes?.mesh.setEnabled(visible);
     };
     applyVisibility();
 
@@ -430,43 +428,26 @@ export const createMarkerNode = (
         lineMeshes.outer.scaling.set(outerW, outerH, 1);
         lineMeshes.outer.position.set(wx, elev + outerH / 2, wz);
 
-        const baseY = elev + lineHeight;
-        const iconH = (iconMeshes?.heightWorld ?? 0) * distScale;
-        const textH = (textMeshes?.heightWorld ?? 0) * distScale;
-        const gap = ICON_TEXT_GAP_M * distScale;
-        if (iconMeshes) {
-            iconMeshes.mesh.scaling.set(distScale, distScale, distScale);
-        }
-        if (textMeshes) {
-            textMeshes.mesh.scaling.set(distScale, distScale, distScale);
-        }
-        if (iconMeshes && textMeshes) {
-            iconMeshes.mesh.position.set(wx, baseY + iconH / 2, wz);
-            textMeshes.mesh.position.set(
-                wx,
-                baseY + iconH + gap + textH / 2,
-                wz,
-            );
-        } else if (iconMeshes) {
-            iconMeshes.mesh.position.set(wx, baseY + iconH / 2, wz);
-        } else if (textMeshes) {
-            textMeshes.mesh.position.set(wx, baseY + textH / 2, wz);
+        // アイコン+テキストの合成プレーン:
+        // - 線の先端 (lineTopY) をアイコン中心に合わせる。
+        // - プレーン内訳 (上→下): textHeight, iconHeight。
+        //   plane center.y = lineTopY + textHeight*distScale / 2
+        //   （icon 無しなら plane center = lineTopY = text bottom、
+        //     text 無しなら plane center = lineTopY = icon center）
+        if (iconTextMeshes) {
+            iconTextMeshes.mesh.scaling.set(distScale, distScale, distScale);
+            const lineTopY = elev + lineHeight;
+            const textH = iconTextMeshes.textHeightWorld * distScale;
+            iconTextMeshes.mesh.position.set(wx, lineTopY + textH / 2, wz);
         }
     };
 
-    const disposeIcon = (): void => {
-        if (!iconMeshes) return;
-        iconMeshes.texture.dispose();
-        iconMeshes.material.dispose();
-        iconMeshes.mesh.dispose();
-        iconMeshes = null;
-    };
-    const disposeText = (): void => {
-        if (!textMeshes) return;
-        textMeshes.texture.dispose();
-        textMeshes.material.dispose();
-        textMeshes.mesh.dispose();
-        textMeshes = null;
+    const disposeIconText = (): void => {
+        if (!iconTextMeshes) return;
+        iconTextMeshes.texture.dispose();
+        iconTextMeshes.material.dispose();
+        iconTextMeshes.mesh.dispose();
+        iconTextMeshes = null;
     };
     const disposeLine = (): void => {
         lineMeshes.outerMaterial.dispose();
@@ -505,19 +486,23 @@ export const createMarkerNode = (
                 disposeLine();
                 lineMeshes = createLineMesh(scene, id, resolved.line);
             }
-            if (partial.icon !== undefined) {
-                resolved = { ...resolved, icon: resolveIcon(partial.icon) };
-                disposeIcon();
-                if (resolved.icon) {
-                    iconMeshes = createIconMesh(scene, id, resolved.icon);
+            // icon / text どちらかが変化したら 1 枚のプレーンを作り直す。
+            const iconChanged = partial.icon !== undefined;
+            const textChanged = partial.text !== undefined;
+            if (iconChanged || textChanged) {
+                if (iconChanged) {
+                    resolved = { ...resolved, icon: resolveIcon(partial.icon) };
                 }
-            }
-            if (partial.text !== undefined) {
-                resolved = { ...resolved, text: resolveText(partial.text) };
-                disposeText();
-                if (resolved.text) {
-                    textMeshes = createTextMesh(scene, id, resolved.text);
+                if (textChanged) {
+                    resolved = { ...resolved, text: resolveText(partial.text) };
                 }
+                disposeIconText();
+                iconTextMeshes = createIconTextMesh(
+                    scene,
+                    id,
+                    resolved.icon,
+                    resolved.text,
+                );
             }
             if (partial.enabled !== undefined) {
                 logicalEnabled = partial.enabled;
@@ -538,8 +523,7 @@ export const createMarkerNode = (
             };
         },
         dispose(): void {
-            disposeIcon();
-            disposeText();
+            disposeIconText();
             disposeLine();
         },
     };

--- a/src/terrain/marker.ts
+++ b/src/terrain/marker.ts
@@ -29,7 +29,13 @@ import {
 const ICON_TEXT_GAP_M = 4;
 const RENDERING_GROUP_ID = 1;
 const MAX_DT_SIZE = 1024;
-const TEXT_WORLD_PX_PER_M = 16;
+/**
+ * `fontSize` (ピクセル表記) を 1ピクセル = N ワールド m として描画プレーンのサイズを決定するための分母。
+ *
+ * デフォルト表示高度 2000m 付近でもテキストが判読可能なサイズになるよう 1 としている。
+ * より小さく見せたい場合は `MarkerOptions.text.fontSize` で調整する。
+ */
+const TEXT_WORLD_PX_PER_M = 1;
 
 const ALLOWED_PROTOCOLS = new Set(["http:", "https:", "data:"]);
 

--- a/src/terrain/markerManager.ts
+++ b/src/terrain/markerManager.ts
@@ -72,7 +72,26 @@ export const createMarkerManager = (ctx: MarkerContext): MarkerManager => {
         return Math.max(scale, 0.1);
     };
 
+    /**
+     * 動的な線高さ (m) をカメラ位置と beta 角度から計算する。
+     *
+     * 画面中央付近にマーカーが表示されるよう、カメラ距離 (radius) に対して
+     * 一定割合の高さにしつつ、仰角 (beta=真上が 0、水平が π/2) で豊かに調整する。
+     * - radius * 0.05 をベースとし、sin(beta) で 0.3 〜1.0 にクランプした係数を掛ける。
+     * - 下限 50m、上限 5000m で見た目の肉付きを安定させる。
+     */
+    const computeDynamicLineHeight = (): number => {
+        const cam = ctx.getCameraPosition();
+        const radius = Math.max(cam.radius, 1);
+        const sinBeta = Math.sin(cam.beta);
+        const factor = Math.min(1, Math.max(0.3, sinBeta));
+        const h = radius * 0.05 * factor;
+        return Math.min(5000, Math.max(50, h));
+    };
+
     const tickFrame = (): void => {
+        if (nodes.size === 0) return;
+        const dynamicLineHeight = computeDynamicLineHeight();
         for (const node of nodes.values()) {
             const { wx, wz } = computeWorld(node.lat, node.lon);
             const elev = ctx.tileManager.queryElevationAtWorld(wx, wz);
@@ -82,7 +101,7 @@ export const createMarkerManager = (ctx: MarkerContext): MarkerManager => {
             }
             node.setElevationResolved(true);
             const scale = computeDistScale(wx, elev, wz);
-            node.applyTransform(wx, elev, wz, scale);
+            node.applyTransform(wx, elev, wz, scale, dynamicLineHeight);
         }
     };
 
@@ -124,7 +143,8 @@ export const createMarkerManager = (ctx: MarkerContext): MarkerManager => {
             if (elev !== null) {
                 node.setElevationResolved(true);
                 const scale = computeDistScale(wx, elev, wz);
-                node.applyTransform(wx, elev, wz, scale);
+                const dynamicLineHeight = computeDynamicLineHeight();
+                node.applyTransform(wx, elev, wz, scale, dynamicLineHeight);
             }
             return node.getHandle();
         },

--- a/src/terrain/markerManager.ts
+++ b/src/terrain/markerManager.ts
@@ -1,0 +1,168 @@
+/**
+ * MarkerManager (Issue #167)。
+ *
+ * `JpmapTerrain.addMarker / updateMarker / removeMarker / setMarkerEnabled / listMarkers / getMarker`
+ * から呼び出される。マーカーの ID 管理・スタブ標高解決・毎フレームの位置更新を担う。
+ */
+
+import type { Observer } from "@babylonjs/core/Misc/observable";
+import type { Scene } from "@babylonjs/core/scene";
+
+import { JAPAN_BOUNDS } from "./gsiTile";
+import { createMarkerNode, type MarkerNode } from "./marker";
+import { METERS_PER_DEGREE_LAT, type MarkerContext } from "../scenes/default";
+import type {
+    MarkerHandle,
+    MarkerOptions,
+    MarkerUpdate,
+} from "../lib/types";
+
+export interface MarkerManager {
+    add(id: string, options: MarkerOptions): MarkerHandle;
+    get(id: string): MarkerHandle | null;
+    update(id: string, partial: MarkerUpdate): MarkerHandle;
+    remove(id: string): void;
+    setEnabled(id: string, enabled: boolean): void;
+    list(): readonly string[];
+    dispose(): void;
+}
+
+const assertInBounds = (lat: number, lon: number): void => {
+    if (
+        lat < JAPAN_BOUNDS.minLat ||
+        lat > JAPAN_BOUNDS.maxLat ||
+        lon < JAPAN_BOUNDS.minLon ||
+        lon > JAPAN_BOUNDS.maxLon
+    ) {
+        throw new Error(
+            `addMarker: lat/lon out of JAPAN_BOUNDS (lat=${lat}, lon=${lon})`,
+        );
+    }
+};
+
+export const createMarkerManager = (ctx: MarkerContext): MarkerManager => {
+    const nodes = new Map<string, MarkerNode>();
+
+    const computeWorld = (
+        lat: number,
+        lon: number,
+    ): { wx: number; wz: number } => {
+        const origin = ctx.getOrigin();
+        const metersPerDegLon =
+            METERS_PER_DEGREE_LAT * Math.cos((origin.lat * Math.PI) / 180);
+        const wx = (lon - origin.lon) * metersPerDegLon + origin.gridResidualX;
+        const wz = (lat - origin.lat) * METERS_PER_DEGREE_LAT + origin.gridResidualZ;
+        return { wx, wz };
+    };
+
+    const tickFrame = (): void => {
+        for (const node of nodes.values()) {
+            const { wx, wz } = computeWorld(node.lat, node.lon);
+            const elev = ctx.tileManager.queryElevationAtWorld(wx, wz);
+            if (elev === null) {
+                node.setElevationResolved(false);
+                continue;
+            }
+            node.setElevationResolved(true);
+            node.applyTransform(wx, elev, wz);
+        }
+    };
+
+    const observer: Observer<Scene> | null =
+        ctx.scene.onBeforeRenderObservable.add(tickFrame);
+
+    const unsubscribeTerrain = ctx.tileManager.subscribeTerrainUpdated(() => {
+        // 標高更新があれば次フレームに即時反映するため何もしない（tickFrame で再評価）。
+        // 明示的にここで再評価したい場合は tickFrame() を呼んでも良いが、
+        // scene.onBeforeRender で十分早いので副次効果を避けて noop。
+    });
+
+    let disposed = false;
+
+    const requireNode = (id: string): MarkerNode => {
+        const node = nodes.get(id);
+        if (!node) {
+            throw new Error(`Marker id "${id}" not found`);
+        }
+        return node;
+    };
+
+    return {
+        add(id: string, options: MarkerOptions): MarkerHandle {
+            if (disposed) {
+                throw new Error("MarkerManager has been disposed");
+            }
+            if (nodes.has(id)) {
+                throw new Error(
+                    `JpmapTerrain.addMarker: id "${id}" already exists`,
+                );
+            }
+            assertInBounds(options.lat, options.lon);
+            const node = createMarkerNode(ctx.scene, id, options);
+            nodes.set(id, node);
+            // 初回 tick で標高解決を試みる
+            const { wx, wz } = computeWorld(options.lat, options.lon);
+            const elev = ctx.tileManager.queryElevationAtWorld(wx, wz);
+            if (elev !== null) {
+                node.setElevationResolved(true);
+                node.applyTransform(wx, elev, wz);
+            }
+            return node.getHandle();
+        },
+        get(id: string): MarkerHandle | null {
+            const node = nodes.get(id);
+            return node ? node.getHandle() : null;
+        },
+        update(id: string, partial: MarkerUpdate): MarkerHandle {
+            if (disposed) {
+                throw new Error("MarkerManager has been disposed");
+            }
+            const node = requireNode(id);
+            const newLat = partial.lat ?? node.lat;
+            const newLon = partial.lon ?? node.lon;
+            const latLonChanged =
+                partial.lat !== undefined || partial.lon !== undefined;
+            if (latLonChanged) {
+                assertInBounds(newLat, newLon);
+            }
+            node.update(partial, newLat, newLon);
+            if (latLonChanged) {
+                node.setElevationResolved(false);
+            }
+            return node.getHandle();
+        },
+        remove(id: string): void {
+            const node = nodes.get(id);
+            if (!node) {
+                console.warn(
+                    `[jpmap-terrain] removeMarker: id "${id}" not found`,
+                );
+                return;
+            }
+            node.dispose();
+            nodes.delete(id);
+        },
+        setEnabled(id: string, enabled: boolean): void {
+            if (disposed) {
+                throw new Error("MarkerManager has been disposed");
+            }
+            const node = requireNode(id);
+            node.setEnabledLogical(enabled);
+        },
+        list(): readonly string[] {
+            return Array.from(nodes.keys());
+        },
+        dispose(): void {
+            if (disposed) return;
+            disposed = true;
+            if (observer) {
+                ctx.scene.onBeforeRenderObservable.remove(observer);
+            }
+            unsubscribeTerrain();
+            for (const node of nodes.values()) {
+                node.dispose();
+            }
+            nodes.clear();
+        },
+    };
+};

--- a/src/terrain/markerManager.ts
+++ b/src/terrain/markerManager.ts
@@ -77,16 +77,16 @@ export const createMarkerManager = (ctx: MarkerContext): MarkerManager => {
      *
      * 画面中央付近にマーカーが表示されるよう、カメラ距離 (radius) に対して
      * 一定割合の高さにしつつ、仰角 (beta=真上が 0、水平が π/2) で豊かに調整する。
-     * - radius * 0.05 をベースとし、sin(beta) で 0.3 〜1.0 にクランプした係数を掛ける。
-     * - 下限 50m、上限 5000m で見た目の肉付きを安定させる。
+     * - radius * 0.1 をベースとし、sin(beta) で 0.3 〜1.0 にクランプした係数を掛ける。
+     * - 下限 100m、上限 10000m で見た目の肉付きを安定させる。
      */
     const computeDynamicLineHeight = (): number => {
         const cam = ctx.getCameraPosition();
         const radius = Math.max(cam.radius, 1);
         const sinBeta = Math.sin(cam.beta);
         const factor = Math.min(1, Math.max(0.3, sinBeta));
-        const h = radius * 0.05 * factor;
-        return Math.min(5000, Math.max(50, h));
+        const h = radius * 0.1 * factor;
+        return Math.min(10000, Math.max(100, h));
     };
 
     const tickFrame = (): void => {

--- a/src/terrain/markerManager.ts
+++ b/src/terrain/markerManager.ts
@@ -55,6 +55,23 @@ export const createMarkerManager = (ctx: MarkerContext): MarkerManager => {
         return { wx, wz };
     };
 
+    /**
+     * スケール基準距離 (m)。カメラ距離がこの値なら scale=1、それ以上は distance/refDistance
+     * 倍してスクリーン空間サイズを一定に保つ。
+     */
+    const REF_DISTANCE_M = 1000;
+
+    const computeDistScale = (wx: number, wy: number, wz: number): number => {
+        const cam = ctx.getCameraPosition();
+        const dx = cam.x - wx;
+        const dy = cam.y - wy;
+        const dz = cam.z - wz;
+        const dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
+        const scale = dist / REF_DISTANCE_M;
+        // 近すぎるとテクスチャ補間が荷重になるため下限を設ける
+        return Math.max(scale, 0.1);
+    };
+
     const tickFrame = (): void => {
         for (const node of nodes.values()) {
             const { wx, wz } = computeWorld(node.lat, node.lon);
@@ -64,7 +81,8 @@ export const createMarkerManager = (ctx: MarkerContext): MarkerManager => {
                 continue;
             }
             node.setElevationResolved(true);
-            node.applyTransform(wx, elev, wz);
+            const scale = computeDistScale(wx, elev, wz);
+            node.applyTransform(wx, elev, wz, scale);
         }
     };
 
@@ -105,7 +123,8 @@ export const createMarkerManager = (ctx: MarkerContext): MarkerManager => {
             const elev = ctx.tileManager.queryElevationAtWorld(wx, wz);
             if (elev !== null) {
                 node.setElevationResolved(true);
-                node.applyTransform(wx, elev, wz);
+                const scale = computeDistScale(wx, elev, wz);
+                node.applyTransform(wx, elev, wz, scale);
             }
             return node.getHandle();
         },

--- a/src/terrain/markerManager.ts
+++ b/src/terrain/markerManager.ts
@@ -35,7 +35,7 @@ const assertInBounds = (lat: number, lon: number): void => {
         lon > JAPAN_BOUNDS.maxLon
     ) {
         throw new Error(
-            `addMarker: lat/lon out of JAPAN_BOUNDS (lat=${lat}, lon=${lon})`,
+            `marker: lat/lon out of JAPAN_BOUNDS (lat=${lat}, lon=${lon})`,
         );
     }
 };

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -229,6 +229,21 @@ jest.unstable_mockModule("../src/scenes/default", () => {
                     setSunShadows: (enabled: boolean) => {
                         sunShadowsCalls.push(enabled);
                     },
+                    getMarkerContext: () => ({
+                        scene: { onBeforeRenderObservable: createSceneObservable() },
+                        tileManager: {
+                            queryElevationAtWorld: () => 0,
+                            subscribeTerrainUpdated: () => () => {
+                                /* no-op */
+                            },
+                        },
+                        getOrigin: () => ({
+                            lat,
+                            lon,
+                            gridResidualX: 0,
+                            gridResidualZ: 0,
+                        }),
+                    }),
                     dispose: () => {
                         controllerDisposeCount++;
                     },
@@ -243,6 +258,7 @@ jest.unstable_mockModule("../src/scenes/default", () => {
     }
     return {
         DefaultScene,
+        METERS_PER_DEGREE_LAT: 111320,
         __getRefreshCount: (): number => refreshCallCount,
         __resetRefreshCount: (): void => {
             refreshCallCount = 0;

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -243,7 +243,13 @@ jest.unstable_mockModule("../src/scenes/default", () => {
                             gridResidualX: 0,
                             gridResidualZ: 0,
                         }),
-                        getCameraPosition: () => ({ x: 0, y: 0, z: 0 }),
+                        getCameraPosition: () => ({
+                            x: 0,
+                            y: 0,
+                            z: 0,
+                            radius: 1000,
+                            beta: Math.PI / 4,
+                        }),
                     }),
                     dispose: () => {
                         controllerDisposeCount++;

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -243,6 +243,7 @@ jest.unstable_mockModule("../src/scenes/default", () => {
                             gridResidualX: 0,
                             gridResidualZ: 0,
                         }),
+                        getCameraPosition: () => ({ x: 0, y: 0, z: 0 }),
                     }),
                     dispose: () => {
                         controllerDisposeCount++;

--- a/tests/markerManager.unit.spec.ts
+++ b/tests/markerManager.unit.spec.ts
@@ -143,6 +143,7 @@ const buildCtx = (
             gridResidualX: 0,
             gridResidualZ: 0,
         }),
+        getCameraPosition: () => ({ x: 0, y: 1000, z: 0 }),
     };
     return {
         ctx,

--- a/tests/markerManager.unit.spec.ts
+++ b/tests/markerManager.unit.spec.ts
@@ -143,7 +143,13 @@ const buildCtx = (
             gridResidualX: 0,
             gridResidualZ: 0,
         }),
-        getCameraPosition: () => ({ x: 0, y: 1000, z: 0 }),
+        getCameraPosition: () => ({
+            x: 0,
+            y: 1000,
+            z: 0,
+            radius: 1000,
+            beta: Math.PI / 4,
+        }),
     };
     return {
         ctx,

--- a/tests/markerManager.unit.spec.ts
+++ b/tests/markerManager.unit.spec.ts
@@ -1,0 +1,309 @@
+/**
+ * MarkerManager の振る舞い (Issue #167)。
+ *
+ * Babylon の Mesh / Texture 実体を生成しないよう `../src/terrain/marker` を
+ * モック化し、CRUD / enable/disable / 境界判定 / 標高保留→解決 / dispose
+ * を検証する。
+ */
+import { jest } from "@jest/globals";
+
+// `marker` モジュールを軽量スタブに差し替える。実装本体（Babylon）には依存させない。
+jest.unstable_mockModule("../src/terrain/marker", () => {
+    interface StubNode {
+        readonly id: string;
+        lat: number;
+        lon: number;
+        enabled: boolean;
+        elevationResolved: boolean;
+        disposeCount: number;
+        applyTransformCount: number;
+        setEnabledLogical: (v: boolean) => void;
+        setElevationResolved: (v: boolean) => void;
+        applyTransform: (wx: number, elev: number, wz: number) => void;
+        update: (
+            partial: { enabled?: boolean },
+            newLat: number,
+            newLon: number,
+        ) => void;
+        dispose: () => void;
+        getHandle: () => Record<string, unknown>;
+    }
+    const created: StubNode[] = [];
+    const createMarkerNode = (
+        _scene: unknown,
+        id: string,
+        options: { lat: number; lon: number; enabled?: boolean },
+    ): StubNode => {
+        const node: StubNode = {
+            id,
+            lat: options.lat,
+            lon: options.lon,
+            enabled: options.enabled ?? true,
+            elevationResolved: false,
+            disposeCount: 0,
+            applyTransformCount: 0,
+            setEnabledLogical: (v: boolean) => {
+                node.enabled = v;
+            },
+            setElevationResolved: (v: boolean) => {
+                node.elevationResolved = v;
+            },
+            applyTransform: () => {
+                node.applyTransformCount++;
+            },
+            update: (partial, newLat, newLon) => {
+                node.lat = newLat;
+                node.lon = newLon;
+                if (partial.enabled !== undefined) {
+                    node.enabled = partial.enabled;
+                }
+            },
+            dispose: () => {
+                node.disposeCount++;
+            },
+            getHandle: () => ({
+                id,
+                lat: node.lat,
+                lon: node.lon,
+                enabled: node.enabled,
+                elevationResolved: node.elevationResolved,
+            }),
+        };
+        created.push(node);
+        return node;
+    };
+    return {
+        createMarkerNode,
+        __getCreated: (): StubNode[] => created,
+        __resetCreated: (): void => {
+            created.length = 0;
+        },
+    };
+});
+
+const { createMarkerManager } = await import("../src/terrain/markerManager");
+const markerStub = await import("../src/terrain/marker");
+interface StubMarker {
+    enabled: boolean;
+    elevationResolved: boolean;
+    disposeCount: number;
+}
+const __getCreated = (
+    markerStub as unknown as { __getCreated: () => StubMarker[] }
+).__getCreated;
+const __resetCreated = (
+    markerStub as unknown as { __resetCreated: () => void }
+).__resetCreated;
+
+interface FakeObserver {
+    callback: () => void;
+}
+
+const buildCtx = (
+    elevation: number | null = 0,
+): {
+    ctx: Parameters<typeof createMarkerManager>[0];
+    tick: () => void;
+    setElevation: (v: number | null) => void;
+    unsubscribeCount: () => number;
+} => {
+    const observers: FakeObserver[] = [];
+    const sceneLike = {
+        onBeforeRenderObservable: {
+            add: (cb: () => void): FakeObserver => {
+                const o: FakeObserver = { callback: cb };
+                observers.push(o);
+                return o;
+            },
+            remove: (target: FakeObserver): boolean => {
+                const i = observers.indexOf(target);
+                if (i === -1) return false;
+                observers.splice(i, 1);
+                return true;
+            },
+        },
+    };
+    let elev: number | null = elevation;
+    let unsubscribeCalls = 0;
+    const ctx = {
+        scene: sceneLike as unknown as Parameters<
+            typeof createMarkerManager
+        >[0]["scene"],
+        tileManager: {
+            queryElevationAtWorld: (): number | null => elev,
+            subscribeTerrainUpdated: (): (() => void) => {
+                return () => {
+                    unsubscribeCalls++;
+                };
+            },
+        },
+        getOrigin: () => ({
+            lat: 35.681,
+            lon: 139.767,
+            gridResidualX: 0,
+            gridResidualZ: 0,
+        }),
+    };
+    return {
+        ctx,
+        tick: () => {
+            for (const o of observers.slice()) o.callback();
+        },
+        setElevation: (v) => {
+            elev = v;
+        },
+        unsubscribeCount: () => unsubscribeCalls,
+    };
+};
+
+const validOpts = {
+    lat: 35.681236,
+    lon: 139.767125,
+    text: { value: "テスト" },
+};
+
+beforeEach(() => {
+    __resetCreated();
+});
+
+describe("MarkerManager CRUD", () => {
+    test("add → get / list で同 id を取得できる", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createMarkerManager(ctx);
+        const handle = mgr.add("a", validOpts);
+        expect(handle.id).toBe("a");
+        expect(mgr.get("a")?.id).toBe("a");
+        expect(mgr.list()).toEqual(["a"]);
+    });
+
+    test("重複 id の add は throw", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createMarkerManager(ctx);
+        mgr.add("a", validOpts);
+        expect(() => mgr.add("a", validOpts)).toThrow(/already exists/);
+    });
+
+    test("未存在 id の update は throw", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createMarkerManager(ctx);
+        expect(() => mgr.update("missing", { enabled: false })).toThrow(
+            /not found/,
+        );
+    });
+
+    test("未存在 id の remove は warn + no-op", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createMarkerManager(ctx);
+        const warn = jest.spyOn(console, "warn").mockImplementation(() => {
+            /* silence */
+        });
+        mgr.remove("missing");
+        expect(warn).toHaveBeenCalled();
+        warn.mockRestore();
+    });
+
+    test("remove で list / get から消える", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createMarkerManager(ctx);
+        mgr.add("a", validOpts);
+        mgr.remove("a");
+        expect(mgr.get("a")).toBeNull();
+        expect(mgr.list()).toEqual([]);
+    });
+
+    test("生成順が list の順序に反映される", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createMarkerManager(ctx);
+        mgr.add("c", validOpts);
+        mgr.add("a", validOpts);
+        mgr.add("b", validOpts);
+        expect(mgr.list()).toEqual(["c", "a", "b"]);
+    });
+});
+
+describe("MarkerManager 境界 / バリデーション", () => {
+    test("JAPAN_BOUNDS 外 (lat=0,lon=0) は throw", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createMarkerManager(ctx);
+        expect(() =>
+            mgr.add("a", { lat: 0, lon: 0, text: { value: "x" } }),
+        ).toThrow(/JAPAN_BOUNDS/);
+    });
+
+    test("update で lat/lon が範囲外なら throw", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createMarkerManager(ctx);
+        mgr.add("a", validOpts);
+        expect(() => mgr.update("a", { lat: 0, lon: 0 })).toThrow(
+            /JAPAN_BOUNDS/,
+        );
+    });
+});
+
+describe("MarkerManager enable / disable", () => {
+    test("setEnabled で node.enabled が反映される", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createMarkerManager(ctx);
+        mgr.add("a", validOpts);
+        mgr.setEnabled("a", false);
+        const node = __getCreated()[0];
+        expect(node.enabled).toBe(false);
+        mgr.setEnabled("a", true);
+        expect(node.enabled).toBe(true);
+    });
+});
+
+describe("MarkerManager 標高解決", () => {
+    test("add 時に elevation が null なら elevationResolved=false", () => {
+        const { ctx } = buildCtx(null);
+        const mgr = createMarkerManager(ctx);
+        mgr.add("a", validOpts);
+        const node = __getCreated()[0];
+        expect(node.elevationResolved).toBe(false);
+    });
+
+    test("tickFrame 後に elevation が解決すれば elevationResolved=true", () => {
+        const ctxWrap = buildCtx(null);
+        const mgr = createMarkerManager(ctxWrap.ctx);
+        mgr.add("a", validOpts);
+        const node = __getCreated()[0];
+        expect(node.elevationResolved).toBe(false);
+        ctxWrap.setElevation(123);
+        ctxWrap.tick();
+        expect(node.elevationResolved).toBe(true);
+    });
+
+    test("update で lat/lon 変更時に elevationResolved が false に戻る", () => {
+        const ctxWrap = buildCtx(0);
+        const mgr = createMarkerManager(ctxWrap.ctx);
+        mgr.add("a", validOpts);
+        const node = __getCreated()[0];
+        node.elevationResolved = true;
+        mgr.update("a", { lat: 35.7, lon: 139.7 });
+        expect(node.elevationResolved).toBe(false);
+    });
+});
+
+describe("MarkerManager dispose", () => {
+    test("dispose で全 node の dispose が呼ばれ、terrain subscription が解除される", () => {
+        const ctxWrap = buildCtx(0);
+        const mgr = createMarkerManager(ctxWrap.ctx);
+        mgr.add("a", validOpts);
+        mgr.add("b", validOpts);
+        const nodes = __getCreated();
+        mgr.dispose();
+        for (const n of nodes) {
+            expect(n.disposeCount).toBeGreaterThan(0);
+        }
+        expect(ctxWrap.unsubscribeCount()).toBeGreaterThan(0);
+    });
+
+    test("dispose 後の add / update / setEnabled は throw", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createMarkerManager(ctx);
+        mgr.dispose();
+        expect(() => mgr.add("a", validOpts)).toThrow(/disposed/);
+        expect(() => mgr.update("a", { enabled: false })).toThrow(/disposed/);
+        expect(() => mgr.setEnabled("a", false)).toThrow(/disposed/);
+    });
+});


### PR DESCRIPTION
## 概要

Issue #167 のマーカー基本機能を `JpmapTerrain` に追加。タイル表面から垂直に伸びる線の先に、アイコン＋改行可テキスト（カメラ常時追従ビルボード）を表示する公開APIを実装。

Closes #167

## 影響範囲

- 新規公開 API 追加のみ。既存挙動の変更なし。
- `spec/package.md`: §3.3.7 を新設、§4.2 の旧 `addImageMarker` / `addLabel` を本 API に統合（spec のみ、実装は従来から未存在）
- `src/lib/jpmapTerrain.ts`: `addMarker / getMarker / updateMarker / removeMarker / setMarkerEnabled / listMarkers` を追加
- `src/lib/types.ts`: `MarkerOptions` / `MarkerHandle` / `MarkerUpdate` / `MARKER_DEFAULTS` 等
- `src/lib.ts`: 型 re-export
- `src/scenes/default.ts`: `getMarkerContext()` 追加、`METERS_PER_DEGREE_LAT` を export 化、`tileManager.onTerrainUpdated` を subscribe chain 化
- `src/terrain/marker.ts` / `src/terrain/markerManager.ts`: 新規
- `src/demos/viewer/index.ts`: 東京駅・皇居・都庁の3マーカーをデモ表示

## 主な仕様

- `icon` / `text` の少なくとも片方が必須。両方指定時は **上=text、下=icon**
- ビルボードは `BILLBOARDMODE_ALL`、`renderingGroupId=1` で最前面化
- 標高未取得時は描画保留→`onTerrainUpdated` で自動表示
- `icon.url` は `http(s):` / `data:image/*` / 相対パスのみ許可（`javascript:` 等は throw, XSS 対策）
- `lat/lon` は `JAPAN_BOUNDS` でバリデーション
- `dispose()` で全マーカーリソースを解放（scene.dispose 前）

## 動作確認

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test:unit` ✅ 450 tests pass（うち新規 MarkerManager 14 tests）
- 手動確認: `npm start` でビルドエラーなし、viewer でマーカー3点が想定通り表示

## 既知の将来課題（本 PR 範囲外）

- ThinInstance 化等の大量マーカー最適化
- クリックイベント等の対話操作
- カメラ高度連動の `line.height` 自動調整
- Visual regression test（DynamicTexture フォントが flaky になりやすいため別 Issue）

## チェックリスト

- [x] 仕様整合性（spec/package.md §3.3.7 / §4.2 更新済）
- [x] TypeScript any 不使用
- [x] lint / typecheck / test pass
- [x] AGENTS.md Coding Rules 観点でセルフレビュー実施
