### PR TITLE
feat(api): add onTerrainClick (#183)

### DIFF
--- a/spec/package.md
+++ b/spec/package.md
@@ -474,6 +474,44 @@ interface JpmapTerrain {
 - `insertPolygonPoint` / `removePolygonPoint` は labels 配列の対応 index をシフトする（隣接ラベルとの整合を保つ）。
 - `replacePolygonPoints` は新しい点数に合わせ labels を全 undefined で再構成する（明示的にラベルを再付与するには `updatePolygonPoint` を呼び出す）。
 
+#### 3.3.9 地形クリック通知 (Issue #183)
+
+地形タイル上でのマウス／タッチによるクリックを購読するイベント API。距離計測など「クリックで地点を確定する」系デモ（#44）の基盤。
+
+```typescript
+interface TerrainClickEvent {
+  /** クリック地点の緯度（度） */
+  readonly lat: number;
+  /** クリック地点の経度（度） */
+  readonly lon: number;
+  /** クリック地点の標高 (m, 海抜) */
+  readonly altitude: number;
+  /** Babylon.js ワールド座標 */
+  readonly world: { readonly x: number; readonly y: number; readonly z: number };
+  /** 元の `PointerEvent`（修飾キー判定等のため） */
+  readonly pointerEvent: PointerEvent;
+}
+
+type TerrainClickListener = (event: TerrainClickEvent) => void;
+
+interface JpmapTerrain {
+  /**
+   * 地形タイル上でのクリックを購読する。
+   * 戻り値は登録解除関数（複数回呼び出しても安全）。
+   */
+  onTerrainClick(listener: TerrainClickListener): () => void;
+}
+```
+
+**仕様:**
+
+- 主ボタン (`button === 0`) のクリックのみが対象。`Ctrl` / `Cmd` 併用クリックはカメラ操作（パン中心移動）扱いのため発火しない。
+- `pointerdown` から `pointerup` までの移動量が **4 CSS px 以下** の場合のみ「クリック」とみなす。これを超えるとドラッグ扱いで発火しない。
+- `tile-ground-*` メッシュへの `scene.pick` 結果が hit したときのみ発火する。`world` には picked point、`altitude` には picked point の Y 値を採用する。
+- 同一リスナーを複数回登録した場合は登録回数分発火する。リスナーが throw しても他リスナーへ伝播せず `console.error` で握りつぶす。
+- `dispose()` 後の `onTerrainClick` は no-op。返される解除関数も no-op で安全に呼べる。
+- 登録解除関数は二重呼び出ししても throw しない。
+
 ### 3.4 型定義
 
 `CameraChangeEvent` および `CameraChangeListener` は、`jpmap-terrain` から import 可能である（パッケージエントリで re-export 済み）。
@@ -509,6 +547,9 @@ import type {
   PolygonOptions,
   PolygonUpdate,
   PolygonHandle,
+  // 地形クリック (Issue #183)
+  TerrainClickEvent,
+  TerrainClickListener,
 } from "jpmap-terrain";
 ```
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -28,4 +28,6 @@ export type {
     PolygonOptions,
     PolygonUpdate,
     PolygonHandle,
+    TerrainClickEvent,
+    TerrainClickListener,
 } from "./lib/types";

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -32,6 +32,7 @@ import {
     PolygonPointOptions,
     PolygonPointPartial,
     SUN_AUTO_UPDATE_INTERVAL_MS,
+    TerrainClickListener,
 } from "./types";
 import { createMarkerManager, type MarkerManager } from "../terrain/markerManager";
 import { createPolygonManager, type PolygonManager } from "../terrain/polygonManager";
@@ -535,6 +536,31 @@ export class JpmapTerrain {
                 console.error("[JpmapTerrain] onMapTypeChange listener threw:", err);
             }
         }
+    }
+
+    // ---- 地形クリック通知 (Issue #183) ----
+
+    /**
+     * 地形タイル上での「クリック」を購読する。
+     *
+     * - 主ボタン (`button === 0`) のみ対象。
+     * - `pointerdown` から `pointerup` までの移動量が
+     *   {@link TERRAIN_CLICK_DRAG_THRESHOLD_PX} 以下のときのみ発火する
+     *   （ドラッグやカメラ操作は発火しない）。
+     * - `Ctrl` / `Cmd` 併用クリックはカメラ操作扱いのため発火しない。
+     * - `tile-ground-*` メッシュへのヒットがない場合は発火しない。
+     * - `dispose()` 後の登録は no-op、解除関数も no-op。
+     * - リスナー throw は他リスナーに伝播せず、`console.error` で握りつぶす。
+     *
+     * @returns 登録解除関数（複数回呼んでも安全）
+     */
+    public onTerrainClick(listener: TerrainClickListener): () => void {
+        if (this._disposed || !this._controller) {
+            return () => {
+                /* no-op: viewer is already disposed or not ready */
+            };
+        }
+        return this._controller.subscribeTerrainClick(listener);
     }
 
     // ---- 太陽位置 (spec §3.3.6 / Issue #35) ----

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -545,7 +545,7 @@ export class JpmapTerrain {
      *
      * - 主ボタン (`button === 0`) のみ対象。
      * - `pointerdown` から `pointerup` までの移動量が
-     *   {@link TERRAIN_CLICK_DRAG_THRESHOLD_PX} 以下のときのみ発火する
+     *   {@link import("./types").TERRAIN_CLICK_DRAG_THRESHOLD_PX} (= 4 CSS px) 以下のときのみ発火する
      *   （ドラッグやカメラ操作は発火しない）。
      * - `Ctrl` / `Cmd` 併用クリックはカメラ操作扱いのため発火しない。
      * - `tile-ground-*` メッシュへのヒットがない場合は発火しない。

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -120,6 +120,36 @@ export type CameraChangeListener = (event: CameraChangeEvent) => void;
  */
 export type MapTypeChangeListener = (mapType: MapType) => void;
 
+// ---- 地形クリック通知 (Issue #183) ----
+
+/**
+ * `JpmapTerrain.onTerrainClick` のリスナー引数。
+ *
+ * 地形タイル上でマウス/タッチによる「クリック」（ドラッグ閾値未満の pointerdown→pointerup）
+ * が発生したときに通知される。ドラッグ操作（カメラ操作含む）では発火しない。
+ */
+export interface TerrainClickEvent {
+    /** クリック地点の緯度（度） */
+    readonly lat: number;
+    /** クリック地点の経度（度） */
+    readonly lon: number;
+    /** クリック地点の標高 (m, 海抜) */
+    readonly altitude: number;
+    /** Babylon.js ワールド座標 */
+    readonly world: { readonly x: number; readonly y: number; readonly z: number };
+    /** 元の `PointerEvent`（修飾キー判定等のため） */
+    readonly pointerEvent: PointerEvent;
+}
+
+/** `JpmapTerrain.onTerrainClick` リスナー */
+export type TerrainClickListener = (event: TerrainClickEvent) => void;
+
+/**
+ * `pointerdown` から `pointerup` までの最大移動量 (CSS px)。
+ * これを超える移動はクリックではなくドラッグとみなし、`onTerrainClick` を発火しない。
+ */
+export const TERRAIN_CLICK_DRAG_THRESHOLD_PX = 4;
+
 // ---- マーカー (Issue #167) ----
 
 export interface MarkerTextOptions {

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -749,7 +749,8 @@ export class DefaultScene implements CreateSceneClass {
             terrainClickStart = null;
             if (!start || start.pointerId !== e.pointerId) return;
             // Ctrl/Cmd 併用はカメラ操作（パン/チルト）扱いのためクリック通知しない。
-            if (start.modifier) return;
+            // pointerdown 後に修飾キー状態が変わるケースもあるため、pointerup 時点も確認する。
+            if (start.modifier || e.ctrlKey || e.metaKey) return;
             if (terrainClickListeners.length === 0) return;
             const dx = e.clientX - start.x;
             const dy = e.clientY - start.y;

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -1415,6 +1415,10 @@ export class DefaultScene implements CreateSceneClass {
             dispose: () => {
                 // ShadowGenerator が残っていれば確実に解放する (Issue #39)。
                 disableSunShadows();
+                // 地形クリックリスナー (Issue #183) も dispose 時に解放する。
+                // 解除関数を呼ばないまま dispose されたケースで、クロージャに
+                // 残ったリスナー参照経由で外部オブジェクトが解放されないのを防ぐ。
+                terrainClickListeners.length = 0;
                 // controlPanel は document.body に各 UI を直接 append しているため、
                 // ここで親要素から取り除く (T7 / Issue #121)。
                 // - compass / mapToggle は単独要素

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -21,7 +21,12 @@ import { computeSunPosition } from "../terrain/sunPosition";
 import { deriveSunState } from "../terrain/sunState";
 import { resolveTiltCollision, TILT_MAX_RADIUS_INCREASE_RATIO } from "../terrain/cameraCollision";
 import { createUiVisibilityController } from "../terrain/uiVisibility";
-import { SUN_FALLBACK_DATETIME_ISO } from "../lib/types";
+import {
+    SUN_FALLBACK_DATETIME_ISO,
+    TERRAIN_CLICK_DRAG_THRESHOLD_PX,
+    type TerrainClickEvent,
+    type TerrainClickListener,
+} from "../lib/types";
 
 const TERRAIN_SUBDIVISIONS = 128;
 const MAX_ZOOM = 18;
@@ -181,6 +186,19 @@ export interface DefaultSceneController {
 
     /** @internal MarkerManager 構築用コンテキスト (Issue #167) */
     getMarkerContext(): MarkerContext;
+
+    /**
+     * 地形タイルへのクリック通知を購読する (Issue #183)。
+     *
+     * - `pointerdown` から `pointerup` までの移動量が
+     *   {@link TERRAIN_CLICK_DRAG_THRESHOLD_PX} 以下の場合にのみ発火する。
+     * - 主ボタン (`button === 0`) のみが対象。
+     * - 修飾キー (`Ctrl`/`Cmd`) 押下時はカメラ操作のため発火しない。
+     * - クリック地点が `tile-ground-*` メッシュにヒットしなかった場合は発火しない。
+     *
+     * @returns 登録解除関数
+     */
+    subscribeTerrainClick(listener: TerrainClickListener): () => void;
 }
 
 /**
@@ -697,6 +715,80 @@ export class DefaultScene implements CreateSceneClass {
 
         canvas.addEventListener("pointercancel", resetPointerState);
         canvas.addEventListener("lostpointercapture", resetPointerState);
+
+        // ---- 地形クリック通知 (Issue #183) ----
+        //
+        // 既存の pan/rotate 用 pointer ハンドラと独立に、
+        // 「pointerdown→pointerup の間にほとんど動いていない」場合のみ
+        // 地形メッシュへの click とみなして購読リスナーへ通知する。
+        const terrainClickListeners: TerrainClickListener[] = [];
+        let terrainClickStart: {
+            pointerId: number;
+            x: number;
+            y: number;
+            modifier: boolean;
+        } | null = null;
+        canvas.addEventListener("pointerdown", (e: PointerEvent) => {
+            if (e.button !== 0) return;
+            terrainClickStart = {
+                pointerId: e.pointerId,
+                x: e.clientX,
+                y: e.clientY,
+                modifier: e.ctrlKey || e.metaKey,
+            };
+        });
+        const cancelTerrainClick = (e: PointerEvent): void => {
+            if (terrainClickStart && terrainClickStart.pointerId === e.pointerId) {
+                terrainClickStart = null;
+            }
+        };
+        canvas.addEventListener("pointercancel", cancelTerrainClick);
+        canvas.addEventListener("lostpointercapture", cancelTerrainClick);
+        canvas.addEventListener("pointerup", (e: PointerEvent) => {
+            const start = terrainClickStart;
+            terrainClickStart = null;
+            if (!start || start.pointerId !== e.pointerId) return;
+            // Ctrl/Cmd 併用はカメラ操作（パン/チルト）扱いのためクリック通知しない。
+            if (start.modifier) return;
+            if (terrainClickListeners.length === 0) return;
+            const dx = e.clientX - start.x;
+            const dy = e.clientY - start.y;
+            if (
+                Math.abs(dx) > TERRAIN_CLICK_DRAG_THRESHOLD_PX ||
+                Math.abs(dy) > TERRAIN_CLICK_DRAG_THRESHOLD_PX
+            ) {
+                return;
+            }
+            const rect = canvas.getBoundingClientRect();
+            const sx = e.clientX - rect.left;
+            const sy = e.clientY - rect.top;
+            const pick = scene.pick(sx, sy, (m) =>
+                m.name.startsWith("tile-ground-"),
+            );
+            if (!pick?.hit || !pick.pickedPoint) return;
+            const wx = pick.pickedPoint.x;
+            const wy = pick.pickedPoint.y;
+            const wz = pick.pickedPoint.z;
+            const { lat, lon } = worldToLatLon(wx, wz);
+            const event: TerrainClickEvent = {
+                lat,
+                lon,
+                altitude: wy,
+                world: { x: wx, y: wy, z: wz },
+                pointerEvent: e,
+            };
+            // iterate 中の add/remove 安全のため slice
+            for (const listener of terrainClickListeners.slice()) {
+                try {
+                    listener(event);
+                } catch (err) {
+                    console.error(
+                        "[JpmapTerrain] onTerrainClick listener threw:",
+                        err,
+                    );
+                }
+            }
+        });
 
         // ホイール / ダブルクリック: ポインタ方向にズーム
 
@@ -1368,6 +1460,16 @@ export class DefaultScene implements CreateSceneClass {
                     beta: camera.beta,
                 }),
             }),
+            subscribeTerrainClick: (listener) => {
+                terrainClickListeners.push(listener);
+                let removed = false;
+                return (): void => {
+                    if (removed) return;
+                    removed = true;
+                    const idx = terrainClickListeners.indexOf(listener);
+                    if (idx !== -1) terrainClickListeners.splice(idx, 1);
+                };
+            },
         };
         options?.onReady?.(controller);
 

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -417,6 +417,9 @@ jest.unstable_mockModule("../src/scenes/default", () => {
                 listener(event);
             }
         },
+        __resetTerrainClickListeners: (): void => {
+            terrainClickListeners.length = 0;
+        },
     };
 });
 
@@ -452,6 +455,7 @@ const sceneMockModule = (await import("../src/scenes/default")) as unknown as {
         world: { x: number; y: number; z: number };
         pointerEvent: PointerEvent;
     }) => void;
+    __resetTerrainClickListeners: () => void;
 };
 
 describe("JpmapTerrain (skeleton)", () => {
@@ -474,6 +478,8 @@ describe("JpmapTerrain (skeleton)", () => {
                 /* dispose の副作用テストでは事前に呼ばれている可能性があり、無視 */
             }
         }
+        // テスト間でモック内のリスナー残留が副作用にならないよう毎回クリアする (Issue #183)。
+        sceneMockModule.__resetTerrainClickListeners();
     });
 
     describe("create", () => {

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -176,6 +176,15 @@ jest.unstable_mockModule("../src/scenes/default", () => {
     const sunStateCalls: Array<{ dateTime: Date | null }> = [];
     // Issue #39: setSunShadows 呼び出し履歴を保持する。
     const sunShadowsCalls: boolean[] = [];
+    // Issue #183: subscribeTerrainClick の登録リスナー一覧（テストから __triggerTerrainClick で疑似発火）。
+    type TerrainClickEventLike = {
+        readonly lat: number;
+        readonly lon: number;
+        readonly altitude: number;
+        readonly world: { readonly x: number; readonly y: number; readonly z: number };
+        readonly pointerEvent: PointerEvent;
+    };
+    const terrainClickListeners: Array<(e: TerrainClickEventLike) => void> = [];
     // #136: scene.onBeforeRenderObservable のテスト用簡易実装。
     // jpmapTerrain.ts は `add(callback)` の戻り値を `Observer` として保持し、
     // dispose 時に `remove(observer)` する。テストからは `__triggerSceneRender` で
@@ -336,6 +345,18 @@ jest.unstable_mockModule("../src/scenes/default", () => {
                             beta: Math.PI / 4,
                         }),
                     }),
+                    subscribeTerrainClick: (
+                        listener: (e: TerrainClickEventLike) => void,
+                    ) => {
+                        terrainClickListeners.push(listener);
+                        let removed = false;
+                        return (): void => {
+                            if (removed) return;
+                            removed = true;
+                            const idx = terrainClickListeners.indexOf(listener);
+                            if (idx !== -1) terrainClickListeners.splice(idx, 1);
+                        };
+                    },
                     dispose: () => {
                         controllerDisposeCount++;
                     },
@@ -390,6 +411,12 @@ jest.unstable_mockModule("../src/scenes/default", () => {
             sunShadowsCalls.length = 0;
         },
         __triggerSceneRender: (): void => triggerSceneRender(),
+        __getTerrainClickListenerCount: (): number => terrainClickListeners.length,
+        __triggerTerrainClick: (event: TerrainClickEventLike): void => {
+            for (const listener of terrainClickListeners.slice()) {
+                listener(event);
+            }
+        },
     };
 });
 
@@ -417,6 +444,14 @@ const sceneMockModule = (await import("../src/scenes/default")) as unknown as {
     __getSunShadowsCalls: () => boolean[];
     __resetSunShadowsCalls: () => void;
     __triggerSceneRender: () => void;
+    __getTerrainClickListenerCount: () => number;
+    __triggerTerrainClick: (event: {
+        lat: number;
+        lon: number;
+        altitude: number;
+        world: { x: number; y: number; z: number };
+        pointerEvent: PointerEvent;
+    }) => void;
 };
 
 describe("JpmapTerrain (skeleton)", () => {
@@ -1639,6 +1674,68 @@ describe("JpmapTerrain (skeleton)", () => {
                     { lat: 35.682, lon: 139.768 },
                 ]),
             ).toThrow();
+        });
+    });
+
+    // Issue #183
+    describe("onTerrainClick", () => {
+        // jsdom には PointerEvent が無いため、必要な形だけスタブする。
+        const stubPointerEvent = (): PointerEvent =>
+            ({ shiftKey: false, ctrlKey: false } as unknown as PointerEvent);
+        const buildEvent = (overrides?: Partial<{
+            lat: number;
+            lon: number;
+            altitude: number;
+            world: { x: number; y: number; z: number };
+            pointerEvent: PointerEvent;
+        }>): {
+            lat: number;
+            lon: number;
+            altitude: number;
+            world: { x: number; y: number; z: number };
+            pointerEvent: PointerEvent;
+        } => ({
+            lat: 35.5,
+            lon: 139.5,
+            altitude: 123,
+            world: { x: 1, y: 123, z: -2 },
+            pointerEvent: stubPointerEvent(),
+            ...overrides,
+        });
+
+        it("登録したリスナーへクリック情報が通知される", async () => {
+            const viewer = await create(createMountElement());
+            const received: Array<{ lat: number; altitude: number }> = [];
+            viewer.onTerrainClick((e) => {
+                received.push({ lat: e.lat, altitude: e.altitude });
+            });
+            sceneMockModule.__triggerTerrainClick(buildEvent());
+            expect(received).toEqual([{ lat: 35.5, altitude: 123 }]);
+        });
+
+        it("unsubscribe 後はリスナーが呼ばれない", async () => {
+            const viewer = await create(createMountElement());
+            const calls: number[] = [];
+            const off = viewer.onTerrainClick(() => {
+                calls.push(1);
+            });
+            sceneMockModule.__triggerTerrainClick(buildEvent());
+            off();
+            sceneMockModule.__triggerTerrainClick(buildEvent());
+            expect(calls.length).toBe(1);
+            // 二重解除しても安全
+            expect(() => off()).not.toThrow();
+        });
+
+        it("dispose 後の onTerrainClick は no-op", async () => {
+            const viewer = await create(createMountElement());
+            viewer.dispose();
+            const calls: number[] = [];
+            const off = viewer.onTerrainClick(() => calls.push(1));
+            sceneMockModule.__triggerTerrainClick(buildEvent());
+            expect(calls.length).toBe(0);
+            // 戻り値の解除関数も no-op で throw しない
+            expect(() => off()).not.toThrow();
         });
     });
 });


### PR DESCRIPTION
<!-- Copilot Code Review: Follow .github/copilot-instructions.md. -->
<!-- Copilot Code Review: Follow AGENTS.md. -->
<!-- Copilot Code Review: Write all review comments in Japanese. -->

## 概要

地形タイル上でのクリックを購読する公開 API `JpmapTerrain.onTerrainClick` を追加した。距離計測など「クリックで地点を確定する」系デモ（#44）の基盤となる。

## 関連 Issue

Closes #183

Parent: #44

## 変更内容

- `src/lib/types.ts`: `TerrainClickEvent` / `TerrainClickListener` / `TERRAIN_CLICK_DRAG_THRESHOLD_PX` を追加
- `src/scenes/default.ts`: `DefaultSceneController.subscribeTerrainClick` を追加し、canvas に click 検出用 pointer ハンドラを実装（`pointerdown→pointerup` の移動量 ≤ 4 px、`Ctrl`/`Cmd` 併用は除外、`tile-ground-*` メッシュへの hit のみ発火）
- `src/lib/jpmapTerrain.ts`: 公開 API `onTerrainClick(listener)` を追加。`dispose()` 後は no-op、解除関数も二重呼び出し安全
- `src/lib.ts`: 新規型を re-export
- `tests/jpmapTerrain.unit.spec.ts`: 通知 / unsubscribe / dispose 後 no-op の 3 ケースを追加
- `spec/package.md`: §3.3.9（地形クリック通知）を追記、§3.4 の re-export 一覧を更新

## 動作確認方法

```shell
npm run lint
npm run typecheck
npm run test:unit
```

利用例:

```ts
const off = viewer.onTerrainClick((e) => {
    console.log(e.lat, e.lon, e.altitude, e.pointerEvent.shiftKey);
});
// 解除
off();
```

## 確認事項

- [x] Copilot レビューを日本語で実施し、指摘を修正した
- [x] `npm run test:visuals:update` は毎回実行していない
- [x] 画面表示の意図した変更がある場合のみ、開発者がスナップショットを更新した
