### PR TITLE
feat(polygon): walls + closed + per-element color/opacity (#172)

### DIFF
--- a/spec/package.md
+++ b/spec/package.md
@@ -345,7 +345,7 @@ interface MarkerOptions {
 
 任意の点列を受け取り、地表または絶対標高に沿って **ポイント球体** と **ポリライン** を表示する API（基盤）。
 
-##### 3.3.8.1 公開 API（基盤＋ポリライン＋垂線/ラベル: Issue #170 / #171）
+##### 3.3.8.1 公開 API（基盤＋ポリライン＋垂線/ラベル＋壁: Issue #170 / #171 / #172）
 
 ```typescript
 interface JpmapTerrain {
@@ -361,6 +361,8 @@ interface JpmapTerrain {
   setVerticalsEnabled(id: string, enabled: boolean): void;
   /** ラベル表示をポリゴン単位で ON/OFF (#171) */
   setLabelsEnabled(id: string, enabled: boolean): void;
+  /** 壁表示をポリゴン単位で ON/OFF (#172) */
+  setWallsEnabled(id: string, enabled: boolean): void;
   /** 全 id を生成順で返す */
   listPolygons(): readonly string[];
 }
@@ -382,21 +384,22 @@ interface PolygonStyleOptions {
   lineColor?: string;      // CSS color (default "#ff0000")
   lineOpacity?: number;    // 0..1 (default 1)
   lineWidth?: number;      // m (Tube radius, default 2)
-  // 以下は #171/#172 で実装予約（型のみ先出し）
-  dropLineColor?: string;
-  dropLineWidth?: number;
-  dropLineOpacity?: number;
-  labelColor?: string;
-  labelBackgroundColor?: string;
-  labelFontSize?: number;
-  wallColor?: string;
-  wallOpacity?: number;
+  // #171 で実装
+  dropLineColor?: string;     // CSS color (default "#ff0000")
+  dropLineWidth?: number;     // m (Tube radius, default 1)
+  dropLineOpacity?: number;   // 0..1 (default 1)
+  labelColor?: string;        // CSS color (default "#000000")
+  labelBackgroundColor?: string; // CSS color (default "transparent")
+  labelFontSize?: number;     // px (default 14)
+  // #172 で実装
+  wallColor?: string;         // CSS color (default "#ff0000")
+  wallOpacity?: number;       // 0..1 (default 0.3)
 }
 
 interface PolygonOptions {
   points: ReadonlyArray<PolygonPointOptions>; // 2 点以上
   altitudeMode?: AltitudeMode;                // default "terrain"
-  /** `true` でポリラインの末尾と先頭を結んで閉じる（#170 はポリラインのみ閉じる）。default false */
+  /** `true` でポリラインの末尾と先頭を結んで閉じる。壁・垂線も同様に閉じられる (#172)。default false */
   closed?: boolean;
   /** ラベル（点ごと）。#171 で実装済み。`labels[i]` が文字列のときその点にラベルを描画する。 */
   labels?: ReadonlyArray<string>;
@@ -406,6 +409,8 @@ interface PolygonOptions {
   verticalsEnabled?: boolean;
   /** ラベルの表示 (#171 実装済み)。default true */
   labelsEnabled?: boolean;
+  /** 隣接垂線間をつなぐ壁の表示 (#172 実装済み)。default true */
+  wallsEnabled?: boolean;
 }
 ```
 
@@ -419,7 +424,7 @@ interface PolygonOptions {
 - 同 id の重複追加は throw、`removePolygon` の未存在 id は `console.warn` + no-op。
 - `dispose()` で全ポリゴンリソース（Mesh / Material / TransformNode）を解放する。
 - **#171 実装済み**: 各点から地表（タイル標高、未解決時は Y=0 フォールバック）へ落とす垂線を **CreateTube**（updatable、半径 `style.dropLineWidth`）で描画。`labels[i]` が指定された点に DynamicTexture + ビルボード Plane でラベルを描画（`labelColor` / `labelBackgroundColor` / `labelFontSize` 反映）。`JpmapTerrain.setVerticalsEnabled(id, enabled)` / `setLabelsEnabled(id, enabled)` で表示切替が可能。`PolygonOptions.verticalsEnabled` / `labelsEnabled`（既定 true）で初期表示制御。
-- **#172 で実装予定（型予約済み）**: 隣接垂線間を結ぶ「壁」（`closed` 時の閉じも含む）、`wallColor` / `wallOpacity`。
+- **#172 実装済み**: 隣接する点間を上 row=頂点位置、下 row=地表 Y の Ribbon として 1 枚の **CreateRibbon**（`updatable: true`, `sideOrientation: DOUBLESIDE`）で壁表示。`closed=true` のときは上/下 row とも末尾に先頭頂点を append して閉じる。`style.wallColor` / `style.wallOpacity`（default `#ff0000` / `0.3`）を StandardMaterial の `emissiveColor` / `alpha` に反映し、半透明時は `needDepthPrePass=true` で z-fight を緩和する。`JpmapTerrain.setWallsEnabled(id, enabled)` で表示切替が可能。`PolygonOptions.wallsEnabled`（既定 true）で初期表示制御。`renderingGroupId=1` はポリライン・垂線・球・ラベルと同一。
 - **#173 で実装予定**: `updatePolygon`、点単位編集 API（`insertPoint` / `removePoint` / `updatePoint` / `replacePoints`）、デモ拡張、視覚回帰テスト。
 
 ### 3.4 型定義

--- a/src/demos/polygon/index.ts
+++ b/src/demos/polygon/index.ts
@@ -69,6 +69,8 @@ const buildDemoPolygons = (): readonly DemoPolygonDef[] => [
                 lineColor: "#ff5252",
                 pointDiameter: 18,
                 lineWidth: 3,
+                wallColor: "#ff5252",
+                wallOpacity: 0.3,
             },
         },
     },
@@ -89,6 +91,8 @@ const buildDemoPolygons = (): readonly DemoPolygonDef[] => [
                 lineColor: "#42a5f5",
                 pointDiameter: 24,
                 lineWidth: 4,
+                wallColor: "#42a5f5",
+                wallOpacity: 0.4,
             },
         },
     },
