### PR TITLE
chore(demo): remove issue numbers from portal button labels

### DIFF
--- a/src/demos/portal/index.ts
+++ b/src/demos/portal/index.ts
@@ -31,7 +31,7 @@ const DEMO_LIST: readonly DemoEntry[] = [
         href: "timelapse",
     },
     {
-        title: "ポリゴン (Issue #170)",
+        title: "ポリゴン",
         description:
             "PolygonManager 公開 API の動作確認デモ。terrain / absolute / closed の 3 種類のポリラインを表示し、enabled トグルで切替できます。",
         href: "polygon",


### PR DESCRIPTION
## 概要

トップページ (portal) のデモボタンタイトルに含まれる Issue 番号 (`(Issue #170)`) を削除。今後 Issue 単位ではなく機能名で統一表示する。

## 変更点

- `src/demos/portal/index.ts`: "ポリゴン (Issue #170)" → "ポリゴン"

## 影響

- 表示文言のみ。テスト・型・API影響なし。
- lint / typecheck / unit (portal.unit.spec.ts) PASS。

## 備考

PR #177 / #173 ブランチ系列とは独立。マージ順序によっては軽微なコンフリクトが起きうるが追従可能。