### PR TITLE
feat(polygon): PolygonManager foundation with points & polyline (#170)

### DIFF
--- a/public/polygon.html
+++ b/public/polygon.html
@@ -1,0 +1,101 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <title>jpmap_terrain – ポリゴンデモ</title>
+  <meta name="description" content="jpmap_terrain のポリゴン (PolygonManager) 公開 API 動作確認デモ (Issue #170)">
+  <meta name="author" content="8ga3">
+  <style>
+    html, body {
+      overflow: hidden;
+      width: 100%;
+      height: 100%;
+      margin: 0;
+      padding: 0;
+    }
+
+    #root {
+      position: relative;
+      width: 100%;
+      height: 100%;
+      touch-action: none;
+    }
+
+    /* 操作 UI ルート。ポインターイベントは透過。 */
+    #polygon-overlay {
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      z-index: 10;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI",
+        "Hiragino Sans", "Noto Sans JP", Meiryo, sans-serif;
+    }
+
+    #polygon-overlay .back-link {
+      position: absolute;
+      top: 12px;
+      left: 12px;
+      pointer-events: auto;
+      padding: 6px 12px;
+      font-size: 13px;
+      color: #fff;
+      background: rgba(0, 0, 0, 0.45);
+      border: 1px solid rgba(255, 255, 255, 0.25);
+      border-radius: 6px;
+      text-decoration: none;
+    }
+
+    #polygon-overlay .back-link:hover {
+      background: rgba(0, 0, 0, 0.6);
+    }
+
+    #polygon-controls {
+      position: absolute;
+      top: 12px;
+      right: 12px;
+      pointer-events: auto;
+      padding: 10px 12px;
+      font-size: 13px;
+      color: #fff;
+      background: rgba(0, 0, 0, 0.5);
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      border-radius: 8px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      max-width: 240px;
+    }
+
+    #polygon-controls strong {
+      font-size: 12px;
+      letter-spacing: 0.04em;
+      color: #c8d2e6;
+    }
+
+    #polygon-controls button {
+      pointer-events: auto;
+      padding: 4px 8px;
+      font-size: 12px;
+      color: #fff;
+      background: rgba(255, 255, 255, 0.08);
+      border: 1px solid rgba(255, 255, 255, 0.25);
+      border-radius: 4px;
+      cursor: pointer;
+    }
+
+    #polygon-controls button:hover {
+      background: rgba(255, 255, 255, 0.18);
+    }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <div id="polygon-overlay">
+    <a class="back-link" href="/">← デモ一覧へ</a>
+    <div id="polygon-controls">
+      <strong>ポリゴンデモ (Issue #170)</strong>
+      <div id="polygon-controls-buttons"></div>
+    </div>
+  </div>
+</body>
+</html>

--- a/spec/package.md
+++ b/spec/package.md
@@ -341,6 +341,79 @@ interface MarkerOptions {
 - 不正値・欠落・URL 解析失敗時は `JPMAP_TERRAIN_DEFAULTS.mapType`（= `"standard"`）にフォールバックする（例外は投げない）。
 - `viewer.mapType` の変化（UI 切替ボタン / プログラム set）は `onMapTypeChange` 経由でデモ層が `history.replaceState` により URL の `?mapType=` を更新する。パス（`/@lat,lon[,...]`）と他クエリ（`engine`, `dateTime` 等）・ハッシュは保持される。
 
+#### 3.3.8 ポリゴン (Issue #169)
+
+任意の点列を受け取り、地表または絶対標高に沿って **ポイント球体** と **ポリライン** を表示する API（基盤）。
+
+##### 3.3.8.1 公開 API（基盤＋ポリライン: Issue #170）
+
+```typescript
+interface JpmapTerrain {
+  /** ポリゴン追加。同 id 重複は throw、points 2 未満は throw、JAPAN_BOUNDS 外は throw。 */
+  addPolygon(id: string, options: PolygonOptions): PolygonHandle;
+  /** 取得。未存在は null */
+  getPolygon(id: string): PolygonHandle | null;
+  /** 削除。未存在は no-op + warn */
+  removePolygon(id: string): void;
+  /** enabled の薄いショートカット */
+  setPolygonEnabled(id: string, enabled: boolean): void;
+  /** 全 id を生成順で返す */
+  listPolygons(): readonly string[];
+}
+
+type AltitudeMode = "absolute" | "terrain";
+
+interface PolygonPointOptions {
+  lat: number;
+  lon: number;
+  /** `altitudeMode === "absolute"` のとき必須値 (m)。`"terrain"` のときは地表からのオフセット (m)、未指定時は 0 */
+  altitude?: number;
+}
+
+interface PolygonStyleOptions {
+  // #170 で実装
+  pointColor?: string;     // CSS color (default "#ff0000")
+  pointOpacity?: number;   // 0..1 (default 1)
+  pointDiameter?: number;  // m (default 20)
+  lineColor?: string;      // CSS color (default "#ff0000")
+  lineOpacity?: number;    // 0..1 (default 1)
+  lineWidth?: number;      // m (Tube radius, default 2)
+  // 以下は #171/#172 で実装予約（型のみ先出し）
+  dropLineColor?: string;
+  dropLineWidth?: number;
+  dropLineOpacity?: number;
+  labelColor?: string;
+  labelBackgroundColor?: string;
+  labelFontSize?: number;
+  wallColor?: string;
+  wallOpacity?: number;
+}
+
+interface PolygonOptions {
+  points: ReadonlyArray<PolygonPointOptions>; // 2 点以上
+  altitudeMode?: AltitudeMode;                // default "terrain"
+  /** `true` でポリラインの末尾と先頭を結んで閉じる（#170 はポリラインのみ閉じる）。default false */
+  closed?: boolean;
+  /** ラベル（点ごと）。#171 で描画予定。#170 では受け取るが描画しない。 */
+  labels?: ReadonlyArray<string>;
+  style?: PolygonStyleOptions;
+  enabled?: boolean;                          // default true
+}
+```
+
+**#170 範囲の仕様:**
+
+- `points` の各点に対し、`altitudeMode === "absolute"` なら `altitude` をそのまま Y に採用する。`"terrain"` ならタイル標高 (m) を Y に採用し、`altitude` が指定されている場合は地表からのオフセットとして加算する。
+- `terrain` モードで 1 点でも標高未解決の間は **ポリゴン全体を hide** し、`onTerrainUpdated` 後に自動表示する（例外は投げない）。
+- 各点に直径 `style.pointDiameter` (m) の **球体メッシュ** を配置する（既定色 `#ff0000`、emissive、`renderingGroupId = 1`）。スケールはカメラ距離に応じて screen-stable に動的更新される。
+- 隣接点間を **CreateTube**（`updatable: true`、半径 `style.lineWidth`）で結ぶ。`closed = true` のとき末尾→先頭も結ぶ。
+- JAPAN_BOUNDS 外の点・`points.length < 2`・`absolute` で `altitude` 未指定の場合は `addPolygon` で throw（範囲外の点 index をメッセージに含める）。
+- 同 id の重複追加は throw、`removePolygon` の未存在 id は `console.warn` + no-op。
+- `dispose()` で全ポリゴンリソース（Mesh / Material / TransformNode）を解放する。
+- **#171 で実装予定（型予約済み）**: 各ポイントから地表へ落とす垂線、ポイント脇のラベル（`labels`）。
+- **#172 で実装予定（型予約済み）**: 隣接垂線間を結ぶ「壁」（`closed` 時の閉じも含む）、`wallColor` / `wallOpacity`。
+- **#173 で実装予定**: `updatePolygon`、点単位編集 API（`insertPoint` / `removePoint` / `updatePoint` / `replacePoints`）、デモ拡張、視覚回帰テスト。
+
 ### 3.4 型定義
 
 `CameraChangeEvent` および `CameraChangeListener` は、`jpmap-terrain` から import 可能である（パッケージエントリで re-export 済み）。
@@ -368,6 +441,13 @@ import type {
   CameraChangeListener,
   MapType,
   MapTypeChangeListener,
+  // ポリゴン (Issue #170)
+  AltitudeMode,
+  PolygonPointOptions,
+  PolygonStyleOptions,
+  PolygonOptions,
+  PolygonUpdate,
+  PolygonHandle,
 } from "jpmap-terrain";
 ```
 

--- a/src/demos/polygon/index.ts
+++ b/src/demos/polygon/index.ts
@@ -1,0 +1,194 @@
+/**
+ * ポリゴンデモ (Issue #170)
+ *
+ * `JpmapTerrain` の Polygon 公開 API（`addPolygon` / `setPolygonEnabled` /
+ * `removePolygon` / `listPolygons` / `getPolygon`）を目視確認するためのデモ。
+ *
+ * 仕様 (#170 範囲):
+ * - `altitudeMode: "terrain"` で地形に沿って表示するポリライン
+ * - `altitudeMode: "absolute"` で絶対標高 (m) のポリライン
+ * - `closed: true` で末尾と先頭を結んだループ
+ *
+ * 操作:
+ * - 画面右上のボタンで各ポリゴンの enabled を ON/OFF
+ *
+ * 開発デモ層につき `src/lib/**` には依存型のみ依存し、内部実装は触らない。
+ */
+import { JpmapTerrain } from "../../lib/jpmapTerrain";
+import type { JpmapTerrainOptions, PolygonOptions } from "../../lib/types";
+import {
+    parseCameraStateFromUrl,
+    parseMapTypeFromUrl,
+} from "../../terrain/urlState";
+
+const DEMO_MOUNT_ID = "root";
+const CONTROLS_ID = "polygon-controls-buttons";
+
+/**
+ * `?engine=` クエリ文字列から描画エンジン種別を解決する（viewer デモと同規則）。
+ */
+const resolveEngine = (search: string): "webgpu" | "webgl2" | undefined => {
+    const value = new URLSearchParams(search).get("engine");
+    if (value === "webgpu") return "webgpu";
+    if (value === "webgl" || value === "webgl2") return "webgl2";
+    return undefined;
+};
+
+/**
+ * デモ用のポリゴン定義。
+ * よみうりランド付近を中心に、地形追従・絶対標高・closed ループの 3 本を配置する。
+ *
+ * 頂点間隔は数百メートル（緯度 0.0018° ≒ 200m, 経度 0.0022° ≒ 200m を基本ステップ）。
+ * 球体は `computeDistanceScale` によりスクリーン安定スケールで描画される（距離不変）。
+ */
+interface DemoPolygonDef {
+    id: string;
+    label: string;
+    options: PolygonOptions;
+}
+
+const buildDemoPolygons = (): readonly DemoPolygonDef[] => [
+    {
+        id: "yomiuri-terrain",
+        label: "terrain (地表+100m)",
+        options: {
+            // 約 400m × 400m の四角形（地形追従、地表から +100m オフセット）
+            points: [
+                { lat: 35.6225, lon: 139.5126, altitude: 100 },
+                { lat: 35.6261, lon: 139.5126, altitude: 100 },
+                { lat: 35.6261, lon: 139.5170, altitude: 100 },
+                { lat: 35.6225, lon: 139.5170, altitude: 100 },
+            ],
+            altitudeMode: "terrain",
+            style: {
+                pointColor: "#ff5252",
+                lineColor: "#ff5252",
+                pointDiameter: 18,
+                lineWidth: 3,
+            },
+        },
+    },
+    {
+        id: "yomiuri-absolute",
+        label: "absolute (絶対標高 300m)",
+        options: {
+            // 約 300m サイズの三角形（絶対標高 300m）
+            points: [
+                { lat: 35.6234, lon: 139.5132, altitude: 300 },
+                { lat: 35.6252, lon: 139.5132, altitude: 300 },
+                { lat: 35.6243, lon: 139.5165, altitude: 300 },
+            ],
+            altitudeMode: "absolute",
+            style: {
+                pointColor: "#42a5f5",
+                lineColor: "#42a5f5",
+                pointDiameter: 24,
+                lineWidth: 4,
+            },
+        },
+    },
+    {
+        id: "yomiuri-closed",
+        label: "closed=true (ループ 500m)",
+        options: {
+            // 約 200m × 250m の四角形を closed=true でループ表示
+            points: [
+                { lat: 35.6235, lon: 139.5135, altitude: 500 },
+                { lat: 35.6253, lon: 139.5135, altitude: 500 },
+                { lat: 35.6253, lon: 139.5161, altitude: 500 },
+                { lat: 35.6235, lon: 139.5161, altitude: 500 },
+            ],
+            altitudeMode: "absolute",
+            closed: true,
+            style: {
+                pointColor: "#ffca28",
+                lineColor: "#ffca28",
+                pointDiameter: 18,
+                lineWidth: 3,
+            },
+        },
+    },
+];
+
+/** 操作 UI（enabled トグル）を構築する。 */
+const buildControls = (
+    container: HTMLElement,
+    viewer: JpmapTerrain,
+    polygons: readonly DemoPolygonDef[],
+): void => {
+    container.innerHTML = "";
+    for (const def of polygons) {
+        const btn = document.createElement("button");
+        btn.type = "button";
+        btn.dataset.polygonId = def.id;
+        const refreshLabel = (): void => {
+            const handle = viewer.getPolygon(def.id);
+            const enabled = handle ? handle.enabled : false;
+            btn.textContent = `${enabled ? "✔" : "✕"} ${def.label}`;
+        };
+        btn.addEventListener("click", () => {
+            const handle = viewer.getPolygon(def.id);
+            if (!handle) return;
+            viewer.setPolygonEnabled(def.id, !handle.enabled);
+            refreshLabel();
+        });
+        container.appendChild(btn);
+        refreshLabel();
+    }
+};
+
+const start = async (): Promise<void> => {
+    const mount = document.getElementById(DEMO_MOUNT_ID);
+    if (!mount) {
+        throw new Error(`#${DEMO_MOUNT_ID} mount element not found`);
+    }
+
+    const engine = resolveEngine(location.search);
+    const cameraState = parseCameraStateFromUrl(location.href) ?? undefined;
+    const mapType = parseMapTypeFromUrl(location.href);
+    // よみうりランド近傍を初期視点（URL 指定がない場合）。
+    const defaultCamera = {
+        lat: 35.6242625,
+        lon: 139.5148162,
+        altitude: 1500,
+        azimuth: 0,
+        tilt: 55,
+    };
+
+    const opts: JpmapTerrainOptions = {
+        ...(engine ? { engine } : {}),
+        ...(cameraState ?? defaultCamera),
+        ...(mapType !== null ? { mapType } : {}),
+    };
+
+    const viewer = await JpmapTerrain.create(mount, opts);
+    const polygons = buildDemoPolygons();
+    for (const def of polygons) {
+        try {
+            viewer.addPolygon(def.id, def.options);
+        } catch (err) {
+            console.warn(
+                `[jpmap-terrain demo] failed to add polygon "${def.id}":`,
+                err,
+            );
+        }
+    }
+
+    const controls = document.getElementById(CONTROLS_ID);
+    if (controls instanceof HTMLElement) {
+        buildControls(controls, viewer, polygons);
+    }
+
+    if (process.env.NODE_ENV !== "production") {
+        (window as unknown as { viewer: JpmapTerrain }).viewer = viewer;
+    }
+};
+
+if (
+    typeof document !== "undefined" &&
+    document.getElementById(DEMO_MOUNT_ID) !== null
+) {
+    start().catch((err) => {
+        console.error("[jpmap-terrain demo] failed to start:", err);
+    });
+}

--- a/src/demos/portal/index.ts
+++ b/src/demos/portal/index.ts
@@ -30,6 +30,12 @@ const DEMO_LIST: readonly DemoEntry[] = [
             "24 時間を 1 分に圧縮して太陽位置・陰影をアニメーションし、アナログ時計で同期表示するショーケース。",
         href: "timelapse",
     },
+    {
+        title: "ポリゴン (Issue #170)",
+        description:
+            "PolygonManager 公開 API の動作確認デモ。terrain / absolute / closed の 3 種類のポリラインを表示し、enabled トグルで切替できます。",
+        href: "polygon",
+    },
 ];
 
 const PORTAL_MOUNT_ID = "root";

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -21,4 +21,10 @@ export type {
     MarkerOptions,
     MarkerTextOptions,
     MarkerUpdate,
+    AltitudeMode,
+    PolygonPointOptions,
+    PolygonStyleOptions,
+    PolygonOptions,
+    PolygonUpdate,
+    PolygonHandle,
 } from "./lib/types";

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -27,9 +27,12 @@ import {
     MarkerHandle,
     MarkerOptions,
     MarkerUpdate,
+    PolygonHandle,
+    PolygonOptions,
     SUN_AUTO_UPDATE_INTERVAL_MS,
 } from "./types";
 import { createMarkerManager, type MarkerManager } from "../terrain/markerManager";
+import { createPolygonManager, type PolygonManager } from "../terrain/polygonManager";
 
 /**
  * jpmap-terrain ビューア。
@@ -84,6 +87,9 @@ export class JpmapTerrain {
 
     /** マーカー管理 (Issue #167)。`onReady` で初期化される */
     private _markerManager: MarkerManager | null = null;
+
+    /** ポリゴン管理 (Issue #170)。`onReady` で初期化される */
+    private _polygonManager: PolygonManager | null = null;
 
     private constructor(mountElement: HTMLElement, options: JpmapTerrainOptions) {
         this.mountElement = mountElement;
@@ -209,6 +215,10 @@ export class JpmapTerrain {
                     }
                     // マーカー (Issue #167)。境界コンテキスト経由で manager を構築する。
                     this._markerManager = createMarkerManager(
+                        controller.getMarkerContext(),
+                    );
+                    // ポリゴン (Issue #170)。MarkerContext と同一のコンテキストを共有する。
+                    this._polygonManager = createPolygonManager(
                         controller.getMarkerContext(),
                     );
                 },
@@ -741,6 +751,45 @@ export class JpmapTerrain {
         return this._markerManager?.list() ?? [];
     }
 
+    // ---- ポリゴン (Issue #170) ----
+
+    private _requirePolygonManager(): PolygonManager {
+        if (!this._polygonManager) {
+            throw new Error("JpmapTerrain polygon manager is not ready yet");
+        }
+        return this._polygonManager;
+    }
+
+    /**
+     * dispose 後のポリゴン API はマーカーと同方針で統一する:
+     * - 戻り値が `PolygonHandle`（非 null）の API（`addPolygon`）は throw。
+     * - 戻り値が void / `PolygonHandle | null` / `readonly string[]` の API は no-op として扱う。
+     */
+    public addPolygon(id: string, options: PolygonOptions): PolygonHandle {
+        this._assertAlive();
+        return this._requirePolygonManager().add(id, options);
+    }
+
+    public getPolygon(id: string): PolygonHandle | null {
+        if (this._disposed || !this._polygonManager) return null;
+        return this._polygonManager.get(id);
+    }
+
+    public removePolygon(id: string): void {
+        if (this._disposed || !this._polygonManager) return;
+        this._polygonManager.remove(id);
+    }
+
+    public setPolygonEnabled(id: string, enabled: boolean): void {
+        if (this._disposed || !this._polygonManager) return;
+        this._polygonManager.setEnabled(id, enabled);
+    }
+
+    public listPolygons(): readonly string[] {
+        if (this._disposed) return [];
+        return this._polygonManager?.list() ?? [];
+    }
+
     // ---- ライフサイクル (spec §3.3.3) ----
 
     /**
@@ -786,6 +835,15 @@ export class JpmapTerrain {
                 console.error("[JpmapTerrain] markerManager.dispose threw:", err);
             }
             this._markerManager = null;
+        }
+        // ポリゴンマネージャも Scene dispose 前に解放する (Issue #170)。
+        if (this._polygonManager) {
+            try {
+                this._polygonManager.dispose();
+            } catch (err) {
+                console.error("[JpmapTerrain] polygonManager.dispose threw:", err);
+            }
+            this._polygonManager = null;
         }
         // controlPanel が body に追加した UI 要素を Scene dispose 前に除去する。
         if (this._controller) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -238,7 +238,7 @@ export interface PolygonPointOptions {
 export interface PolygonStyleOptions {
     /** 線色 CSS。default `#ff0000` */
     lineColor?: string;
-    /** 線太さ (m, world)。default 2 */
+    /** 線描画に用いる Tube の半径 (m, world)。default 2 */
     lineWidth?: number;
     /** 線の不透明度 [0,1]。default 1 */
     lineOpacity?: number;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -202,3 +202,154 @@ export const MARKER_DEFAULTS = {
     },
     textMaxLength: 512,
 } as const;
