### PR TITLE
feat(polygon): point edit API (insert/remove/update/replace) (#173)

### DIFF
--- a/spec/package.md
+++ b/spec/package.md
@@ -456,7 +456,7 @@ interface JpmapTerrain {
 
 - 共通: dispose 後 / 未存在 id は throw。
 - `insertPolygonPoint`: `index` が `[0, points.length]` の範囲外なら `RangeError`。`lat/lon` が JAPAN_BOUNDS 外なら throw。`altitudeMode === "absolute"` で `altitude` 未指定なら throw。
-- `removePolygonPoint`: 削除後の点数が 2 点未満になる場合は throw（`RangeError`）。`index` が範囲外なら `RangeError`。
+- `removePolygonPoint`: 削除後の点数が 2 点未満になる場合は throw。`index` が範囲外なら `RangeError`。
 - `updatePolygonPoint`: `index` が範囲外なら `RangeError`。`lat`/`lon` の partial が指定されたとき、現状値とのマージ結果に対し JAPAN_BOUNDS 検査を行う。`altitudeMode === "absolute"` のとき `altitude` を `undefined` にしても現状値は維持されるため throw しない（明示的に書き換える場合のみ partial に含める）。
 - `replacePolygonPoints`: `points.length < 2` は throw。各点の JAPAN_BOUNDS / `absolute` モードの altitude 必須は `addPolygon` と同じ規則で検査する。
 

--- a/spec/package.md
+++ b/spec/package.md
@@ -427,6 +427,53 @@ interface PolygonOptions {
 - **#172 実装済み**: 隣接する点間を上 row=頂点位置、下 row=地表 Y の Ribbon として 1 枚の **CreateRibbon**（`updatable: true`, `sideOrientation: DOUBLESIDE`）で壁表示。`closed=true` のときは上/下 row とも末尾に先頭頂点を append して閉じる。`style.wallColor` / `style.wallOpacity`（default `#ff0000` / `0.3`）を StandardMaterial の `emissiveColor` / `alpha` に反映し、半透明時は `needDepthPrePass=true` で z-fight を緩和する。`JpmapTerrain.setWallsEnabled(id, enabled)` で表示切替が可能。`PolygonOptions.wallsEnabled`（既定 true）で初期表示制御。`renderingGroupId=1` はポリライン・垂線・球・ラベルと同一。
 - **#173 で実装予定**: `updatePolygon`、点単位編集 API（`insertPoint` / `removePoint` / `updatePoint` / `replacePoints`）、デモ拡張、視覚回帰テスト。
 
+##### 3.3.8.2 ポリゴン点編集 API（Issue #173）
+
+`addPolygon` 後のポリゴンに対し、頂点列を **動的に編集** する 4 API を提供する。`PolygonHandle` を都度返し、ハンドル経由で点列の現在値を確認できる。
+
+```typescript
+interface PolygonPointPartial {
+  lat?: number;
+  lon?: number;
+  altitude?: number;
+  /** 文字列: 当該 index にラベルを設定 / `null`: 当該 index のラベルを削除 / `undefined`: 現状維持 */
+  label?: string | null;
+}
+
+interface JpmapTerrain {
+  /** 指定 index に新しい頂点を挿入する。`index === points.length` で末尾追加。 */
+  insertPolygonPoint(id: string, index: number, point: PolygonPointOptions): PolygonHandle;
+  /** 指定 index の頂点を削除する。残り 2 点未満になる場合は throw。 */
+  removePolygonPoint(id: string, index: number): PolygonHandle;
+  /** 指定 index の頂点を部分更新する。partial 未指定フィールドは現状維持。 */
+  updatePolygonPoint(id: string, index: number, partial: PolygonPointPartial): PolygonHandle;
+  /** 全頂点を置き換える。`points.length < 2` は throw。 */
+  replacePolygonPoints(id: string, points: ReadonlyArray<PolygonPointOptions>): PolygonHandle;
+}
+```
+
+**バリデーション:**
+
+- 共通: dispose 後 / 未存在 id は throw。
+- `insertPolygonPoint`: `index` が `[0, points.length]` の範囲外なら `RangeError`。`lat/lon` が JAPAN_BOUNDS 外なら throw。`altitudeMode === "absolute"` で `altitude` 未指定なら throw。
+- `removePolygonPoint`: 削除後の点数が 2 点未満になる場合は throw（`RangeError`）。`index` が範囲外なら `RangeError`。
+- `updatePolygonPoint`: `index` が範囲外なら `RangeError`。`lat`/`lon` の partial が指定されたとき、現状値とのマージ結果に対し JAPAN_BOUNDS 検査を行う。`altitudeMode === "absolute"` のとき `altitude` を `undefined` にしても現状値は維持されるため throw しない（明示的に書き換える場合のみ partial に含める）。
+- `replacePolygonPoints`: `points.length < 2` は throw。各点の JAPAN_BOUNDS / `absolute` モードの altitude 必須は `addPolygon` と同じ規則で検査する。
+
+**差分更新の保証範囲:**
+
+- `updatePolygonPoint` は **点数を変えない** 編集なので、ポリライン (`CreateTube`) と壁 (`CreateRibbon`) は dispose せず instance を更新する。球 / 垂線 / ラベルは index 単位で in-place 更新する（label のみ追加/削除のとき該当 mesh を生成 / dispose）。
+- `insertPolygonPoint` / `removePolygonPoint` は **点数が変わる** ため、ポリライン・壁は dispose+再生成（Material は再 attach）して新しい頂点列を反映する。球・垂線・ラベルは差分のみ生成 / dispose する。
+- `replacePolygonPoints` は全点を入れ替えるため、球・垂線・ラベルは全 dispose+再生成、ポリライン・壁も dispose+再生成となる。
+- いずれの編集でも次フレームを待たずに位置が反映されるよう、`PolygonManager` は編集直後に `tickPolygon` を即時実行する。`lastWorldPoints` / `lastGroundYs` のキャッシュは点数が変わる編集ではクリアされる。
+
+**labels の sparse 同期:**
+
+- `PolygonHandle.labels` は **sparse 配列** として再構成される（`labels[i] === undefined` は当該 index にラベルなし）。
+- `updatePolygonPoint(index, { label: "..." })` で当該 index にラベルが追加され、`updatePolygonPoint(index, { label: null })` で当該 index のラベルが削除される。
+- `insertPolygonPoint` / `removePolygonPoint` は labels 配列の対応 index をシフトする（隣接ラベルとの整合を保つ）。
+- `replacePolygonPoints` は新しい点数に合わせ labels を全 undefined で再構成する（明示的にラベルを再付与するには `updatePolygonPoint` を呼び出す）。
+
 ### 3.4 型定義
 
 `CameraChangeEvent` および `CameraChangeListener` は、`jpmap-terrain` から import 可能である（パッケージエントリで re-export 済み）。
@@ -457,6 +504,7 @@ import type {
   // ポリゴン (Issue #170)
   AltitudeMode,
   PolygonPointOptions,
+  PolygonPointPartial,
   PolygonStyleOptions,
   PolygonOptions,
   PolygonUpdate,

--- a/src/demos/polygon/index.ts
+++ b/src/demos/polygon/index.ts
@@ -327,6 +327,7 @@ const start = async (): Promise<void> => {
 
     if (process.env.NODE_ENV !== "production") {
         (window as unknown as { viewer: JpmapTerrain }).viewer = viewer;
+        (window as unknown as { scene: unknown }).scene = viewer.__debugScene;
     }
 };
 

--- a/src/demos/polygon/index.ts
+++ b/src/demos/polygon/index.ts
@@ -191,6 +191,96 @@ const buildControls = (
             }
         }),
     );
+
+    // 点編集 API デモ (Issue #173)。`yomiuri-closed` を編集対象とする。
+    const editTargetId = "yomiuri-closed";
+    let insertCounter = 0;
+    let updateCounter = 0;
+    let replaceToggle = false;
+    const buildEditButton = (
+        label: string,
+        onClick: () => void,
+    ): HTMLButtonElement => {
+        const btn = document.createElement("button");
+        btn.type = "button";
+        btn.textContent = label;
+        btn.dataset.polygonEdit = label;
+        btn.addEventListener("click", () => {
+            try {
+                onClick();
+            } catch (err) {
+                console.warn(
+                    `[jpmap-terrain demo] polygon edit "${label}" failed:`,
+                    err,
+                );
+            }
+        });
+        return btn;
+    };
+    container.appendChild(
+        buildEditButton("点 insert", () => {
+            // 既存頂点列の中央付近に少しずつズラした点を順次挿入する。
+            const handle = viewer.getPolygon(editTargetId);
+            if (!handle || handle.points.length === 0) return;
+            const idx = Math.min(
+                handle.points.length,
+                1 + (insertCounter % handle.points.length),
+            );
+            const base = handle.points[idx - 1];
+            const offset = 0.0003 * (insertCounter + 1);
+            viewer.insertPolygonPoint(editTargetId, idx, {
+                lat: base.lat + offset,
+                lon: base.lon + offset,
+                altitude: base.altitude ?? 500,
+            });
+            insertCounter++;
+        }),
+    );
+    container.appendChild(
+        buildEditButton("点 remove", () => {
+            // 末尾を削除（ただし 2 点未満にはしない）。
+            const handle = viewer.getPolygon(editTargetId);
+            if (!handle) return;
+            if (handle.points.length <= 2) return;
+            viewer.removePolygonPoint(
+                editTargetId,
+                handle.points.length - 1,
+            );
+        }),
+    );
+    container.appendChild(
+        buildEditButton("点 update", () => {
+            // 先頭頂点の altitude をトグル風に上下させる。
+            const handle = viewer.getPolygon(editTargetId);
+            if (!handle || handle.points.length === 0) return;
+            updateCounter++;
+            const altitude = 500 + ((updateCounter % 4) * 80);
+            viewer.updatePolygonPoint(editTargetId, 0, {
+                altitude,
+                label: `upd${updateCounter}`,
+            });
+        }),
+    );
+    container.appendChild(
+        buildEditButton("点 replace", () => {
+            // 2 種類の頂点列を交互に切り替える。
+            replaceToggle = !replaceToggle;
+            const altitude = 500;
+            const next = replaceToggle
+                ? [
+                      { lat: 35.6235, lon: 139.5135, altitude },
+                      { lat: 35.6260, lon: 139.5135, altitude },
+                      { lat: 35.6260, lon: 139.5170, altitude },
+                  ]
+                : [
+                      { lat: 35.6235, lon: 139.5135, altitude },
+                      { lat: 35.6253, lon: 139.5135, altitude },
+                      { lat: 35.6253, lon: 139.5161, altitude },
+                      { lat: 35.6235, lon: 139.5161, altitude },
+                  ];
+            viewer.replacePolygonPoints(editTargetId, next);
+        }),
+    );
 };
 
 const start = async (): Promise<void> => {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -23,6 +23,7 @@ export type {
     MarkerUpdate,
     AltitudeMode,
     PolygonPointOptions,
+    PolygonPointPartial,
     PolygonStyleOptions,
     PolygonOptions,
     PolygonUpdate,

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -29,6 +29,8 @@ import {
     MarkerUpdate,
     PolygonHandle,
     PolygonOptions,
+    PolygonPointOptions,
+    PolygonPointPartial,
     SUN_AUTO_UPDATE_INTERVAL_MS,
 } from "./types";
 import { createMarkerManager, type MarkerManager } from "../terrain/markerManager";
@@ -803,6 +805,52 @@ export class JpmapTerrain {
     public listPolygons(): readonly string[] {
         if (this._disposed) return [];
         return this._polygonManager?.list() ?? [];
+    }
+
+    /**
+     * 指定 index に新しい頂点を挿入する (#173)。`index === points.length` で末尾追加。
+     * 範囲外 index・JAPAN_BOUNDS 外・`absolute` モードで altitude 未指定 は throw。
+     * dispose 後 / マネージャ未初期化 / 未存在 id は throw。
+     */
+    public insertPolygonPoint(
+        id: string,
+        index: number,
+        point: PolygonPointOptions,
+    ): PolygonHandle {
+        this._assertAlive();
+        return this._requirePolygonManager().insertPoint(id, index, point);
+    }
+
+    /**
+     * 指定 index の頂点を削除する (#173)。残り 2 点未満になる場合は throw。
+     */
+    public removePolygonPoint(id: string, index: number): PolygonHandle {
+        this._assertAlive();
+        return this._requirePolygonManager().removePoint(id, index);
+    }
+
+    /**
+     * 指定 index の頂点を部分更新する (#173)。
+     * `partial.label === null` のときラベルを削除する。`undefined` のフィールドは現状維持。
+     */
+    public updatePolygonPoint(
+        id: string,
+        index: number,
+        partial: PolygonPointPartial,
+    ): PolygonHandle {
+        this._assertAlive();
+        return this._requirePolygonManager().updatePoint(id, index, partial);
+    }
+
+    /**
+     * 全頂点を置き換える (#173)。`points.length < 2` は throw。
+     */
+    public replacePolygonPoints(
+        id: string,
+        points: readonly PolygonPointOptions[],
+    ): PolygonHandle {
+        this._assertAlive();
+        return this._requirePolygonManager().replacePoints(id, points);
     }
 
     // ---- ライフサイクル (spec §3.3.3) ----

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -297,6 +297,20 @@ export interface PolygonOptions {
 }
 
 /**
+ * 点単位の部分更新型 (Issue #173)。
+ *
+ * - `lat` / `lon` / `altitude` / `label` のいずれか（複数可）を指定可能。
+ * - `label` に `null` を渡した場合、当該 index のラベル（メッシュ）を削除する。
+ * - `altitudeMode` はポリゴン全体の属性のため partial には含めない。
+ */
+export interface PolygonPointPartial {
+    readonly lat?: number;
+    readonly lon?: number;
+    readonly altitude?: number;
+    readonly label?: string | null;
+}
+
+/**
  * `JpmapTerrain.updatePolygon`（#173 で公開予定）の部分更新型。
  * `#170` では `PolygonManager` 内部実装でのみ使用する。
  */
@@ -323,7 +337,7 @@ export interface PolygonHandle {
     readonly points: readonly Readonly<PolygonPointOptions>[];
     readonly closed: boolean;
     readonly altitudeMode: AltitudeMode;
-    readonly labels: ReadonlyArray<string> | undefined;
+    readonly labels: ReadonlyArray<string | undefined> | undefined;
     readonly style: Readonly<Required<PolygonStyleOptions>>;
     readonly enabled: boolean;
     /** 垂線の表示状態 */

--- a/src/terrain/polygon.ts
+++ b/src/terrain/polygon.ts
@@ -30,6 +30,7 @@ import {
     type PolygonHandle,
     type PolygonOptions,
     type PolygonPointOptions,
+    type PolygonPointPartial,
     type PolygonStyleOptions,
 } from "../lib/types";
 
@@ -106,6 +107,17 @@ export interface PolygonNode {
     setLabelsEnabledLogical(enabled: boolean): void;
     setWallsEnabledLogical(enabled: boolean): void;
     setElevationResolved(resolved: boolean): void;
+    /**
+     * 頂点列の編集 API (#173)。
+     * いずれも内部状態（points / labels / メッシュ配列）を更新したのち、
+     * 即時の applyTransform を呼ばずに完了する（呼び出し側が tick で反映する）。
+     * 点数が変化した場合 lineMesh / wallMesh は dispose され、次回 applyTransform
+     * 時に instance なしで再生成される。
+     */
+    insertPoint(index: number, point: PolygonPointOptions): void;
+    removePoint(index: number): void;
+    updatePoint(index: number, partial: PolygonPointPartial): void;
+    replacePoints(points: readonly PolygonPointOptions[]): void;
     getHandle(): PolygonHandle;
     dispose(): void;
 }
@@ -351,9 +363,6 @@ export const createPolygonNode = (
 ): PolygonNode => {
     const closed = options.closed ?? POLYGON_DEFAULTS.closed;
     const altitudeMode = options.altitudeMode ?? POLYGON_DEFAULTS.altitudeMode;
-    const labels = options.labels
-        ? Object.freeze([...options.labels])
-        : undefined;
     const style = resolveStyle(options.style);
     let logicalEnabled = options.enabled ?? POLYGON_DEFAULTS.enabled;
     let verticalsEnabled =
@@ -379,6 +388,14 @@ export const createPolygonNode = (
         altitude: p.altitude,
     }));
 
+    // ラベルは常に points と同じ長さで保持する (#173)。`undefined` はラベルなし。
+    // 一度でも labels が指定された（または `updatePoint(label)` で設定された）場合、
+    // getHandle().labels で外部に露出する。
+    let hasLabels = options.labels !== undefined;
+    const labels: (string | undefined)[] = points.map((_, i) =>
+        options.labels ? options.labels[i] : undefined,
+    );
+
     const root = new TransformNode(`polygon-${id}`, scene);
 
     // 各頂点に対応する球を 1 つだけ作る。スケールは applyTransform で更新する。
@@ -393,7 +410,7 @@ export const createPolygonNode = (
 
     // labels[i] が指定された頂点にのみラベルを作る。indexed by 頂点 index。
     const labelEntries: (LabelEntry | null)[] = points.map((_pt, index) => {
-        const text = labels ? labels[index] : undefined;
+        const text = labels[index];
         if (text === undefined || text === null) return null;
         return createLabelMesh(scene, id, index, text, style, root);
     });
@@ -470,6 +487,118 @@ export const createPolygonNode = (
         wallMesh.setEnabled(visible && wallsEnabled);
     };
     applyVisibility();
+
+    /**
+     * 点数変更時の lineMesh / wallMesh 再生成 (#173)。
+     * Babylon の `CreateTube` / `CreateRibbon` は instance 更新時に頂点数を変えられないため、
+     * insert/remove/replace で点数が変わった直後に既存メッシュを dispose し、
+     * 新しい点数に合わせた placeholder で作り直す。Material は再 attach する。
+     */
+    const rebuildLineMeshForCurrentPointCount = (): void => {
+        lineMesh.dispose();
+        const placeholder: Vector3[] = points.map(
+            (_, i) => new Vector3(i, 0, 0),
+        );
+        const path = buildLinePath(placeholder, closed);
+        lineMesh = CreateTube(
+            `polygon-${id}-line`,
+            {
+                path,
+                radius: Math.max(style.lineWidth, 0.001),
+                updatable: true,
+                cap: Mesh.NO_CAP,
+            },
+            scene,
+        );
+        lineMesh.material = lineMaterial;
+        lineMesh.renderingGroupId = RENDERING_GROUP_ID;
+        lineMesh.isPickable = false;
+        lineMesh.parent = root;
+    };
+    const rebuildWallMeshForCurrentPointCount = (): void => {
+        wallMesh.dispose();
+        const placeholder: Vector3[] = points.map(
+            (_, i) => new Vector3(i, 0, 0),
+        );
+        const groundPlaceholder: (number | null)[] = points.map(() => null);
+        const pathArray = buildWallPathArray(
+            placeholder,
+            groundPlaceholder,
+            closed,
+        );
+        wallMesh = CreateRibbon(
+            `polygon-${id}-walls`,
+            {
+                pathArray,
+                updatable: true,
+                sideOrientation: Mesh.DOUBLESIDE,
+                closeArray: false,
+            },
+            scene,
+        );
+        wallMesh.material = wallMaterial;
+        wallMesh.renderingGroupId = RENDERING_GROUP_ID;
+        wallMesh.isPickable = false;
+        wallMesh.parent = root;
+    };
+
+    /** 点数変動時の共通後処理。stale キャッシュをクリアし可視状態を再評価する。 */
+    const onPointCountChanged = (): void => {
+        rebuildLineMeshForCurrentPointCount();
+        rebuildWallMeshForCurrentPointCount();
+        // 再 enable 時の stale 適用を防ぐためキャッシュ破棄。
+        lastWorldPoints = null;
+        lastGroundYs = null;
+        // terrain モードで再評価するまで一旦 hide。次回 tick で resolve される。
+        if (altitudeMode === "terrain") {
+            elevationResolved = false;
+        }
+        applyVisibility();
+    };
+
+    /** 内部: lat/lon/altitude のバリデーション (#173)。 */
+    const assertValidPoint = (p: PolygonPointOptions, prefix: string): void => {
+        if (!Number.isFinite(p.lat) || p.lat < -90 || p.lat > 90) {
+            throw new RangeError(`${prefix}: lat out of range (got ${p.lat})`);
+        }
+        if (!Number.isFinite(p.lon) || p.lon < -180 || p.lon > 180) {
+            throw new RangeError(`${prefix}: lon out of range (got ${p.lon})`);
+        }
+        if (p.altitude !== undefined && !Number.isFinite(p.altitude)) {
+            throw new RangeError(
+                `${prefix}: altitude must be a finite number (got ${p.altitude})`,
+            );
+        }
+        if (altitudeMode === "absolute" && p.altitude === undefined) {
+            throw new Error(
+                `${prefix}: altitudeMode="absolute" requires altitude on every point`,
+            );
+        }
+    };
+
+    /** ラベル mesh を index に対応するエントリに設定 / 解放する (#173)。 */
+    const setLabelAt = (index: number, value: string | undefined): void => {
+        const existing = labelEntries[index];
+        if (value === undefined) {
+            if (existing) {
+                existing.texture.dispose();
+                existing.material.dispose();
+                existing.mesh.dispose();
+                labelEntries[index] = null;
+            }
+            labels[index] = undefined;
+            return;
+        }
+        // value が定義済み: 既存があれば dispose して作り直す（テキスト変更に対応）。
+        if (existing) {
+            existing.texture.dispose();
+            existing.material.dispose();
+            existing.mesh.dispose();
+        }
+        labelEntries[index] = createLabelMesh(scene, id, index, value, style, root);
+        labels[index] = value;
+        hasLabels = true;
+    };
 
     const applyTransform = (
         worldPoints: readonly Vector3[],
@@ -554,7 +683,7 @@ export const createPolygonNode = (
         points: points.map((p) => ({ ...p })),
         closed,
         altitudeMode,
-        labels,
+        labels: hasLabels ? Object.freeze([...labels]) : undefined,
         style: { ...style },
         enabled: logicalEnabled,
         verticalsEnabled,
@@ -634,6 +763,145 @@ export const createPolygonNode = (
         setElevationResolved(resolved: boolean): void {
             elevationResolved = resolved;
             applyVisibility();
+        },
+        insertPoint(index: number, point: PolygonPointOptions): void {
+            const prefix = `polygon[${id}].insertPoint`;
+            if (!Number.isInteger(index) || index < 0 || index > points.length) {
+                throw new RangeError(
+                    `${prefix}: index out of range (got ${index}, length=${points.length})`,
+                );
+            }
+            assertValidPoint(point, prefix);
+            points.splice(index, 0, {
+                lat: point.lat,
+                lon: point.lon,
+                altitude: point.altitude,
+            });
+            // sphere / drop / label を index 位置に挿入する。
+            const sphere = createPointSphere(
+                scene,
+                id,
+                index,
+                style,
+                root,
+            );
+            sphereEntries.splice(index, 0, sphere);
+            const drop = createDropLine(scene, id, index, style, root);
+            dropEntries.splice(index, 0, drop);
+            labels.splice(index, 0, undefined);
+            labelEntries.splice(index, 0, null);
+            onPointCountChanged();
+        },
+        removePoint(index: number): void {
+            const prefix = `polygon[${id}].removePoint`;
+            if (!Number.isInteger(index) || index < 0 || index >= points.length) {
+                throw new RangeError(
+                    `${prefix}: index out of range (got ${index}, length=${points.length})`,
+                );
+            }
+            if (points.length <= 2) {
+                throw new Error(
+                    `${prefix}: cannot remove (must keep at least 2 points)`,
+                );
+            }
+            points.splice(index, 1);
+            const sphere = sphereEntries.splice(index, 1)[0];
+            sphere.material.dispose();
+            sphere.mesh.dispose();
+            const drop = dropEntries.splice(index, 1)[0];
+            drop.material.dispose();
+            drop.mesh.dispose();
+            labels.splice(index, 1);
+            const lbl = labelEntries.splice(index, 1)[0];
+            if (lbl) {
+                lbl.texture.dispose();
+                lbl.material.dispose();
+                lbl.mesh.dispose();
+            }
+            onPointCountChanged();
+        },
+        updatePoint(index: number, partial: PolygonPointPartial): void {
+            const prefix = `polygon[${id}].updatePoint`;
+            if (!Number.isInteger(index) || index < 0 || index >= points.length) {
+                throw new RangeError(
+                    `${prefix}: index out of range (got ${index}, length=${points.length})`,
+                );
+            }
+            const current = points[index];
+            const next: PolygonPointOptions = {
+                lat: partial.lat ?? current.lat,
+                lon: partial.lon ?? current.lon,
+                altitude:
+                    partial.altitude !== undefined
+                        ? partial.altitude
+                        : current.altitude,
+            };
+            assertValidPoint(next, prefix);
+            points[index] = next;
+            if (partial.label !== undefined) {
+                if (partial.label === null) {
+                    setLabelAt(index, undefined);
+                } else {
+                    setLabelAt(index, partial.label);
+                }
+            }
+            // 点数は不変なので line/wall は再生成しない。次回 applyTransform で位置反映。
+            // terrain モードで lat/lon が変われば標高再解決が必要なため hide 復帰。
+            if (
+                altitudeMode === "terrain" &&
+                (partial.lat !== undefined || partial.lon !== undefined)
+            ) {
+                elevationResolved = false;
+                applyVisibility();
+            }
+        },
+        replacePoints(newPoints: readonly PolygonPointOptions[]): void {
+            const prefix = `polygon[${id}].replacePoints`;
+            if (!newPoints || newPoints.length < 2) {
+                throw new Error(
+                    `${prefix}: points must contain at least 2 entries (got ${
+                        newPoints?.length ?? 0
+                    })`,
+                );
+            }
+            for (let i = 0; i < newPoints.length; i++) {
+                assertValidPoint(newPoints[i], `${prefix}[${i}]`);
+            }
+            // 既存 sphere / drop / label を全 dispose してから再構築する。
+            for (const entry of sphereEntries) {
+                entry.material.dispose();
+                entry.mesh.dispose();
+            }
+            sphereEntries.length = 0;
+            for (const entry of dropEntries) {
+                entry.material.dispose();
+                entry.mesh.dispose();
+            }
+            dropEntries.length = 0;
+            for (const entry of labelEntries) {
+                if (!entry) continue;
+                entry.texture.dispose();
+                entry.material.dispose();
+                entry.mesh.dispose();
+            }
+            labelEntries.length = 0;
+            labels.length = 0;
+            points.length = 0;
+            for (let i = 0; i < newPoints.length; i++) {
+                const p = newPoints[i];
+                points.push({
+                    lat: p.lat,
+                    lon: p.lon,
+                    altitude: p.altitude,
+                });
+                sphereEntries.push(
+                    createPointSphere(scene, id, i, style, root),
+                );
+                dropEntries.push(createDropLine(scene, id, i, style, root));
+                labels.push(undefined);
+                labelEntries.push(null);
+            }
+            onPointCountChanged();
         },
         getHandle,
         dispose,

--- a/src/terrain/polygon.ts
+++ b/src/terrain/polygon.ts
@@ -844,6 +844,10 @@ export const createPolygonNode = (
                 } else {
                     setLabelAt(index, partial.label);
                 }
+                // 新規 label mesh は default で enabled=true なので、現行の表示
+                // フラグ (logicalEnabled / labelsEnabled / elevationResolved) と
+                // 整合させるため applyVisibility() で再評価する。
+                applyVisibility();
             }
             // 点数は不変なので line/wall は再生成しない。次回 applyTransform で位置反映。
             // terrain モードで lat/lon が変われば標高再解決が必要なため hide 復帰。

--- a/src/terrain/polygon.ts
+++ b/src/terrain/polygon.ts
@@ -556,6 +556,32 @@ export const createPolygonNode = (
         applyVisibility();
     };
 
+    /**
+     * 配列上の index と mesh / material / texture 名の整合を保つために
+     * sphere / drop / label の name を index に合わせて再採番する (#173)。
+     * insert/remove での部分編集では同名 mesh の共存と index ズレを招くため、
+     * splice 後に必ず呼び出して名前を再付与する。
+     */
+    const renumberEntries = (): void => {
+        for (let i = 0; i < sphereEntries.length; i++) {
+            const e = sphereEntries[i];
+            e.mesh.name = `polygon-${id}-point-${i}`;
+            e.material.name = `polygon-${id}-point-mat-${i}`;
+        }
+        for (let i = 0; i < dropEntries.length; i++) {
+            const e = dropEntries[i];
+            e.mesh.name = `polygon-${id}-drop-${i}`;
+            e.material.name = `polygon-${id}-drop-mat-${i}`;
+        }
+        for (let i = 0; i < labelEntries.length; i++) {
+            const e = labelEntries[i];
+            if (!e) continue;
+            e.mesh.name = `polygon-${id}-label-${i}`;
+            e.material.name = `polygon-${id}-label-mat-${i}`;
+            e.texture.name = `polygon-${id}-label-${i}`;
+        }
+    };
+
     /** 内部: lat/lon/altitude のバリデーション (#173)。 */
     const assertValidPoint = (p: PolygonPointOptions, prefix: string): void => {
         if (!Number.isFinite(p.lat) || p.lat < -90 || p.lat > 90) {
@@ -790,6 +816,7 @@ export const createPolygonNode = (
             dropEntries.splice(index, 0, drop);
             labels.splice(index, 0, undefined);
             labelEntries.splice(index, 0, null);
+            renumberEntries();
             onPointCountChanged();
         },
         removePoint(index: number): void {
@@ -818,6 +845,7 @@ export const createPolygonNode = (
                 lbl.material.dispose();
                 lbl.mesh.dispose();
             }
+            renumberEntries();
             onPointCountChanged();
         },
         updatePoint(index: number, partial: PolygonPointPartial): void {

--- a/src/terrain/polygon.ts
+++ b/src/terrain/polygon.ts
@@ -886,6 +886,7 @@ export const createPolygonNode = (
             }
             labelEntries.length = 0;
             labels.length = 0;
+            hasLabels = false;
             points.length = 0;
             for (let i = 0; i < newPoints.length; i++) {
                 const p = newPoints[i];

--- a/src/terrain/polygonManager.ts
+++ b/src/terrain/polygonManager.ts
@@ -24,6 +24,8 @@ import {
     POLYGON_DEFAULTS,
     type PolygonHandle,
     type PolygonOptions,
+    type PolygonPointOptions,
+    type PolygonPointPartial,
     type PolygonUpdate,
 } from "../lib/types";
 
@@ -42,6 +44,28 @@ export interface PolygonManager {
     setVerticalsEnabled(id: string, enabled: boolean): void;
     setLabelsEnabled(id: string, enabled: boolean): void;
     setWallsEnabled(id: string, enabled: boolean): void;
+    /**
+     * 指定 index に新しい頂点を挿入する (#173)。`index === points.length` で末尾追加。
+     * 範囲外 / 緯度経度範囲外 / `absolute` モードでの altitude 未指定 は throw。
+     */
+    insertPoint(
+        id: string,
+        index: number,
+        point: PolygonPointOptions,
+    ): PolygonHandle;
+    /** 指定 index の頂点を削除する (#173)。残り 2 点未満になる場合は throw。 */
+    removePoint(id: string, index: number): PolygonHandle;
+    /** 指定 index の頂点を部分更新する (#173)。 */
+    updatePoint(
+        id: string,
+        index: number,
+        partial: PolygonPointPartial,
+    ): PolygonHandle;
+    /** 全頂点を置き換える (#173)。`points.length < 2` は throw。 */
+    replacePoints(
+        id: string,
+        points: readonly PolygonPointOptions[],
+    ): PolygonHandle;
     list(): readonly string[];
     dispose(): void;
 }
@@ -210,6 +234,86 @@ export const createPolygonManager = (ctx: OverlayContext): PolygonManager => {
             }
             const node = requireNode(id);
             node.setWallsEnabledLogical(enabled);
+        },
+        insertPoint(
+            id: string,
+            index: number,
+            point: PolygonPointOptions,
+        ): PolygonHandle {
+            if (disposed) {
+                throw new Error("PolygonManager has been disposed");
+            }
+            const node = requireNode(id);
+            // assertLatLonInBounds は addPolygon と同じ JAPAN_BOUNDS 検査で揃える。
+            assertLatLonInBounds(
+                point.lat,
+                point.lon,
+                `JpmapTerrain.insertPolygonPoint[${id}]`,
+            );
+            node.insertPoint(index, point);
+            tickPolygon(node);
+            return node.getHandle();
+        },
+        removePoint(id: string, index: number): PolygonHandle {
+            if (disposed) {
+                throw new Error("PolygonManager has been disposed");
+            }
+            const node = requireNode(id);
+            node.removePoint(index);
+            tickPolygon(node);
+            return node.getHandle();
+        },
+        updatePoint(
+            id: string,
+            index: number,
+            partial: PolygonPointPartial,
+        ): PolygonHandle {
+            if (disposed) {
+                throw new Error("PolygonManager has been disposed");
+            }
+            const node = requireNode(id);
+            // 緯度経度の partial がある場合は JAPAN_BOUNDS チェックを先行する。
+            if (partial.lat !== undefined || partial.lon !== undefined) {
+                const current = node.points[index];
+                const lat = partial.lat ?? current?.lat;
+                const lon = partial.lon ?? current?.lon;
+                if (lat !== undefined && lon !== undefined) {
+                    assertLatLonInBounds(
+                        lat,
+                        lon,
+                        `JpmapTerrain.updatePolygonPoint[${id}][${index}]`,
+                    );
+                }
+            }
+            node.updatePoint(index, partial);
+            tickPolygon(node);
+            return node.getHandle();
+        },
+        replacePoints(
+            id: string,
+            points: readonly PolygonPointOptions[],
+        ): PolygonHandle {
+            if (disposed) {
+                throw new Error("PolygonManager has been disposed");
+            }
+            const node = requireNode(id);
+            if (!points || points.length < 2) {
+                throw new Error(
+                    `JpmapTerrain.replacePolygonPoints[${id}]: points must contain at least 2 entries (got ${
+                        points?.length ?? 0
+                    })`,
+                );
+            }
+            for (let i = 0; i < points.length; i++) {
+                assertLatLonInBounds(
+                    points[i].lat,
+                    points[i].lon,
+                    `JpmapTerrain.replacePolygonPoints[${id}][${i}]`,
+                );
+            }
+            node.replacePoints(points);
+            tickPolygon(node);
+            return node.getHandle();
         },
         list(): readonly string[] {
             return Array.from(nodes.keys());

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -129,6 +129,36 @@ jest.unstable_mockModule("../src/terrain/polygon", () => ({
             dispose: () => {
                 /* no-op */
             },
+            insertPoint: (
+                index: number,
+                point: { lat: number; lon: number; altitude?: number },
+            ) => {
+                points.splice(index, 0, { ...point });
+            },
+            removePoint: (index: number) => {
+                points.splice(index, 1);
+            },
+            updatePoint: (
+                index: number,
+                partial: {
+                    lat?: number;
+                    lon?: number;
+                    altitude?: number;
+                    label?: string | null;
+                },
+            ) => {
+                const cur = points[index];
+                if (!cur) return;
+                if (partial.lat !== undefined) cur.lat = partial.lat;
+                if (partial.lon !== undefined) cur.lon = partial.lon;
+                if (partial.altitude !== undefined) cur.altitude = partial.altitude;
+            },
+            replacePoints: (
+                next: readonly { lat: number; lon: number; altitude?: number }[],
+            ) => {
+                points.length = 0;
+                for (const p of next) points.push({ ...p });
+            },
         };
     },
 }));
@@ -1517,6 +1547,98 @@ describe("JpmapTerrain (skeleton)", () => {
             expect(() => viewer.setVerticalsEnabled("p1", false)).not.toThrow();
             expect(() => viewer.setLabelsEnabled("p1", false)).not.toThrow();
             expect(() => viewer.setWallsEnabled("p1", false)).not.toThrow();
+        });
+    });
+
+    describe("Polygon point edit API (Issue #173)", () => {
+        const validPoints = [
+            { lat: 35.681, lon: 139.767 },
+            { lat: 35.682, lon: 139.768 },
+            { lat: 35.683, lon: 139.769 },
+        ];
+
+        it("insertPolygonPoint で頂点が増える", async () => {
+            const viewer = await create(createMountElement());
+            viewer.addPolygon("p1", { points: validPoints });
+            const handle = viewer.insertPolygonPoint("p1", 1, {
+                lat: 35.6815,
+                lon: 139.7675,
+            });
+            expect(handle.points.length).toBe(4);
+            expect(handle.points[1].lat).toBeCloseTo(35.6815);
+        });
+
+        it("removePolygonPoint で頂点が減る", async () => {
+            const viewer = await create(createMountElement());
+            viewer.addPolygon("p1", { points: validPoints });
+            const handle = viewer.removePolygonPoint("p1", 0);
+            expect(handle.points.length).toBe(2);
+        });
+
+        it("updatePolygonPoint は partial を反映する", async () => {
+            const viewer = await create(createMountElement());
+            viewer.addPolygon("p1", {
+                points: validPoints.map((p) => ({ ...p, altitude: 0 })),
+                altitudeMode: "absolute",
+            });
+            const handle = viewer.updatePolygonPoint("p1", 0, {
+                altitude: 123,
+            });
+            expect(handle.points[0].altitude).toBe(123);
+        });
+
+        it("replacePolygonPoints で全置換される", async () => {
+            const viewer = await create(createMountElement());
+            viewer.addPolygon("p1", { points: validPoints });
+            const next = [
+                { lat: 35.7, lon: 139.7 },
+                { lat: 35.71, lon: 139.71 },
+            ];
+            const handle = viewer.replacePolygonPoints("p1", next);
+            expect(handle.points.length).toBe(2);
+            expect(handle.points[0].lat).toBeCloseTo(35.7);
+        });
+
+        it("未存在 id の点編集 API は throw", async () => {
+            const viewer = await create(createMountElement());
+            expect(() =>
+                viewer.insertPolygonPoint("nope", 0, {
+                    lat: 35.681,
+                    lon: 139.767,
+                }),
+            ).toThrow();
+            expect(() => viewer.removePolygonPoint("nope", 0)).toThrow();
+            expect(() =>
+                viewer.updatePolygonPoint("nope", 0, { lat: 35.681 }),
+            ).toThrow();
+            expect(() =>
+                viewer.replacePolygonPoints("nope", [
+                    { lat: 35.681, lon: 139.767 },
+                    { lat: 35.682, lon: 139.768 },
+                ]),
+            ).toThrow();
+        });
+
+        it("dispose 後の点編集 API は throw", async () => {
+            const viewer = await create(createMountElement());
+            viewer.addPolygon("p1", { points: validPoints });
+            viewer.dispose();
+            expect(() =>
+                viewer.insertPolygonPoint("p1", 0, {
+                    lat: 35.681,
+                    lon: 139.767,
+                }),
+            ).toThrow();
+            expect(() => viewer.removePolygonPoint("p1", 0)).toThrow();
+            expect(() =>
+                viewer.updatePolygonPoint("p1", 0, { lat: 35.681 }),
+            ).toThrow();
+            expect(() =>
+                viewer.replacePolygonPoints("p1", [
+                    { lat: 35.681, lon: 139.767 },
+                    { lat: 35.682, lon: 139.768 },
+                ]),
+            ).toThrow();
         });
     });
 });

--- a/tests/polygon.unit.spec.ts
+++ b/tests/polygon.unit.spec.ts
@@ -717,3 +717,197 @@ describe("createPolygonNode 壁 (#172)", () => {
         expect(path[0][1].y).toBe(200);
     });
 });
+
+describe("createPolygonNode 点編集 API (#173)", () => {
+    const basePoints = [
+        { lat: 35.0, lon: 139.0, altitude: 100 },
+        { lat: 35.1, lon: 139.1, altitude: 200 },
+        { lat: 35.2, lon: 139.2, altitude: 300 },
+    ];
+
+    it("insertPoint で sphere / drop / line / wall が再構築され、handle.points が伸びる", () => {
+        const node = createPolygonNode(sceneStub, "pi", {
+            points: [...basePoints],
+            altitudeMode: "absolute",
+        });
+        const sphereBefore = sphereCalls.length;
+        const tubeBefore = tubeCalls.length;
+        const ribbonBefore = ribbonCalls.length;
+        node.insertPoint(1, { lat: 35.05, lon: 139.05, altitude: 150 });
+        // sphere: 新規 1 本、drop: 新規 1 本、line/wall: 1 回 dispose+再生成。
+        expect(sphereCalls.length - sphereBefore).toBe(1);
+        // 垂線 (drop) 新規 1 + line 再生成 1 = +2 Tube call
+        expect(tubeCalls.length - tubeBefore).toBe(2);
+        expect(ribbonCalls.length - ribbonBefore).toBe(1);
+        const h = node.getHandle();
+        expect(h.points.length).toBe(4);
+        expect(h.points[1].lat).toBe(35.05);
+    });
+
+    it("insertPoint は範囲外 index で RangeError", () => {
+        const node = createPolygonNode(sceneStub, "pi2", {
+            points: [...basePoints],
+            altitudeMode: "absolute",
+        });
+        expect(() =>
+            node.insertPoint(-1, { lat: 35, lon: 139, altitude: 0 }),
+        ).toThrow(RangeError);
+        expect(() =>
+            node.insertPoint(99, { lat: 35, lon: 139, altitude: 0 }),
+        ).toThrow(RangeError);
+    });
+
+    it("insertPoint は absolute モードで altitude 未指定なら throw", () => {
+        const node = createPolygonNode(sceneStub, "pi3", {
+            points: [...basePoints],
+            altitudeMode: "absolute",
+        });
+        expect(() => node.insertPoint(0, { lat: 35, lon: 139 })).toThrow(
+            /absolute/,
+        );
+    });
+
+    it("removePoint で末尾 sphere / drop が dispose され、line/wall が再生成される", () => {
+        const node = createPolygonNode(sceneStub, "pr", {
+            points: [...basePoints],
+            altitudeMode: "absolute",
+        });
+        const tubeBefore = tubeCalls.length;
+        const ribbonBefore = ribbonCalls.length;
+        const sphereMeshBefore = allMeshes.find(
+            (m) => m.name === "polygon-pr-point-2",
+        );
+        const dropMeshBefore = allMeshes.find(
+            (m) => m.name === "polygon-pr-drop-2",
+        );
+        node.removePoint(2);
+        expect(sphereMeshBefore?.disposed).toBe(true);
+        expect(dropMeshBefore?.disposed).toBe(true);
+        // line/wall 1 回ずつ再生成。
+        expect(tubeCalls.length - tubeBefore).toBe(1);
+        expect(ribbonCalls.length - ribbonBefore).toBe(1);
+        expect(node.getHandle().points.length).toBe(2);
+    });
+
+    it("removePoint は残り 2 点未満で throw", () => {
+        const node = createPolygonNode(sceneStub, "pr2", {
+            points: [
+                { lat: 35.0, lon: 139.0, altitude: 0 },
+                { lat: 35.1, lon: 139.1, altitude: 0 },
+            ],
+            altitudeMode: "absolute",
+        });
+        expect(() => node.removePoint(0)).toThrow(/at least 2/);
+    });
+
+    it("updatePoint は点数同一なので line/wall を dispose しない", () => {
+        const node = createPolygonNode(sceneStub, "pu", {
+            points: [...basePoints],
+            altitudeMode: "absolute",
+        });
+        const lineMesh = allMeshes.find((m) => m.name === "polygon-pu-line");
+        const wallMesh = allMeshes.find((m) => m.name === "polygon-pu-walls");
+        const tubeBefore = tubeCalls.length;
+        const ribbonBefore = ribbonCalls.length;
+        node.updatePoint(0, { altitude: 999 });
+        // 点数不変 → 再生成なし。Tube/Ribbon の追加 call も発生しない。
+        expect(lineMesh?.disposed).toBe(false);
+        expect(wallMesh?.disposed).toBe(false);
+        expect(tubeCalls.length).toBe(tubeBefore);
+        expect(ribbonCalls.length).toBe(ribbonBefore);
+        expect(node.getHandle().points[0].altitude).toBe(999);
+    });
+
+    it("updatePoint(label) は sparse 同期する: 文字列で生成、null で破棄", () => {
+        const node = createPolygonNode(sceneStub, "pul", {
+            points: [...basePoints],
+            altitudeMode: "absolute",
+        });
+        // labels 未指定 → handle.labels=undefined。
+        expect(node.getHandle().labels).toBeUndefined();
+
+        node.updatePoint(1, { label: "L1" });
+        // index=1 にラベル平面が新規生成される。
+        const planeAfterAdd = planeCalls.filter((p) =>
+            p.name.startsWith("polygon-pul-label-"),
+        );
+        expect(planeAfterAdd.length).toBe(1);
+        const labels1 = node.getHandle().labels;
+        expect(labels1).toBeDefined();
+        expect(labels1?.[0]).toBeUndefined();
+        expect(labels1?.[1]).toBe("L1");
+
+        // null 指定でラベル mesh が dispose される。
+        const labelMesh = allMeshes.find(
+            (m) => m.name === "polygon-pul-label-1",
+        );
+        node.updatePoint(1, { label: null });
+        expect(labelMesh?.disposed).toBe(true);
+        const labels2 = node.getHandle().labels;
+        expect(labels2?.[1]).toBeUndefined();
+    });
+
+    it("updatePoint は範囲外で RangeError、altitudeMode=absolute では altitude=undefined のままなら throw しない (現状値継承)", () => {
+        const node = createPolygonNode(sceneStub, "pu2", {
+            points: [...basePoints],
+            altitudeMode: "absolute",
+        });
+        expect(() => node.updatePoint(99, { lat: 35 })).toThrow(RangeError);
+        // partial.altitude 未指定でも、現状の altitude を継承するため throw しない。
+        expect(() => node.updatePoint(0, { lat: 35.5 })).not.toThrow();
+    });
+
+    it("replacePoints で全 sphere/drop/label が dispose+再生成され、line/wall も再構築される", () => {
+        const node = createPolygonNode(sceneStub, "prep", {
+            points: [...basePoints],
+            altitudeMode: "absolute",
+            labels: ["a", "b", "c"],
+        });
+        const labelDtBefore = dynamicTextures.filter((t) =>
+            t.name.startsWith("polygon-prep-label-"),
+        );
+        const sphereBefore = sphereCalls.length;
+        const tubeBefore = tubeCalls.length;
+        const ribbonBefore = ribbonCalls.length;
+        node.replacePoints([
+            { lat: 35.5, lon: 139.5, altitude: 50 },
+            { lat: 35.6, lon: 139.6, altitude: 60 },
+        ]);
+        // sphere 新規 2 本、drop 新規 2 本、line+wall 各 1 回再構築。
+        expect(sphereCalls.length - sphereBefore).toBe(2);
+        expect(tubeCalls.length - tubeBefore).toBe(2 + 1);
+        expect(ribbonCalls.length - ribbonBefore).toBe(1);
+        // 旧 label の DT が dispose される。
+        for (const dt of labelDtBefore) {
+            expect(dt.disposed).toBe(true);
+        }
+        const h = node.getHandle();
+        expect(h.points.length).toBe(2);
+        // labels は全 undefined（hasLabels=true は維持）。
+        expect(h.labels).toBeDefined();
+        expect(h.labels?.[0]).toBeUndefined();
+    });
+
+    it("replacePoints は 2 点未満で throw", () => {
+        const node = createPolygonNode(sceneStub, "prep2", {
+            points: [...basePoints],
+            altitudeMode: "absolute",
+        });
+        expect(() =>
+            node.replacePoints([{ lat: 35, lon: 139, altitude: 0 }]),
+        ).toThrow(/at least 2/);
+    });
+
+    it("replacePoints は緯度経度範囲外で RangeError", () => {
+        const node = createPolygonNode(sceneStub, "prep3", {
+            points: [...basePoints],
+            altitudeMode: "absolute",
+        });
+        expect(() =>
+            node.replacePoints([
+                { lat: 35, lon: 139, altitude: 0 },
+                { lat: 999, lon: 139, altitude: 0 },
+            ]),
+        ).toThrow(RangeError);
+    });
+});

--- a/tests/polygon.unit.spec.ts
+++ b/tests/polygon.unit.spec.ts
@@ -883,9 +883,8 @@ describe("createPolygonNode 点編集 API (#173)", () => {
         }
         const h = node.getHandle();
         expect(h.points.length).toBe(2);
-        // labels は全 undefined（hasLabels=true は維持）。
-        expect(h.labels).toBeDefined();
-        expect(h.labels?.[0]).toBeUndefined();
+        // replacePoints はラベルを再構成しないため hasLabels=false にリセットされる。
+        expect(h.labels).toBeUndefined();
     });
 
     it("replacePoints は 2 点未満で throw", () => {

--- a/tests/polygon.unit.spec.ts
+++ b/tests/polygon.unit.spec.ts
@@ -767,6 +767,55 @@ describe("createPolygonNode 点編集 API (#173)", () => {
         );
     });
 
+    it("insertPoint / removePoint 後に sphere/drop の name が連番で重複しない", () => {
+        const node = createPolygonNode(sceneStub, "pn", {
+            points: [...basePoints],
+            altitudeMode: "absolute",
+        });
+        node.insertPoint(1, { lat: 35.05, lon: 139.05, altitude: 150 });
+        const liveSphereNames = allMeshes
+            .filter(
+                (m) =>
+                    !m.disposed &&
+                    /^polygon-pn-point-\d+$/.test(m.name),
+            )
+            .map((m) => m.name)
+            .sort();
+        expect(liveSphereNames).toEqual([
+            "polygon-pn-point-0",
+            "polygon-pn-point-1",
+            "polygon-pn-point-2",
+            "polygon-pn-point-3",
+        ]);
+        node.removePoint(0);
+        const liveSphereNamesAfterRemove = allMeshes
+            .filter(
+                (m) =>
+                    !m.disposed &&
+                    /^polygon-pn-point-\d+$/.test(m.name),
+            )
+            .map((m) => m.name)
+            .sort();
+        expect(liveSphereNamesAfterRemove).toEqual([
+            "polygon-pn-point-0",
+            "polygon-pn-point-1",
+            "polygon-pn-point-2",
+        ]);
+        const liveDropNames = allMeshes
+            .filter(
+                (m) =>
+                    !m.disposed &&
+                    /^polygon-pn-drop-\d+$/.test(m.name),
+            )
+            .map((m) => m.name)
+            .sort();
+        expect(liveDropNames).toEqual([
+            "polygon-pn-drop-0",
+            "polygon-pn-drop-1",
+            "polygon-pn-drop-2",
+        ]);
+    });
+
     it("removePoint で末尾 sphere / drop が dispose され、line/wall が再生成される", () => {
         const node = createPolygonNode(sceneStub, "pr", {
             points: [...basePoints],

--- a/tests/polygonManager.unit.spec.ts
+++ b/tests/polygonManager.unit.spec.ts
@@ -6,7 +6,11 @@
  */
 
 import { jest } from "@jest/globals";
-import type { PolygonOptions } from "../src/lib/types";
+import type {
+    PolygonOptions,
+    PolygonPointOptions,
+    PolygonPointPartial,
+} from "../src/lib/types";
 
 interface StubNode {
     id: string;
@@ -28,6 +32,10 @@ interface StubNode {
     setLabelsEnabledHistory: boolean[];
     setWallsEnabledHistory: boolean[];
     setElevationResolvedHistory: boolean[];
+    insertCalls: Array<{ index: number; point: PolygonPointOptions }>;
+    removeCalls: number[];
+    updateCalls: Array<{ index: number; partial: PolygonPointPartial }>;
+    replaceCalls: Array<readonly PolygonPointOptions[]>;
 }
 
 const created: StubNode[] = [];
@@ -55,6 +63,10 @@ jest.unstable_mockModule("../src/terrain/polygon", () => ({
             setLabelsEnabledHistory: [],
             setWallsEnabledHistory: [],
             setElevationResolvedHistory: [],
+            insertCalls: [],
+            removeCalls: [],
+            updateCalls: [],
+            replaceCalls: [],
         };
         const wrapped = {
             ...node,
@@ -105,6 +117,41 @@ jest.unstable_mockModule("../src/terrain/polygon", () => ({
             }),
             dispose: () => {
                 node.disposed = true;
+            },
+            insertPoint: (index: number, point: PolygonPointOptions) => {
+                node.insertCalls.push({ index, point });
+                node.points.splice(index, 0, { ...point });
+            },
+            removePoint: (index: number) => {
+                node.removeCalls.push(index);
+                node.points.splice(index, 1);
+            },
+            updatePoint: (
+                index: number,
+                partial: PolygonPointPartial,
+            ) => {
+                node.updateCalls.push({ index, partial });
+                const cur = node.points[index];
+                if (cur) {
+                    node.points[index] = {
+                        ...cur,
+                        ...(partial.lat !== undefined
+                            ? { lat: partial.lat }
+                            : {}),
+                        ...(partial.lon !== undefined
+                            ? { lon: partial.lon }
+                            : {}),
+                        ...(partial.altitude !== undefined
+                            ? { altitude: partial.altitude }
+                            : {}),
+                    };
+                }
+            },
+            replacePoints: (
+                points: readonly PolygonPointOptions[],
+            ) => {
+                node.replaceCalls.push(points.map((p) => ({ ...p })));
+                node.points = points.map((p) => ({ ...p }));
             },
         };
         // 内部状態を `created` 経由でテストから観測するため、両方のオブジェクトを
@@ -438,5 +485,123 @@ describe("PolygonManager update (#170 では未公開)", () => {
         expect(() => mgr.update("a", { enabled: false })).toThrow(
             /not implemented/,
         );
+    });
+});
+
+describe("PolygonManager 点編集 API (#173)", () => {
+    // `created` (mock 内で push される StubNode) の最新エントリを参照することで、
+    // PolygonManager が node 側へ委譲したかを履歴で検証する。
+    it("insertPoint が node.insertPoint へ委譲され、handle を返す", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createPolygonManager(ctx);
+        mgr.add("a", { points: validPoints });
+        const node = created[created.length - 1];
+        const handle = mgr.insertPoint("a", 1, {
+            lat: 35.6815,
+            lon: 139.7675,
+        });
+        expect(node.insertCalls).toEqual([
+            { index: 1, point: { lat: 35.6815, lon: 139.7675 } },
+        ]);
+        expect(handle.id).toBe("a");
+    });
+
+    it("insertPoint は JAPAN_BOUNDS 外で throw（node 委譲前）", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createPolygonManager(ctx);
+        mgr.add("a", { points: validPoints });
+        expect(() => mgr.insertPoint("a", 0, { lat: 0, lon: 0 })).toThrow(
+            /JAPAN_BOUNDS/,
+        );
+    });
+
+    it("removePoint が node.removePoint へ委譲される", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createPolygonManager(ctx);
+        mgr.add("a", { points: validPoints });
+        const node = created[created.length - 1];
+        mgr.removePoint("a", 0);
+        expect(node.removeCalls).toEqual([0]);
+    });
+
+    it("updatePoint が node.updatePoint へ委譲される", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createPolygonManager(ctx);
+        mgr.add("a", { points: validPoints });
+        const node = created[created.length - 1];
+        mgr.updatePoint("a", 1, { altitude: 50 });
+        expect(node.updateCalls).toEqual([
+            { index: 1, partial: { altitude: 50 } },
+        ]);
+    });
+
+    it("updatePoint は lat/lon partial で JAPAN_BOUNDS 検査が走る", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createPolygonManager(ctx);
+        mgr.add("a", { points: validPoints });
+        expect(() =>
+            mgr.updatePoint("a", 0, { lat: 0, lon: 0 }),
+        ).toThrow(/JAPAN_BOUNDS/);
+    });
+
+    it("replacePoints は points.length<2 で throw", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createPolygonManager(ctx);
+        mgr.add("a", { points: validPoints });
+        expect(() =>
+            mgr.replacePoints("a", [{ lat: 35.681, lon: 139.767 }]),
+        ).toThrow(/at least 2/);
+    });
+
+    it("replacePoints が node.replacePoints へ委譲される", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createPolygonManager(ctx);
+        mgr.add("a", { points: validPoints });
+        const node = created[created.length - 1];
+        const next = [
+            { lat: 35.681, lon: 139.767 },
+            { lat: 35.682, lon: 139.768 },
+        ];
+        mgr.replacePoints("a", next);
+        expect(node.replaceCalls.length).toBe(1);
+        expect(node.replaceCalls[0]).toEqual(next);
+    });
+
+    it("未存在 id で insert/remove/update/replace は throw", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createPolygonManager(ctx);
+        expect(() =>
+            mgr.insertPoint("missing", 0, { lat: 35.681, lon: 139.767 }),
+        ).toThrow(/not found/);
+        expect(() => mgr.removePoint("missing", 0)).toThrow(/not found/);
+        expect(() => mgr.updatePoint("missing", 0, { lat: 35.681 })).toThrow(
+            /not found/,
+        );
+        expect(() =>
+            mgr.replacePoints("missing", [
+                { lat: 35.681, lon: 139.767 },
+                { lat: 35.682, lon: 139.768 },
+            ]),
+        ).toThrow(/not found/);
+    });
+
+    it("dispose 後の insert/remove/update/replace は throw", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createPolygonManager(ctx);
+        mgr.add("a", { points: validPoints });
+        mgr.dispose();
+        expect(() =>
+            mgr.insertPoint("a", 0, { lat: 35.681, lon: 139.767 }),
+        ).toThrow(/disposed/);
+        expect(() => mgr.removePoint("a", 0)).toThrow(/disposed/);
+        expect(() => mgr.updatePoint("a", 0, { lat: 35.681 })).toThrow(
+            /disposed/,
+        );
+        expect(() =>
+            mgr.replacePoints("a", [
+                { lat: 35.681, lon: 139.767 },
+                { lat: 35.682, lon: 139.768 },
+            ]),
+        ).toThrow(/disposed/);
     });
 });