@@ -111,6 +115,8 @@ const buildDemoPolygons = (): readonly DemoPolygonDef[] => [
                 lineColor: "#ffca28",
                 pointDiameter: 18,
                 lineWidth: 3,
+                wallColor: "#ffca28",
+                wallOpacity: 0.5,
             },
         },
     },
@@ -174,6 +180,14 @@ const buildControls = (
         buildToggle("✔ ラベル ON", "✕ ラベル OFF", true, (next) => {
             for (const def of polygons) {
                 viewer.setLabelsEnabled(def.id, next);
+            }
+        }),
+    );
+    // 壁 ON/OFF (Issue #172)
+    container.appendChild(
+        buildToggle("✔ 壁 ON", "✕ 壁 OFF", true, (next) => {
+            for (const def of polygons) {
+                viewer.setWallsEnabled(def.id, next);
             }
         }),
     );

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -795,6 +795,11 @@ export class JpmapTerrain {
         this._polygonManager.setLabelsEnabled(id, enabled);
     }
 
+    public setWallsEnabled(id: string, enabled: boolean): void {
+        if (this._disposed || !this._polygonManager) return;
+        this._polygonManager.setWallsEnabled(id, enabled);
+    }
+
     public listPolygons(): readonly string[] {
         if (this._disposed) return [];
         return this._polygonManager?.list() ?? [];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -260,9 +260,9 @@ export interface PolygonStyleOptions {
     labelBackgroundColor?: string;
     /** ラベル文字サイズ (px)。default 14 */
     labelFontSize?: number;
-    /** 壁の色 CSS（#172 で適用）。 */
+    /** 壁の色 CSS (#172)。default `#ff0000` */
     wallColor?: string;
-    /** 壁の不透明度 [0,1]（#172 で適用）。 */
+    /** 壁の不透明度 [0,1] (#172)。default 0.3 */
     wallOpacity?: number;
 }
 
@@ -292,6 +292,8 @@ export interface PolygonOptions {
     verticalsEnabled?: boolean;
     /** ポイント脇のラベルの表示 ON/OFF。default true */
     labelsEnabled?: boolean;
+    /** 隣接垂線間をつなぐ「壁」の表示 ON/OFF (#172)。default true */
+    wallsEnabled?: boolean;
 }
 
 /**
@@ -309,6 +311,7 @@ export type PolygonUpdate = Partial<
         | "enabled"
         | "verticalsEnabled"
         | "labelsEnabled"
+        | "wallsEnabled"
     >
 >;
 
@@ -327,6 +330,8 @@ export interface PolygonHandle {
     readonly verticalsEnabled: boolean;
     /** ラベルの表示状態 */
     readonly labelsEnabled: boolean;
+    /** 壁の表示状態 (#172) */
+    readonly wallsEnabled: boolean;
     /**
      * `terrain` モード時、全頂点の標高が解決済みなら true。
      * `absolute` モード時は常に true。
@@ -346,6 +351,7 @@ export const POLYGON_DEFAULTS = {
     enabled: true,
     verticalsEnabled: true,
     labelsEnabled: true,
+    wallsEnabled: true,
     style: {
         lineColor: "#ff0000",
         lineWidth: 2,

--- a/src/terrain/polygon.ts
+++ b/src/terrain/polygon.ts
@@ -365,10 +365,12 @@ export const createPolygonNode = (
     let elevationResolved = altitudeMode === "absolute";
 
     // wallsEnabled が false の間は Ribbon 更新をスキップするため、適用した
-    // worldPoints / groundYs の直近スナップショットを保持して、
-    // 再 enable 時に即時で位置を追い付かせる。`null` は未適用を表す。
-    let lastWorldPoints: Vector3[] | null = null;
-    let lastGroundYs: (number | null)[] | null = null;
+    // worldPoints / groundYs の参照を保持して、再 enable 時に即時で
+    // 位置を追い付かせる。呼び出し側 (PolygonManager.tickPolygon) は毎フレーム
+    // 新規配列を生成するため、参照保持でも次フレームに上書きされず
+    // 時間取り不整合は起きない。`null` は未適用を表す。
+    let lastWorldPoints: readonly Vector3[] | null = null;
+    let lastGroundYs: readonly (number | null)[] | null = null;
 
     // 頂点はディープコピーして外部からの破壊変更を無効化する。
     const points: PolygonPointOptions[] = options.points.map((p) => ({
@@ -529,12 +531,10 @@ export const createPolygonNode = (
         );
 
         // 壁 Ribbon (#172) の更新。非表示中はスキップしてフレーム負荷を下げるが、
-        // 上で lastWorldPoints / lastGroundYs にスナップしておき、setWallsEnabled(true) 時に
-        // 即時で同一データで Ribbon を再適用して stale 表示を避ける。
-        lastWorldPoints = worldPoints.map(
-            (p) => new Vector3(p.x, p.y, p.z),
-        );
-        lastGroundYs = groundYs.slice();
+        // 上で lastWorldPoints / lastGroundYs の参照を保持しておき、setWallsEnabled(true)
+        // 時に同一データで Ribbon を再適用して stale 表示を避ける。
+        lastWorldPoints = worldPoints;
+        lastGroundYs = groundYs;
         if (wallsEnabled) {
             const wallPathArray = buildWallPathArray(
                 worldPoints,

--- a/src/terrain/polygon.ts
+++ b/src/terrain/polygon.ts
@@ -16,6 +16,7 @@ import { Color3 } from "@babylonjs/core/Maths/math.color";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { CreateSphere } from "@babylonjs/core/Meshes/Builders/sphereBuilder";
 import { CreateTube } from "@babylonjs/core/Meshes/Builders/tubeBuilder";
+import { CreateRibbon } from "@babylonjs/core/Meshes/Builders/ribbonBuilder";
 import { CreatePlane } from "@babylonjs/core/Meshes/Builders/planeBuilder";
 import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
 import { DynamicTexture } from "@babylonjs/core/Materials/Textures/dynamicTexture";
@@ -103,6 +104,7 @@ export interface PolygonNode {
     setEnabledLogical(enabled: boolean): void;
     setVerticalsEnabledLogical(enabled: boolean): void;
     setLabelsEnabledLogical(enabled: boolean): void;
+    setWallsEnabledLogical(enabled: boolean): void;
     setElevationResolved(resolved: boolean): void;
     getHandle(): PolygonHandle;
     dispose(): void;
@@ -313,6 +315,33 @@ const buildLinePath = (
 };
 
 /**
+ * 壁 Ribbon の pathArray を構築する。
+ * 上側 row = 各頂点の世界座標、下側 row = 同じ XZ で Y を地表値に置き換えたもの。
+ * `closed=true` のときは先頭頂点を末尾にも追加して閉じる。
+ *
+ * Ribbon は updatable + instance 更新時に長さを変えられないため、
+ * 構築時の長さ（`closed ? N+1 : N`）で固定される。
+ */
+const buildWallPathArray = (
+    worldPoints: readonly Vector3[],
+    groundYs: readonly (number | null)[],
+    closed: boolean,
+): [Vector3[], Vector3[]] => {
+    const top: Vector3[] = worldPoints.map((p) => new Vector3(p.x, p.y, p.z));
+    const ground: Vector3[] = worldPoints.map((p, i) => {
+        const gy = groundYs[i];
+        return new Vector3(p.x, gy ?? 0, p.z);
+    });
+    if (closed && top.length >= 2) {
+        const ft = top[0];
+        const fg = ground[0];
+        top.push(new Vector3(ft.x, ft.y, ft.z));
+        ground.push(new Vector3(fg.x, fg.y, fg.z));
+    }
+    return [top, ground];
+};
+
+/**
  * `PolygonNode` を生成する。`points.length >= 2` 前提（`PolygonManager` 側で検証済み）。
  */
 export const createPolygonNode = (
@@ -331,7 +360,15 @@ export const createPolygonNode = (
         options.verticalsEnabled ?? POLYGON_DEFAULTS.verticalsEnabled;
     let labelsEnabled =
         options.labelsEnabled ?? POLYGON_DEFAULTS.labelsEnabled;
+    let wallsEnabled =
+        options.wallsEnabled ?? POLYGON_DEFAULTS.wallsEnabled;
     let elevationResolved = altitudeMode === "absolute";
+
+    // wallsEnabled が false の間は Ribbon 更新をスキップするため、適用した
+    // worldPoints / groundYs の直近スナップショットを保持して、
+    // 再 enable 時に即時で位置を追い付かせる。`null` は未適用を表す。
+    let lastWorldPoints: Vector3[] | null = null;
+    let lastGroundYs: (number | null)[] | null = null;
 
     // 頂点はディープコピーして外部からの破壊変更を無効化する。
     const points: PolygonPointOptions[] = options.points.map((p) => ({
@@ -383,11 +420,44 @@ export const createPolygonNode = (
     lineMesh.isPickable = false;
     lineMesh.parent = root;
 
+    // 壁 Ribbon (#172): 上 row = 各頂点 world、下 row = 地表 Y。
+    // 構築時は groundY を 0 とした placeholder を渡し、applyTransform で実値で更新する。
+    const initialGroundYs: (number | null)[] = points.map(() => null);
+    const initialWallPathArray = buildWallPathArray(
+        initialPath,
+        initialGroundYs,
+        closed,
+    );
+    let wallMesh: Mesh = CreateRibbon(
+        `polygon-${id}-walls`,
+        {
+            pathArray: initialWallPathArray,
+            updatable: true,
+            // 半透明の壁を裏面からも見えるようにする。
+            sideOrientation: Mesh.DOUBLESIDE,
+            closeArray: false,
+        },
+        scene,
+    );
+    const wallMaterial = new StandardMaterial(`polygon-${id}-walls-mat`, scene);
+    wallMaterial.disableLighting = true;
+    wallMaterial.backFaceCulling = false;
+    wallMaterial.emissiveColor = Color3.FromHexString(style.wallColor);
+    wallMaterial.alpha = style.wallOpacity;
+    // 半透明の z-fight 緩和（同一面が前後関係で乱れないようにする）。
+    if (style.wallOpacity < 1) {
+        wallMaterial.needDepthPrePass = true;
+    }
+    wallMesh.material = wallMaterial;
+    wallMesh.renderingGroupId = RENDERING_GROUP_ID;
+    wallMesh.isPickable = false;
+    wallMesh.parent = root;
+
     const applyVisibility = (): void => {
         const visible = logicalEnabled && elevationResolved;
         root.setEnabled(visible);
-        // 子要素の個別 ON/OFF（垂線・ラベル）。root が無効なら自動で隠れるので、
-        // root が有効なときに verticals/labels の個別設定を反映する。
+        // 子要素の個別 ON/OFF（垂線・ラベル・壁）。root が無効なら自動で隠れるので、
+        // root が有効なときに verticals/labels/walls の個別設定を反映する。
         for (const entry of dropEntries) {
             entry.mesh.setEnabled(visible && verticalsEnabled);
         }
@@ -395,6 +465,7 @@ export const createPolygonNode = (
             if (!entry) continue;
             entry.mesh.setEnabled(visible && labelsEnabled);
         }
+        wallMesh.setEnabled(visible && wallsEnabled);
     };
     applyVisibility();
 
@@ -456,6 +527,26 @@ export const createPolygonNode = (
             { path: tubePath, instance: lineMesh },
             scene,
         );
+
+        // 壁 Ribbon (#172) の更新。非表示中はスキップしてフレーム負荷を下げるが、
+        // 上で lastWorldPoints / lastGroundYs にスナップしておき、setWallsEnabled(true) 時に
+        // 即時で同一データで Ribbon を再適用して stale 表示を避ける。
+        lastWorldPoints = worldPoints.map(
+            (p) => new Vector3(p.x, p.y, p.z),
+        );
+        lastGroundYs = groundYs.slice();
+        if (wallsEnabled) {
+            const wallPathArray = buildWallPathArray(
+                worldPoints,
+                groundYs,
+                closed,
+            );
+            wallMesh = CreateRibbon(
+                `polygon-${id}-walls`,
+                { pathArray: wallPathArray, instance: wallMesh },
+                scene,
+            );
+        }
     };
 
     const getHandle = (): PolygonHandle => ({
@@ -468,6 +559,7 @@ export const createPolygonNode = (
         enabled: logicalEnabled,
         verticalsEnabled,
         labelsEnabled,
+        wallsEnabled,
         elevationResolved,
     });
 
@@ -491,6 +583,8 @@ export const createPolygonNode = (
         labelEntries.length = 0;
         lineMaterial.dispose();
         lineMesh.dispose();
+        wallMaterial.dispose();
+        wallMesh.dispose();
         root.dispose();
     };
 
@@ -510,6 +604,31 @@ export const createPolygonNode = (
         },
         setLabelsEnabledLogical(enabled: boolean): void {
             labelsEnabled = enabled;
+            applyVisibility();
+        },
+        setWallsEnabledLogical(enabled: boolean): void {
+            const wasEnabled = wallsEnabled;
+            wallsEnabled = enabled;
+            // false → true に切り替わったタイミングで stale を避けるため、
+            // 直近適用された worldPoints / groundYs で Ribbon を即時再計算する。
+            if (
+                enabled &&
+                !wasEnabled &&
+                lastWorldPoints !== null &&
+                lastGroundYs !== null &&
+                lastWorldPoints.length === sphereEntries.length
+            ) {
+                const wallPathArray = buildWallPathArray(
+                    lastWorldPoints,
+                    lastGroundYs,
+                    closed,
+                );
+                wallMesh = CreateRibbon(
+                    `polygon-${id}-walls`,
+                    { pathArray: wallPathArray, instance: wallMesh },
+                    scene,
+                );
+            }
             applyVisibility();
         },
         setElevationResolved(resolved: boolean): void {

--- a/src/terrain/polygonManager.ts
+++ b/src/terrain/polygonManager.ts
@@ -41,6 +41,7 @@ export interface PolygonManager {
     setEnabled(id: string, enabled: boolean): void;
     setVerticalsEnabled(id: string, enabled: boolean): void;
     setLabelsEnabled(id: string, enabled: boolean): void;
+    setWallsEnabled(id: string, enabled: boolean): void;
     list(): readonly string[];
     dispose(): void;
 }
@@ -202,6 +203,13 @@ export const createPolygonManager = (ctx: OverlayContext): PolygonManager => {
             }
             const node = requireNode(id);
             node.setLabelsEnabledLogical(enabled);
+        },
+        setWallsEnabled(id: string, enabled: boolean): void {
+            if (disposed) {
+                throw new Error("PolygonManager has been disposed");
+            }
+            const node = requireNode(id);
+            node.setWallsEnabledLogical(enabled);
         },
         list(): readonly string[] {
             return Array.from(nodes.keys());

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -84,7 +84,7 @@ jest.unstable_mockModule("../src/terrain/polygon", () => ({
     createPolygonNode: (
         _scene: unknown,
         id: string,
-        options: { points: readonly { lat: number; lon: number; altitude?: number }[]; closed?: boolean; altitudeMode?: "terrain" | "absolute"; enabled?: boolean; verticalsEnabled?: boolean; labelsEnabled?: boolean },
+        options: { points: readonly { lat: number; lon: number; altitude?: number }[]; closed?: boolean; altitudeMode?: "terrain" | "absolute"; enabled?: boolean; verticalsEnabled?: boolean; labelsEnabled?: boolean; wallsEnabled?: boolean },
     ) => {
         let enabled = options.enabled ?? true;
         const altitudeMode = options.altitudeMode ?? "terrain";
@@ -107,6 +107,9 @@ jest.unstable_mockModule("../src/terrain/polygon", () => ({
             setLabelsEnabledLogical: () => {
                 /* no-op */
             },
+            setWallsEnabledLogical: () => {
+                /* no-op */
+            },
             setElevationResolved: (v: boolean) => {
                 elevationResolved = v;
             },
@@ -120,6 +123,7 @@ jest.unstable_mockModule("../src/terrain/polygon", () => ({
                 enabled,
                 verticalsEnabled: options.verticalsEnabled ?? true,
                 labelsEnabled: options.labelsEnabled ?? true,
+                wallsEnabled: options.wallsEnabled ?? true,
                 elevationResolved,
             }),
             dispose: () => {
@@ -1495,6 +1499,13 @@ describe("JpmapTerrain (skeleton)", () => {
             expect(() => viewer.setLabelsEnabled("p1", true)).not.toThrow();
         });
 
+        it("setWallsEnabled は存在する id に対して throw しない (Issue #172)", async () => {
+            const viewer = await create(createMountElement());
+            viewer.addPolygon("p1", { points: validPoints });
+            expect(() => viewer.setWallsEnabled("p1", false)).not.toThrow();
+            expect(() => viewer.setWallsEnabled("p1", true)).not.toThrow();
+        });
+
         it("dispose 後の addPolygon は throw、その他 API は no-op / null / [] を返す", async () => {
             const viewer = await create(createMountElement());
             viewer.dispose();
@@ -1505,6 +1516,7 @@ describe("JpmapTerrain (skeleton)", () => {
             expect(() => viewer.setPolygonEnabled("p1", false)).not.toThrow();
             expect(() => viewer.setVerticalsEnabled("p1", false)).not.toThrow();
             expect(() => viewer.setLabelsEnabled("p1", false)).not.toThrow();
+            expect(() => viewer.setWallsEnabled("p1", false)).not.toThrow();
         });
     });
 });

--- a/tests/polygon.unit.spec.ts
+++ b/tests/polygon.unit.spec.ts
@@ -47,7 +47,18 @@ const tubeCalls: Array<{
     options: { path: unknown[]; instance?: StubMesh; updatable?: boolean };
 }> = [];
 const planeCalls: Array<{ name: string; options: { width: number; height: number } }> = [];
+const ribbonCalls: Array<{
+    name: string;
+    options: { pathArray?: unknown[][]; instance?: StubMesh };
+}> = [];
 const dynamicTextures: Array<{ name: string; disposed: boolean }> = [];
+interface StubMaterialRecord {
+    name: string;
+    alpha: number;
+    needDepthPrePass: boolean;
+    emissiveColor: { r: number; g: number; b: number } | null;
+}
+const materials: StubMaterialRecord[] = [];
 const transformNodes: StubTransformNode[] = [];
 const allMeshes: StubMesh[] = [];
 
@@ -128,9 +139,11 @@ jest.unstable_mockModule("@babylonjs/core/Materials/standardMaterial", () => ({
         public alpha = 1;
         public backFaceCulling = true;
         public disableLighting = false;
+        public needDepthPrePass = false;
         public emissiveColor: { r: number; g: number; b: number } | null = null;
         constructor(name: string) {
             this.name = name;
+            materials.push(this);
         }
         dispose(): void {
             this.disposed = true;
@@ -158,7 +171,7 @@ jest.unstable_mockModule("@babylonjs/core/Meshes/transformNode", () => ({
 
 // Mesh は NO_CAP 静的定数のみ参照される。
 jest.unstable_mockModule("@babylonjs/core/Meshes/mesh", () => ({
-    Mesh: { NO_CAP: 0 },
+    Mesh: { NO_CAP: 0, DOUBLESIDE: 2 },
 }));
 
 jest.unstable_mockModule(
@@ -169,6 +182,20 @@ jest.unstable_mockModule(
             options: { width: number; height: number },
         ): StubMesh => {
             planeCalls.push({ name, options });
+            return buildMesh(name);
+        },
+    }),
+);
+
+jest.unstable_mockModule(
+    "@babylonjs/core/Meshes/Builders/ribbonBuilder",
+    () => ({
+        CreateRibbon: (
+            name: string,
+            options: { pathArray?: unknown[][]; instance?: StubMesh },
+        ): StubMesh => {
+            ribbonCalls.push({ name, options });
+            if (options.instance) return options.instance;
             return buildMesh(name);
         },
     }),
@@ -235,9 +262,11 @@ beforeEach(() => {
     sphereCalls.length = 0;
     tubeCalls.length = 0;
     planeCalls.length = 0;
+    ribbonCalls.length = 0;
     dynamicTextures.length = 0;
     transformNodes.length = 0;
     allMeshes.length = 0;
+    materials.length = 0;
 });
 
 describe("createPolygonNode 構築", () => {
@@ -493,5 +522,198 @@ describe("createPolygonNode enabled / dispose", () => {
             expect(dt.disposed).toBe(true);
         }
         expect(transformNodes[0].disposed).toBe(true);
+    });
+});
+
+describe("createPolygonNode 壁 (#172)", () => {
+    it("構築時に壁 Ribbon が 1 本生成される (closed=false)", () => {
+        createPolygonNode(sceneStub, "pW1", {
+            points: [
+                { lat: 35.0, lon: 139.0, altitude: 100 },
+                { lat: 35.1, lon: 139.1, altitude: 100 },
+                { lat: 35.2, lon: 139.2, altitude: 100 },
+            ],
+            altitudeMode: "absolute",
+        });
+        expect(ribbonCalls.length).toBe(1);
+        const initial = ribbonCalls[0].options.pathArray as unknown[][];
+        // pathArray = [topRow, groundRow]
+        expect(initial.length).toBe(2);
+        expect(initial[0].length).toBe(3);
+        expect(initial[1].length).toBe(3);
+    });
+
+    it("closed=true で壁 Ribbon の各 row 末尾に先頭頂点が append される", async () => {
+        const { Vector3 } = await import("@babylonjs/core/Maths/math.vector");
+        const node = createPolygonNode(sceneStub, "pW2", {
+            points: [
+                { lat: 35.0, lon: 139.0, altitude: 100 },
+                { lat: 35.1, lon: 139.1, altitude: 100 },
+                { lat: 35.2, lon: 139.2, altitude: 100 },
+            ],
+            altitudeMode: "absolute",
+            closed: true,
+        });
+        node.applyTransform(
+            [
+                new Vector3(0, 100, 0),
+                new Vector3(50, 100, 0),
+                new Vector3(50, 100, 50),
+            ],
+            [10, 20, 30],
+            1,
+        );
+        // 構築 1 + 更新 1 = 2 回
+        expect(ribbonCalls.length).toBe(2);
+        const update = ribbonCalls[1].options.pathArray as Array<
+            Array<{ x: number; y: number; z: number }>
+        >;
+        expect(update[0].length).toBe(4); // top row: 3 + 1 (先頭再追加)
+        expect(update[1].length).toBe(4);
+        // top: y は worldPoints[i].y がそのまま入る
+        expect(update[0][0].y).toBe(100);
+        expect(update[0][3].y).toBe(100);
+        // ground: y は groundYs[i]、末尾は先頭の groundY
+        expect(update[1][0].y).toBe(10);
+        expect(update[1][3].y).toBe(10);
+    });
+
+    it("applyTransform で壁 Ribbon が instance 指定で更新される", async () => {
+        const { Vector3 } = await import("@babylonjs/core/Maths/math.vector");
+        const node = createPolygonNode(sceneStub, "pW3", {
+            points: [
+                { lat: 35.0, lon: 139.0, altitude: 100 },
+                { lat: 35.1, lon: 139.1, altitude: 100 },
+            ],
+            altitudeMode: "absolute",
+        });
+        const before = ribbonCalls.length;
+        node.applyTransform(
+            [new Vector3(0, 100, 0), new Vector3(50, 100, 0)],
+            [0, 0],
+            1,
+        );
+        expect(ribbonCalls.length - before).toBe(1);
+        expect(ribbonCalls[before].options.instance).toBeDefined();
+    });
+
+    it("setWallsEnabledLogical(false) で壁メッシュの setEnabled(false) が呼ばれ、その後の更新がスキップされる", async () => {
+        const { Vector3 } = await import("@babylonjs/core/Maths/math.vector");
+        const node = createPolygonNode(sceneStub, "pW4", {
+            points: [
+                { lat: 35.0, lon: 139.0, altitude: 100 },
+                { lat: 35.1, lon: 139.1, altitude: 100 },
+            ],
+            altitudeMode: "absolute",
+        });
+        const wallMeshes = allMeshes.filter(
+            (m) => m.name === "polygon-pW4-walls",
+        );
+        expect(wallMeshes.length).toBe(1);
+        node.setWallsEnabledLogical(false);
+        expect(wallMeshes[0].enabledHistory).toContain(false);
+        expect(node.getHandle().wallsEnabled).toBe(false);
+
+        const before = ribbonCalls.length;
+        node.applyTransform(
+            [new Vector3(0, 100, 0), new Vector3(50, 100, 0)],
+            [0, 0],
+            1,
+        );
+        // wallsEnabled=false の間は CreateRibbon 更新を行わない。
+        expect(ribbonCalls.length).toBe(before);
+
+        node.setWallsEnabledLogical(true);
+        node.applyTransform(
+            [new Vector3(0, 100, 0), new Vector3(50, 100, 0)],
+            [0, 0],
+            1,
+        );
+        // 再 enable 時に直近スナップショットで 1 回 + applyTransform で 1 回 = +2
+        expect(ribbonCalls.length).toBe(before + 2);
+    });
+
+    it("wallsEnabled は初期値 true、PolygonOptions.wallsEnabled=false で初期 hide になる", () => {
+        const node = createPolygonNode(sceneStub, "pW5", {
+            points: [
+                { lat: 35.0, lon: 139.0, altitude: 100 },
+                { lat: 35.1, lon: 139.1, altitude: 100 },
+            ],
+            altitudeMode: "absolute",
+            wallsEnabled: false,
+        });
+        expect(node.getHandle().wallsEnabled).toBe(false);
+        const wallMesh = allMeshes.find((m) => m.name === "polygon-pW5-walls");
+        expect(wallMesh).toBeDefined();
+        // 初回 applyVisibility で false が積まれる。
+        expect(wallMesh!.enabledHistory).toContain(false);
+    });
+
+    it("wallColor / wallOpacity が壁マテリアルへ反映され、半透明時は needDepthPrePass=true となる", () => {
+        createPolygonNode(sceneStub, "pW6", {
+            points: [
+                { lat: 35.0, lon: 139.0, altitude: 100 },
+                { lat: 35.1, lon: 139.1, altitude: 100 },
+            ],
+            altitudeMode: "absolute",
+            style: { wallColor: "#00ff00", wallOpacity: 0.5 },
+        });
+        const wallMat = materials.find(
+            (m) => m.name === "polygon-pW6-walls-mat",
+        );
+        expect(wallMat).toBeDefined();
+        expect(wallMat!.alpha).toBe(0.5);
+        expect(wallMat!.needDepthPrePass).toBe(true);
+        // emissive: #00ff00 → r=0, g=1, b=0
+        expect(wallMat!.emissiveColor!.r).toBe(0);
+        expect(wallMat!.emissiveColor!.g).toBe(1);
+        expect(wallMat!.emissiveColor!.b).toBe(0);
+    });
+
+    it("wallOpacity=1 のときは needDepthPrePass を有効化しない", () => {
+        createPolygonNode(sceneStub, "pW7", {
+            points: [
+                { lat: 35.0, lon: 139.0, altitude: 100 },
+                { lat: 35.1, lon: 139.1, altitude: 100 },
+            ],
+            altitudeMode: "absolute",
+            style: { wallOpacity: 1 },
+        });
+        const wallMat = materials.find(
+            (m) => m.name === "polygon-pW7-walls-mat",
+        );
+        expect(wallMat).toBeDefined();
+        expect(wallMat!.alpha).toBe(1);
+        expect(wallMat!.needDepthPrePass).toBe(false);
+    });
+
+    it("wallsEnabled を false→true に切り替えた直後に Ribbon が直近 transform で再適用される (stale 回避)", async () => {
+        const { Vector3 } = await import("@babylonjs/core/Maths/math.vector");
+        const node = createPolygonNode(sceneStub, "pW8", {
+            points: [
+                { lat: 35.0, lon: 139.0, altitude: 100 },
+                { lat: 35.1, lon: 139.1, altitude: 100 },
+            ],
+            altitudeMode: "absolute",
+        });
+        // 一度 transform を適用して直近スナップショットを保持させる。
+        node.applyTransform(
+            [new Vector3(10, 100, 0), new Vector3(50, 200, 0)],
+            [10, 20],
+            1,
+        );
+        node.setWallsEnabledLogical(false);
+        const before = ribbonCalls.length;
+        node.setWallsEnabledLogical(true);
+        // 再 enable で 1 回 Ribbon 再適用される。
+        expect(ribbonCalls.length).toBe(before + 1);
+        const lastCall = ribbonCalls[ribbonCalls.length - 1];
+        expect(lastCall.options.instance).toBeDefined();
+        const path = lastCall.options.pathArray as Array<
+            Array<{ y: number }>
+        >;
+        // 直近 worldPoints の Y が反映されていること。
+        expect(path[0][0].y).toBe(100);
+        expect(path[0][1].y).toBe(200);
     });
 });

--- a/tests/polygonManager.unit.spec.ts
+++ b/tests/polygonManager.unit.spec.ts
@@ -26,6 +26,7 @@ interface StubNode {
     setEnabledHistory: boolean[];
     setVerticalsEnabledHistory: boolean[];
     setLabelsEnabledHistory: boolean[];
+    setWallsEnabledHistory: boolean[];
     setElevationResolvedHistory: boolean[];
 }
 
@@ -52,6 +53,7 @@ jest.unstable_mockModule("../src/terrain/polygon", () => ({
             setEnabledHistory: [],
             setVerticalsEnabledHistory: [],
             setLabelsEnabledHistory: [],
+            setWallsEnabledHistory: [],
             setElevationResolvedHistory: [],
         };
         const wrapped = {
@@ -83,6 +85,9 @@ jest.unstable_mockModule("../src/terrain/polygon", () => ({
             },
             setLabelsEnabledLogical: (v: boolean) => {
                 node.setLabelsEnabledHistory.push(v);
+            },
+            setWallsEnabledLogical: (v: boolean) => {
+                node.setWallsEnabledHistory.push(v);
             },
             setElevationResolved: (v: boolean) => {
                 node.elevationResolved = v;
@@ -366,11 +371,21 @@ describe("PolygonManager enable / disable", () => {
         expect(created[0].setLabelsEnabledHistory).toEqual([false, true]);
     });
 
-    it("未存在 id の setVerticalsEnabled / setLabelsEnabled は throw (Issue #171)", () => {
+    it("setWallsEnabled が node.setWallsEnabledLogical へ委譲される (Issue #172)", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createPolygonManager(ctx);
+        mgr.add("a", { points: validPoints });
+        mgr.setWallsEnabled("a", false);
+        mgr.setWallsEnabled("a", true);
+        expect(created[0].setWallsEnabledHistory).toEqual([false, true]);
+    });
+
+    it("未存在 id の setVerticalsEnabled / setLabelsEnabled / setWallsEnabled は throw", () => {
         const { ctx } = buildCtx(0);
         const mgr = createPolygonManager(ctx);
         expect(() => mgr.setVerticalsEnabled("missing", false)).toThrow(/not found/);
         expect(() => mgr.setLabelsEnabled("missing", false)).toThrow(/not found/);
+        expect(() => mgr.setWallsEnabled("missing", false)).toThrow(/not found/);
     });
 });
 
@@ -395,6 +410,7 @@ describe("PolygonManager dispose", () => {
         expect(() => mgr.setEnabled("a", false)).toThrow(/disposed/);
         expect(() => mgr.setVerticalsEnabled("a", false)).toThrow(/disposed/);
         expect(() => mgr.setLabelsEnabled("a", false)).toThrow(/disposed/);
+        expect(() => mgr.setWallsEnabled("a", false)).toThrow(/disposed/);
     });
 
     it("dispose 後の get は null、list は []、remove は no-op", () => {


### PR DESCRIPTION
## 概要
Issue #172 (Parent #169) を実装。ポリゴンに「壁」表示を追加し、`closed`・色/透明度オプションを完全にサポート。

## 範囲
- **壁メッシュ**: 隣接点間を `CreateRibbon`（上 row=頂点位置、下 row=地表 Y、updatable, DOUBLESIDE）で 1 枚生成。`closed=true` で末尾 row に先頭頂点を append して閉じる。
- **API**: `JpmapTerrain.setWallsEnabled(id, enabled)` / `PolygonOptions.wallsEnabled`（既定 true）/ `PolygonHandle.wallsEnabled`。
- **色/透明度**: `style.wallColor`（既定 `#ff0000`）/ `style.wallOpacity`（既定 0.3）を `emissiveColor` / `alpha` に反映。
- **z-fight 対策**: `wallOpacity<1` のとき `needDepthPrePass=true`、`sideOrientation=DOUBLESIDE`、`renderingGroupId=1`。
- **stale 回避**: 直近 `worldPoints` / `groundYs` をキャッシュし、`setWallsEnabled(true)` で 1 フレーム待たず即時再適用。
- **デモ**: `src/demos/polygon/` に「壁 ON/OFF」トグル追加。各デモポリゴンに `wallColor` / `wallOpacity` を個別設定。

## チェックリスト（Issue #172 DoD）
- [x] `closed` 切替で線・壁とも整合した描画
- [x] 球/線/壁/ラベル各色・透明度の設定が反映
- [x] 壁の半透明表示で z-fight 対策（`needDepthPrePass` + `renderingGroupId`）
- [x] unit テスト緑（26 suites / 510 tests）
- [x] `npm run lint` / `npm run typecheck` 緑
- [x] 壁表示・closed切替・色透明度の差分がデモで確認できる

## ゲート結果
- **Reviewer (50_reviewer)**: 条件付き承認 → MAJOR (再 enable 時 stale)・MINOR (test 整形)・MINOR (material 値テスト不足) すべて対応済み
- **Security (60_security)**: approve（XSS/入力検証/Secrets 観点で問題なし。minor JSDoc 推奨は将来対応）

## 関連
- Parent: #169
- Refs: #170, #171
- 仕様: spec/package.md §3.3.8.1（更新済み）
