### PR TITLE
feat(api): add polygon point pointer interactions (#184)

### DIFF
--- a/spec/package.md
+++ b/spec/package.md
@@ -512,6 +512,55 @@ interface JpmapTerrain {
 - `dispose()` 後の `onTerrainClick` は no-op。返される解除関数も no-op で安全に呼べる。
 - 登録解除関数は二重呼び出ししても throw しない。
 
+#### 3.3.10 ポリゴン頂点インタラクション (Issue #184)
+
+ポリゴンの頂点（球体メッシュ）に対する hover / click / drag を購読するイベント API。距離計測などのデモ（#44）で頂点の編集 UI を構築するための基盤。
+
+```typescript
+interface PolygonPointPointerEvent {
+  /** 対象ポリゴンの ID */
+  readonly polygonId: string;
+  /** 頂点インデックス（0 起点） */
+  readonly index: number;
+  /** 元の `PointerEvent` */
+  readonly pointerEvent: PointerEvent;
+}
+
+interface PolygonPointDragEvent extends PolygonPointPointerEvent {
+  /** ドラッグ中カーソル直下の地形交点の緯度（地形未ヒット時 `null`） */
+  readonly lat: number | null;
+  /** ドラッグ中カーソル直下の地形交点の経度（地形未ヒット時 `null`） */
+  readonly lon: number | null;
+  /** ドラッグ中カーソル直下の地形交点の標高 m（地形未ヒット時 `null`） */
+  readonly groundAltitude: number | null;
+}
+
+type PolygonPointHoverListener = (
+  event: PolygonPointPointerEvent | null,
+) => void;
+type PolygonPointClickListener = (event: PolygonPointPointerEvent) => void;
+type PolygonPointDragListener = (event: PolygonPointDragEvent) => void;
+
+interface JpmapTerrain {
+  onPolygonPointHover(listener: PolygonPointHoverListener): () => void;
+  onPolygonPointClick(listener: PolygonPointClickListener): () => void;
+  onPolygonPointDragStart(listener: PolygonPointDragListener): () => void;
+  onPolygonPointDrag(listener: PolygonPointDragListener): () => void;
+  onPolygonPointDragEnd(listener: PolygonPointDragListener): () => void;
+}
+```
+
+**仕様:**
+
+- 対象は `polygon-${id}-point-${i}` メッシュ。`scene.pick` で hit したときのみ各イベントを発火する。
+- **hover**: 頂点に入った瞬間および対象切替時に `PolygonPointPointerEvent` を、頂点から離れた瞬間に `null` を通知する。hover 中はキャンバスのカーソルを `pointer` に切り替え、hover 解除時に空文字へ戻す。リスナーが 1 件も無いときは hover 検出を行わずカーソル変更も発生しない。
+- **click**: `pointerdown` した頂点上で `pointerup` し、かつ `pointerdown` から `pointerup` までの移動量が **3 CSS px 未満** のとき発火する。`Ctrl` / `Cmd` 併用時は従来どおりカメラ操作扱いのため発火しない。
+- **dragStart / drag / dragEnd**: 頂点 `pointerdown` 後に 3 CSS px 以上移動した時点で `dragStart` を発火し、以降の `pointermove` ごとに `drag` を発火、`pointerup` または `pointercancel` / `lostpointercapture` で `dragEnd` を発火する。`drag` / `dragStart` / `dragEnd` の `lat` / `lon` / `groundAltitude` には現在のカーソル直下の地形交点を採用し、地形未ヒット時は `null`。
+- 頂点ジェスチャ中は通常の地形クリック (#183) およびカメラ操作は抑制される。
+- リスナー未登録時は頂点メッシュの hit 判定 / カーソル変更コストも発生しない。
+- 各リスナーが throw しても他リスナーへ伝播せず `console.error` で握りつぶす。
+- `dispose()` 後の `onPolygonPoint*` は no-op。返される解除関数は二重呼び出ししても throw しない。
+
 ### 3.4 型定義
 
 `CameraChangeEvent` および `CameraChangeListener` は、`jpmap-terrain` から import 可能である（パッケージエントリで re-export 済み）。
@@ -550,6 +599,12 @@ import type {
   // 地形クリック (Issue #183)
   TerrainClickEvent,
   TerrainClickListener,
+  // ポリゴン頂点インタラクション (Issue #184)
+  PolygonPointPointerEvent,
+  PolygonPointDragEvent,
+  PolygonPointHoverListener,
+  PolygonPointClickListener,
+  PolygonPointDragListener,
 } from "jpmap-terrain";
 ```
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -30,4 +30,9 @@ export type {
     PolygonHandle,
     TerrainClickEvent,
     TerrainClickListener,
+    PolygonPointPointerEvent,
+    PolygonPointDragEvent,
+    PolygonPointHoverListener,
+    PolygonPointClickListener,
+    PolygonPointDragListener,
 } from "./lib/types";

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -33,6 +33,9 @@ import {
     PolygonPointPartial,
     SUN_AUTO_UPDATE_INTERVAL_MS,
     TerrainClickListener,
+    PolygonPointHoverListener,
+    PolygonPointClickListener,
+    PolygonPointDragListener,
 } from "./types";
 import { createMarkerManager, type MarkerManager } from "../terrain/markerManager";
 import { createPolygonManager, type PolygonManager } from "../terrain/polygonManager";
@@ -561,6 +564,81 @@ export class JpmapTerrain {
             };
         }
         return this._controller.subscribeTerrainClick(listener);
+    }
+
+    // ---- ポリゴン頂点インタラクション (Issue #184) ----
+
+    /**
+     * ポリゴン頂点上の hover を購読する。リスナーは頂点に入った/対象切替時に
+     * `{ polygonId, index, pointerEvent }` を、頂点から離れたときに `null` を受け取る。
+     * hover 中はカーソルが自動的に `pointer` に切り替わり、解除時に空文字へ戻る。
+     */
+    public onPolygonPointHover(
+        listener: PolygonPointHoverListener,
+    ): () => void {
+        if (this._disposed || !this._controller) {
+            return () => {
+                /* no-op */
+            };
+        }
+        return this._controller.subscribePolygonPointHover(listener);
+    }
+
+    /**
+     * ポリゴン頂点上のクリックを購読する。
+     * `pointerdown` から `pointerup` までの移動量が
+     * {@link import("./types").POLYGON_POINT_DRAG_THRESHOLD_PX} (= 3 CSS px) 未満のとき発火する。
+     * 修飾キー `Ctrl` / `Cmd` 併用時はカメラ操作のため発火しない。
+     */
+    public onPolygonPointClick(
+        listener: PolygonPointClickListener,
+    ): () => void {
+        if (this._disposed || !this._controller) {
+            return () => {
+                /* no-op */
+            };
+        }
+        return this._controller.subscribePolygonPointClick(listener);
+    }
+
+    /** ポリゴン頂点ドラッグ開始 (#184)。閾値は 3 CSS px。 */
+    public onPolygonPointDragStart(
+        listener: PolygonPointDragListener,
+    ): () => void {
+        if (this._disposed || !this._controller) {
+            return () => {
+                /* no-op */
+            };
+        }
+        return this._controller.subscribePolygonPointDragStart(listener);
+    }
+
+    /**
+     * ポリゴン頂点ドラッグ中（`pointermove` 毎） (#184)。
+     * カーソル位置の地形メッシュ交点を `lat` / `lon` / `groundAltitude` で通知する
+     * （地形にヒットしなかった場合は `null`）。
+     */
+    public onPolygonPointDrag(
+        listener: PolygonPointDragListener,
+    ): () => void {
+        if (this._disposed || !this._controller) {
+            return () => {
+                /* no-op */
+            };
+        }
+        return this._controller.subscribePolygonPointDrag(listener);
+    }
+
+    /** ポリゴン頂点ドラッグ終了 (#184)。`pointerup` または `pointercancel` で発火する。 */
+    public onPolygonPointDragEnd(
+        listener: PolygonPointDragListener,
+    ): () => void {
+        if (this._disposed || !this._controller) {
+            return () => {
+                /* no-op */
+            };
+        }
+        return this._controller.subscribePolygonPointDragEnd(listener);
     }
 
     // ---- 太陽位置 (spec §3.3.6 / Issue #35) ----

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -150,6 +150,58 @@ export type TerrainClickListener = (event: TerrainClickEvent) => void;
  */
 export const TERRAIN_CLICK_DRAG_THRESHOLD_PX = 4;
 
+// ---- ポリゴン頂点インタラクション (Issue #184) ----
+
+/**
+ * ポリゴン頂点上のポインタイベント共通ペイロード。
+ *
+ * `JpmapTerrain.onPolygonPointHover` / `onPolygonPointClick` /
+ * `onPolygonPointDragStart` / `onPolygonPointDrag` / `onPolygonPointDragEnd`
+ * のリスナー引数として共通利用される。
+ */
+export interface PolygonPointPointerEvent {
+    /** 対象ポリゴンの id */
+    readonly polygonId: string;
+    /** 対象頂点の index（0-based） */
+    readonly index: number;
+    /** 元の `PointerEvent`（`shiftKey` / `ctrlKey` / `button` 判定等） */
+    readonly pointerEvent: PointerEvent;
+}
+
+/**
+ * ポリゴン頂点ドラッグ中のペイロード。
+ *
+ * カーソル位置の地形メッシュとの交点に基づく lat/lon と地表標高を含む。
+ * 地形にヒットしなかった場合は `lat`/`lon`/`groundAltitude` が `null`。
+ */
+export interface PolygonPointDragEvent extends PolygonPointPointerEvent {
+    /** カーソル位置の地形メッシュ交点の緯度（ヒットなしのとき null） */
+    readonly lat: number | null;
+    /** カーソル位置の地形メッシュ交点の経度（ヒットなしのとき null） */
+    readonly lon: number | null;
+    /** カーソル位置の地表標高 (m, ヒットなしのとき null) */
+    readonly groundAltitude: number | null;
+}
+
+/** `onPolygonPointHover` リスナー（hover 解除時は `null` で呼ばれる） */
+export type PolygonPointHoverListener = (
+    event: PolygonPointPointerEvent | null,
+) => void;
+
+/** `onPolygonPointClick` リスナー */
+export type PolygonPointClickListener = (
+    event: PolygonPointPointerEvent,
+) => void;
+
+/** `onPolygonPointDragStart` / `onPolygonPointDrag` / `onPolygonPointDragEnd` リスナー */
+export type PolygonPointDragListener = (event: PolygonPointDragEvent) => void;
+
+/**
+ * `pointerdown` から開始し、ドラッグ判定に必要な最小移動量 (CSS px)。
+ * これ未満の移動量で pointerup した場合は click 扱いとなる。
+ */
+export const POLYGON_POINT_DRAG_THRESHOLD_PX = 3;
+
 // ---- マーカー (Issue #167) ----
 
 export interface MarkerTextOptions {

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -745,6 +745,12 @@ export class DefaultScene implements CreateSceneClass {
                         dragging: false,
                     };
                     canvas.setPointerCapture(e.pointerId);
+                    // 同じ canvas に登録されている後続 pointerdown リスナー
+                    // （地形クリック追跡 #183 など）まで伝播させると、頂点
+                    // ジェスチャと並行して onTerrainClick が発火しうる。仕様
+                    // どおり頂点ジェスチャ中はそれらを完全に抑制するため、
+                    // 同イベントの後続リスナーへの配送を止める。
+                    e.stopImmediatePropagation();
                     return;
                 }
             }

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -813,8 +813,8 @@ export class DefaultScene implements CreateSceneClass {
                     const dx = e.clientX - polygonPointGesture.startClientX;
                     const dy = e.clientY - polygonPointGesture.startClientY;
                     if (
-                        Math.abs(dx) > POLYGON_POINT_DRAG_THRESHOLD_PX ||
-                        Math.abs(dy) > POLYGON_POINT_DRAG_THRESHOLD_PX
+                        Math.abs(dx) >= POLYGON_POINT_DRAG_THRESHOLD_PX ||
+                        Math.abs(dy) >= POLYGON_POINT_DRAG_THRESHOLD_PX
                     ) {
                         polygonPointGesture.dragging = true;
                         const ground = computeDragGroundHit(sx, sy);

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -1769,6 +1769,10 @@ export class DefaultScene implements CreateSceneClass {
                 polygonPointDragStartListeners.length = 0;
                 polygonPointDragListeners.length = 0;
                 polygonPointDragEndListeners.length = 0;
+                // hover カーソル/状態も元に戻す。dispose 時点で hover 中だった
+                // 場合に canvas.style.cursor = 'pointer' が残らないようにする。
+                polygonPointHoverState = null;
+                canvas.style.cursor = "";
                 // controlPanel は document.body に各 UI を直接 append しているため、
                 // ここで親要素から取り除く (T7 / Issue #121)。
                 // - compass / mapToggle は単独要素
@@ -1825,8 +1829,23 @@ export class DefaultScene implements CreateSceneClass {
                     if (idx !== -1) terrainClickListeners.splice(idx, 1);
                 };
             },
-            subscribePolygonPointHover: (listener) =>
-                subscribe(polygonPointHoverListeners, listener),
+            subscribePolygonPointHover: (listener) => {
+                polygonPointHoverListeners.push(listener);
+                let removed = false;
+                return (): void => {
+                    if (removed) return;
+                    removed = true;
+                    const idx = polygonPointHoverListeners.indexOf(listener);
+                    if (idx !== -1) polygonPointHoverListeners.splice(idx, 1);
+                    // 最後の hover リスナーが解除されたタイミングで、以後の
+                    // pointermove では hover 検出が走らずカーソルが pointer の
+                    // まま残り得る。明示的にクリアして元の状態へ戻す。
+                    if (polygonPointHoverListeners.length === 0) {
+                        polygonPointHoverState = null;
+                        canvas.style.cursor = "";
+                    }
+                };
+            },
             subscribePolygonPointClick: (listener) =>
                 subscribe(polygonPointClickListeners, listener),
             subscribePolygonPointDragStart: (listener) =>

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -979,16 +979,33 @@ export class DefaultScene implements CreateSceneClass {
                         "onPolygonPointDragEnd",
                     );
                 } else {
-                    const clickEvent: PolygonPointPointerEvent = {
-                        polygonId: gesture.polygonId,
-                        index: gesture.index,
-                        pointerEvent: e,
-                    };
-                    dispatchPointEvent(
-                        polygonPointClickListeners,
-                        clickEvent,
-                        "onPolygonPointClick",
-                    );
+                    // pointerup 時点で修飾キーが押下されていればカメラ操作扱い
+                    // とし、click を発火しない（terrain click と同じポリシー）。
+                    // また、pointerup 位置が pointerdown と同じ頂点上にあることを
+                    // 再確認し、別頂点上や頂点外での click 誤発火を抑止する。
+                    if (e.ctrlKey || e.metaKey) {
+                        return;
+                    }
+                    const rect = canvas.getBoundingClientRect();
+                    const sx = e.clientX - rect.left;
+                    const sy = e.clientY - rect.top;
+                    const pickedPoint = pickPolygonPoint(sx, sy);
+                    if (
+                        pickedPoint &&
+                        pickedPoint.polygonId === gesture.polygonId &&
+                        pickedPoint.index === gesture.index
+                    ) {
+                        const clickEvent: PolygonPointPointerEvent = {
+                            polygonId: gesture.polygonId,
+                            index: gesture.index,
+                            pointerEvent: e,
+                        };
+                        dispatchPointEvent(
+                            polygonPointClickListeners,
+                            clickEvent,
+                            "onPolygonPointClick",
+                        );
+                    }
                 }
                 return;
             }

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -1026,13 +1026,18 @@ export class DefaultScene implements CreateSceneClass {
                 const gesture = polygonPointGesture;
                 polygonPointGesture = null;
                 if (gesture.dragging && e) {
+                    // spec/package.md §3.3.10: dragEnd も「現在カーソル直下の
+                    // 地形交点」を採用する。pointercancel / lostpointercapture
+                    // 経由でも実イベント座標を解決し直して通知する。
+                    const rect = canvas.getBoundingClientRect();
+                    const sx = e.clientX - rect.left;
+                    const sy = e.clientY - rect.top;
+                    const ground = computeDragGroundHit(sx, sy);
                     const endEvent: PolygonPointDragEvent = {
                         polygonId: gesture.polygonId,
                         index: gesture.index,
                         pointerEvent: e,
-                        lat: null,
-                        lon: null,
-                        groundAltitude: null,
+                        ...ground,
                     };
                     dispatchDragEvent(
                         polygonPointDragEndListeners,

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -24,8 +24,14 @@ import { createUiVisibilityController } from "../terrain/uiVisibility";
 import {
     SUN_FALLBACK_DATETIME_ISO,
     TERRAIN_CLICK_DRAG_THRESHOLD_PX,
+    POLYGON_POINT_DRAG_THRESHOLD_PX,
     type TerrainClickEvent,
     type TerrainClickListener,
+    type PolygonPointPointerEvent,
+    type PolygonPointDragEvent,
+    type PolygonPointHoverListener,
+    type PolygonPointClickListener,
+    type PolygonPointDragListener,
 } from "../lib/types";
 
 const TERRAIN_SUBDIVISIONS = 128;
@@ -199,6 +205,34 @@ export interface DefaultSceneController {
      * @returns 登録解除関数
      */
     subscribeTerrainClick(listener: TerrainClickListener): () => void;
+
+    /**
+     * ポリゴン頂点上の hover 通知を購読する (Issue #184)。
+     * リスナーは hover 開始/対象切替時にイベントを、hover 解除時に `null` を受け取る。
+     */
+    subscribePolygonPointHover(
+        listener: PolygonPointHoverListener,
+    ): () => void;
+    /**
+     * ポリゴン頂点上の click 通知を購読する (Issue #184)。
+     * `pointerdown` → `pointerup` の移動量が
+     * {@link POLYGON_POINT_DRAG_THRESHOLD_PX} 未満のときのみ発火する。
+     */
+    subscribePolygonPointClick(
+        listener: PolygonPointClickListener,
+    ): () => void;
+    /** 頂点ドラッグ開始 (Issue #184) */
+    subscribePolygonPointDragStart(
+        listener: PolygonPointDragListener,
+    ): () => void;
+    /** 頂点ドラッグ中（移動毎） (Issue #184) */
+    subscribePolygonPointDrag(
+        listener: PolygonPointDragListener,
+    ): () => void;
+    /** 頂点ドラッグ終了 (Issue #184) */
+    subscribePolygonPointDragEnd(
+        listener: PolygonPointDragListener,
+    ): () => void;
 }
 
 /**
@@ -559,6 +593,126 @@ export class DefaultScene implements CreateSceneClass {
         let dragAnchorLat = 0;
         let dragAnchorLon = 0;
 
+        // ---- ポリゴン頂点インタラクション (Issue #184) ----
+        const polygonPointHoverListeners: PolygonPointHoverListener[] = [];
+        const polygonPointClickListeners: PolygonPointClickListener[] = [];
+        const polygonPointDragStartListeners: PolygonPointDragListener[] = [];
+        const polygonPointDragListeners: PolygonPointDragListener[] = [];
+        const polygonPointDragEndListeners: PolygonPointDragListener[] = [];
+        const POLYGON_POINT_NAME_RE = /^polygon-(.+)-point-(\d+)$/;
+        const pickPolygonPoint = (
+            sx: number,
+            sy: number,
+        ): { polygonId: string; index: number } | null => {
+            const pick = scene.pick(
+                sx,
+                sy,
+                (m) => POLYGON_POINT_NAME_RE.test(m.name),
+            );
+            if (!pick?.hit || !pick.pickedMesh) return null;
+            const match = POLYGON_POINT_NAME_RE.exec(pick.pickedMesh.name);
+            if (!match) return null;
+            return { polygonId: match[1], index: parseInt(match[2], 10) };
+        };
+        /** 頂点ドラッグ中のカーソル位置から地形交点を解決する */
+        const computeDragGroundHit = (
+            sx: number,
+            sy: number,
+        ): {
+            lat: number | null;
+            lon: number | null;
+            groundAltitude: number | null;
+        } => {
+            const pick = scene.pick(sx, sy, (m) =>
+                m.name.startsWith("tile-ground-"),
+            );
+            if (!pick?.hit || !pick.pickedPoint) {
+                return { lat: null, lon: null, groundAltitude: null };
+            }
+            const { lat, lon } = worldToLatLon(
+                pick.pickedPoint.x,
+                pick.pickedPoint.z,
+            );
+            return { lat, lon, groundAltitude: pick.pickedPoint.y };
+        };
+        const hasPolygonPointGestureListeners = (): boolean =>
+            polygonPointClickListeners.length > 0 ||
+            polygonPointDragStartListeners.length > 0 ||
+            polygonPointDragListeners.length > 0 ||
+            polygonPointDragEndListeners.length > 0;
+        let polygonPointGesture:
+            | {
+                  pointerId: number;
+                  polygonId: string;
+                  index: number;
+                  startClientX: number;
+                  startClientY: number;
+                  dragging: boolean;
+              }
+            | null = null;
+        let polygonPointHoverState: { polygonId: string; index: number } | null =
+            null;
+        const dispatchHoverListeners = (
+            event: PolygonPointPointerEvent | null,
+        ): void => {
+            for (const l of polygonPointHoverListeners.slice()) {
+                try {
+                    l(event);
+                } catch (err) {
+                    console.error(
+                        "[JpmapTerrain] onPolygonPointHover listener threw:",
+                        err,
+                    );
+                }
+            }
+        };
+        const dispatchPointEvent = (
+            listeners: PolygonPointClickListener[],
+            event: PolygonPointPointerEvent,
+            label: string,
+        ): void => {
+            for (const l of listeners.slice()) {
+                try {
+                    l(event);
+                } catch (err) {
+                    console.error(
+                        `[JpmapTerrain] ${label} listener threw:`,
+                        err,
+                    );
+                }
+            }
+        };
+        const dispatchDragEvent = (
+            listeners: PolygonPointDragListener[],
+            event: PolygonPointDragEvent,
+            label: string,
+        ): void => {
+            for (const l of listeners.slice()) {
+                try {
+                    l(event);
+                } catch (err) {
+                    console.error(
+                        `[JpmapTerrain] ${label} listener threw:`,
+                        err,
+                    );
+                }
+            }
+        };
+        /** 汎用 subscribe ヘルパ。配列に listener を追加し、解除関数を返す (#184) */
+        const subscribe = <T>(
+            listeners: T[],
+            listener: T,
+        ): (() => void) => {
+            listeners.push(listener);
+            let removed = false;
+            return (): void => {
+                if (removed) return;
+                removed = true;
+                const idx = listeners.indexOf(listener);
+                if (idx !== -1) listeners.splice(idx, 1);
+            };
+        };
+
         /** ワールド座標(wx, wz)を現在のgrid基準で緯度経度に変換 */
         const worldToLatLon = (wx: number, wz: number): { lat: number; lon: number } => {
             const metersPerDegreeLon = METERS_PER_DEGREE_LAT * Math.cos((currentLat * Math.PI) / 180);
@@ -571,6 +725,29 @@ export class DefaultScene implements CreateSceneClass {
 
         canvas.addEventListener("pointerdown", (e: PointerEvent) => {
             if (e.button !== 0) return;
+            // 頂点インタラクション (#184): 頂点 mesh 上の主ボタン pointerdown は
+            // ドラッグ/クリックジェスチャに切り替え、既存のカメラ操作には進めない。
+            if (
+                hasPolygonPointGestureListeners() &&
+                !(e.ctrlKey || e.metaKey)
+            ) {
+                const rect = canvas.getBoundingClientRect();
+                const sx = e.clientX - rect.left;
+                const sy = e.clientY - rect.top;
+                const hit = pickPolygonPoint(sx, sy);
+                if (hit) {
+                    polygonPointGesture = {
+                        pointerId: e.pointerId,
+                        polygonId: hit.polygonId,
+                        index: hit.index,
+                        startClientX: e.clientX,
+                        startClientY: e.clientY,
+                        dragging: false,
+                    };
+                    canvas.setPointerCapture(e.pointerId);
+                    return;
+                }
+            }
             pointerDown = true;
             lastPointerX = e.clientX;
             lastPointerY = e.clientY;
@@ -621,6 +798,80 @@ export class DefaultScene implements CreateSceneClass {
         });
 
         canvas.addEventListener("pointermove", (e: PointerEvent) => {
+            // 頂点インタラクション (#184) のジェスチャ進行中はカメラ操作に進めない
+            if (polygonPointGesture && polygonPointGesture.pointerId === e.pointerId) {
+                const rect = canvas.getBoundingClientRect();
+                const sx = e.clientX - rect.left;
+                const sy = e.clientY - rect.top;
+                if (!polygonPointGesture.dragging) {
+                    const dx = e.clientX - polygonPointGesture.startClientX;
+                    const dy = e.clientY - polygonPointGesture.startClientY;
+                    if (
+                        Math.abs(dx) > POLYGON_POINT_DRAG_THRESHOLD_PX ||
+                        Math.abs(dy) > POLYGON_POINT_DRAG_THRESHOLD_PX
+                    ) {
+                        polygonPointGesture.dragging = true;
+                        const ground = computeDragGroundHit(sx, sy);
+                        const startEvent: PolygonPointDragEvent = {
+                            polygonId: polygonPointGesture.polygonId,
+                            index: polygonPointGesture.index,
+                            pointerEvent: e,
+                            ...ground,
+                        };
+                        dispatchDragEvent(
+                            polygonPointDragStartListeners,
+                            startEvent,
+                            "onPolygonPointDragStart",
+                        );
+                    }
+                }
+                if (polygonPointGesture.dragging) {
+                    const ground = computeDragGroundHit(sx, sy);
+                    const dragEvent: PolygonPointDragEvent = {
+                        polygonId: polygonPointGesture.polygonId,
+                        index: polygonPointGesture.index,
+                        pointerEvent: e,
+                        ...ground,
+                    };
+                    dispatchDragEvent(
+                        polygonPointDragListeners,
+                        dragEvent,
+                        "onPolygonPointDrag",
+                    );
+                }
+                return;
+            }
+
+            // hover 検出 (#184): pointer が押下されておらず、リスナーが存在するときのみ
+            if (
+                !pointerDown &&
+                polygonPointHoverListeners.length > 0
+            ) {
+                const rect = canvas.getBoundingClientRect();
+                const sx = e.clientX - rect.left;
+                const sy = e.clientY - rect.top;
+                const hit = pickPolygonPoint(sx, sy);
+                if (hit) {
+                    if (
+                        !polygonPointHoverState ||
+                        polygonPointHoverState.polygonId !== hit.polygonId ||
+                        polygonPointHoverState.index !== hit.index
+                    ) {
+                        polygonPointHoverState = hit;
+                        canvas.style.cursor = "pointer";
+                        dispatchHoverListeners({
+                            polygonId: hit.polygonId,
+                            index: hit.index,
+                            pointerEvent: e,
+                        });
+                    }
+                } else if (polygonPointHoverState !== null) {
+                    polygonPointHoverState = null;
+                    canvas.style.cursor = "";
+                    dispatchHoverListeners(null);
+                }
+            }
+
             if (!pointerDown || e.pointerId !== activePointerId) return;
 
             if (e.ctrlKey || e.metaKey) {
@@ -697,6 +948,44 @@ export class DefaultScene implements CreateSceneClass {
         });
 
         canvas.addEventListener("pointerup", (e: PointerEvent) => {
+            // 頂点インタラクション (#184): ジェスチャ進行中の up は click / dragEnd を発火する
+            if (
+                polygonPointGesture &&
+                polygonPointGesture.pointerId === e.pointerId
+            ) {
+                const gesture = polygonPointGesture;
+                polygonPointGesture = null;
+                canvas.releasePointerCapture(e.pointerId);
+                if (gesture.dragging) {
+                    const rect = canvas.getBoundingClientRect();
+                    const sx = e.clientX - rect.left;
+                    const sy = e.clientY - rect.top;
+                    const ground = computeDragGroundHit(sx, sy);
+                    const endEvent: PolygonPointDragEvent = {
+                        polygonId: gesture.polygonId,
+                        index: gesture.index,
+                        pointerEvent: e,
+                        ...ground,
+                    };
+                    dispatchDragEvent(
+                        polygonPointDragEndListeners,
+                        endEvent,
+                        "onPolygonPointDragEnd",
+                    );
+                } else {
+                    const clickEvent: PolygonPointPointerEvent = {
+                        polygonId: gesture.polygonId,
+                        index: gesture.index,
+                        pointerEvent: e,
+                    };
+                    dispatchPointEvent(
+                        polygonPointClickListeners,
+                        clickEvent,
+                        "onPolygonPointClick",
+                    );
+                }
+                return;
+            }
             if (e.pointerId !== activePointerId) return;
             pointerDown = false;
             canvas.releasePointerCapture(e.pointerId);
@@ -704,17 +993,41 @@ export class DefaultScene implements CreateSceneClass {
             retargetAtCameraPosition(camera.position.x, camera.position.y, camera.position.z);
         });
 
-        const resetPointerState = (): void => {
+        const resetPointerState = (e?: PointerEvent): void => {
             pointerDown = false;
             activePointerId = -1;
             dragAnchor = null;
             dragMeshMode = false;
+            // 頂点ジェスチャも併せて中断する (#184)
+            if (polygonPointGesture && (!e || polygonPointGesture.pointerId === e.pointerId)) {
+                const gesture = polygonPointGesture;
+                polygonPointGesture = null;
+                if (gesture.dragging && e) {
+                    const endEvent: PolygonPointDragEvent = {
+                        polygonId: gesture.polygonId,
+                        index: gesture.index,
+                        pointerEvent: e,
+                        lat: null,
+                        lon: null,
+                        groundAltitude: null,
+                    };
+                    dispatchDragEvent(
+                        polygonPointDragEndListeners,
+                        endEvent,
+                        "onPolygonPointDragEnd",
+                    );
+                }
+            }
             commitPanOffset();
             retargetAtCameraPosition(camera.position.x, camera.position.y, camera.position.z);
         };
 
-        canvas.addEventListener("pointercancel", resetPointerState);
-        canvas.addEventListener("lostpointercapture", resetPointerState);
+        canvas.addEventListener("pointercancel", (e: PointerEvent) =>
+            resetPointerState(e),
+        );
+        canvas.addEventListener("lostpointercapture", (e: PointerEvent) =>
+            resetPointerState(e),
+        );
 
         // ---- 地形クリック通知 (Issue #183) ----
         //
@@ -868,8 +1181,11 @@ export class DefaultScene implements CreateSceneClass {
             sx: number,
             sy: number
         ): { worldX: number; worldZ: number } | null => {
-            // scene.pick() は内部で DPR スケーリングを行うため CSS 座標をそのまま渡す
-            const pick = scene.pick(sx, sy);
+            // scene.pick() は内部で DPR スケーリングを行うため CSS 座標をそのまま渡す。
+            // 頂点メッシュ等が pickable な場合はノイズになるため、地形メッシュに限定する (#184)。
+            const pick = scene.pick(sx, sy, (m) =>
+                m.name.startsWith("tile-ground-"),
+            );
             if (pick?.hit && pick.pickedPoint) {
                 return {
                     worldX: pick.pickedPoint.x,
@@ -1419,6 +1735,12 @@ export class DefaultScene implements CreateSceneClass {
                 // 解除関数を呼ばないまま dispose されたケースで、クロージャに
                 // 残ったリスナー参照経由で外部オブジェクトが解放されないのを防ぐ。
                 terrainClickListeners.length = 0;
+                // 頂点インタラクションのリスナー (Issue #184) も同様にクリアする。
+                polygonPointHoverListeners.length = 0;
+                polygonPointClickListeners.length = 0;
+                polygonPointDragStartListeners.length = 0;
+                polygonPointDragListeners.length = 0;
+                polygonPointDragEndListeners.length = 0;
                 // controlPanel は document.body に各 UI を直接 append しているため、
                 // ここで親要素から取り除く (T7 / Issue #121)。
                 // - compass / mapToggle は単独要素
@@ -1475,6 +1797,16 @@ export class DefaultScene implements CreateSceneClass {
                     if (idx !== -1) terrainClickListeners.splice(idx, 1);
                 };
             },
+            subscribePolygonPointHover: (listener) =>
+                subscribe(polygonPointHoverListeners, listener),
+            subscribePolygonPointClick: (listener) =>
+                subscribe(polygonPointClickListeners, listener),
+            subscribePolygonPointDragStart: (listener) =>
+                subscribe(polygonPointDragStartListeners, listener),
+            subscribePolygonPointDrag: (listener) =>
+                subscribe(polygonPointDragListeners, listener),
+            subscribePolygonPointDragEnd: (listener) =>
+                subscribe(polygonPointDragEndListeners, listener),
         };
         options?.onReady?.(controller);
 

--- a/src/terrain/polygon.ts
+++ b/src/terrain/polygon.ts
@@ -144,7 +144,10 @@ const createPointSphere = (
     material.alpha = style.pointOpacity;
     mesh.material = material;
     mesh.renderingGroupId = RENDERING_GROUP_ID;
-    mesh.isPickable = false;
+    // 頂点インタラクション API (#184) のため pickable にする。
+    // 名前 `polygon-${id}-point-${i}` を `JpmapTerrain.onPolygonPoint*` 側でパースして
+    // polygonId / index を解決する。
+    mesh.isPickable = true;
     mesh.parent = parent;
     return { mesh, material };
 };

--- a/src/terrain/polygon.ts
+++ b/src/terrain/polygon.ts
@@ -145,8 +145,8 @@ const createPointSphere = (
     mesh.material = material;
     mesh.renderingGroupId = RENDERING_GROUP_ID;
     // 頂点インタラクション API (#184) のため pickable にする。
-    // 名前 `polygon-${id}-point-${i}` を `JpmapTerrain.onPolygonPoint*` 側でパースして
-    // polygonId / index を解決する。
+    // 名前 `polygon-${id}-point-${index}` は DefaultScene 側の
+    // `pickPolygonPoint` でパースされ、polygonId / index の解決に使われる。
     mesh.isPickable = true;
     mesh.parent = parent;
     return { mesh, material };

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -185,6 +185,42 @@ jest.unstable_mockModule("../src/scenes/default", () => {
         readonly pointerEvent: PointerEvent;
     };
     const terrainClickListeners: Array<(e: TerrainClickEventLike) => void> = [];
+    // Issue #184: 頂点インタラクション API のリスナー一覧。
+    type PolygonPointPointerEventLike = {
+        readonly polygonId: string;
+        readonly index: number;
+        readonly pointerEvent: PointerEvent;
+    };
+    type PolygonPointDragEventLike = PolygonPointPointerEventLike & {
+        readonly lat: number | null;
+        readonly lon: number | null;
+        readonly groundAltitude: number | null;
+    };
+    const polygonPointHoverListeners: Array<
+        (e: PolygonPointPointerEventLike | null) => void
+    > = [];
+    const polygonPointClickListeners: Array<
+        (e: PolygonPointPointerEventLike) => void
+    > = [];
+    const polygonPointDragStartListeners: Array<
+        (e: PolygonPointDragEventLike) => void
+    > = [];
+    const polygonPointDragListeners: Array<
+        (e: PolygonPointDragEventLike) => void
+    > = [];
+    const polygonPointDragEndListeners: Array<
+        (e: PolygonPointDragEventLike) => void
+    > = [];
+    const subscribeStub = <T>(arr: T[], listener: T): (() => void) => {
+        arr.push(listener);
+        let removed = false;
+        return (): void => {
+            if (removed) return;
+            removed = true;
+            const idx = arr.indexOf(listener);
+            if (idx !== -1) arr.splice(idx, 1);
+        };
+    };
     // #136: scene.onBeforeRenderObservable のテスト用簡易実装。
     // jpmapTerrain.ts は `add(callback)` の戻り値を `Observer` として保持し、
     // dispose 時に `remove(observer)` する。テストからは `__triggerSceneRender` で
@@ -357,6 +393,21 @@ jest.unstable_mockModule("../src/scenes/default", () => {
                             if (idx !== -1) terrainClickListeners.splice(idx, 1);
                         };
                     },
+                    subscribePolygonPointHover: (
+                        listener: (e: PolygonPointPointerEventLike | null) => void,
+                    ) => subscribeStub(polygonPointHoverListeners, listener),
+                    subscribePolygonPointClick: (
+                        listener: (e: PolygonPointPointerEventLike) => void,
+                    ) => subscribeStub(polygonPointClickListeners, listener),
+                    subscribePolygonPointDragStart: (
+                        listener: (e: PolygonPointDragEventLike) => void,
+                    ) => subscribeStub(polygonPointDragStartListeners, listener),
+                    subscribePolygonPointDrag: (
+                        listener: (e: PolygonPointDragEventLike) => void,
+                    ) => subscribeStub(polygonPointDragListeners, listener),
+                    subscribePolygonPointDragEnd: (
+                        listener: (e: PolygonPointDragEventLike) => void,
+                    ) => subscribeStub(polygonPointDragEndListeners, listener),
                     dispose: () => {
                         controllerDisposeCount++;
                     },
@@ -420,6 +471,39 @@ jest.unstable_mockModule("../src/scenes/default", () => {
         __resetTerrainClickListeners: (): void => {
             terrainClickListeners.length = 0;
         },
+        // Issue #184
+        __triggerPolygonPointHover: (
+            event: PolygonPointPointerEventLike | null,
+        ): void => {
+            for (const l of polygonPointHoverListeners.slice()) l(event);
+        },
+        __triggerPolygonPointClick: (
+            event: PolygonPointPointerEventLike,
+        ): void => {
+            for (const l of polygonPointClickListeners.slice()) l(event);
+        },
+        __triggerPolygonPointDragStart: (
+            event: PolygonPointDragEventLike,
+        ): void => {
+            for (const l of polygonPointDragStartListeners.slice()) l(event);
+        },
+        __triggerPolygonPointDrag: (
+            event: PolygonPointDragEventLike,
+        ): void => {
+            for (const l of polygonPointDragListeners.slice()) l(event);
+        },
+        __triggerPolygonPointDragEnd: (
+            event: PolygonPointDragEventLike,
+        ): void => {
+            for (const l of polygonPointDragEndListeners.slice()) l(event);
+        },
+        __resetPolygonPointListeners: (): void => {
+            polygonPointHoverListeners.length = 0;
+            polygonPointClickListeners.length = 0;
+            polygonPointDragStartListeners.length = 0;
+            polygonPointDragListeners.length = 0;
+            polygonPointDragEndListeners.length = 0;
+        },
     };
 });
 
@@ -456,6 +540,41 @@ const sceneMockModule = (await import("../src/scenes/default")) as unknown as {
         pointerEvent: PointerEvent;
     }) => void;
     __resetTerrainClickListeners: () => void;
+    __triggerPolygonPointHover: (event: {
+        polygonId: string;
+        index: number;
+        pointerEvent: PointerEvent;
+    } | null) => void;
+    __triggerPolygonPointClick: (event: {
+        polygonId: string;
+        index: number;
+        pointerEvent: PointerEvent;
+    }) => void;
+    __triggerPolygonPointDragStart: (event: {
+        polygonId: string;
+        index: number;
+        pointerEvent: PointerEvent;
+        lat: number | null;
+        lon: number | null;
+        groundAltitude: number | null;
+    }) => void;
+    __triggerPolygonPointDrag: (event: {
+        polygonId: string;
+        index: number;
+        pointerEvent: PointerEvent;
+        lat: number | null;
+        lon: number | null;
+        groundAltitude: number | null;
+    }) => void;
+    __triggerPolygonPointDragEnd: (event: {
+        polygonId: string;
+        index: number;
+        pointerEvent: PointerEvent;
+        lat: number | null;
+        lon: number | null;
+        groundAltitude: number | null;
+    }) => void;
+    __resetPolygonPointListeners: () => void;
 };
 
 describe("JpmapTerrain (skeleton)", () => {
@@ -480,6 +599,8 @@ describe("JpmapTerrain (skeleton)", () => {
         }
         // テスト間でモック内のリスナー残留が副作用にならないよう毎回クリアする (Issue #183)。
         sceneMockModule.__resetTerrainClickListeners();
+        // Issue #184: 頂点インタラクションのリスナーも同様にクリアする。
+        sceneMockModule.__resetPolygonPointListeners();
     });
 
     describe("create", () => {
@@ -1742,6 +1863,110 @@ describe("JpmapTerrain (skeleton)", () => {
             expect(calls.length).toBe(0);
             // 戻り値の解除関数も no-op で throw しない
             expect(() => off()).not.toThrow();
+        });
+    });
+
+    // Issue #184: ポリゴン頂点インタラクション API
+    describe("onPolygonPoint*", () => {
+        const stubPointerEvent = (): PointerEvent =>
+            ({ shiftKey: false, ctrlKey: false } as unknown as PointerEvent);
+        const buildPointer = (
+            overrides?: Partial<{ polygonId: string; index: number }>,
+        ) => ({
+            polygonId: "p1",
+            index: 0,
+            pointerEvent: stubPointerEvent(),
+            ...overrides,
+        });
+        const buildDrag = (
+            overrides?: Partial<{
+                polygonId: string;
+                index: number;
+                lat: number | null;
+                lon: number | null;
+                groundAltitude: number | null;
+            }>,
+        ) => ({
+            polygonId: "p1",
+            index: 0,
+            pointerEvent: stubPointerEvent(),
+            lat: 35.5,
+            lon: 139.5,
+            groundAltitude: 100,
+            ...overrides,
+        });
+
+        it("hover リスナーが頂点情報および null（離脱）を受け取る", async () => {
+            const viewer = await create(createMountElement());
+            const received: Array<string | null> = [];
+            viewer.onPolygonPointHover((e) => {
+                received.push(e ? `${e.polygonId}#${e.index}` : null);
+            });
+            sceneMockModule.__triggerPolygonPointHover(
+                buildPointer({ polygonId: "a", index: 2 }),
+            );
+            sceneMockModule.__triggerPolygonPointHover(null);
+            expect(received).toEqual(["a#2", null]);
+        });
+
+        it("click リスナーが頂点クリックを受け取る", async () => {
+            const viewer = await create(createMountElement());
+            const ids: string[] = [];
+            viewer.onPolygonPointClick((e) => {
+                ids.push(`${e.polygonId}#${e.index}`);
+            });
+            sceneMockModule.__triggerPolygonPointClick(
+                buildPointer({ polygonId: "p", index: 1 }),
+            );
+            expect(ids).toEqual(["p#1"]);
+        });
+
+        it("drag start/move/end のリスナーが順に呼ばれる", async () => {
+            const viewer = await create(createMountElement());
+            const log: string[] = [];
+            viewer.onPolygonPointDragStart(() => log.push("start"));
+            viewer.onPolygonPointDrag((e) =>
+                log.push(`drag:${e.lat ?? "null"}`),
+            );
+            viewer.onPolygonPointDragEnd(() => log.push("end"));
+            sceneMockModule.__triggerPolygonPointDragStart(buildDrag());
+            sceneMockModule.__triggerPolygonPointDrag(buildDrag({ lat: 36 }));
+            sceneMockModule.__triggerPolygonPointDrag(
+                buildDrag({ lat: null, lon: null, groundAltitude: null }),
+            );
+            sceneMockModule.__triggerPolygonPointDragEnd(buildDrag());
+            expect(log).toEqual(["start", "drag:36", "drag:null", "end"]);
+        });
+
+        it("unsubscribe 後はリスナーが呼ばれない", async () => {
+            const viewer = await create(createMountElement());
+            const calls: number[] = [];
+            const off = viewer.onPolygonPointHover(() => calls.push(1));
+            sceneMockModule.__triggerPolygonPointHover(buildPointer());
+            off();
+            sceneMockModule.__triggerPolygonPointHover(buildPointer());
+            expect(calls.length).toBe(1);
+            expect(() => off()).not.toThrow();
+        });
+
+        it("dispose 後の onPolygonPoint* は no-op", async () => {
+            const viewer = await create(createMountElement());
+            viewer.dispose();
+            const calls: number[] = [];
+            const offs = [
+                viewer.onPolygonPointHover(() => calls.push(1)),
+                viewer.onPolygonPointClick(() => calls.push(1)),
+                viewer.onPolygonPointDragStart(() => calls.push(1)),
+                viewer.onPolygonPointDrag(() => calls.push(1)),
+                viewer.onPolygonPointDragEnd(() => calls.push(1)),
+            ];
+            sceneMockModule.__triggerPolygonPointHover(buildPointer());
+            sceneMockModule.__triggerPolygonPointClick(buildPointer());
+            sceneMockModule.__triggerPolygonPointDragStart(buildDrag());
+            sceneMockModule.__triggerPolygonPointDrag(buildDrag());
+            sceneMockModule.__triggerPolygonPointDragEnd(buildDrag());
+            expect(calls.length).toBe(0);
+            expect(() => offs.forEach((o) => o())).not.toThrow();
         });
     });
 });