--- a/tests/validation.spec.ts
+++ b/tests/validation.spec.ts
@@ -333,3 +333,113 @@ for (const engine of engines) {
         expect(testInfo.errors).toHaveLength(0);
     });
 }
+
+// ---------- ポリゴン点編集 API 視覚回帰 (Issue #173) ----------
+//
+// 4 種の点編集 API (insertPolygonPoint / removePolygonPoint /
+// updatePolygonPoint / replacePolygonPoints) を順に適用し、
+// 「初期」と「最終 (4 API 適用後)」の 2 枚のスクリーンショットを取得して
+// VR baseline とする。WebGL2 のみで実行し、時刻と autoSunPosition を固定する。
+
+const POLYGON_EDIT_TARGET_ID = "yomiuri-closed";
+
+async function waitForPolygonScene(
+    page: import("@playwright/test").Page,
+): Promise<void> {
+    const url = new URL("/polygon.html", "http://localhost");
+    url.searchParams.set("engine", "webgl");
+    applyDeterministicSunQuery(url);
+    await page.goto(`${url.pathname}${url.search}`, { timeout: 120000 });
+    await page.waitForFunction(
+        () =>
+            (window as unknown as { scene?: { isReady: () => boolean } }).scene
+                ?.isReady?.() ?? false,
+        { timeout: 15000 },
+    );
+    await page.waitForLoadState("networkidle", { timeout: 30000 });
+    await page.waitForFunction(
+        () =>
+            new Promise((resolve) => {
+                let count = 0;
+                const tick = (): void => {
+                    if (++count >= 15) return resolve(true);
+                    requestAnimationFrame(tick);
+                };
+                requestAnimationFrame(tick);
+            }),
+        { timeout: 10000 },
+    );
+}
+
+test("Polygon point edit (initial) with WebGL2", async ({
+    page,
+}, testInfo) => {
+    await waitForPolygonScene(page);
+    await expect(page).toHaveScreenshot({
+        timeout: 30000,
+        maxDiffPixelRatio: 0.02,
+    });
+    expect(testInfo.errors).toHaveLength(0);
+});
+
+test("Polygon point edit (after all edits) with WebGL2", async ({
+    page,
+}, testInfo) => {
+    await waitForPolygonScene(page);
+
+    await page.evaluate((id) => {
+        type ViewerLike = {
+            insertPolygonPoint: (
+                id: string,
+                index: number,
+                point: { lat: number; lon: number; altitude: number },
+            ) => unknown;
+            removePolygonPoint: (id: string, index: number) => unknown;
+            updatePolygonPoint: (
+                id: string,
+                index: number,
+                partial: { altitude?: number; label?: string | null },
+            ) => unknown;
+            replacePolygonPoints: (
+                id: string,
+                points: ReadonlyArray<{
+                    lat: number;
+                    lon: number;
+                    altitude: number;
+                }>,
+            ) => unknown;
+        };
+        const viewer = (window as unknown as { viewer: ViewerLike }).viewer;
+        viewer.insertPolygonPoint(id, 4, {
+            lat: 35.6244,
+            lon: 139.5208,
+            altitude: 600,
+        });
+        viewer.removePolygonPoint(id, 0);
+        viewer.updatePolygonPoint(id, 0, { altitude: 700 });
+        viewer.replacePolygonPoints(id, [
+            { lat: 35.6240, lon: 139.5198, altitude: 550 },
+            { lat: 35.6250, lon: 139.5198, altitude: 550 },
+            { lat: 35.6245, lon: 139.5215, altitude: 650 },
+        ]);
+    }, POLYGON_EDIT_TARGET_ID);
+
+    await page.waitForFunction(
+        () =>
+            new Promise((resolve) => {
+                let count = 0;
+                const tick = (): void => {
+                    if (++count >= 15) return resolve(true);
+                    requestAnimationFrame(tick);
+                };
+                requestAnimationFrame(tick);
+            }),
+        { timeout: 10000 },
+    );
+
+    await expect(page).toHaveScreenshot({
+        timeout: 30000,
+        maxDiffPixelRatio: 0.02,
+    });
+    expect(testInfo.errors).toHaveLength(0);
+});


