### PR TITLE
chore(demo): align polygon replace button coords with east shift (#180)

### DIFF
--- a/src/demos/polygon/index.ts
+++ b/src/demos/polygon/index.ts
@@ -267,7 +267,7 @@ const buildControls = (
         buildEditButton("点 replace", () => {
             // 2 種類の頂点列を交互に切り替える。
             // 初期ポリゴンと同じ東側シフト (lon +0.006° ≒ +540m) 位置で描画されるようずらして表示し、
-            // replace を押しても他ポリゴンと重なり位置に戻らないようにする (#180)。
+            // replace を押しても他ポリゴンと重なる位置に戻らないようにする (#180)。
             replaceToggle = !replaceToggle;
             const altitude = 500;
             const next = replaceToggle

--- a/src/demos/polygon/index.ts
+++ b/src/demos/polygon/index.ts
@@ -266,19 +266,21 @@ const buildControls = (
     container.appendChild(
         buildEditButton("点 replace", () => {
             // 2 種類の頂点列を交互に切り替える。
+            // 初期ポリゴンと同じ東側シフト (lon +0.006° ≒ +540m) 位置で描画されるようずらして表示し、
+            // replace を押しても他ポリゴンと重なり位置に戻らないようにする (#180)。
             replaceToggle = !replaceToggle;
             const altitude = 500;
             const next = replaceToggle
                 ? [
-                      { lat: 35.6235, lon: 139.5135, altitude },
-                      { lat: 35.6260, lon: 139.5135, altitude },
-                      { lat: 35.6260, lon: 139.5170, altitude },
+                      { lat: 35.6235, lon: 139.5195, altitude },
+                      { lat: 35.6260, lon: 139.5195, altitude },
+                      { lat: 35.6260, lon: 139.5230, altitude },
                   ]
                 : [
-                      { lat: 35.6235, lon: 139.5135, altitude },
-                      { lat: 35.6253, lon: 139.5135, altitude },
-                      { lat: 35.6253, lon: 139.5161, altitude },
-                      { lat: 35.6235, lon: 139.5161, altitude },
+                      { lat: 35.6235, lon: 139.5195, altitude },
+                      { lat: 35.6253, lon: 139.5195, altitude },
+                      { lat: 35.6253, lon: 139.5221, altitude },
+                      { lat: 35.6235, lon: 139.5221, altitude },
                   ];
             viewer.replacePolygonPoints(editTargetId, next);
         }),


### PR DESCRIPTION
## 概要

Issue #180 対応。ポリゴンデモの `yomiuri-closed` (closed loop) は初期座標が東側 (lon 139.5195–139.5221) にずらされているが、点編集デモの「点 replace」ボタンの `next` 配列は元の座標 (lon 139.5135–139.5170) のままになっていた。

その結果、replace を押すとループポリゴンが他のポリゴンと重なる元位置 (absolute) に戻ってしまっていた。元シフト commit 8ce975a の +0.006° を replace の両 toggle 値にも適用する。

## 変更点

- `src/demos/polygon/index.ts`: 「点 replace」ボタン内 `next` 配列の lon を +0.006° 東シフト
  - 139.5135 → 139.5195
  - 139.5161 → 139.5221
  - 139.5170 → 139.5230

## 影響

- デモ表示文言・座標のみ。型・API・テスト・spec への影響なし
- lint / typecheck PASS

## 関連

- Closes #180
- Parent: #169
- 元シフト: 8ce975a