+
+// ---- ポリゴン (Issue #169 / #170) ----
+
+/**
+ * ポリゴン頂点の Y 値解決方法。
+ * - `terrain` (default): タイル標高に追従する。1 点でも未解決の場合はポリゴン全体を非表示にする。
+ * - `absolute`: `altitude` (m) を絶対高度として使用する。`altitude` 未指定の点があれば throw する。
+ */
+export type AltitudeMode = "terrain" | "absolute";
+
+/**
+ * ポリゴンを構成する 1 頂点。
+ */
+export interface PolygonPointOptions {
+    /** 緯度 (度) */
+    lat: number;
+    /** 経度 (度) */
+    lon: number;
+    /**
+     * 高度 (m)。
+     * - `altitudeMode === "absolute"` のとき必須。海抜高度として Y に直接採用する。
+     * - `altitudeMode === "terrain"` のとき任意。指定値は地表標高への加算オフセット (m)。未指定時は 0。
+     */
+    altitude?: number;
+}
+
+/**
+ * ポリゴン全体のスタイル（spec/package.md §3.3.8.1）。
+ *
+ * - `lineColor` / `lineWidth` / `lineOpacity` / `pointColor` / `pointDiameter` / `pointOpacity` は #170 で適用。
+ * - `dropLine*` / `label*` は #171 で適用予定。`#170` では型予約のみ（既定値で埋めるが描画には未使用）。
+ * - `wallColor` / `wallOpacity` は #172 で適用予定。
+ */
+export interface PolygonStyleOptions {
+    /** 線色 CSS。default `#ff0000` */
+    lineColor?: string;
+    /** 線太さ (m, world)。default 2 */
+    lineWidth?: number;
+    /** 線の不透明度 [0,1]。default 1 */
+    lineOpacity?: number;
+    /** 球の色 CSS。default `#ff0000` */
+    pointColor?: string;
+    /** 球の直径 (m, world、distScale 適用前)。default 20 */
+    pointDiameter?: number;
+    /** 球の不透明度 [0,1]。default 1 */
+    pointOpacity?: number;
+    /** 垂線の色 CSS（#171 で適用）。 */
+    dropLineColor?: string;
+    /** 垂線の太さ (m, world)（#171 で適用）。 */
+    dropLineWidth?: number;
+    /** 垂線の不透明度 [0,1]（#171 で適用）。 */
+    dropLineOpacity?: number;
+    /** ラベル文字色 CSS（#171 で適用）。 */
+    labelColor?: string;
+    /** ラベル背景色 CSS（#171 で適用）。 */
+    labelBackgroundColor?: string;
+    /** ラベル文字サイズ (px)（#171 で適用）。 */
+    labelFontSize?: number;
+    /** 壁の色 CSS（#172 で適用）。 */
+    wallColor?: string;
+    /** 壁の不透明度 [0,1]（#172 で適用）。 */
+    wallOpacity?: number;
+}
+
+/**
+ * ポリゴン追加オプション。
+ */
+export interface PolygonOptions {
+    /** 頂点列。最低 2 点。 */
+    points: readonly PolygonPointOptions[];
+    /**
+     * `true` の場合、最後の頂点と最初の頂点を結ぶ線を 1 本追加する（#170）。
+     * 面塗りなどは #172 で実装する。default false
+     */
+    closed?: boolean;
+    /** 高度モード。default `"terrain"` */
+    altitudeMode?: AltitudeMode;
+    /**
+     * ラベル（点ごと）。`points[i]` に対応する文字列を `labels[i]` で渡す。
+     * `#171` で描画予定。`#170` では受け取るが描画はしない。
+     */
+    labels?: ReadonlyArray<string>;
+    /** スタイル */
+    style?: PolygonStyleOptions;
+    /** default true */
+    enabled?: boolean;
+}
+
+/**
+ * `JpmapTerrain.updatePolygon`（#173 で公開予定）の部分更新型。
+ * `#170` では `PolygonManager` 内部実装でのみ使用する。
+ */
+export type PolygonUpdate = Partial<
+    Pick<
+        PolygonOptions,
+        | "points"
+        | "closed"
+        | "altitudeMode"
+        | "labels"
+        | "style"
+        | "enabled"
+    >
+>;
+
+/**
+ * `JpmapTerrain.addPolygon` / `getPolygon` の戻り値（read-only スナップショット）。
+ */
+export interface PolygonHandle {
+    readonly id: string;
+    readonly points: readonly Readonly<PolygonPointOptions>[];
+    readonly closed: boolean;
+    readonly altitudeMode: AltitudeMode;
+    readonly labels: ReadonlyArray<string> | undefined;
+    readonly style: Readonly<Required<PolygonStyleOptions>>;
+    readonly enabled: boolean;
+    /**
+     * `terrain` モード時、全頂点の標高が解決済みなら true。
+     * `absolute` モード時は常に true。
+     */
+    readonly elevationResolved: boolean;
+}
+
+/**
+ * ポリゴンの既定値（spec/package.md §3.3.8.1）。
+ *
+ * `style` は仕様書記載の #170 範囲既定値（`#ff0000` / 直径 20m / 線幅 2m / opacity 1）を採用する。
+ * `dropLine*` / `label*` / `wallColor` / `wallOpacity` は型予約のため、ハンドル `style` の
+ * `Required<>` を満たすための既定値を内部的に保持するが、`#170` では描画には使用されない。
+ */
+export const POLYGON_DEFAULTS = {
+    closed: false,
+    altitudeMode: "terrain" as AltitudeMode,
+    enabled: true,
+    style: {
+        lineColor: "#ff0000",
+        lineWidth: 2,
+        lineOpacity: 1,
+        pointColor: "#ff0000",
+        pointDiameter: 20,
+        pointOpacity: 1,
+        // 以下は #171 / #172 用の予約値（描画未使用）。Required<> 充足のために保持。
+        dropLineColor: "#ff0000",
+        dropLineWidth: 1,
+        dropLineOpacity: 1,
+        labelColor: "#ffffff",
+        labelBackgroundColor: "#000000",
+        labelFontSize: 14,
+        wallColor: "#ff0000",
+        wallOpacity: 0.3,
+    },
+} as const;

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -571,9 +571,11 @@ export class DefaultScene implements CreateSceneClass {
                 );
                 if (centerPick?.hit && centerPick.pickedPoint) {
                     camera.setTarget(centerPick.pickedPoint);
-                    // 新 target の xz を新たなグリッド残差基準として同期
-                    gridResidualX = camera.target.x;
-                    gridResidualZ = camera.target.z;
+                    // ターゲット差分を緯度経度へ折り込み、Marker/Polygon の位置基準
+                    // (currentLat/Lon と gridResidualX/Z) を新ターゲットと整合させる。
+                    // これを行わずに gridResidualX/Z だけ更新すると、currentLat/Lon
+                    // との不整合により Polygon ノードが回転開始時に微小ジャンプする (#170)。
+                    commitPanOffset();
                 }
             } else {
                 // 単独ドラッグ

--- a/src/terrain/markerManager.ts
+++ b/src/terrain/markerManager.ts
@@ -3,14 +3,22 @@
  *
  * `JpmapTerrain.addMarker / updateMarker / removeMarker / setMarkerEnabled / listMarkers / getMarker`
  * から呼び出される。マーカーの ID 管理・スタブ標高解決・毎フレームの位置更新を担う。
+ *
+ * Issue #170 で座標系ユーティリティを `./overlayCoords` に分離したが、
+ * `MarkerManager` の挙動は不変。
  */
 
 import type { Observer } from "@babylonjs/core/Misc/observable";
 import type { Scene } from "@babylonjs/core/scene";
 
-import { JAPAN_BOUNDS } from "./gsiTile";
 import { createMarkerNode, type MarkerNode } from "./marker";
-import { METERS_PER_DEGREE_LAT, type MarkerContext } from "../scenes/default";
+import {
+    assertLatLonInBounds,
+    computeDistanceScale,
+    computeDynamicLineHeight,
+    latLonToWorld,
+} from "./overlayCoords";
+import { type MarkerContext } from "../scenes/default";
 import type {
     MarkerHandle,
     MarkerOptions,
@@ -27,80 +35,23 @@ export interface MarkerManager {
     dispose(): void;
 }
 
-const assertInBounds = (lat: number, lon: number): void => {
-    if (
-        lat < JAPAN_BOUNDS.minLat ||
-        lat > JAPAN_BOUNDS.maxLat ||
-        lon < JAPAN_BOUNDS.minLon ||
-        lon > JAPAN_BOUNDS.maxLon
-    ) {
-        throw new Error(
-            `marker: lat/lon out of JAPAN_BOUNDS (lat=${lat}, lon=${lon})`,
-        );
-    }
-};
+const ERROR_PREFIX = "marker";
 
 export const createMarkerManager = (ctx: MarkerContext): MarkerManager => {
     const nodes = new Map<string, MarkerNode>();
 
-    const computeWorld = (
-        lat: number,
-        lon: number,
-    ): { wx: number; wz: number } => {
-        const origin = ctx.getOrigin();
-        const metersPerDegLon =
-            METERS_PER_DEGREE_LAT * Math.cos((origin.lat * Math.PI) / 180);
-        const wx = (lon - origin.lon) * metersPerDegLon + origin.gridResidualX;
-        const wz = (lat - origin.lat) * METERS_PER_DEGREE_LAT + origin.gridResidualZ;
-        return { wx, wz };
-    };
-
-    /**
-     * スケール基準距離 (m)。カメラ距離がこの値なら scale=1、それ以上は distance/refDistance
-     * 倍してスクリーン空間サイズを一定に保つ。
-     */
-    const REF_DISTANCE_M = 1000;
-
-    const computeDistScale = (wx: number, wy: number, wz: number): number => {
-        const cam = ctx.getCameraPosition();
-        const dx = cam.x - wx;
-        const dy = cam.y - wy;
-        const dz = cam.z - wz;
-        const dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
-        const scale = dist / REF_DISTANCE_M;
-        // 近すぎるとテクスチャ補間が荷重になるため下限を設ける
-        return Math.max(scale, 0.1);
-    };
-
-    /**
-     * 動的な線高さ (m) をカメラ位置と beta 角度から計算する。
-     *
-     * 画面中央付近にマーカーが表示されるよう、カメラ距離 (radius) に対して
-     * 一定割合の高さにしつつ、仰角 (beta=真上が 0、水平が π/2) で豊かに調整する。
-     * - radius * 0.1 をベースとし、sin(beta) で 0.3 〜1.0 にクランプした係数を掛ける。
-     * - 下限 100m、上限 10000m で見た目の肉付きを安定させる。
-     */
-    const computeDynamicLineHeight = (): number => {
-        const cam = ctx.getCameraPosition();
-        const radius = Math.max(cam.radius, 1);
-        const sinBeta = Math.sin(cam.beta);
-        const factor = Math.min(1, Math.max(0.3, sinBeta));
-        const h = radius * 0.1 * factor;
-        return Math.min(10000, Math.max(100, h));
-    };
-
     const tickFrame = (): void => {
         if (nodes.size === 0) return;
-        const dynamicLineHeight = computeDynamicLineHeight();
+        const dynamicLineHeight = computeDynamicLineHeight(ctx);
         for (const node of nodes.values()) {
-            const { wx, wz } = computeWorld(node.lat, node.lon);
+            const { wx, wz } = latLonToWorld(ctx, node.lat, node.lon);
             const elev = ctx.tileManager.queryElevationAtWorld(wx, wz);
             if (elev === null) {
                 node.setElevationResolved(false);
                 continue;
             }
             node.setElevationResolved(true);
-            const scale = computeDistScale(wx, elev, wz);
+            const scale = computeDistanceScale(ctx, wx, elev, wz);
             node.applyTransform(wx, elev, wz, scale, dynamicLineHeight);
         }
     };
@@ -134,16 +85,16 @@ export const createMarkerManager = (ctx: MarkerContext): MarkerManager => {
                     `JpmapTerrain.addMarker: id "${id}" already exists`,
                 );
             }
-            assertInBounds(options.lat, options.lon);
+            assertLatLonInBounds(options.lat, options.lon, ERROR_PREFIX);
             const node = createMarkerNode(ctx.scene, id, options);
             nodes.set(id, node);
             // 初回 tick で標高解決を試みる
-            const { wx, wz } = computeWorld(options.lat, options.lon);
+            const { wx, wz } = latLonToWorld(ctx, options.lat, options.lon);
             const elev = ctx.tileManager.queryElevationAtWorld(wx, wz);
             if (elev !== null) {
                 node.setElevationResolved(true);
-                const scale = computeDistScale(wx, elev, wz);
-                const dynamicLineHeight = computeDynamicLineHeight();
+                const scale = computeDistanceScale(ctx, wx, elev, wz);
+                const dynamicLineHeight = computeDynamicLineHeight(ctx);
                 node.applyTransform(wx, elev, wz, scale, dynamicLineHeight);
             }
             return node.getHandle();
@@ -162,7 +113,7 @@ export const createMarkerManager = (ctx: MarkerContext): MarkerManager => {
             const latLonChanged =
                 partial.lat !== undefined || partial.lon !== undefined;
             if (latLonChanged) {
-                assertInBounds(newLat, newLon);
+                assertLatLonInBounds(newLat, newLon, ERROR_PREFIX);
             }
             node.update(partial, newLat, newLon);
             if (latLonChanged) {

--- a/src/terrain/overlayCoords.ts
+++ b/src/terrain/overlayCoords.ts
@@ -1,0 +1,104 @@
+/**
+ * Overlay 共通座標ユーティリティ (Issue #170)。
+ *
+ * Marker / Polygon など、`MarkerContext`（= {@link OverlayContext}）を共有する
+ * オーバーレイ実装が共通で利用する関数を集約する。
+ *
+ * - `latLonToWorld`: 緯度経度 → ワールド座標 (wx, wz) 変換
+ * - `assertLatLonInBounds`: JAPAN_BOUNDS 範囲外なら Error
+ * - `computeDistanceScale`: カメラ距離に応じたスクリーン定スケール係数（下限 0.1）
+ * - `computeDynamicLineHeight`: カメラ距離・仰角から動的に決まる「線の高さ (m)」
+ *
+ * すべて `MarkerManager` から移設したロジックそのままで、挙動は不変である。
+ */
+
+import { JAPAN_BOUNDS } from "./gsiTile";
+import { METERS_PER_DEGREE_LAT, type MarkerContext } from "../scenes/default";
+
+/**
+ * Marker / Polygon が共有する境界コンテキスト。
+ *
+ * 構造変更を避けるため `MarkerContext` の型 alias として定義する。
+ */
+export type OverlayContext = MarkerContext;
+
+/**
+ * スケール基準距離 (m)。カメラ距離がこの値なら scale=1、それ以上は distance/refDistance
+ * 倍してスクリーン空間サイズを一定に保つ。
+ */
+export const REF_DISTANCE_M = 1000;
+
+/**
+ * 緯度経度をシーン内ワールド座標 (wx, wz) に変換する。
+ *
+ * 原点 (`ctx.getOrigin()`) と地理院タイル整列のための `gridResidualX/Z` を加味する。
+ */
+export const latLonToWorld = (
+    ctx: OverlayContext,
+    lat: number,
+    lon: number,
+): { wx: number; wz: number } => {
+    const origin = ctx.getOrigin();
+    const metersPerDegLon =
+        METERS_PER_DEGREE_LAT * Math.cos((origin.lat * Math.PI) / 180);
+    const wx = (lon - origin.lon) * metersPerDegLon + origin.gridResidualX;
+    const wz = (lat - origin.lat) * METERS_PER_DEGREE_LAT + origin.gridResidualZ;
+    return { wx, wz };
+};
+
+/**
+ * `lat` / `lon` が `JAPAN_BOUNDS` の範囲内であることを検証する。
+ * 範囲外なら `errorPrefix` を含むメッセージで Error を投げる。
+ */
+export const assertLatLonInBounds = (
+    lat: number,
+    lon: number,
+    errorPrefix: string,
+): void => {
+    if (
+        lat < JAPAN_BOUNDS.minLat ||
+        lat > JAPAN_BOUNDS.maxLat ||
+        lon < JAPAN_BOUNDS.minLon ||
+        lon > JAPAN_BOUNDS.maxLon
+    ) {
+        throw new Error(
+            `${errorPrefix}: lat/lon out of JAPAN_BOUNDS (lat=${lat}, lon=${lon})`,
+        );
+    }
+};
+
+/**
+ * カメラ位置とワールド座標 (wx, wy, wz) からスクリーン定スケール係数を計算する。
+ * 近距離での過大スケールを抑えるため下限 0.1 を持つ。
+ */
+export const computeDistanceScale = (
+    ctx: OverlayContext,
+    wx: number,
+    wy: number,
+    wz: number,
+): number => {
+    const cam = ctx.getCameraPosition();
+    const dx = cam.x - wx;
+    const dy = cam.y - wy;
+    const dz = cam.z - wz;
+    const dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
+    const scale = dist / REF_DISTANCE_M;
+    return Math.max(scale, 0.1);
+};
+
+/**
+ * 動的な線高さ (m) をカメラ位置と beta 角度から計算する。
+ *
+ * 画面中央付近にマーカー/ポリゴン頂点が表示されるよう、
+ * カメラ距離 (radius) に対して一定割合の高さにしつつ、仰角 (beta) で調整する。
+ * - radius * 0.1 をベースとし、sin(beta) で 0.3 〜1.0 にクランプした係数を掛ける。
+ * - 下限 100m、上限 10000m で見た目の肉付きを安定させる。
+ */
+export const computeDynamicLineHeight = (ctx: OverlayContext): number => {
+    const cam = ctx.getCameraPosition();
+    const radius = Math.max(cam.radius, 1);
+    const sinBeta = Math.sin(cam.beta);
+    const factor = Math.min(1, Math.max(0.3, sinBeta));
+    const h = radius * 0.1 * factor;
+    return Math.min(10000, Math.max(100, h));
+};

--- a/src/terrain/polygon.ts
+++ b/src/terrain/polygon.ts
@@ -1,0 +1,256 @@
+/**
+ * 個別ポリゴンノード (Issue #170)。
+ *
+ * - 頂点ごとの球（{@link CreateSphere}）
+ * - 頂点列を結ぶチューブ（{@link CreateTube}、`updatable: true`）
+ * を 1 つの root TransformNode 配下に親子化して管理する。
+ *
+ * `closed=true` のときはチューブ末端に最初の頂点を append し、可視的に閉じる。
+ * 面塗り・壁・点ラベル・垂線は本タスクでは実装しない（#171 / #172 / #173）。
+ */
+
+import type { Scene } from "@babylonjs/core/scene";
+import { Color3 } from "@babylonjs/core/Maths/math.color";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { CreateSphere } from "@babylonjs/core/Meshes/Builders/sphereBuilder";
+import { CreateTube } from "@babylonjs/core/Meshes/Builders/tubeBuilder";
+import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
+import { Mesh } from "@babylonjs/core/Meshes/mesh";
+import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
+
+import {
+    POLYGON_DEFAULTS,
+    type AltitudeMode,
+    type PolygonHandle,
+    type PolygonOptions,
+    type PolygonPointOptions,
+    type PolygonStyleOptions,
+} from "../lib/types";
+
+const RENDERING_GROUP_ID = 1;
+
+interface ResolvedStyle {
+    lineColor: string;
+    lineWidth: number;
+    lineOpacity: number;
+    pointDiameter: number;
+    pointColor: string;
+    pointOpacity: number;
+    dropLineColor: string;
+    dropLineWidth: number;
+    dropLineOpacity: number;
+    labelColor: string;
+    labelBackgroundColor: string;
+    labelFontSize: number;
+    wallColor: string;
+    wallOpacity: number;
+}
+
+const resolveStyle = (style: PolygonStyleOptions | undefined): ResolvedStyle => ({
+    lineColor: style?.lineColor ?? POLYGON_DEFAULTS.style.lineColor,
+    lineWidth: style?.lineWidth ?? POLYGON_DEFAULTS.style.lineWidth,
+    lineOpacity: style?.lineOpacity ?? POLYGON_DEFAULTS.style.lineOpacity,
+    pointDiameter:
+        style?.pointDiameter ?? POLYGON_DEFAULTS.style.pointDiameter,
+    pointColor: style?.pointColor ?? POLYGON_DEFAULTS.style.pointColor,
+    pointOpacity: style?.pointOpacity ?? POLYGON_DEFAULTS.style.pointOpacity,
+    dropLineColor:
+        style?.dropLineColor ?? POLYGON_DEFAULTS.style.dropLineColor,
+    dropLineWidth:
+        style?.dropLineWidth ?? POLYGON_DEFAULTS.style.dropLineWidth,
+    dropLineOpacity:
+        style?.dropLineOpacity ?? POLYGON_DEFAULTS.style.dropLineOpacity,
+    labelColor: style?.labelColor ?? POLYGON_DEFAULTS.style.labelColor,
+    labelBackgroundColor:
+        style?.labelBackgroundColor ??
+        POLYGON_DEFAULTS.style.labelBackgroundColor,
+    labelFontSize:
+        style?.labelFontSize ?? POLYGON_DEFAULTS.style.labelFontSize,
+    wallColor: style?.wallColor ?? POLYGON_DEFAULTS.style.wallColor,
+    wallOpacity: style?.wallOpacity ?? POLYGON_DEFAULTS.style.wallOpacity,
+});
+
+/**
+ * 1 ポリゴン分の Babylon ノード。`PolygonManager` から生成・更新・破棄される。
+ */
+export interface PolygonNode {
+    readonly id: string;
+    readonly altitudeMode: AltitudeMode;
+    readonly closed: boolean;
+    /** 頂点座標 (lat / lon / altitude) のスナップショット。manager から更新される */
+    readonly points: readonly PolygonPointOptions[];
+    /** 全頂点を更新する。`worldPoints[i].y` には標高が反映済みのワールド Y を渡す */
+    applyTransform(worldPoints: readonly Vector3[], pointScale: number): void;
+    setEnabledLogical(enabled: boolean): void;
+    setElevationResolved(resolved: boolean): void;
+    getHandle(): PolygonHandle;
+    dispose(): void;
+}
+
+const createPointSphere = (
+    scene: Scene,
+    id: string,
+    index: number,
+    style: ResolvedStyle,
+    parent: TransformNode,
+): { mesh: Mesh; material: StandardMaterial } => {
+    const mesh = CreateSphere(
+        `polygon-${id}-point-${index}`,
+        { diameter: 1, segments: 16 },
+        scene,
+    );
+    const material = new StandardMaterial(
+        `polygon-${id}-point-mat-${index}`,
+        scene,
+    );
+    material.disableLighting = true;
+    material.backFaceCulling = false;
+    material.emissiveColor = Color3.FromHexString(style.pointColor);
+    material.alpha = style.pointOpacity;
+    mesh.material = material;
+    mesh.renderingGroupId = RENDERING_GROUP_ID;
+    mesh.isPickable = false;
+    mesh.parent = parent;
+    return { mesh, material };
+};
+
+/**
+ * 線パスを構築する。`closed=true` のときは先頭頂点を末尾に append する。
+ * 参照を分けるために常に新しい配列・新しい Vector3 を返す。
+ */
+const buildLinePath = (
+    worldPoints: readonly Vector3[],
+    closed: boolean,
+): Vector3[] => {
+    const path: Vector3[] = worldPoints.map((p) => new Vector3(p.x, p.y, p.z));
+    if (closed && path.length >= 2) {
+        const first = path[0];
+        path.push(new Vector3(first.x, first.y, first.z));
+    }
+    return path;
+};
+
+/**
+ * `PolygonNode` を生成する。`points.length >= 2` 前提（`PolygonManager` 側で検証済み）。
+ */
+export const createPolygonNode = (
+    scene: Scene,
+    id: string,
+    options: PolygonOptions,
+): PolygonNode => {
+    const closed = options.closed ?? POLYGON_DEFAULTS.closed;
+    const altitudeMode = options.altitudeMode ?? POLYGON_DEFAULTS.altitudeMode;
+    const labels = options.labels
+        ? Object.freeze([...options.labels])
+        : undefined;
+    const style = resolveStyle(options.style);
+    let logicalEnabled = options.enabled ?? POLYGON_DEFAULTS.enabled;
+    let elevationResolved = altitudeMode === "absolute";
+
+    // 頂点はディープコピーして外部からの破壊変更を無効化する。
+    const points: PolygonPointOptions[] = options.points.map((p) => ({
+        lat: p.lat,
+        lon: p.lon,
+        altitude: p.altitude,
+    }));
+
+    const root = new TransformNode(`polygon-${id}`, scene);
+
+    // 各頂点に対応する球を 1 つだけ作る。スケールは applyTransform で更新する。
+    const sphereEntries = points.map((_pt, index) =>
+        createPointSphere(scene, id, index, style, root),
+    );
+
+    // 初期 path（仮）。applyTransform で必ず上書きされる前提だが、
+    // 構築時にも有効な Tube が必要なので原点付近の placeholder を渡す。
+    const initialPath: Vector3[] = points.map((_, i) => new Vector3(i, 0, 0));
+    const initialTubePath = buildLinePath(initialPath, closed);
+    let lineMesh: Mesh = CreateTube(
+        `polygon-${id}-line`,
+        {
+            path: initialTubePath,
+            radius: Math.max(style.lineWidth, 0.001),
+            updatable: true,
+            cap: Mesh.NO_CAP,
+        },
+        scene,
+    );
+    const lineMaterial = new StandardMaterial(`polygon-${id}-line-mat`, scene);
+    lineMaterial.disableLighting = true;
+    lineMaterial.backFaceCulling = false;
+    lineMaterial.emissiveColor = Color3.FromHexString(style.lineColor);
+    lineMaterial.alpha = style.lineOpacity;
+    lineMesh.material = lineMaterial;
+    lineMesh.renderingGroupId = RENDERING_GROUP_ID;
+    lineMesh.isPickable = false;
+    lineMesh.parent = root;
+
+    const applyVisibility = (): void => {
+        const visible = logicalEnabled && elevationResolved;
+        root.setEnabled(visible);
+    };
+    applyVisibility();
+
+    const applyTransform = (
+        worldPoints: readonly Vector3[],
+        pointScale: number,
+    ): void => {
+        if (worldPoints.length !== sphereEntries.length) {
+            // ディフェンシブ: 想定外。何もしない（次フレームで更新されうる）。
+            return;
+        }
+        const sphereDiameter = Math.max(style.pointDiameter, 0.001);
+        for (let i = 0; i < sphereEntries.length; i++) {
+            const sphere = sphereEntries[i].mesh;
+            const wp = worldPoints[i];
+            sphere.position.set(wp.x, wp.y, wp.z);
+            sphere.scaling.setAll(sphereDiameter * pointScale);
+        }
+        const tubePath = buildLinePath(worldPoints, closed);
+        lineMesh = CreateTube(
+            `polygon-${id}-line`,
+            { path: tubePath, instance: lineMesh },
+            scene,
+        );
+    };
+
+    const getHandle = (): PolygonHandle => ({
+        id,
+        points: points.map((p) => ({ ...p })),
+        closed,
+        altitudeMode,
+        labels,
+        style: { ...style },
+        enabled: logicalEnabled,
+        elevationResolved,
+    });
+
+    const dispose = (): void => {
+        for (const entry of sphereEntries) {
+            entry.material.dispose();
+            entry.mesh.dispose();
+        }
+        sphereEntries.length = 0;
+        lineMaterial.dispose();
+        lineMesh.dispose();
+        root.dispose();
+    };
+
+    return {
+        id,
+        altitudeMode,
+        closed,
+        points,
+        applyTransform,
+        setEnabledLogical(enabled: boolean): void {
+            logicalEnabled = enabled;
+            applyVisibility();
+        },
+        setElevationResolved(resolved: boolean): void {
+            elevationResolved = resolved;
+            applyVisibility();
+        },
+        getHandle,
+        dispose,
+    };
+};

--- a/src/terrain/polygonManager.ts
+++ b/src/terrain/polygonManager.ts
@@ -1,0 +1,202 @@
+/**
+ * PolygonManager (Issue #170)。
+ *
+ * `JpmapTerrain.addPolygon / getPolygon / removePolygon / setPolygonEnabled / listPolygons`
+ * から呼び出される。
+ *
+ * - 各 polygon を `OverlayContext` 共有のフレームループで毎フレーム位置更新する。
+ * - `altitudeMode === "terrain"` のとき、1 点でも標高未解決なら polygon 全体を非表示にする。
+ * - `altitudeMode === "absolute"` のとき、`altitude` を Y として使用する。
+ */
+
+import type { Observer } from "@babylonjs/core/Misc/observable";
+import type { Scene } from "@babylonjs/core/scene";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+
+import {
+    assertLatLonInBounds,
+    computeDistanceScale,
+    latLonToWorld,
+    type OverlayContext,
+} from "./overlayCoords";
+import { createPolygonNode, type PolygonNode } from "./polygon";
+import {
+    POLYGON_DEFAULTS,
+    type PolygonHandle,
+    type PolygonOptions,
+    type PolygonUpdate,
+} from "../lib/types";
+
+const ERROR_PREFIX = "JpmapTerrain.addPolygon";
+
+export interface PolygonManager {
+    add(id: string, options: PolygonOptions): PolygonHandle;
+    get(id: string): PolygonHandle | null;
+    /**
+     * 部分更新。`#170` では `JpmapTerrain` 公開 API として露出しない（#173 で公開）。
+     * 内部実装としてのみ提供する。
+     */
+    update(id: string, partial: PolygonUpdate): PolygonHandle;
+    remove(id: string): void;
+    setEnabled(id: string, enabled: boolean): void;
+    list(): readonly string[];
+    dispose(): void;
+}
+
+const validateOptions = (options: PolygonOptions): void => {
+    if (!options.points || options.points.length < 2) {
+        throw new Error(
+            `${ERROR_PREFIX}: points must contain at least 2 entries (got ${
+                options.points?.length ?? 0
+            })`,
+        );
+    }
+    const altitudeMode =
+        options.altitudeMode ?? POLYGON_DEFAULTS.altitudeMode;
+    for (let i = 0; i < options.points.length; i++) {
+        const p = options.points[i];
+        assertLatLonInBounds(p.lat, p.lon, `${ERROR_PREFIX}[${i}]`);
+        if (altitudeMode === "absolute" && p.altitude === undefined) {
+            throw new Error(
+                `${ERROR_PREFIX}: altitudeMode="absolute" requires altitude on every point (missing at index ${i})`,
+            );
+        }
+    }
+};
+
+export const createPolygonManager = (ctx: OverlayContext): PolygonManager => {
+    const nodes = new Map<string, PolygonNode>();
+    let disposed = false;
+
+    /**
+     * 1 ポリゴンの 1 フレーム分更新を行い、全頂点が解決したかを返す。
+     */
+    const tickPolygon = (node: PolygonNode): void => {
+        const worldPoints: Vector3[] = [];
+        let allResolved = true;
+        for (const pt of node.points) {
+            const { wx, wz } = latLonToWorld(ctx, pt.lat, pt.lon);
+            let wy: number;
+            if (node.altitudeMode === "absolute") {
+                // validateOptions で undefined は弾いている前提。
+                wy = pt.altitude ?? 0;
+            } else {
+                const elev = ctx.tileManager.queryElevationAtWorld(wx, wz);
+                if (elev === null) {
+                    allResolved = false;
+                    break;
+                }
+                wy = elev + (pt.altitude ?? 0);
+            }
+            worldPoints.push(new Vector3(wx, wy, wz));
+        }
+        if (!allResolved) {
+            node.setElevationResolved(false);
+            return;
+        }
+        // 頂点列の重心を distScale 計算用に使う（点ごとに変えると球サイズがバラつくため統一）。
+        let cx = 0;
+        let cy = 0;
+        let cz = 0;
+        for (const p of worldPoints) {
+            cx += p.x;
+            cy += p.y;
+            cz += p.z;
+        }
+        const n = worldPoints.length;
+        cx /= n;
+        cy /= n;
+        cz /= n;
+        const scale = computeDistanceScale(ctx, cx, cy, cz);
+        node.setElevationResolved(true);
+        node.applyTransform(worldPoints, scale);
+    };
+
+    const tickFrame = (): void => {
+        if (nodes.size === 0) return;
+        for (const node of nodes.values()) {
+            tickPolygon(node);
+        }
+    };
+
+    const observer: Observer<Scene> | null =
+        ctx.scene.onBeforeRenderObservable.add(tickFrame);
+
+    const unsubscribeTerrain = ctx.tileManager.subscribeTerrainUpdated(() => {
+        // tickFrame で次フレームに反映される。明示的な再評価は不要。
+    });
+
+    const requireNode = (id: string): PolygonNode => {
+        const node = nodes.get(id);
+        if (!node) {
+            throw new Error(`Polygon id "${id}" not found`);
+        }
+        return node;
+    };
+
+    return {
+        add(id: string, options: PolygonOptions): PolygonHandle {
+            if (disposed) {
+                throw new Error("PolygonManager has been disposed");
+            }
+            if (nodes.has(id)) {
+                throw new Error(
+                    `JpmapTerrain.addPolygon: id "${id}" already exists`,
+                );
+            }
+            validateOptions(options);
+            const node = createPolygonNode(ctx.scene, id, options);
+            nodes.set(id, node);
+            // 初回 tick を即時実行して、初期表示状態を整える。
+            tickPolygon(node);
+            return node.getHandle();
+        },
+        get(id: string): PolygonHandle | null {
+            const node = nodes.get(id);
+            return node ? node.getHandle() : null;
+        },
+        update(id: string, partial: PolygonUpdate): PolygonHandle {
+            // #170 では公開しない。#173 で実装。
+            // 引数は #173 実装時に使用するため、シグネチャ維持の目的で void で
+            // 参照しておく（@typescript-eslint/no-unused-vars 対策）。
+            void id;
+            void partial;
+            throw new Error(
+                "PolygonManager.update is not implemented yet (Issue #173)",
+            );
+        },
+        remove(id: string): void {
+            const node = nodes.get(id);
+            if (!node) {
+                console.warn(
+                    `[jpmap-terrain] removePolygon: id "${id}" not found`,
+                );
+                return;
+            }
+            node.dispose();
+            nodes.delete(id);
+        },
+        setEnabled(id: string, enabled: boolean): void {
+            if (disposed) {
+                throw new Error("PolygonManager has been disposed");
+            }
+            const node = requireNode(id);
+            node.setEnabledLogical(enabled);
+        },
+        list(): readonly string[] {
+            return Array.from(nodes.keys());
+        },
+        dispose(): void {
+            if (disposed) return;
+            disposed = true;
+            if (observer) {
+                ctx.scene.onBeforeRenderObservable.remove(observer);
+            }
+            unsubscribeTerrain();
+            for (const node of nodes.values()) {
+                node.dispose();
+            }
+            nodes.clear();
+        },
+    };
+};

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -78,6 +78,49 @@ const triggerResizeObservers = (): void => {
     }
 };
 
+// `polygon.ts` は Babylon 実体に依存するため、Polygon API テストでは
+// `createPolygonNode` を軽量スタブに差し替える。
+jest.unstable_mockModule("../src/terrain/polygon", () => ({
+    createPolygonNode: (
+        _scene: unknown,
+        id: string,
+        options: { points: readonly { lat: number; lon: number; altitude?: number }[]; closed?: boolean; altitudeMode?: "terrain" | "absolute"; enabled?: boolean },
+    ) => {
+        let enabled = options.enabled ?? true;
+        const altitudeMode = options.altitudeMode ?? "terrain";
+        let elevationResolved = altitudeMode === "absolute";
+        const points = options.points.map((p) => ({ ...p }));
+        return {
+            id,
+            altitudeMode,
+            closed: options.closed ?? false,
+            points,
+            applyTransform: () => {
+                /* no-op */
+            },
+            setEnabledLogical: (v: boolean) => {
+                enabled = v;
+            },
+            setElevationResolved: (v: boolean) => {
+                elevationResolved = v;
+            },
+            getHandle: () => ({
+                id,
+                points: points.map((p) => ({ ...p })),
+                closed: options.closed ?? false,
+                altitudeMode,
+                labels: undefined,
+                style: {} as unknown as Record<string, unknown>,
+                enabled,
+                elevationResolved,
+            }),
+            dispose: () => {
+                /* no-op */
+            },
+        };
+    },
+}));
+
 jest.unstable_mockModule("../src/scenes/default", () => {
     // モック内で refreshTerrain 相当の呼び出し回数を記録し、
     // テストから検証できるよう getter を export する（T5 のバッチ refresh 検証用）。
@@ -1403,6 +1446,46 @@ describe("JpmapTerrain (skeleton)", () => {
             viewer.showSunShadows = true;
             expect(viewer.showSunShadows).toBe(false);
             expect(sceneMockModule.__getSunShadowsCalls()).toEqual([]);
+        });
+    });
+
+    describe("Polygon API (Issue #170)", () => {
+        const validPoints = [
+            { lat: 35.681, lon: 139.767 },
+            { lat: 35.682, lon: 139.768 },
+        ];
+
+        it("addPolygon → getPolygon / listPolygons で参照できる", async () => {
+            const viewer = await create(createMountElement());
+            const handle = viewer.addPolygon("p1", { points: validPoints });
+            expect(handle.id).toBe("p1");
+            expect(viewer.getPolygon("p1")?.id).toBe("p1");
+            expect(viewer.listPolygons()).toEqual(["p1"]);
+        });
+
+        it("removePolygon で消える", async () => {
+            const viewer = await create(createMountElement());
+            viewer.addPolygon("p1", { points: validPoints });
+            viewer.removePolygon("p1");
+            expect(viewer.getPolygon("p1")).toBeNull();
+            expect(viewer.listPolygons()).toEqual([]);
+        });
+
+        it("setPolygonEnabled は未存在 id でも throw しない（manager 側で throw されるため例外）", async () => {
+            const viewer = await create(createMountElement());
+            viewer.addPolygon("p1", { points: validPoints });
+            // 正常系: 存在 id では throw しない
+            expect(() => viewer.setPolygonEnabled("p1", false)).not.toThrow();
+        });
+
+        it("dispose 後の addPolygon は throw、その他 API は no-op / null / [] を返す", async () => {
+            const viewer = await create(createMountElement());
+            viewer.dispose();
+            expect(() => viewer.addPolygon("p1", { points: validPoints })).toThrow();
+            expect(viewer.getPolygon("p1")).toBeNull();
+            expect(viewer.listPolygons()).toEqual([]);
+            expect(() => viewer.removePolygon("p1")).not.toThrow();
+            expect(() => viewer.setPolygonEnabled("p1", false)).not.toThrow();
         });
     });
 });

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -1471,10 +1471,10 @@ describe("JpmapTerrain (skeleton)", () => {
             expect(viewer.listPolygons()).toEqual([]);
         });
 
-        it("setPolygonEnabled は未存在 id でも throw しない（manager 側で throw されるため例外）", async () => {
+        it("setPolygonEnabled は存在する id に対して有効/無効を切り替えても throw しない", async () => {
             const viewer = await create(createMountElement());
             viewer.addPolygon("p1", { points: validPoints });
-            // 正常系: 存在 id では throw しない
+            // 正常系: 登録済み id に対する切り替えは例外にならない
             expect(() => viewer.setPolygonEnabled("p1", false)).not.toThrow();
         });
 

--- a/tests/libExports.unit.spec.ts
+++ b/tests/libExports.unit.spec.ts
@@ -22,6 +22,12 @@ import type {
     FlyToOptions,
     JpmapTerrainOptions,
     MapType,
+    AltitudeMode,
+    PolygonPointOptions,
+    PolygonStyleOptions,
+    PolygonOptions,
+    PolygonUpdate,
+    PolygonHandle,
 } from "../src/lib";
 
 describe("package entry exports (T8)", () => {
@@ -58,5 +64,33 @@ describe("package entry exports (T8)", () => {
         };
         listener(event);
         expect(received).toEqual(event);
+    });
+
+    // #170: ポリゴン公開型 (AltitudeMode / PolygonPointOptions / PolygonStyleOptions /
+    // PolygonOptions / PolygonUpdate / PolygonHandle) がパッケージエントリから import 可能であること。
+    it("ポリゴン公開型 (Issue #170) がパッケージエントリから import できる（typecheck）", () => {
+        const altitudeMode: AltitudeMode = "terrain";
+        const point: PolygonPointOptions = { lat: 35.0, lon: 139.0 };
+        const style: PolygonStyleOptions = {
+            pointColor: "#ff0000",
+            lineWidth: 2,
+        };
+        const opts: PolygonOptions = {
+            points: [point, { lat: 35.1, lon: 139.1 }],
+            altitudeMode,
+            closed: false,
+            style,
+        };
+        const update: PolygonUpdate = { enabled: false };
+        // PolygonHandle は実装が返すスナップショット型であり、テストでは形だけ検証する。
+        const handleShape: Pick<PolygonHandle, "id" | "altitudeMode"> = {
+            id: "p1",
+            altitudeMode,
+        };
+
+        expect(opts.points.length).toBe(2);
+        expect(update.enabled).toBe(false);
+        expect(handleShape.id).toBe("p1");
+        expect(style.pointColor).toBe("#ff0000");
     });
 });

--- a/tests/overlayCoords.unit.spec.ts
+++ b/tests/overlayCoords.unit.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * overlayCoords ユーティリティの単体テスト (Issue #170)。
+ *
+ * - latLonToWorld: origin / gridResidual を加味して既存実装と同じ値を返すか
+ * - assertLatLonInBounds: bounds 外で throw、prefix がメッセージに含まれる
+ * - computeDistanceScale: 下限 0.1 にクランプされる
+ * - computeDynamicLineHeight: 100m 〜 10000m の clamp、sin(beta) 係数 0.3〜1
+ */
+
+import { describe, it, expect } from "@jest/globals";
+
+import {
+    REF_DISTANCE_M,
+    assertLatLonInBounds,
+    computeDistanceScale,
+    computeDynamicLineHeight,
+    latLonToWorld,
+    type OverlayContext,
+} from "../src/terrain/overlayCoords";
+
+const buildCtx = (overrides?: {
+    origin?: {
+        lat: number;
+        lon: number;
+        gridResidualX: number;
+        gridResidualZ: number;
+    };
+    camera?: { x: number; y: number; z: number; radius: number; beta: number };
+}): OverlayContext => {
+    const origin = overrides?.origin ?? {
+        lat: 35.681,
+        lon: 139.767,
+        gridResidualX: 0,
+        gridResidualZ: 0,
+    };
+    const camera = overrides?.camera ?? {
+        x: 0,
+        y: 0,
+        z: 0,
+        radius: 1000,
+        beta: Math.PI / 4,
+    };
+    return {
+        scene: {
+            onBeforeRenderObservable: {
+                add: () => null,
+                remove: () => false,
+            },
+        } as unknown as OverlayContext["scene"],
+        tileManager: {
+            queryElevationAtWorld: () => 0,
+            subscribeTerrainUpdated: () => () => {
+                /* no-op */
+            },
+        },
+        getOrigin: () => ({ ...origin }),
+        getCameraPosition: () => ({ ...camera }),
+    };
+};
+
+describe("latLonToWorld", () => {
+    it("origin と一致する点は (gridResidualX, gridResidualZ) を返す", () => {
+        const ctx = buildCtx({
+            origin: {
+                lat: 35.681,
+                lon: 139.767,
+                gridResidualX: 12,
+                gridResidualZ: -7,
+            },
+        });
+        const { wx, wz } = latLonToWorld(ctx, 35.681, 139.767);
+        expect(wx).toBeCloseTo(12);
+        expect(wz).toBeCloseTo(-7);
+    });
+
+    it("緯度差に応じて wz が線形に変化する (1 度 ≒ 111320m)", () => {
+        const ctx = buildCtx();
+        const { wz } = latLonToWorld(ctx, 35.681 + 1, 139.767);
+        expect(wz).toBeCloseTo(111320, 0);
+    });
+
+    it("経度差は cos(lat) 補正される", () => {
+        const ctx = buildCtx();
+        const { wx } = latLonToWorld(ctx, 35.681, 139.767 + 1);
+        const expected = 111320 * Math.cos((35.681 * Math.PI) / 180);
+        expect(wx).toBeCloseTo(expected, 0);
+    });
+});
+
+describe("assertLatLonInBounds", () => {
+    it("範囲内なら例外を投げない", () => {
+        expect(() => assertLatLonInBounds(35.681, 139.767, "test")).not.toThrow();
+    });
+    it("範囲外で prefix を含むメッセージで throw", () => {
+        expect(() => assertLatLonInBounds(0, 0, "addPolygon")).toThrow(
+            /addPolygon: lat\/lon out of JAPAN_BOUNDS/,
+        );
+    });
+});
+
+describe("computeDistanceScale", () => {
+    it("基準距離で 1.0 になる", () => {
+        const ctx = buildCtx({
+            camera: {
+                x: REF_DISTANCE_M,
+                y: 0,
+                z: 0,
+                radius: 1000,
+                beta: Math.PI / 4,
+            },
+        });
+        const scale = computeDistanceScale(ctx, 0, 0, 0);
+        expect(scale).toBeCloseTo(1);
+    });
+    it("近距離では 0.1 にクランプされる", () => {
+        const ctx = buildCtx({
+            camera: { x: 0, y: 0, z: 0, radius: 1000, beta: Math.PI / 4 },
+        });
+        const scale = computeDistanceScale(ctx, 0, 0, 0);
+        expect(scale).toBe(0.1);
+    });
+});
+
+describe("computeDynamicLineHeight", () => {
+    it("100m 下限で clamp", () => {
+        const ctx = buildCtx({
+            camera: { x: 0, y: 0, z: 0, radius: 1, beta: Math.PI / 2 },
+        });
+        expect(computeDynamicLineHeight(ctx)).toBe(100);
+    });
+    it("10000m 上限で clamp", () => {
+        const ctx = buildCtx({
+            camera: {
+                x: 0,
+                y: 0,
+                z: 0,
+                radius: 10_000_000,
+                beta: Math.PI / 2,
+            },
+        });
+        expect(computeDynamicLineHeight(ctx)).toBe(10000);
+    });
+    it("sin(beta) は 0.3 で下限 clamp", () => {
+        // beta=0 → sinBeta=0 → factor=0.3、radius=10000 → 10000*0.1*0.3=300
+        const ctx = buildCtx({
+            camera: { x: 0, y: 0, z: 0, radius: 10000, beta: 0 },
+        });
+        expect(computeDynamicLineHeight(ctx)).toBeCloseTo(300);
+    });
+});

--- a/tests/polygon.unit.spec.ts
+++ b/tests/polygon.unit.spec.ts
@@ -1,0 +1,288 @@
+/**
+ * createPolygonNode の単体テスト (Issue #170)。
+ *
+ * Babylon 実体を立ち上げるとテストが重くなるため、Builders / TransformNode /
+ * StandardMaterial を `jest.unstable_mockModule` で軽量スタブに差し替える。
+ * Vector3 / Color3 は計算用に実体を使う（外部 I/O を持たない純数学）。
+ */
+
+import { jest } from "@jest/globals";
+
+interface StubMaterial {
+    name: string;
+    disposed: boolean;
+    alpha: number;
+    backFaceCulling: boolean;
+    disableLighting: boolean;
+    emissiveColor: { r: number; g: number; b: number } | null;
+    dispose(): void;
+}
+
+interface StubMesh {
+    name: string;
+    parent: unknown;
+    material: StubMaterial | null;
+    renderingGroupId: number;
+    isPickable: boolean;
+    position: { x: number; y: number; z: number; set: (x: number, y: number, z: number) => void };
+    scaling: { x: number; y: number; z: number; setAll: (v: number) => void };
+    disposed: boolean;
+    dispose(): void;
+    setEnabled?: (v: boolean) => void;
+}
+
+interface StubTransformNode {
+    name: string;
+    enabledHistory: boolean[];
+    setEnabled(value: boolean): void;
+    disposed: boolean;
+    dispose(): void;
+}
+
+const sphereCalls: Array<{ name: string; options: unknown }> = [];
+const tubeCalls: Array<{
+    name: string;
+    options: { path: unknown[]; instance?: StubMesh; updatable?: boolean };
+}> = [];
+const transformNodes: StubTransformNode[] = [];
+const allMeshes: StubMesh[] = [];
+
+const buildMesh = (name: string): StubMesh => {
+    const mesh: StubMesh = {
+        name,
+        parent: null,
+        material: null,
+        renderingGroupId: 0,
+        isPickable: true,
+        position: {
+            x: 0,
+            y: 0,
+            z: 0,
+            set(x, y, z) {
+                this.x = x;
+                this.y = y;
+                this.z = z;
+            },
+        },
+        scaling: {
+            x: 1,
+            y: 1,
+            z: 1,
+            setAll(v) {
+                this.x = v;
+                this.y = v;
+                this.z = v;
+            },
+        },
+        disposed: false,
+        dispose() {
+            this.disposed = true;
+        },
+    };
+    allMeshes.push(mesh);
+    return mesh;
+};
+
+jest.unstable_mockModule(
+    "@babylonjs/core/Meshes/Builders/sphereBuilder",
+    () => ({
+        CreateSphere: (name: string, options: unknown): StubMesh => {
+            sphereCalls.push({ name, options });
+            return buildMesh(name);
+        },
+    }),
+);
+
+jest.unstable_mockModule(
+    "@babylonjs/core/Meshes/Builders/tubeBuilder",
+    () => ({
+        CreateTube: (
+            name: string,
+            options: {
+                path: unknown[];
+                instance?: StubMesh;
+                updatable?: boolean;
+            },
+        ): StubMesh => {
+            tubeCalls.push({ name, options });
+            // instance 指定時は同じインスタンスを返すのが Babylon の挙動。
+            if (options.instance) return options.instance;
+            return buildMesh(name);
+        },
+    }),
+);
+
+jest.unstable_mockModule("@babylonjs/core/Materials/standardMaterial", () => ({
+    StandardMaterial: class {
+        public name: string;
+        public disposed = false;
+        public alpha = 1;
+        public backFaceCulling = true;
+        public disableLighting = false;
+        public emissiveColor: { r: number; g: number; b: number } | null = null;
+        constructor(name: string) {
+            this.name = name;
+        }
+        dispose(): void {
+            this.disposed = true;
+        }
+    },
+}));
+
+jest.unstable_mockModule("@babylonjs/core/Meshes/transformNode", () => ({
+    TransformNode: class implements StubTransformNode {
+        public name: string;
+        public enabledHistory: boolean[] = [];
+        public disposed = false;
+        constructor(name: string) {
+            this.name = name;
+            transformNodes.push(this);
+        }
+        setEnabled(value: boolean): void {
+            this.enabledHistory.push(value);
+        }
+        dispose(): void {
+            this.disposed = true;
+        }
+    },
+}));
+
+// Mesh は NO_CAP 静的定数のみ参照される。
+jest.unstable_mockModule("@babylonjs/core/Meshes/mesh", () => ({
+    Mesh: { NO_CAP: 0 },
+}));
+
+const { createPolygonNode } = await import("../src/terrain/polygon");
+
+const sceneStub = {} as unknown as Parameters<typeof createPolygonNode>[0];
+
+beforeEach(() => {
+    sphereCalls.length = 0;
+    tubeCalls.length = 0;
+    transformNodes.length = 0;
+    allMeshes.length = 0;
+});
+
+describe("createPolygonNode 構築", () => {
+    it("頂点数分の球と 1 本の Tube を生成する (closed=false)", () => {
+        const node = createPolygonNode(sceneStub, "p1", {
+            points: [
+                { lat: 35.0, lon: 139.0 },
+                { lat: 35.1, lon: 139.1 },
+                { lat: 35.2, lon: 139.2 },
+            ],
+        });
+        expect(sphereCalls.length).toBe(3);
+        // 初期構築の Tube 1 回 + 即時 applyTransform は呼ばれていないので 1 回のみ
+        expect(tubeCalls.length).toBe(1);
+        expect(node.id).toBe("p1");
+        expect(transformNodes.length).toBe(1);
+        expect(transformNodes[0].name).toBe("polygon-p1");
+    });
+
+    it("closed=true のとき初期 Tube path に先頭頂点が append される", () => {
+        createPolygonNode(sceneStub, "p2", {
+            points: [
+                { lat: 35.0, lon: 139.0 },
+                { lat: 35.1, lon: 139.1 },
+                { lat: 35.2, lon: 139.2 },
+            ],
+            closed: true,
+        });
+        const initialPath = tubeCalls[0].options.path as Array<{
+            x: number;
+            y: number;
+            z: number;
+        }>;
+        // 3 点 + closed の先頭再追加 = 4
+        expect(initialPath.length).toBe(4);
+        // 先頭と末尾は別オブジェクト（参照分離）かつ同値。
+        expect(initialPath[0]).not.toBe(initialPath[initialPath.length - 1]);
+        expect(initialPath[0].x).toBe(initialPath[initialPath.length - 1].x);
+        expect(initialPath[0].y).toBe(initialPath[initialPath.length - 1].y);
+        expect(initialPath[0].z).toBe(initialPath[initialPath.length - 1].z);
+    });
+
+    it("absolute モードでは elevationResolved が即時 true となる", () => {
+        const node = createPolygonNode(sceneStub, "p3", {
+            points: [
+                { lat: 35.0, lon: 139.0, altitude: 10 },
+                { lat: 35.1, lon: 139.1, altitude: 20 },
+            ],
+            altitudeMode: "absolute",
+        });
+        expect(node.getHandle().elevationResolved).toBe(true);
+    });
+});
+
+describe("createPolygonNode applyTransform", () => {
+    it("applyTransform で Tube が instance 指定で更新される", async () => {
+        const { Vector3 } = await import("@babylonjs/core/Maths/math.vector");
+        const node = createPolygonNode(sceneStub, "p4", {
+            points: [
+                { lat: 35.0, lon: 139.0, altitude: 0 },
+                { lat: 35.1, lon: 139.1, altitude: 5 },
+            ],
+            altitudeMode: "absolute",
+        });
+        node.applyTransform(
+            [new Vector3(0, 0, 0), new Vector3(100, 5, 200)],
+            1,
+        );
+        // 構築時 1 回 + applyTransform 1 回
+        expect(tubeCalls.length).toBe(2);
+        expect(tubeCalls[1].options.instance).toBeDefined();
+    });
+
+    it("absolute モードで applyTransform に渡された Y がそのまま使われる", async () => {
+        const { Vector3 } = await import("@babylonjs/core/Maths/math.vector");
+        const node = createPolygonNode(sceneStub, "p5", {
+            points: [
+                { lat: 35.0, lon: 139.0, altitude: 100 },
+                { lat: 35.1, lon: 139.1, altitude: 200 },
+            ],
+            altitudeMode: "absolute",
+        });
+        node.applyTransform(
+            [new Vector3(10, 100, 20), new Vector3(30, 200, 40)],
+            1,
+        );
+        const path = tubeCalls[1].options.path as Array<{ y: number }>;
+        expect(path[0].y).toBe(100);
+        expect(path[1].y).toBe(200);
+    });
+});
+
+describe("createPolygonNode enabled / dispose", () => {
+    it("setEnabledLogical(false) で root.setEnabled(false) が呼ばれる", () => {
+        const node = createPolygonNode(sceneStub, "p6", {
+            points: [
+                { lat: 35.0, lon: 139.0, altitude: 0 },
+                { lat: 35.1, lon: 139.1, altitude: 0 },
+            ],
+            altitudeMode: "absolute",
+        });
+        const root = transformNodes[0];
+        // 構築時の applyVisibility 呼び出しを差し引いて、明示的な false 切替を確認する
+        const beforeLen = root.enabledHistory.length;
+        node.setEnabledLogical(false);
+        expect(root.enabledHistory.slice(beforeLen)).toContain(false);
+    });
+
+    it("dispose で全 sphere / Tube / material / root が dispose される", () => {
+        const node = createPolygonNode(sceneStub, "p7", {
+            points: [
+                { lat: 35.0, lon: 139.0, altitude: 0 },
+                { lat: 35.1, lon: 139.1, altitude: 0 },
+                { lat: 35.2, lon: 139.2, altitude: 0 },
+            ],
+            altitudeMode: "absolute",
+        });
+        node.dispose();
+        // 構築時の全 mesh が dispose 済み
+        for (const m of allMeshes) {
+            expect(m.disposed).toBe(true);
+        }
+        expect(transformNodes[0].disposed).toBe(true);
+    });
+});

--- a/tests/polygonManager.unit.spec.ts
+++ b/tests/polygonManager.unit.spec.ts
@@ -1,0 +1,383 @@
+/**
+ * PolygonManager の単体テスト (Issue #170)。
+ *
+ * `polygon` モジュール（Babylon 依存）を軽量スタブに差し替え、
+ * CRUD / 境界 / altitudeMode / 標高解決 / dispose の挙動を検証する。
+ */
+
+import { jest } from "@jest/globals";
+import type { PolygonOptions } from "../src/lib/types";
+
+interface StubNode {
+    id: string;
+    altitudeMode: "terrain" | "absolute";
+    closed: boolean;
+    points: Array<{
+        lat: number;
+        lon: number;
+        altitude?: number;
+    }>;
+    enabled: boolean;
+    elevationResolved: boolean;
+    applyTransformCalls: number;
+    lastWorldPoints: Array<{ x: number; y: number; z: number }>;
+    disposed: boolean;
+    setEnabledHistory: boolean[];
+    setElevationResolvedHistory: boolean[];
+}
+
+const created: StubNode[] = [];
+
+jest.unstable_mockModule("../src/terrain/polygon", () => ({
+    createPolygonNode: (
+        _scene: unknown,
+        id: string,
+        options: PolygonOptions,
+    ): StubNode => {
+        const altitudeMode = options.altitudeMode ?? "terrain";
+        const node: StubNode = {
+            id,
+            altitudeMode,
+            closed: options.closed ?? false,
+            points: options.points.map((p) => ({ ...p })),
+            enabled: options.enabled ?? true,
+            elevationResolved: altitudeMode === "absolute",
+            applyTransformCalls: 0,
+            lastWorldPoints: [],
+            disposed: false,
+            setEnabledHistory: [],
+            setElevationResolvedHistory: [],
+        };
+        const wrapped = {
+            ...node,
+            applyTransform: (
+                worldPoints: ReadonlyArray<{
+                    x: number;
+                    y: number;
+                    z: number;
+                }>,
+            ) => {
+                node.applyTransformCalls++;
+                node.lastWorldPoints = worldPoints.map((p) => ({
+                    x: p.x,
+                    y: p.y,
+                    z: p.z,
+                }));
+            },
+            setEnabledLogical: (v: boolean) => {
+                node.enabled = v;
+                node.setEnabledHistory.push(v);
+            },
+            setElevationResolved: (v: boolean) => {
+                node.elevationResolved = v;
+                node.setElevationResolvedHistory.push(v);
+            },
+            getHandle: () => ({
+                id,
+                points: node.points.map((p) => ({ ...p })),
+                closed: node.closed,
+                altitudeMode: node.altitudeMode,
+                labels: undefined,
+                style: {} as unknown as Record<string, unknown>,
+                enabled: node.enabled,
+                elevationResolved: node.elevationResolved,
+            }),
+            dispose: () => {
+                node.disposed = true;
+            },
+        };
+        // 内部状態を `created` 経由でテストから観測するため、両方のオブジェクトを
+        // 同じプロパティで参照できるよう同一参照で push する。
+        created.push(node);
+        return wrapped as unknown as StubNode;
+    },
+}));
+
+const { createPolygonManager } = await import(
+    "../src/terrain/polygonManager"
+);
+
+interface FakeObserver {
+    callback: () => void;
+}
+
+const buildCtx = (
+    elevation: number | null = 0,
+): {
+    ctx: Parameters<typeof createPolygonManager>[0];
+    tick: () => void;
+    setElevation: (v: number | null) => void;
+    unsubscribeCount: () => number;
+} => {
+    const observers: FakeObserver[] = [];
+    const sceneLike = {
+        onBeforeRenderObservable: {
+            add: (cb: () => void): FakeObserver => {
+                const o: FakeObserver = { callback: cb };
+                observers.push(o);
+                return o;
+            },
+            remove: (target: FakeObserver): boolean => {
+                const i = observers.indexOf(target);
+                if (i === -1) return false;
+                observers.splice(i, 1);
+                return true;
+            },
+        },
+    };
+    let elev: number | null = elevation;
+    let unsubscribeCalls = 0;
+    const ctx: Parameters<typeof createPolygonManager>[0] = {
+        scene: sceneLike as unknown as Parameters<
+            typeof createPolygonManager
+        >[0]["scene"],
+        tileManager: {
+            queryElevationAtWorld: (): number | null => elev,
+            subscribeTerrainUpdated: (): (() => void) => {
+                return () => {
+                    unsubscribeCalls++;
+                };
+            },
+        },
+        getOrigin: () => ({
+            lat: 35.681,
+            lon: 139.767,
+            gridResidualX: 0,
+            gridResidualZ: 0,
+        }),
+        getCameraPosition: () => ({
+            x: 0,
+            y: 1000,
+            z: 0,
+            radius: 1000,
+            beta: Math.PI / 4,
+        }),
+    };
+    return {
+        ctx,
+        tick: () => {
+            for (const o of observers.slice()) o.callback();
+        },
+        setElevation: (v) => {
+            elev = v;
+        },
+        unsubscribeCount: () => unsubscribeCalls,
+    };
+};
+
+const validPoints = [
+    { lat: 35.681, lon: 139.767 },
+    { lat: 35.682, lon: 139.768 },
+    { lat: 35.683, lon: 139.769 },
+];
+
+beforeEach(() => {
+    created.length = 0;
+});
+
+describe("PolygonManager CRUD", () => {
+    it("add → get / list で同 id を取得できる", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createPolygonManager(ctx);
+        const handle = mgr.add("a", { points: validPoints });
+        expect(handle.id).toBe("a");
+        expect(mgr.get("a")?.id).toBe("a");
+        expect(mgr.list()).toEqual(["a"]);
+    });
+
+    it("重複 id で throw", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createPolygonManager(ctx);
+        mgr.add("a", { points: validPoints });
+        expect(() => mgr.add("a", { points: validPoints })).toThrow(
+            /already exists/,
+        );
+    });
+
+    it("remove で list / get から消える", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createPolygonManager(ctx);
+        mgr.add("a", { points: validPoints });
+        mgr.remove("a");
+        expect(mgr.get("a")).toBeNull();
+        expect(mgr.list()).toEqual([]);
+    });
+
+    it("未存在 id の remove は warn + no-op", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createPolygonManager(ctx);
+        const warn = jest.spyOn(console, "warn").mockImplementation(() => {
+            /* silence */
+        });
+        mgr.remove("missing");
+        expect(warn).toHaveBeenCalled();
+        warn.mockRestore();
+    });
+});
+
+describe("PolygonManager バリデーション", () => {
+    it("2 点未満で throw", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createPolygonManager(ctx);
+        expect(() =>
+            mgr.add("a", {
+                points: [{ lat: 35.681, lon: 139.767 }],
+            }),
+        ).toThrow(/at least 2/);
+    });
+
+    it("JAPAN_BOUNDS 外で throw", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createPolygonManager(ctx);
+        expect(() =>
+            mgr.add("a", {
+                points: [
+                    { lat: 35.681, lon: 139.767 },
+                    { lat: 0, lon: 0 },
+                ],
+            }),
+        ).toThrow(/JAPAN_BOUNDS/);
+    });
+
+    it("absolute モードで altitude 未指定の点があれば throw", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createPolygonManager(ctx);
+        expect(() =>
+            mgr.add("a", {
+                altitudeMode: "absolute",
+                points: [
+                    { lat: 35.681, lon: 139.767, altitude: 100 },
+                    { lat: 35.682, lon: 139.768 },
+                ],
+            }),
+        ).toThrow(/requires altitude/);
+    });
+});
+
+describe("PolygonManager 標高解決", () => {
+    it("terrain モードで 1 点でも未解決なら elevationResolved=false", () => {
+        const ctxWrap = buildCtx(null);
+        const mgr = createPolygonManager(ctxWrap.ctx);
+        mgr.add("a", { points: validPoints });
+        expect(created[0].elevationResolved).toBe(false);
+    });
+
+    it("terrain モードで全頂点解決すれば applyTransform が呼ばれる", () => {
+        const ctxWrap = buildCtx(0);
+        const mgr = createPolygonManager(ctxWrap.ctx);
+        mgr.add("a", { points: validPoints });
+        // 初回 add 時にも tickPolygon が呼ばれる
+        expect(created[0].applyTransformCalls).toBeGreaterThan(0);
+        expect(created[0].elevationResolved).toBe(true);
+    });
+
+    it("absolute モードでは elevation が null でも resolved=true で applyTransform が走る", () => {
+        const ctxWrap = buildCtx(null);
+        const mgr = createPolygonManager(ctxWrap.ctx);
+        mgr.add("a", {
+            altitudeMode: "absolute",
+            points: [
+                { lat: 35.681, lon: 139.767, altitude: 100 },
+                { lat: 35.682, lon: 139.768, altitude: 200 },
+            ],
+        });
+        expect(created[0].elevationResolved).toBe(true);
+        expect(created[0].applyTransformCalls).toBeGreaterThan(0);
+    });
+
+    it("terrain モードで altitude を地表標高に加算した値が Y に反映される", () => {
+        // tileManager のスタブ標高を 10m に固定 → altitude=5 を加えた wy=15 を期待
+        const ctxWrap = buildCtx(10);
+        const mgr = createPolygonManager(ctxWrap.ctx);
+        mgr.add("a", {
+            altitudeMode: "terrain",
+            points: [
+                { lat: 35.681, lon: 139.767, altitude: 5 },
+                { lat: 35.682, lon: 139.768, altitude: 5 },
+            ],
+        });
+        const ys = created[0].lastWorldPoints.map((p) => p.y);
+        expect(ys).toEqual([15, 15]);
+    });
+
+    it("terrain モードで altitude 未指定なら地表標高そのままが Y に反映される", () => {
+        const ctxWrap = buildCtx(20);
+        const mgr = createPolygonManager(ctxWrap.ctx);
+        mgr.add("a", {
+            altitudeMode: "terrain",
+            points: [
+                { lat: 35.681, lon: 139.767 },
+                { lat: 35.682, lon: 139.768 },
+            ],
+        });
+        const ys = created[0].lastWorldPoints.map((p) => p.y);
+        expect(ys).toEqual([20, 20]);
+    });
+});
+
+describe("PolygonManager enable / disable", () => {
+    it("setEnabled で node.enabled が反映される", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createPolygonManager(ctx);
+        mgr.add("a", { points: validPoints });
+        mgr.setEnabled("a", false);
+        expect(created[0].setEnabledHistory).toContain(false);
+        mgr.setEnabled("a", true);
+        expect(created[0].setEnabledHistory).toContain(true);
+    });
+
+    it("未存在 id の setEnabled は throw", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createPolygonManager(ctx);
+        expect(() => mgr.setEnabled("missing", false)).toThrow(/not found/);
+    });
+});
+
+describe("PolygonManager dispose", () => {
+    it("dispose で全 node が解放され、terrain subscription が解除される", () => {
+        const ctxWrap = buildCtx(0);
+        const mgr = createPolygonManager(ctxWrap.ctx);
+        mgr.add("a", { points: validPoints });
+        mgr.add("b", { points: validPoints });
+        mgr.dispose();
+        for (const n of created) {
+            expect(n.disposed).toBe(true);
+        }
+        expect(ctxWrap.unsubscribeCount()).toBeGreaterThan(0);
+    });
+
+    it("dispose 後の add は throw、setEnabled も throw", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createPolygonManager(ctx);
+        mgr.dispose();
+        expect(() => mgr.add("a", { points: validPoints })).toThrow(/disposed/);
+        expect(() => mgr.setEnabled("a", false)).toThrow(/disposed/);
+    });
+
+    it("dispose 後の get は null、list は []、remove は no-op", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createPolygonManager(ctx);
+        mgr.add("a", { points: validPoints });
+        mgr.dispose();
+        // dispose 後は内部 Map がクリアされる
+        expect(mgr.get("a")).toBeNull();
+        expect(mgr.list()).toEqual([]);
+        // remove は warn を出すが throw はしない
+        const warn = jest
+            .spyOn(console, "warn")
+            .mockImplementation(() => undefined);
+        mgr.remove("a");
+        warn.mockRestore();
+    });
+});
+
+describe("PolygonManager update (#170 では未公開)", () => {
+    it("内部 update は throw する（#173 で実装）", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createPolygonManager(ctx);
+        mgr.add("a", { points: validPoints });
+        expect(() => mgr.update("a", { enabled: false })).toThrow(
+            /not implemented/,
+        );
+    });
+});