### PR DESCRIPTION
## 概要

Issue #173 の点編集 API 4 種を実装し、デモ・視覚回帰・仕様書を整備する。Parent: #169。

## 変更点

### API (公開)
- `JpmapTerrain.insertPolygonPoint(id, index, point): PolygonHandle`
- `JpmapTerrain.removePolygonPoint(id, index): PolygonHandle`
- `JpmapTerrain.updatePolygonPoint(id, index, partial): PolygonHandle`
- `JpmapTerrain.replacePolygonPoints(id, points): PolygonHandle`
- 補助型 `PolygonPointPartial { lat?, lon?, altitude?, label?: string | null }` を追加 (`label === null` でラベル削除、`undefined` で変更なし)

### バリデーション
- 例外で統一 (`Error` / `RangeError`): id 不在 / index 範囲外 / 空配列・2 点未満 / lat/lon/altitude の NaN・Infinity / JAPAN_BOUNDS 外 / `absolute` モード altitude 必須

### 差分更新戦略
- sphere / dropTube / labels: 編集に応じて dispose+再生成 (point 単位)
- lineMesh (CreateTube) / wallMesh (CreateRibbon): 点数変化時のみ dispose+再生成、点数同一の `updatePoint` では `instance` 更新で温存
- 点数変化時に `lastWorldPoints` / `lastGroundYs` キャッシュをリセットして次フレームで自動同期
- Material は単一インスタンスを使い回し再 attach

