### PR TITLE
chore(demo): restore polygon labels after replacePolygonPoints

### DIFF
--- a/src/demos/polygon/index.ts
+++ b/src/demos/polygon/index.ts
@@ -281,6 +281,14 @@ const buildControls = (
                       { lat: 35.6235, lon: 139.5161, altitude },
                   ];
             viewer.replacePolygonPoints(editTargetId, next);
+            // replacePolygonPoints は仕様上 labels を全 undefined にリセットするため
+            // (spec/package.md §3.3.8.2)、ラベルが消えないよう updatePolygonPoint で再付与する。
+            const labels = ["P1", "P2", "P3", "P4"];
+            for (let i = 0; i < next.length; i++) {
+                viewer.updatePolygonPoint(editTargetId, i, {
+                    label: labels[i] ?? `P${i + 1}`,
+                });
+            }
         }),
     );
 };

--- a/src/demos/polygon/index.ts
+++ b/src/demos/polygon/index.ts
@@ -266,19 +266,21 @@ const buildControls = (
     container.appendChild(
         buildEditButton("点 replace", () => {
             // 2 種類の頂点列を交互に切り替える。
+            // 初期ポリゴン yomiuri-closed と同じ東側シフト (lon +0.006° ≒ +540m) 位置で
+            // 描画されるようずらして表示し、replace で他ポリゴンと重なる元位置に戻らないようにする (#180)。
             replaceToggle = !replaceToggle;
             const altitude = 500;
             const next = replaceToggle
                 ? [
-                      { lat: 35.6235, lon: 139.5135, altitude },
-                      { lat: 35.6260, lon: 139.5135, altitude },
-                      { lat: 35.6260, lon: 139.5170, altitude },
+                      { lat: 35.6235, lon: 139.5195, altitude },
+                      { lat: 35.6260, lon: 139.5195, altitude },
+                      { lat: 35.6260, lon: 139.5230, altitude },
                   ]
                 : [
-                      { lat: 35.6235, lon: 139.5135, altitude },
-                      { lat: 35.6253, lon: 139.5135, altitude },
-                      { lat: 35.6253, lon: 139.5161, altitude },
-                      { lat: 35.6235, lon: 139.5161, altitude },
+                      { lat: 35.6235, lon: 139.5195, altitude },
+                      { lat: 35.6253, lon: 139.5195, altitude },
+                      { lat: 35.6253, lon: 139.5221, altitude },
+                      { lat: 35.6235, lon: 139.5221, altitude },
                   ];
             viewer.replacePolygonPoints(editTargetId, next);
             // replacePolygonPoints は仕様上 labels を全 undefined にリセットするため

--- a/src/demos/polygon/index.ts
+++ b/src/demos/polygon/index.ts
@@ -285,10 +285,9 @@ const buildControls = (
             viewer.replacePolygonPoints(editTargetId, next);
             // replacePolygonPoints は仕様上 labels を全 undefined にリセットするため
             // (spec/package.md §3.3.8.2)、ラベルが消えないよう updatePolygonPoint で再付与する。
-            const labels = ["P1", "P2", "P3", "P4"];
             for (let i = 0; i < next.length; i++) {
                 viewer.updatePolygonPoint(editTargetId, i, {
-                    label: labels[i] ?? `P${i + 1}`,
+                    label: `P${i + 1}`,
                 });
             }
         }),


### PR DESCRIPTION
## 概要

ポリゴンデモの「点 replace」ボタンに関する 2 つの修正を含みます。

### 1. ラベル再付与 (主目的)

「点 replace」ボタンを押すと P1..Pn のラベルが消える挙動を修正する。

`replacePolygonPoints` は spec/package.md §3.3.8.2 のとおり「新しい点数に合わせ labels を全 undefined で再構成する。明示的にラベルを再付与するには `updatePolygonPoint` を呼び出す」と定義された意図仕様であり、ライブラリ側はそのまま。

デモでは replace 直後に各点へ `updatePolygonPoint({ label: \`P${i + 1}\` })` を呼んでラベルを再付与する。

### 2. replace ボタン座標の東シフト整合 (#180)

`yomiuri-closed` ポリゴンは 8ce975a (PR #177) で他ポリゴンと重ならないよう lon +0.006° (≒ +540m) 東側にずらされているが、replace ボタン内 `next` 配列は元の lon 139.5135–139.5170 のままだった。本 PR は main 起点で作成したため #181 の修正を継承しておらず、replace を押すと絶対座標の元位置に戻る回帰が再発していた。同じ +0.006° 東シフトを適用する。

## 変更点

- `src/demos/polygon/index.ts`:
  - 「点 replace」後に各点 `updatePolygonPoint` で `P${i + 1}` を再付与
  - `next` 配列の lon を +0.006° 東シフト (139.5195–139.5230)

## 影響

- デモの挙動のみ。型・API・spec・ユニット/VRテストへの影響なし
- lint / typecheck PASS

## 関連

- Parent: #169
- Related: #180, #181
- 仕様: spec/package.md §3.3.8.2