--- a/tests/libExports.unit.spec.ts
+++ b/tests/libExports.unit.spec.ts
@@ -29,6 +29,15 @@ import type {
     PolygonUpdate,
     PolygonHandle,
 } from "../src/lib";
+import type {
+    TerrainClickEvent,
+    TerrainClickListener,
+    PolygonPointPointerEvent,
+    PolygonPointDragEvent,
+    PolygonPointHoverListener,
+    PolygonPointClickListener,
+    PolygonPointDragListener,
+} from "../src/lib";
 
 describe("package entry exports (T8)", () => {
     it("JpmapTerrain クラスがトップレベルから export されている", () => {
@@ -92,5 +101,47 @@ describe("package entry exports (T8)", () => {
         expect(update.enabled).toBe(false);
         expect(handleShape.id).toBe("p1");
         expect(style.pointColor).toBe("#ff0000");
+    });
+
+    // #183 / #184: クリック・頂点インタラクションの公開型がエントリから import 可能。
+    it("クリック・頂点インタラクション公開型 (#183/#184) がエントリから import できる（typecheck）", () => {
+        const click: TerrainClickEvent = {
+            lat: 0,
+            lon: 0,
+            altitude: 0,
+            world: { x: 0, y: 0, z: 0 },
+            pointerEvent: { shiftKey: false, ctrlKey: false } as unknown as PointerEvent,
+        };
+        const clickListener: TerrainClickListener = () => {
+            /* no-op */
+        };
+        const point: PolygonPointPointerEvent = {
+            polygonId: "p1",
+            index: 0,
+            pointerEvent: click.pointerEvent,
+        };
+        const drag: PolygonPointDragEvent = {
+            ...point,
+            lat: null,
+            lon: null,
+            groundAltitude: null,
+        };
+        const hover: PolygonPointHoverListener = () => {
+            /* no-op */
+        };
+        const onClick: PolygonPointClickListener = () => {
+            /* no-op */
+        };
+        const onDrag: PolygonPointDragListener = () => {
+            /* no-op */
+        };
+        clickListener(click);
+        hover(point);
+        hover(null);
+        onClick(point);
+        onDrag(drag);
+        expect(click.lat).toBe(0);
+        expect(point.polygonId).toBe("p1");
+        expect(drag.lat).toBeNull();
     });
 });


### PR DESCRIPTION
<!-- Copilot Code Review: Follow .github/copilot-instructions.md. -->
<!-- Copilot Code Review: Follow AGENTS.md. -->
<!-- Copilot Code Review: Write all review comments in Japanese. -->

## 概要

ポリゴン頂点（球体メッシュ）に対する hover / click / drag を購読する公開 API を `JpmapTerrain` に追加します。距離計測などのデモ（#44）で頂点編集 UI を構築するための基盤となります。

Parent: #44

## 関連 Issue

Closes #184

## 変更内容

- `src/lib/types.ts`: `PolygonPointPointerEvent` / `PolygonPointDragEvent` / `PolygonPointHoverListener` / `PolygonPointClickListener` / `PolygonPointDragListener` / `POLYGON_POINT_DRAG_THRESHOLD_PX` (= 3) を追加。
- `src/terrain/polygon.ts`: 頂点スフィアを `isPickable = true` に変更（メッシュ命名 `polygon-${id}-point-${i}` は維持）。
- `src/scenes/default.ts`:
  - `DefaultSceneController` に `subscribePolygonPointHover` / `subscribePolygonPointClick` / `subscribePolygonPointDragStart` / `subscribePolygonPointDrag` / `subscribePolygonPointDragEnd` を追加。
  - 既存の `pointerdown` / `pointermove` / `pointerup` / `pointercancel` / `lostpointercapture` ハンドラに頂点ジェスチャ処理を統合（早期リターンによりカメラ操作を抑制）。
  - `pickOrPlane` を `tile-ground-*` メッシュのみに限定。
  - hover 状態の管理（カーソル `pointer` 切替）と 3 CSS px のドラッグ閾値判定。
  - `dispose` 時に新規リスナー配列もクリア。
- `src/lib/jpmapTerrain.ts`: 公開メソッド `onPolygonPointHover` / `onPolygonPointClick` / `onPolygonPointDragStart` / `onPolygonPointDrag` / `onPolygonPointDragEnd` を追加（`dispose` 後は no-op、解除関数は冪等）。
- `src/lib.ts`: 新規型を re-export。
- `tests/jpmapTerrain.unit.spec.ts`: モックコントローラに `subscribePolygonPoint*` および `__triggerPolygonPoint*` / `__resetPolygonPointListeners` ヘルパを追加。hover / click / drag / unsubscribe / dispose の 5 ケースを `describe("onPolygonPoint*")` で追加（+5 tests）。
- `tests/libExports.unit.spec.ts`: 新規型 5 種が `jpmap-terrain` から import 可能であることを typecheck 経由で検証（+1 test）。
- `spec/package.md`: §3.3.10「ポリゴン頂点インタラクション」を追加し、§3.4 の re-export リストへ新規型を追記。

## 動作確認方法

```shell
npm run lint
npm run typecheck
npm run test:unit
```

すべて成功すること（`Tests: 546 passed`、新規 +6）。

## 確認事項

- [x] Copilot レビューを日本語で実施し、指摘を修正した
- [x] `npm run test:visuals:update` は毎回実行していない
- [x] 画面表示の意図した変更がある場合のみ、開発者がスナップショットを更新した