### デモ
- `src/demos/polygon/index.ts`: 1 ポリゴン (`yomiuri-closed`) に対し insert/remove/update/replace の 4 ボタンを追加
- `__debugScene` を `window.scene` に露出 (NODE_ENV!=='production' のみ) → Playwright `scene.isReady()` で利用

### 視覚回帰
- WebGL2 のみ、`autoSunPosition: false` + 固定 `dateTime` で「初期」「最終 (4 API 適用後)」の 2 baseline
- baseline: `tests/validation.spec.ts-snapshots/Polygon-point-edit-{initial,after-all-edits}-with-WebGL2-1-chromium-darwin.png`

### 仕様書
- `spec/package.md` §3.3.8 末尾に「3.3.8.2 ポリゴン点編集 API (#173)」章を追加。シグネチャ・partial 型・バリデーション・差分更新の保証範囲・labels sparse 同期を記載。

### テスト
- `tests/polygon.unit.spec.ts`: 11 ケース (差分更新の境界、line/wall 再生成 vs 温存、partial の null/undefined 挙動、例外系)
- `tests/polygonManager.unit.spec.ts`: 9 ケース (delegate / id 不在 throw / JAPAN_BOUNDS)
- `tests/jpmapTerrain.unit.spec.ts`: 6 ケース (facade delegate / disposed throw)
- 合計 unit 26 suites / 536 tests PASS
- visuals: 2 baseline 安定 PASS

## 影響範囲

- 公開 API: `JpmapTerrain` に 4 メソッド追加
- 型: `PolygonPointPartial` を `src/lib.ts` から re-export
- 仕様書: `spec/package.md` 章追加
- デモ: `polygon` デモに編集 UI ボタン追加
- 視覚回帰: 新規 baseline 2 枚

## 検証
- `npm run lint`: PASS
- `npm run typecheck`: PASS
- `npm run test:unit`: PASS (26 suites / 536 tests)
- `npm run test:visuals -- --grep "Polygon point edit"`: PASS (2/2、安定再実行確認済)

## レビュー / セキュリティ
- 50_reviewer: GO (MINOR `hasLabels` リセット指摘 → commit a61b33b で対応済)
- 60_security: GO (BLOCKER/HIGH/MEDIUM なし、LOW のみ将来改善提案)

Refs: #169 #173
Closes: #173