### PR TITLE
feat(polygon): drop lines and point labels (#171)

### DIFF
--- a/spec/package.md
+++ b/spec/package.md
@@ -345,7 +345,7 @@ interface MarkerOptions {
 
 任意の点列を受け取り、地表または絶対標高に沿って **ポイント球体** と **ポリライン** を表示する API（基盤）。
 
-##### 3.3.8.1 公開 API（基盤＋ポリライン: Issue #170）
+##### 3.3.8.1 公開 API（基盤＋ポリライン＋垂線/ラベル: Issue #170 / #171）
 
 ```typescript
 interface JpmapTerrain {
@@ -357,6 +357,10 @@ interface JpmapTerrain {
   removePolygon(id: string): void;
   /** enabled の薄いショートカット */
   setPolygonEnabled(id: string, enabled: boolean): void;
+  /** 各点からの垂線表示をポリゴン単位で ON/OFF (#171) */
+  setVerticalsEnabled(id: string, enabled: boolean): void;
+  /** ラベル表示をポリゴン単位で ON/OFF (#171) */
+  setLabelsEnabled(id: string, enabled: boolean): void;
   /** 全 id を生成順で返す */
   listPolygons(): readonly string[];
 }
@@ -394,10 +398,14 @@ interface PolygonOptions {
   altitudeMode?: AltitudeMode;                // default "terrain"
   /** `true` でポリラインの末尾と先頭を結んで閉じる（#170 はポリラインのみ閉じる）。default false */
   closed?: boolean;
-  /** ラベル（点ごと）。#171 で描画予定。#170 では受け取るが描画しない。 */
+  /** ラベル（点ごと）。#171 で実装済み。`labels[i]` が文字列のときその点にラベルを描画する。 */
   labels?: ReadonlyArray<string>;
   style?: PolygonStyleOptions;
   enabled?: boolean;                          // default true
+  /** 各点から地表へ落とす垂線の表示 (#171 実装済み)。default true */
+  verticalsEnabled?: boolean;
+  /** ラベルの表示 (#171 実装済み)。default true */
+  labelsEnabled?: boolean;
 }
 ```
 
@@ -410,7 +418,7 @@ interface PolygonOptions {
 - JAPAN_BOUNDS 外の点・`points.length < 2`・`absolute` で `altitude` 未指定の場合は `addPolygon` で throw（範囲外の点 index をメッセージに含める）。
 - 同 id の重複追加は throw、`removePolygon` の未存在 id は `console.warn` + no-op。
 - `dispose()` で全ポリゴンリソース（Mesh / Material / TransformNode）を解放する。
-- **#171 で実装予定（型予約済み）**: 各ポイントから地表へ落とす垂線、ポイント脇のラベル（`labels`）。
+- **#171 実装済み**: 各点から地表（タイル標高、未解決時は Y=0 フォールバック）へ落とす垂線を **CreateTube**（updatable、半径 `style.dropLineWidth`）で描画。`labels[i]` が指定された点に DynamicTexture + ビルボード Plane でラベルを描画（`labelColor` / `labelBackgroundColor` / `labelFontSize` 反映）。`JpmapTerrain.setVerticalsEnabled(id, enabled)` / `setLabelsEnabled(id, enabled)` で表示切替が可能。`PolygonOptions.verticalsEnabled` / `labelsEnabled`（既定 true）で初期表示制御。
 - **#172 で実装予定（型予約済み）**: 隣接垂線間を結ぶ「壁」（`closed` 時の閉じも含む）、`wallColor` / `wallOpacity`。
 - **#173 で実装予定**: `updatePolygon`、点単位編集 API（`insertPoint` / `removePoint` / `updatePoint` / `replacePoints`）、デモ拡張、視覚回帰テスト。
 

--- a/src/demos/polygon/index.ts
+++ b/src/demos/polygon/index.ts
@@ -1,16 +1,19 @@
 /**
- * ポリゴンデモ (Issue #170)
+ * ポリゴンデモ (Issue #170 / #171)
  *
  * `JpmapTerrain` の Polygon 公開 API（`addPolygon` / `setPolygonEnabled` /
- * `removePolygon` / `listPolygons` / `getPolygon`）を目視確認するためのデモ。
+ * `setVerticalsEnabled` / `setLabelsEnabled` / `removePolygon` / `listPolygons` /
+ * `getPolygon`）を目視確認するためのデモ。
  *
- * 仕様 (#170 範囲):
+ * 仕様 (#170 / #171 範囲):
  * - `altitudeMode: "terrain"` で地形に沿って表示するポリライン
  * - `altitudeMode: "absolute"` で絶対標高 (m) のポリライン
  * - `closed: true` で末尾と先頭を結んだループ
+ * - 各頂点から地表へ落とす垂線と頂点ラベル（#171）
  *
  * 操作:
  * - 画面右上のボタンで各ポリゴンの enabled を ON/OFF
+ * - 垂線 / ラベル の全体 ON/OFF ボタン
  *
  * 開発デモ層につき `src/lib/**` には依存型のみ依存し、内部実装は触らない。
  */
@@ -60,6 +63,7 @@ const buildDemoPolygons = (): readonly DemoPolygonDef[] => [
                 { lat: 35.6225, lon: 139.5170, altitude: 100 },
             ],
             altitudeMode: "terrain",
+            labels: ["NW +100m", "NE +100m", "SE +100m", "SW +100m"],
             style: {
                 pointColor: "#ff5252",
                 lineColor: "#ff5252",
@@ -79,6 +83,7 @@ const buildDemoPolygons = (): readonly DemoPolygonDef[] => [
                 { lat: 35.6243, lon: 139.5165, altitude: 300 },
             ],
             altitudeMode: "absolute",
+            labels: ["abs A", "abs B", "abs C"],
             style: {
                 pointColor: "#42a5f5",
                 lineColor: "#42a5f5",
@@ -100,6 +105,7 @@ const buildDemoPolygons = (): readonly DemoPolygonDef[] => [
             ],
             altitudeMode: "absolute",
             closed: true,
+            labels: ["P1", "P2", "P3", "P4"],
             style: {
                 pointColor: "#ffca28",
                 lineColor: "#ffca28",
@@ -110,7 +116,7 @@ const buildDemoPolygons = (): readonly DemoPolygonDef[] => [
     },
 ];
 
-/** 操作 UI（enabled トグル）を構築する。 */
+/** 操作 UI（enabled トグル + 垂線/ラベル全体トグル）を構築する。 */
 const buildControls = (
     container: HTMLElement,
     viewer: JpmapTerrain,
@@ -135,6 +141,42 @@ const buildControls = (
         container.appendChild(btn);
         refreshLabel();
     }
+
+    // 垂線/ラベルの全体トグル (Issue #171)
+    const buildToggle = (
+        labelOn: string,
+        labelOff: string,
+        initial: boolean,
+        onClick: (next: boolean) => void,
+    ): HTMLButtonElement => {
+        const btn = document.createElement("button");
+        btn.type = "button";
+        let state = initial;
+        const refresh = (): void => {
+            btn.textContent = state ? labelOn : labelOff;
+        };
+        btn.addEventListener("click", () => {
+            state = !state;
+            onClick(state);
+            refresh();
+        });
+        refresh();
+        return btn;
+    };
+    container.appendChild(
+        buildToggle("✔ 垂線 ON", "✕ 垂線 OFF", true, (next) => {
+            for (const def of polygons) {
+                viewer.setVerticalsEnabled(def.id, next);
+            }
+        }),
+    );
+    container.appendChild(
+        buildToggle("✔ ラベル ON", "✕ ラベル OFF", true, (next) => {
+            for (const def of polygons) {
+                viewer.setLabelsEnabled(def.id, next);
+            }
+        }),
+    );
 };
 
 const start = async (): Promise<void> => {

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -785,6 +785,16 @@ export class JpmapTerrain {
         this._polygonManager.setEnabled(id, enabled);
     }
 
+    public setVerticalsEnabled(id: string, enabled: boolean): void {
+        if (this._disposed || !this._polygonManager) return;
+        this._polygonManager.setVerticalsEnabled(id, enabled);
+    }
+
+    public setLabelsEnabled(id: string, enabled: boolean): void {
+        if (this._disposed || !this._polygonManager) return;
+        this._polygonManager.setLabelsEnabled(id, enabled);
+    }
+
     public listPolygons(): readonly string[] {
         if (this._disposed) return [];
         return this._polygonManager?.list() ?? [];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -232,7 +232,7 @@ export interface PolygonPointOptions {
  * ポリゴン全体のスタイル（spec/package.md §3.3.8.1）。
  *
  * - `lineColor` / `lineWidth` / `lineOpacity` / `pointColor` / `pointDiameter` / `pointOpacity` は #170 で適用。
- * - `dropLine*` / `label*` は #171 で適用予定。`#170` では型予約のみ（既定値で埋めるが描画には未使用）。
+ * - `dropLine*` / `label*` は #171 で適用。
  * - `wallColor` / `wallOpacity` は #172 で適用予定。
  */
 export interface PolygonStyleOptions {
@@ -248,17 +248,17 @@ export interface PolygonStyleOptions {
     pointDiameter?: number;
     /** 球の不透明度 [0,1]。default 1 */
     pointOpacity?: number;
-    /** 垂線の色 CSS（#171 で適用）。 */
+    /** 垂線の色 CSS。default `#ff0000` */
     dropLineColor?: string;
-    /** 垂線の太さ (m, world)（#171 で適用）。 */
+    /** 垂線の太さ (m, world、Tube 半径)。default 1 */
     dropLineWidth?: number;
-    /** 垂線の不透明度 [0,1]（#171 で適用）。 */
+    /** 垂線の不透明度 [0,1]。default 1 */
     dropLineOpacity?: number;
-    /** ラベル文字色 CSS（#171 で適用）。 */
+    /** ラベル文字色 CSS。default `#000000` */
     labelColor?: string;
-    /** ラベル背景色 CSS（#171 で適用）。 */
+    /** ラベル背景色 CSS。default `"transparent"`。不透明色を指定するとラベル領域全体をその色で塗る。 */
     labelBackgroundColor?: string;
-    /** ラベル文字サイズ (px)（#171 で適用）。 */
+    /** ラベル文字サイズ (px)。default 14 */
     labelFontSize?: number;
     /** 壁の色 CSS（#172 で適用）。 */
     wallColor?: string;
@@ -281,13 +281,17 @@ export interface PolygonOptions {
     altitudeMode?: AltitudeMode;
     /**
      * ラベル（点ごと）。`points[i]` に対応する文字列を `labels[i]` で渡す。
-     * `#171` で描画予定。`#170` では受け取るが描画はしない。
+     * 値が指定された点にのみラベル平面（ビルボード + DynamicTexture）を描画する。
      */
     labels?: ReadonlyArray<string>;
     /** スタイル */
     style?: PolygonStyleOptions;
     /** default true */
     enabled?: boolean;
+    /** 各ポイントから地表へ落とす垂線の表示 ON/OFF。default true */
+    verticalsEnabled?: boolean;
+    /** ポイント脇のラベルの表示 ON/OFF。default true */
+    labelsEnabled?: boolean;
 }
 
 /**
@@ -303,6 +307,8 @@ export type PolygonUpdate = Partial<
         | "labels"
         | "style"
         | "enabled"
+        | "verticalsEnabled"
+        | "labelsEnabled"
     >
 >;
 
@@ -317,6 +323,10 @@ export interface PolygonHandle {
     readonly labels: ReadonlyArray<string> | undefined;
     readonly style: Readonly<Required<PolygonStyleOptions>>;
     readonly enabled: boolean;
+    /** 垂線の表示状態 */
+    readonly verticalsEnabled: boolean;
+    /** ラベルの表示状態 */
+    readonly labelsEnabled: boolean;
     /**
      * `terrain` モード時、全頂点の標高が解決済みなら true。
      * `absolute` モード時は常に true。
@@ -327,14 +337,15 @@ export interface PolygonHandle {
 /**
  * ポリゴンの既定値（spec/package.md §3.3.8.1）。
  *
- * `style` は仕様書記載の #170 範囲既定値（`#ff0000` / 直径 20m / 線幅 2m / opacity 1）を採用する。
- * `dropLine*` / `label*` / `wallColor` / `wallOpacity` は型予約のため、ハンドル `style` の
- * `Required<>` を満たすための既定値を内部的に保持するが、`#170` では描画には使用されない。
+ * `style` は仕様書記載の既定値を採用する。
+ * `wallColor` / `wallOpacity` は #172 で適用予定（型予約）。
  */
 export const POLYGON_DEFAULTS = {
     closed: false,
     altitudeMode: "terrain" as AltitudeMode,
     enabled: true,
+    verticalsEnabled: true,
+    labelsEnabled: true,
     style: {
         lineColor: "#ff0000",
         lineWidth: 2,
@@ -342,13 +353,13 @@ export const POLYGON_DEFAULTS = {
         pointColor: "#ff0000",
         pointDiameter: 20,
         pointOpacity: 1,
-        // 以下は #171 / #172 用の予約値（描画未使用）。Required<> 充足のために保持。
         dropLineColor: "#ff0000",
         dropLineWidth: 1,
         dropLineOpacity: 1,
-        labelColor: "#ffffff",
-        labelBackgroundColor: "#000000",
+        labelColor: "#000000",
+        labelBackgroundColor: "transparent",
         labelFontSize: 14,
+        // 以下は #172 用の予約値（描画未使用）。Required<> 充足のために保持。
         wallColor: "#ff0000",
         wallOpacity: 0.3,
     },

--- a/src/terrain/polygon.ts
+++ b/src/terrain/polygon.ts
@@ -1,12 +1,14 @@
 /**
- * 個別ポリゴンノード (Issue #170)。
+ * 個別ポリゴンノード (Issue #170 / #171)。
  *
  * - 頂点ごとの球（{@link CreateSphere}）
  * - 頂点列を結ぶチューブ（{@link CreateTube}、`updatable: true`）
+ * - 各頂点から地表へ落ちる垂線（#171, 1 頂点 1 Tube、`updatable: true`）
+ * - `labels[i]` が指定された頂点に対応するラベル平面（#171, ビルボード + DynamicTexture）
  * を 1 つの root TransformNode 配下に親子化して管理する。
  *
  * `closed=true` のときはチューブ末端に最初の頂点を append し、可視的に閉じる。
- * 面塗り・壁・点ラベル・垂線は本タスクでは実装しない（#171 / #172 / #173）。
+ * 面塗り・壁は本タスクでは実装しない（#172 / #173）。
  */
 
 import type { Scene } from "@babylonjs/core/scene";
@@ -14,7 +16,10 @@ import { Color3 } from "@babylonjs/core/Maths/math.color";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { CreateSphere } from "@babylonjs/core/Meshes/Builders/sphereBuilder";
 import { CreateTube } from "@babylonjs/core/Meshes/Builders/tubeBuilder";
+import { CreatePlane } from "@babylonjs/core/Meshes/Builders/planeBuilder";
 import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
+import { DynamicTexture } from "@babylonjs/core/Materials/Textures/dynamicTexture";
+import { AbstractMesh } from "@babylonjs/core/Meshes/abstractMesh";
 import { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 
@@ -28,6 +33,11 @@ import {
 } from "../lib/types";
 
 const RENDERING_GROUP_ID = 1;
+const LABEL_MAX_DT_SIZE = 1024;
+// テキストにフィットさせるため MIN は小さくし、余白は innerPad のみで表現する。
+const LABEL_MIN_DT_SIZE = 32;
+// 球トップとラベル下端の間隔 (フォント高さに対する比率をスケール反映)。 (#171)
+const LABEL_GAP_FONT_RATIO = 0.0;
 
 interface ResolvedStyle {
     lineColor: string;
@@ -79,9 +89,20 @@ export interface PolygonNode {
     readonly closed: boolean;
     /** 頂点座標 (lat / lon / altitude) のスナップショット。manager から更新される */
     readonly points: readonly PolygonPointOptions[];
-    /** 全頂点を更新する。`worldPoints[i].y` には標高が反映済みのワールド Y を渡す */
-    applyTransform(worldPoints: readonly Vector3[], pointScale: number): void;
+    /**
+     * 全頂点を更新する。
+     * @param worldPoints 各頂点のワールド座標（Y は標高反映済み）。
+     * @param groundYs 各頂点の地表ワールド Y。`null` のときは 0 にフォールバックする。
+     * @param pointScale screen-stable な距離スケール係数。
+     */
+    applyTransform(
+        worldPoints: readonly Vector3[],
+        groundYs: readonly (number | null)[],
+        pointScale: number,
+    ): void;
     setEnabledLogical(enabled: boolean): void;
+    setVerticalsEnabledLogical(enabled: boolean): void;
+    setLabelsEnabledLogical(enabled: boolean): void;
     setElevationResolved(resolved: boolean): void;
     getHandle(): PolygonHandle;
     dispose(): void;
@@ -112,6 +133,167 @@ const createPointSphere = (
     mesh.isPickable = false;
     mesh.parent = parent;
     return { mesh, material };
+};
+
+const createDropLine = (
+    scene: Scene,
+    id: string,
+    index: number,
+    style: ResolvedStyle,
+    parent: TransformNode,
+): { mesh: Mesh; material: StandardMaterial } => {
+    // updatable Tube は path 長を変えられないため、placeholder の 2 点で構築する。
+    const path = [new Vector3(0, 0, 0), new Vector3(0, 1, 0)];
+    const mesh = CreateTube(
+        `polygon-${id}-drop-${index}`,
+        {
+            path,
+            radius: Math.max(style.dropLineWidth, 0.001),
+            updatable: true,
+            cap: Mesh.NO_CAP,
+        },
+        scene,
+    );
+    const material = new StandardMaterial(
+        `polygon-${id}-drop-mat-${index}`,
+        scene,
+    );
+    material.disableLighting = true;
+    material.backFaceCulling = false;
+    material.emissiveColor = Color3.FromHexString(style.dropLineColor);
+    material.alpha = style.dropLineOpacity;
+    mesh.material = material;
+    mesh.renderingGroupId = RENDERING_GROUP_ID;
+    mesh.isPickable = false;
+    mesh.parent = parent;
+    return { mesh, material };
+};
+
+interface LabelEntry {
+    mesh: Mesh;
+    material: StandardMaterial;
+    texture: DynamicTexture;
+    /** 平面の幅（world m, スケール=1 時）。 */
+    widthWorld: number;
+    /** 平面の高さ（world m, スケール=1 時）。 */
+    heightWorld: number;
+}
+
+const createLabelMesh = (
+    scene: Scene,
+    id: string,
+    index: number,
+    text: string,
+    style: ResolvedStyle,
+    parent: TransformNode,
+): LabelEntry => {
+    const dpr =
+        typeof globalThis !== "undefined" &&
+        typeof (globalThis as { devicePixelRatio?: number }).devicePixelRatio ===
+            "number"
+            ? Math.max(
+                  (globalThis as { devicePixelRatio: number }).devicePixelRatio,
+                  1,
+              )
+            : 1;
+
+    const lines = text.split("\n");
+    const fontSize = Math.max(style.labelFontSize, 1);
+    const padPx = Math.round(fontSize * 0.1);
+    const strokePx = Math.max(2, Math.round(fontSize * 0.12));
+    const lineHeightPx = fontSize * 1.2;
+
+    // 文字幅を測るための probe テクスチャ。
+    const probe = new DynamicTexture(
+        `polygon-${id}-label-probe-${index}`,
+        { width: 16, height: 16 },
+        scene,
+        false,
+    );
+    const probeCtx = probe.getContext();
+    probeCtx.font = `${fontSize}px sans-serif`;
+    let maxLineWidth = 0;
+    for (const ln of lines) {
+        const m = probeCtx.measureText(ln === "" ? " " : ln);
+        if (m.width > maxLineWidth) maxLineWidth = m.width;
+    }
+    probe.dispose();
+
+    // 縁取り (stroke) ぶんも余白に確保する。
+    const innerPad = padPx + strokePx;
+    const innerW = maxLineWidth + innerPad * 2;
+    const innerH = lineHeightPx * Math.max(lines.length, 1) + innerPad * 2;
+    const dtWidth = Math.max(
+        LABEL_MIN_DT_SIZE,
+        Math.min(LABEL_MAX_DT_SIZE, Math.ceil(innerW * dpr)),
+    );
+    const dtHeight = Math.max(
+        LABEL_MIN_DT_SIZE,
+        Math.min(LABEL_MAX_DT_SIZE, Math.ceil(innerH * dpr)),
+    );
+
+    const texture = new DynamicTexture(
+        `polygon-${id}-label-${index}`,
+        { width: dtWidth, height: dtHeight },
+        scene,
+        false,
+    );
+    texture.hasAlpha = true;
+    // Plane の UV と canvas の Y 軸を一致させる（上下反転防止）。
+    texture.vScale = -1;
+    texture.vOffset = 1;
+
+    const ctx = texture.getContext() as unknown as CanvasRenderingContext2D;
+    ctx.clearRect(0, 0, dtWidth, dtHeight);
+    if (style.labelBackgroundColor && style.labelBackgroundColor !== "transparent") {
+        ctx.fillStyle = style.labelBackgroundColor;
+        ctx.fillRect(0, 0, dtWidth, dtHeight);
+    }
+    ctx.font = `${fontSize * dpr}px sans-serif`;
+    ctx.textBaseline = "top";
+    ctx.textAlign = "center";
+    ctx.lineJoin = "round";
+    ctx.miterLimit = 2;
+    const startY = innerPad * dpr;
+    const centerX = dtWidth / 2;
+    // 1) 白縁取り → 2) テキスト本体（マーカーと同じ描画順）
+    ctx.lineWidth = strokePx * 2 * dpr;
+    ctx.strokeStyle = "#ffffff";
+    for (let i = 0; i < lines.length; i++) {
+        ctx.strokeText(lines[i], centerX, startY + i * lineHeightPx * dpr);
+    }
+    ctx.fillStyle = style.labelColor;
+    for (let i = 0; i < lines.length; i++) {
+        ctx.fillText(lines[i], centerX, startY + i * lineHeightPx * dpr);
+    }
+    texture.update(false);
+
+    // pixel→world は 1px = 1m 換算（distScale 適用前のベースサイズ）。
+    const widthWorld = dtWidth / dpr;
+    const heightWorld = dtHeight / dpr;
+
+    const mesh = CreatePlane(
+        `polygon-${id}-label-${index}`,
+        { width: widthWorld, height: heightWorld },
+        scene,
+    );
+    mesh.billboardMode = AbstractMesh.BILLBOARDMODE_ALL;
+    mesh.renderingGroupId = RENDERING_GROUP_ID;
+    mesh.isPickable = false;
+    mesh.parent = parent;
+
+    const material = new StandardMaterial(
+        `polygon-${id}-label-mat-${index}`,
+        scene,
+    );
+    material.disableLighting = true;
+    material.backFaceCulling = false;
+    material.useAlphaFromDiffuseTexture = true;
+    material.emissiveColor = Color3.White();
+    material.diffuseTexture = texture;
+    mesh.material = material;
+
+    return { mesh, material, texture, widthWorld, heightWorld };
 };
 
 /**
@@ -145,6 +327,10 @@ export const createPolygonNode = (
         : undefined;
     const style = resolveStyle(options.style);
     let logicalEnabled = options.enabled ?? POLYGON_DEFAULTS.enabled;
+    let verticalsEnabled =
+        options.verticalsEnabled ?? POLYGON_DEFAULTS.verticalsEnabled;
+    let labelsEnabled =
+        options.labelsEnabled ?? POLYGON_DEFAULTS.labelsEnabled;
     let elevationResolved = altitudeMode === "absolute";
 
     // 頂点はディープコピーして外部からの破壊変更を無効化する。
@@ -160,6 +346,18 @@ export const createPolygonNode = (
     const sphereEntries = points.map((_pt, index) =>
         createPointSphere(scene, id, index, style, root),
     );
+
+    // 各頂点に対応する垂線 Tube を 1 本ずつ作る。
+    const dropEntries = points.map((_pt, index) =>
+        createDropLine(scene, id, index, style, root),
+    );
+
+    // labels[i] が指定された頂点にのみラベルを作る。indexed by 頂点 index。
+    const labelEntries: (LabelEntry | null)[] = points.map((_pt, index) => {
+        const text = labels ? labels[index] : undefined;
+        if (text === undefined || text === null) return null;
+        return createLabelMesh(scene, id, index, text, style, root);
+    });
 
     // 初期 path（仮）。applyTransform で必ず上書きされる前提だが、
     // 構築時にも有効な Tube が必要なので原点付近の placeholder を渡す。
@@ -188,11 +386,21 @@ export const createPolygonNode = (
     const applyVisibility = (): void => {
         const visible = logicalEnabled && elevationResolved;
         root.setEnabled(visible);
+        // 子要素の個別 ON/OFF（垂線・ラベル）。root が無効なら自動で隠れるので、
+        // root が有効なときに verticals/labels の個別設定を反映する。
+        for (const entry of dropEntries) {
+            entry.mesh.setEnabled(visible && verticalsEnabled);
+        }
+        for (const entry of labelEntries) {
+            if (!entry) continue;
+            entry.mesh.setEnabled(visible && labelsEnabled);
+        }
     };
     applyVisibility();
 
     const applyTransform = (
         worldPoints: readonly Vector3[],
+        groundYs: readonly (number | null)[],
         pointScale: number,
     ): void => {
         if (worldPoints.length !== sphereEntries.length) {
@@ -200,11 +408,38 @@ export const createPolygonNode = (
             return;
         }
         const sphereDiameter = Math.max(style.pointDiameter, 0.001);
+        const sphereRadiusWorld = sphereDiameter * pointScale * 0.5;
+        // ラベル下端を球トップから 1 フォント高さぶん離す。
+        const labelGap = style.labelFontSize * pointScale * LABEL_GAP_FONT_RATIO;
         for (let i = 0; i < sphereEntries.length; i++) {
             const sphere = sphereEntries[i].mesh;
             const wp = worldPoints[i];
             sphere.position.set(wp.x, wp.y, wp.z);
             sphere.scaling.setAll(sphereDiameter * pointScale);
+
+            // 垂線: top = wp.y, bottom = groundYs[i] ?? 0。
+            const dropMesh = dropEntries[i].mesh;
+            const groundY = groundYs[i] ?? 0;
+            const dropPath = [
+                new Vector3(wp.x, wp.y, wp.z),
+                new Vector3(wp.x, groundY, wp.z),
+            ];
+            // CreateTube に instance を渡すと in-place で更新される。
+            CreateTube(
+                `polygon-${id}-drop-${i}`,
+                { path: dropPath, instance: dropMesh },
+                scene,
+            );
+
+            // ラベル: 球の上にオフセット配置 + distScale 連動。
+            // 中心位置 = 球中心 + 球半径 + ギャップ(font 1つ分) + ラベル平面の半分。
+            const label = labelEntries[i];
+            if (label) {
+                const labelHalfWorld = label.heightWorld * pointScale * 0.5;
+                const offsetY = sphereRadiusWorld + labelGap + labelHalfWorld;
+                label.mesh.position.set(wp.x, wp.y + offsetY, wp.z);
+                label.mesh.scaling.setAll(pointScale);
+            }
         }
         const tubePath = buildLinePath(worldPoints, closed);
         lineMesh = CreateTube(
@@ -222,6 +457,8 @@ export const createPolygonNode = (
         labels,
         style: { ...style },
         enabled: logicalEnabled,
+        verticalsEnabled,
+        labelsEnabled,
         elevationResolved,
     });
 
@@ -231,6 +468,18 @@ export const createPolygonNode = (
             entry.mesh.dispose();
         }
         sphereEntries.length = 0;
+        for (const entry of dropEntries) {
+            entry.material.dispose();
+            entry.mesh.dispose();
+        }
+        dropEntries.length = 0;
+        for (const entry of labelEntries) {
+            if (!entry) continue;
+            entry.texture.dispose();
+            entry.material.dispose();
+            entry.mesh.dispose();
+        }
+        labelEntries.length = 0;
         lineMaterial.dispose();
         lineMesh.dispose();
         root.dispose();
@@ -244,6 +493,14 @@ export const createPolygonNode = (
         applyTransform,
         setEnabledLogical(enabled: boolean): void {
             logicalEnabled = enabled;
+            applyVisibility();
+        },
+        setVerticalsEnabledLogical(enabled: boolean): void {
+            verticalsEnabled = enabled;
+            applyVisibility();
+        },
+        setLabelsEnabledLogical(enabled: boolean): void {
+            labelsEnabled = enabled;
             applyVisibility();
         },
         setElevationResolved(resolved: boolean): void {

--- a/src/terrain/polygon.ts
+++ b/src/terrain/polygon.ts
@@ -423,18 +423,22 @@ export const createPolygonNode = (
             sphere.scaling.setAll(sphereDiameter * pointScale);
 
             // 垂線: top = wp.y, bottom = groundYs[i] ?? 0。
-            const dropMesh = dropEntries[i].mesh;
-            const groundY = groundYs[i] ?? 0;
-            const dropPath = [
-                new Vector3(wp.x, wp.y, wp.z),
-                new Vector3(wp.x, groundY, wp.z),
-            ];
-            // CreateTube に instance を渡すと in-place で更新される。
-            CreateTube(
-                `polygon-${id}-drop-${i}`,
-                { path: dropPath, instance: dropMesh },
-                scene,
-            );
+            // verticalsEnabled が false（非表示中）はメッシュ更新をスキップして
+            // フレーム負荷を下げる。次回 enable 時にこのループで再更新される。
+            if (verticalsEnabled) {
+                const dropMesh = dropEntries[i].mesh;
+                const groundY = groundYs[i] ?? 0;
+                const dropPath = [
+                    new Vector3(wp.x, wp.y, wp.z),
+                    new Vector3(wp.x, groundY, wp.z),
+                ];
+                // CreateTube に instance を渡すと in-place で更新される。
+                CreateTube(
+                    `polygon-${id}-drop-${i}`,
+                    { path: dropPath, instance: dropMesh },
+                    scene,
+                );
+            }
 
             // ラベル: 球の上にオフセット配置 + distScale 連動。
             // 中心位置 = 球中心 + 球半径 + ギャップ + ラベル平面の半分。

--- a/src/terrain/polygon.ts
+++ b/src/terrain/polygon.ts
@@ -407,6 +407,11 @@ export const createPolygonNode = (
             // ディフェンシブ: 想定外。何もしない（次フレームで更新されうる）。
             return;
         }
+        if (groundYs.length !== sphereEntries.length) {
+            // groundYs の長さ不一致は呼び出し側バグ。黙って 0 フォールバックせず
+            // 当フレームの更新をスキップして検知しやすくする。
+            return;
+        }
         const sphereDiameter = Math.max(style.pointDiameter, 0.001);
         const sphereRadiusWorld = sphereDiameter * pointScale * 0.5;
         // ラベル下端を球トップから 1 フォント高さぶん離す。

--- a/src/terrain/polygon.ts
+++ b/src/terrain/polygon.ts
@@ -414,7 +414,7 @@ export const createPolygonNode = (
         }
         const sphereDiameter = Math.max(style.pointDiameter, 0.001);
         const sphereRadiusWorld = sphereDiameter * pointScale * 0.5;
-        // ラベル下端を球トップから 1 フォント高さぶん離す。
+        // 球トップとラベル下端の間隔。`LABEL_GAP_FONT_RATIO === 0` ならギャップなし。
         const labelGap = style.labelFontSize * pointScale * LABEL_GAP_FONT_RATIO;
         for (let i = 0; i < sphereEntries.length; i++) {
             const sphere = sphereEntries[i].mesh;
@@ -437,7 +437,7 @@ export const createPolygonNode = (
             );
 
             // ラベル: 球の上にオフセット配置 + distScale 連動。
-            // 中心位置 = 球中心 + 球半径 + ギャップ(font 1つ分) + ラベル平面の半分。
+            // 中心位置 = 球中心 + 球半径 + ギャップ + ラベル平面の半分。
             const label = labelEntries[i];
             if (label) {
                 const labelHalfWorld = label.heightWorld * pointScale * 0.5;

--- a/src/terrain/polygonManager.ts
+++ b/src/terrain/polygonManager.ts
@@ -39,6 +39,8 @@ export interface PolygonManager {
     update(id: string, partial: PolygonUpdate): PolygonHandle;
     remove(id: string): void;
     setEnabled(id: string, enabled: boolean): void;
+    setVerticalsEnabled(id: string, enabled: boolean): void;
+    setLabelsEnabled(id: string, enabled: boolean): void;
     list(): readonly string[];
     dispose(): void;
 }
@@ -73,20 +75,24 @@ export const createPolygonManager = (ctx: OverlayContext): PolygonManager => {
      */
     const tickPolygon = (node: PolygonNode): void => {
         const worldPoints: Vector3[] = [];
+        const groundYs: (number | null)[] = [];
         let allResolved = true;
         for (const pt of node.points) {
             const { wx, wz } = latLonToWorld(ctx, pt.lat, pt.lon);
+            const elev = ctx.tileManager.queryElevationAtWorld(wx, wz);
             let wy: number;
             if (node.altitudeMode === "absolute") {
                 // validateOptions で undefined は弾いている前提。
                 wy = pt.altitude ?? 0;
+                // 垂線終端用の地表 Y。null のときは applyTransform 側で 0 フォールバック。
+                groundYs.push(elev);
             } else {
-                const elev = ctx.tileManager.queryElevationAtWorld(wx, wz);
                 if (elev === null) {
                     allResolved = false;
                     break;
                 }
                 wy = elev + (pt.altitude ?? 0);
+                groundYs.push(elev);
             }
             worldPoints.push(new Vector3(wx, wy, wz));
         }
@@ -109,7 +115,7 @@ export const createPolygonManager = (ctx: OverlayContext): PolygonManager => {
         cz /= n;
         const scale = computeDistanceScale(ctx, cx, cy, cz);
         node.setElevationResolved(true);
-        node.applyTransform(worldPoints, scale);
+        node.applyTransform(worldPoints, groundYs, scale);
     };
 
     const tickFrame = (): void => {
@@ -182,6 +188,20 @@ export const createPolygonManager = (ctx: OverlayContext): PolygonManager => {
             }
             const node = requireNode(id);
             node.setEnabledLogical(enabled);
+        },
+        setVerticalsEnabled(id: string, enabled: boolean): void {
+            if (disposed) {
+                throw new Error("PolygonManager has been disposed");
+            }
+            const node = requireNode(id);
+            node.setVerticalsEnabledLogical(enabled);
+        },
+        setLabelsEnabled(id: string, enabled: boolean): void {
+            if (disposed) {
+                throw new Error("PolygonManager has been disposed");
+            }
+            const node = requireNode(id);
+            node.setLabelsEnabledLogical(enabled);
         },
         list(): readonly string[] {
             return Array.from(nodes.keys());

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -84,7 +84,7 @@ jest.unstable_mockModule("../src/terrain/polygon", () => ({
     createPolygonNode: (
         _scene: unknown,
         id: string,
-        options: { points: readonly { lat: number; lon: number; altitude?: number }[]; closed?: boolean; altitudeMode?: "terrain" | "absolute"; enabled?: boolean },
+        options: { points: readonly { lat: number; lon: number; altitude?: number }[]; closed?: boolean; altitudeMode?: "terrain" | "absolute"; enabled?: boolean; verticalsEnabled?: boolean; labelsEnabled?: boolean },
     ) => {
         let enabled = options.enabled ?? true;
         const altitudeMode = options.altitudeMode ?? "terrain";
@@ -101,6 +101,12 @@ jest.unstable_mockModule("../src/terrain/polygon", () => ({
             setEnabledLogical: (v: boolean) => {
                 enabled = v;
             },
+            setVerticalsEnabledLogical: () => {
+                /* no-op */
+            },
+            setLabelsEnabledLogical: () => {
+                /* no-op */
+            },
             setElevationResolved: (v: boolean) => {
                 elevationResolved = v;
             },
@@ -112,6 +118,8 @@ jest.unstable_mockModule("../src/terrain/polygon", () => ({
                 labels: undefined,
                 style: {} as unknown as Record<string, unknown>,
                 enabled,
+                verticalsEnabled: options.verticalsEnabled ?? true,
+                labelsEnabled: options.labelsEnabled ?? true,
                 elevationResolved,
             }),
             dispose: () => {
@@ -1478,6 +1486,15 @@ describe("JpmapTerrain (skeleton)", () => {
             expect(() => viewer.setPolygonEnabled("p1", false)).not.toThrow();
         });
 
+        it("setVerticalsEnabled / setLabelsEnabled は存在する id に対して throw しない (Issue #171)", async () => {
+            const viewer = await create(createMountElement());
+            viewer.addPolygon("p1", { points: validPoints });
+            expect(() => viewer.setVerticalsEnabled("p1", false)).not.toThrow();
+            expect(() => viewer.setVerticalsEnabled("p1", true)).not.toThrow();
+            expect(() => viewer.setLabelsEnabled("p1", false)).not.toThrow();
+            expect(() => viewer.setLabelsEnabled("p1", true)).not.toThrow();
+        });
+
         it("dispose 後の addPolygon は throw、その他 API は no-op / null / [] を返す", async () => {
             const viewer = await create(createMountElement());
             viewer.dispose();
@@ -1486,6 +1503,8 @@ describe("JpmapTerrain (skeleton)", () => {
             expect(viewer.listPolygons()).toEqual([]);
             expect(() => viewer.removePolygon("p1")).not.toThrow();
             expect(() => viewer.setPolygonEnabled("p1", false)).not.toThrow();
+            expect(() => viewer.setVerticalsEnabled("p1", false)).not.toThrow();
+            expect(() => viewer.setLabelsEnabled("p1", false)).not.toThrow();
         });
     });
 });

--- a/tests/polygon.unit.spec.ts
+++ b/tests/polygon.unit.spec.ts
@@ -24,11 +24,13 @@ interface StubMesh {
     material: StubMaterial | null;
     renderingGroupId: number;
     isPickable: boolean;
+    billboardMode: number;
     position: { x: number; y: number; z: number; set: (x: number, y: number, z: number) => void };
     scaling: { x: number; y: number; z: number; setAll: (v: number) => void };
+    enabledHistory: boolean[];
     disposed: boolean;
     dispose(): void;
-    setEnabled?: (v: boolean) => void;
+    setEnabled(v: boolean): void;
 }
 
 interface StubTransformNode {
@@ -44,6 +46,8 @@ const tubeCalls: Array<{
     name: string;
     options: { path: unknown[]; instance?: StubMesh; updatable?: boolean };
 }> = [];
+const planeCalls: Array<{ name: string; options: { width: number; height: number } }> = [];
+const dynamicTextures: Array<{ name: string; disposed: boolean }> = [];
 const transformNodes: StubTransformNode[] = [];
 const allMeshes: StubMesh[] = [];
 
@@ -54,6 +58,7 @@ const buildMesh = (name: string): StubMesh => {
         material: null,
         renderingGroupId: 0,
         isPickable: true,
+        billboardMode: 0,
         position: {
             x: 0,
             y: 0,
@@ -74,9 +79,13 @@ const buildMesh = (name: string): StubMesh => {
                 this.z = v;
             },
         },
+        enabledHistory: [],
         disposed: false,
         dispose() {
             this.disposed = true;
+        },
+        setEnabled(v: boolean) {
+            this.enabledHistory.push(v);
         },
     };
     allMeshes.push(mesh);
@@ -152,6 +161,72 @@ jest.unstable_mockModule("@babylonjs/core/Meshes/mesh", () => ({
     Mesh: { NO_CAP: 0 },
 }));
 
+jest.unstable_mockModule(
+    "@babylonjs/core/Meshes/Builders/planeBuilder",
+    () => ({
+        CreatePlane: (
+            name: string,
+            options: { width: number; height: number },
+        ): StubMesh => {
+            planeCalls.push({ name, options });
+            return buildMesh(name);
+        },
+    }),
+);
+
+jest.unstable_mockModule(
+    "@babylonjs/core/Materials/Textures/dynamicTexture",
+    () => ({
+        DynamicTexture: class {
+            public name: string;
+            public hasAlpha = false;
+            public vScale = 1;
+            public vOffset = 0;
+            public disposed = false;
+            constructor(name: string) {
+                this.name = name;
+                dynamicTextures.push(this);
+            }
+            getContext(): unknown {
+                // 文字幅 measure をスタブ。長さ * 8 を文字幅とする。
+                return {
+                    font: "",
+                    textBaseline: "",
+                    textAlign: "",
+                    fillStyle: "",
+                    strokeStyle: "",
+                    lineWidth: 0,
+                    lineJoin: "",
+                    miterLimit: 0,
+                    measureText: (s: string) => ({ width: s.length * 8 }),
+                    fillRect: (): void => {
+                        /* noop */
+                    },
+                    clearRect: (): void => {
+                        /* noop */
+                    },
+                    fillText: (): void => {
+                        /* noop */
+                    },
+                    strokeText: (): void => {
+                        /* noop */
+                    },
+                };
+            }
+            update(): void {
+                /* noop */
+            }
+            dispose(): void {
+                this.disposed = true;
+            }
+        },
+    }),
+);
+
+jest.unstable_mockModule("@babylonjs/core/Meshes/abstractMesh", () => ({
+    AbstractMesh: { BILLBOARDMODE_ALL: 7 },
+}));
+
 const { createPolygonNode } = await import("../src/terrain/polygon");
 
 const sceneStub = {} as unknown as Parameters<typeof createPolygonNode>[0];
@@ -159,12 +234,14 @@ const sceneStub = {} as unknown as Parameters<typeof createPolygonNode>[0];
 beforeEach(() => {
     sphereCalls.length = 0;
     tubeCalls.length = 0;
+    planeCalls.length = 0;
+    dynamicTextures.length = 0;
     transformNodes.length = 0;
     allMeshes.length = 0;
 });
 
 describe("createPolygonNode 構築", () => {
-    it("頂点数分の球と 1 本の Tube を生成する (closed=false)", () => {
+    it("頂点数分の球と垂線 Tube + 1 本のポリライン Tube を生成する (closed=false)", () => {
         const node = createPolygonNode(sceneStub, "p1", {
             points: [
                 { lat: 35.0, lon: 139.0 },
@@ -173,8 +250,8 @@ describe("createPolygonNode 構築", () => {
             ],
         });
         expect(sphereCalls.length).toBe(3);
-        // 初期構築の Tube 1 回 + 即時 applyTransform は呼ばれていないので 1 回のみ
-        expect(tubeCalls.length).toBe(1);
+        // 構築時: 垂線 Tube 3 本 + ポリライン Tube 1 本 = 4
+        expect(tubeCalls.length).toBe(4);
         expect(node.id).toBe("p1");
         expect(transformNodes.length).toBe(1);
         expect(transformNodes[0].name).toBe("polygon-p1");
@@ -189,14 +266,15 @@ describe("createPolygonNode 構築", () => {
             ],
             closed: true,
         });
-        const initialPath = tubeCalls[0].options.path as Array<{
+        // 末尾の Tube call がポリライン本体（垂線が先に 3 本構築される）。
+        const lineCall = tubeCalls[tubeCalls.length - 1];
+        const initialPath = lineCall.options.path as Array<{
             x: number;
             y: number;
             z: number;
         }>;
         // 3 点 + closed の先頭再追加 = 4
         expect(initialPath.length).toBe(4);
-        // 先頭と末尾は別オブジェクト（参照分離）かつ同値。
         expect(initialPath[0]).not.toBe(initialPath[initialPath.length - 1]);
         expect(initialPath[0].x).toBe(initialPath[initialPath.length - 1].x);
         expect(initialPath[0].y).toBe(initialPath[initialPath.length - 1].y);
@@ -213,10 +291,35 @@ describe("createPolygonNode 構築", () => {
         });
         expect(node.getHandle().elevationResolved).toBe(true);
     });
+
+    it("labels[i] が指定された頂点にのみラベル平面を生成する", () => {
+        createPolygonNode(sceneStub, "pL", {
+            points: [
+                { lat: 35.0, lon: 139.0, altitude: 0 },
+                { lat: 35.1, lon: 139.1, altitude: 0 },
+                { lat: 35.2, lon: 139.2, altitude: 0 },
+            ],
+            altitudeMode: "absolute",
+            labels: ["A", "", "C"],
+        });
+        // 空文字列もラベル対象（明示指定されている）。3 点 → 3 plane。
+        expect(planeCalls.length).toBe(3);
+    });
+
+    it("labels が一切指定されない場合はラベル平面を作らない", () => {
+        createPolygonNode(sceneStub, "pL2", {
+            points: [
+                { lat: 35.0, lon: 139.0, altitude: 0 },
+                { lat: 35.1, lon: 139.1, altitude: 0 },
+            ],
+            altitudeMode: "absolute",
+        });
+        expect(planeCalls.length).toBe(0);
+    });
 });
 
 describe("createPolygonNode applyTransform", () => {
-    it("applyTransform で Tube が instance 指定で更新される", async () => {
+    it("applyTransform でポリライン Tube が instance 指定で更新される", async () => {
         const { Vector3 } = await import("@babylonjs/core/Maths/math.vector");
         const node = createPolygonNode(sceneStub, "p4", {
             points: [
@@ -225,13 +328,18 @@ describe("createPolygonNode applyTransform", () => {
             ],
             altitudeMode: "absolute",
         });
+        const beforeLen = tubeCalls.length;
         node.applyTransform(
             [new Vector3(0, 0, 0), new Vector3(100, 5, 200)],
+            [0, 0],
             1,
         );
-        // 構築時 1 回 + applyTransform 1 回
-        expect(tubeCalls.length).toBe(2);
-        expect(tubeCalls[1].options.instance).toBeDefined();
+        // 各頂点の垂線更新 (2) + ポリライン更新 (1)
+        expect(tubeCalls.length - beforeLen).toBe(3);
+        // applyTransform 由来の呼び出しはすべて instance 指定。
+        for (let i = beforeLen; i < tubeCalls.length; i++) {
+            expect(tubeCalls[i].options.instance).toBeDefined();
+        }
     });
 
     it("absolute モードで applyTransform に渡された Y がそのまま使われる", async () => {
@@ -245,11 +353,68 @@ describe("createPolygonNode applyTransform", () => {
         });
         node.applyTransform(
             [new Vector3(10, 100, 20), new Vector3(30, 200, 40)],
+            [0, 0],
             1,
         );
-        const path = tubeCalls[1].options.path as Array<{ y: number }>;
+        // 末尾呼び出しがポリライン更新（垂線 2 本の後）。
+        const lineUpdate = tubeCalls[tubeCalls.length - 1];
+        const path = lineUpdate.options.path as Array<{ y: number }>;
         expect(path[0].y).toBe(100);
         expect(path[1].y).toBe(200);
+    });
+
+    it("垂線の終端 Y が groundYs に追従する（null は 0 フォールバック）", async () => {
+        const { Vector3 } = await import("@babylonjs/core/Maths/math.vector");
+        const node = createPolygonNode(sceneStub, "pV", {
+            points: [
+                { lat: 35.0, lon: 139.0, altitude: 100 },
+                { lat: 35.1, lon: 139.1, altitude: 100 },
+            ],
+            altitudeMode: "absolute",
+        });
+        const beforeLen = tubeCalls.length;
+        node.applyTransform(
+            [new Vector3(0, 100, 0), new Vector3(50, 100, 0)],
+            [25, null],
+            1,
+        );
+        // 構築直後の applyTransform: 垂線 2 本 + ポリライン 1 本 が追加される。
+        const drop0 = tubeCalls[beforeLen];
+        const drop1 = tubeCalls[beforeLen + 1];
+        const drop0Path = drop0.options.path as Array<{ y: number }>;
+        const drop1Path = drop1.options.path as Array<{ y: number }>;
+        expect(drop0Path[0].y).toBe(100);
+        expect(drop0Path[1].y).toBe(25);
+        expect(drop1Path[0].y).toBe(100);
+        expect(drop1Path[1].y).toBe(0); // null → 0 フォールバック
+    });
+
+    it("ラベル位置が球より上 (Y オフセット) に配置される", async () => {
+        const { Vector3 } = await import("@babylonjs/core/Maths/math.vector");
+        const node = createPolygonNode(sceneStub, "pLpos", {
+            points: [
+                { lat: 35.0, lon: 139.0, altitude: 100 },
+                { lat: 35.1, lon: 139.1, altitude: 100 },
+            ],
+            altitudeMode: "absolute",
+            labels: ["X", "Y"],
+            style: { pointDiameter: 20 },
+        });
+        node.applyTransform(
+            [new Vector3(0, 100, 0), new Vector3(50, 100, 0)],
+            [0, 0],
+            1,
+        );
+        // ラベル平面は plane 順序で記録されている。
+        // sphere の position(=100) より上にあること。
+        // allMeshes のうち polygon-pLpos-label-* を抽出する。
+        const labelMeshes = allMeshes.filter((m) =>
+            m.name.startsWith("polygon-pLpos-label-"),
+        );
+        expect(labelMeshes.length).toBe(2);
+        for (const lm of labelMeshes) {
+            expect(lm.position.y).toBeGreaterThan(100);
+        }
     });
 });
 
@@ -263,13 +428,53 @@ describe("createPolygonNode enabled / dispose", () => {
             altitudeMode: "absolute",
         });
         const root = transformNodes[0];
-        // 構築時の applyVisibility 呼び出しを差し引いて、明示的な false 切替を確認する
         const beforeLen = root.enabledHistory.length;
         node.setEnabledLogical(false);
         expect(root.enabledHistory.slice(beforeLen)).toContain(false);
     });
 
-    it("dispose で全 sphere / Tube / material / root が dispose される", () => {
+    it("setVerticalsEnabledLogical で垂線メッシュの setEnabled が連動する", () => {
+        const node = createPolygonNode(sceneStub, "pVe", {
+            points: [
+                { lat: 35.0, lon: 139.0, altitude: 0 },
+                { lat: 35.1, lon: 139.1, altitude: 0 },
+            ],
+            altitudeMode: "absolute",
+        });
+        const dropMeshes = allMeshes.filter((m) =>
+            m.name.startsWith("polygon-pVe-drop-"),
+        );
+        expect(dropMeshes.length).toBe(2);
+        node.setVerticalsEnabledLogical(false);
+        for (const dm of dropMeshes) {
+            expect(dm.enabledHistory).toContain(false);
+        }
+        expect(node.getHandle().verticalsEnabled).toBe(false);
+        node.setVerticalsEnabledLogical(true);
+        expect(node.getHandle().verticalsEnabled).toBe(true);
+    });
+
+    it("setLabelsEnabledLogical でラベルメッシュの setEnabled が連動する", () => {
+        const node = createPolygonNode(sceneStub, "pLe", {
+            points: [
+                { lat: 35.0, lon: 139.0, altitude: 0 },
+                { lat: 35.1, lon: 139.1, altitude: 0 },
+            ],
+            altitudeMode: "absolute",
+            labels: ["a", "b"],
+        });
+        const labelMeshes = allMeshes.filter((m) =>
+            m.name.startsWith("polygon-pLe-label-"),
+        );
+        expect(labelMeshes.length).toBe(2);
+        node.setLabelsEnabledLogical(false);
+        for (const lm of labelMeshes) {
+            expect(lm.enabledHistory).toContain(false);
+        }
+        expect(node.getHandle().labelsEnabled).toBe(false);
+    });
+
+    it("dispose で sphere / drop / label / line / material / texture / root が全て解放される", () => {
         const node = createPolygonNode(sceneStub, "p7", {
             points: [
                 { lat: 35.0, lon: 139.0, altitude: 0 },
@@ -277,11 +482,15 @@ describe("createPolygonNode enabled / dispose", () => {
                 { lat: 35.2, lon: 139.2, altitude: 0 },
             ],
             altitudeMode: "absolute",
+            labels: ["a", "b", "c"],
         });
         node.dispose();
-        // 構築時の全 mesh が dispose 済み
         for (const m of allMeshes) {
             expect(m.disposed).toBe(true);
+        }
+        // probe DT は構築時に dispose 済み、ラベル DT は dispose() で解放される。
+        for (const dt of dynamicTextures) {
+            expect(dt.disposed).toBe(true);
         }
         expect(transformNodes[0].disposed).toBe(true);
     });

--- a/tests/polygonManager.unit.spec.ts
+++ b/tests/polygonManager.unit.spec.ts
@@ -21,8 +21,11 @@ interface StubNode {
     elevationResolved: boolean;
     applyTransformCalls: number;
     lastWorldPoints: Array<{ x: number; y: number; z: number }>;
+    lastGroundYs: Array<number | null>;
     disposed: boolean;
     setEnabledHistory: boolean[];
+    setVerticalsEnabledHistory: boolean[];
+    setLabelsEnabledHistory: boolean[];
     setElevationResolvedHistory: boolean[];
 }
 
@@ -44,8 +47,11 @@ jest.unstable_mockModule("../src/terrain/polygon", () => ({
             elevationResolved: altitudeMode === "absolute",
             applyTransformCalls: 0,
             lastWorldPoints: [],
+            lastGroundYs: [],
             disposed: false,
             setEnabledHistory: [],
+            setVerticalsEnabledHistory: [],
+            setLabelsEnabledHistory: [],
             setElevationResolvedHistory: [],
         };
         const wrapped = {
@@ -56,6 +62,7 @@ jest.unstable_mockModule("../src/terrain/polygon", () => ({
                     y: number;
                     z: number;
                 }>,
+                groundYs?: ReadonlyArray<number | null>,
             ) => {
                 node.applyTransformCalls++;
                 node.lastWorldPoints = worldPoints.map((p) => ({
@@ -63,10 +70,19 @@ jest.unstable_mockModule("../src/terrain/polygon", () => ({
                     y: p.y,
                     z: p.z,
                 }));
+                if (groundYs) {
+                    node.lastGroundYs = groundYs.slice();
+                }
             },
             setEnabledLogical: (v: boolean) => {
                 node.enabled = v;
                 node.setEnabledHistory.push(v);
+            },
+            setVerticalsEnabledLogical: (v: boolean) => {
+                node.setVerticalsEnabledHistory.push(v);
+            },
+            setLabelsEnabledLogical: (v: boolean) => {
+                node.setLabelsEnabledHistory.push(v);
             },
             setElevationResolved: (v: boolean) => {
                 node.elevationResolved = v;
@@ -331,6 +347,31 @@ describe("PolygonManager enable / disable", () => {
         const mgr = createPolygonManager(ctx);
         expect(() => mgr.setEnabled("missing", false)).toThrow(/not found/);
     });
+
+    it("setVerticalsEnabled が node.setVerticalsEnabledLogical へ委譲される (Issue #171)", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createPolygonManager(ctx);
+        mgr.add("a", { points: validPoints });
+        mgr.setVerticalsEnabled("a", false);
+        mgr.setVerticalsEnabled("a", true);
+        expect(created[0].setVerticalsEnabledHistory).toEqual([false, true]);
+    });
+
+    it("setLabelsEnabled が node.setLabelsEnabledLogical へ委譲される (Issue #171)", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createPolygonManager(ctx);
+        mgr.add("a", { points: validPoints });
+        mgr.setLabelsEnabled("a", false);
+        mgr.setLabelsEnabled("a", true);
+        expect(created[0].setLabelsEnabledHistory).toEqual([false, true]);
+    });
+
+    it("未存在 id の setVerticalsEnabled / setLabelsEnabled は throw (Issue #171)", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createPolygonManager(ctx);
+        expect(() => mgr.setVerticalsEnabled("missing", false)).toThrow(/not found/);
+        expect(() => mgr.setLabelsEnabled("missing", false)).toThrow(/not found/);
+    });
 });
 
 describe("PolygonManager dispose", () => {
@@ -352,6 +393,8 @@ describe("PolygonManager dispose", () => {
         mgr.dispose();
         expect(() => mgr.add("a", { points: validPoints })).toThrow(/disposed/);
         expect(() => mgr.setEnabled("a", false)).toThrow(/disposed/);
+        expect(() => mgr.setVerticalsEnabled("a", false)).toThrow(/disposed/);
+        expect(() => mgr.setLabelsEnabled("a", false)).toThrow(/disposed/);
     });
 
     it("dispose 後の get は null、list は []、remove は no-op", () => {


### PR DESCRIPTION
## 概要
Issue #171 — ポリゴンの「各ポイントから地表へ落とす垂線」と「ポイント脇のラベル」を実装。

Closes #171

## 主な変更
- 垂線: 各頂点から `(lat, lon)` のタイル標高 Y まで `CreateTube`（updatable）で描画。標高未解決時は Y=0 にフォールバック。
- ラベル: `PolygonOptions.labels[i]` 指定時のみ DynamicTexture + ビルボード Plane で描画。マーカーと同じ「黒文字 + 白縁取り、背景透明」スタイル。
- 公開 API: `setVerticalsEnabled(id, enabled)` / `setLabelsEnabled(id, enabled)` を追加。dispose 後は no-op。
- `PolygonOptions.verticalsEnabled` / `labelsEnabled`（既定 true）と `PolygonHandle` の対応 readonly フラグ。
- /polygon デモに labels と垂線/ラベル ON/OFF 全体トグルを追加。
- spec/package.md §3.3.8.1 を「#171 実装済み」に更新（インターフェース宣言と API 説明を反映）。

## 検証
- npm run lint / npm run typecheck / npm run test:unit (500/500) すべて成功
- Reviewer / Security レビュー済（Reviewer LOW 2 件反映済、Security LOW 2 件は別 PR 検討）