--- a/tests/portal.unit.spec.ts
+++ b/tests/portal.unit.spec.ts
@@ -13,6 +13,8 @@ describe("buildPortalHtml", () => {
         const html = buildPortalHtml();
         expect(html).toContain('href="viewer"');
         expect(html).toContain('href="timelapse"');
+        // ポリゴンデモ (Issue #170) もポータル一覧に並ぶ。
+        expect(html).toContain('href="polygon"');
         expect(html).toContain("<h1>");
     });
 

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -35,6 +35,13 @@ const ENTRY_DEFINITIONS = [
         filename: "timelapse.html",
         title: "jpmap_terrain – タイムラプスデモ",
     },
+    {
+        name: "polygon",
+        entry: "src/demos/polygon/index.ts",
+        template: "public/polygon.html",
+        filename: "polygon.html",
+        title: "jpmap_terrain – ポリゴンデモ",
+    },
 ];
 
 const entry = Object.fromEntries(

--- a/webpack.rewrites.js
+++ b/webpack.rewrites.js
@@ -12,5 +12,7 @@ module.exports = {
         { from: /^\/viewer\.html(?:\/?@.*)?\/?$/, to: '/viewer.html' },
         { from: /^\/timelapse(?:\/@.*)?\/?$/, to: '/timelapse.html' },
         { from: /^\/timelapse\.html(?:\/?@.*)?\/?$/, to: '/timelapse.html' },
+        { from: /^\/polygon(?:\/@.*)?\/?$/, to: '/polygon.html' },
+        { from: /^\/polygon\.html(?:\/?@.*)?\/?$/, to: '/polygon.html' },
     ],
 };


### PR DESCRIPTION
## 概要
Issue #170 — PolygonManager の基盤、頂点（球体）、ポリライン（Tube）を実装。

Closes #170

## 主な変更
- `JpmapTerrain.addPolygon / getPolygon / removePolygon / setPolygonEnabled / listPolygons` を公開
- `terrain` / `absolute` 両モードに対応。`terrain` モードでは `altitude` を地表標高への加算オフセットとして扱う（仕様 §3.3.8.1 更新）
- 距離不変スケールの球体頂点 + 太さ可変の Tube ポリライン
- マーカーと共通の overlay 座標ユーティリティを `overlayCoords.ts` に抽出
- `/polygon` デモ追加（よみうりランド付近）
- Ctrl/Cmd 回転開始時のオーバーレイ微小ジャンプを修正（pan offset 再コミット）

## 注意
**マーカー挙動への影響なし**。Ctrl/Cmd 回転開始時のジャンプ修正は座標基準の整合化のみで、ドラッグ移動やズームの挙動は変更していません。

## 検証
- npm run lint / npm run typecheck / npm run test:unit (490/490) すべて成功
- Reviewer / Security レビュー済（要対応なし）