### PR TITLE
feat(polygon): add edgeLabels for midpoint edge labels (#185)

### DIFF
--- a/spec/package.md
+++ b/spec/package.md
@@ -403,6 +403,12 @@ interface PolygonOptions {
   closed?: boolean;
   /** ラベル（点ごと）。#171 で実装済み。`labels[i]` が文字列のときその点にラベルを描画する。 */
   labels?: ReadonlyArray<string>;
+  /**
+   * 辺ラベル（隣接点間ごと、#185）。`edgeLabels[i]` は `points[i]` → `points[i+1]` の中点に表示する。
+   * `closed === true` のとき末尾要素 `edgeLabels[points.length-1]` は `points[points.length-1]` → `points[0]` のラベル。
+   * `undefined` または範囲外の辺にはラベルを描画しない。
+   */
+  edgeLabels?: ReadonlyArray<string | undefined>;
   style?: PolygonStyleOptions;
   enabled?: boolean;                          // default true
   /** 各点から地表へ落とす垂線の表示 (#171 実装済み)。default true */
@@ -425,6 +431,7 @@ interface PolygonOptions {
 - `dispose()` で全ポリゴンリソース（Mesh / Material / TransformNode）を解放する。
 - **#171 実装済み**: 各点から地表（タイル標高、未解決時は Y=0 フォールバック）へ落とす垂線を **CreateTube**（updatable、半径 `style.dropLineWidth`）で描画。`labels[i]` が指定された点に DynamicTexture + ビルボード Plane でラベルを描画（`labelColor` / `labelBackgroundColor` / `labelFontSize` 反映）。`JpmapTerrain.setVerticalsEnabled(id, enabled)` / `setLabelsEnabled(id, enabled)` で表示切替が可能。`PolygonOptions.verticalsEnabled` / `labelsEnabled`（既定 true）で初期表示制御。
 - **#172 実装済み**: 隣接する点間を上 row=頂点位置、下 row=地表 Y の Ribbon として 1 枚の **CreateRibbon**（`updatable: true`, `sideOrientation: DOUBLESIDE`）で壁表示。`closed=true` のときは上/下 row とも末尾に先頭頂点を append して閉じる。`style.wallColor` / `style.wallOpacity`（default `#ff0000` / `0.3`）を StandardMaterial の `emissiveColor` / `alpha` に反映し、半透明時は `needDepthPrePass=true` で z-fight を緩和する。`JpmapTerrain.setWallsEnabled(id, enabled)` で表示切替が可能。`PolygonOptions.wallsEnabled`（既定 true）で初期表示制御。`renderingGroupId=1` はポリライン・垂線・球・ラベルと同一。
+- **#185 実装済み（辺ラベル）**: `PolygonOptions.edgeLabels[i]` が文字列のとき、`points[i]` → `points[i+1]` の中点に DynamicTexture + ビルボード Plane（`polygon-${id}-edge-label-${i}`）でラベルを描画する。`closed === true` のとき配列長は `points.length` で末尾要素は `points[N-1]` → `points[0]` のラベル、`closed === false` のとき配列長は `points.length - 1`。`labels` と同じ `style.labelColor` / `labelBackgroundColor` / `labelFontSize` を共用し、`setLabelsEnabled(id, enabled)` の対象に含む。`distScale` 連動でビルボードがスクリーン安定する。`insertPolygonPoint` / `removePolygonPoint` は対応 index を点ラベルと同じ規則でシフトする（open ポリゴンの末尾頂点削除時は末尾の辺ラベルを除去）。`replacePolygonPoints` 後は `edgeLabels` を全 `undefined` で再構成する。`PolygonHandle.edgeLabels` は一度でも設定されていれば配列を返し、未指定のままなら `undefined`。
 - **#173 で実装予定**: `updatePolygon`、点単位編集 API（`insertPoint` / `removePoint` / `updatePoint` / `replacePoints`）、デモ拡張、視覚回帰テスト。
 
 ##### 3.3.8.2 ポリゴン点編集 API（Issue #173）

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -366,6 +366,13 @@ export interface PolygonOptions {
      * 値が指定された点にのみラベル平面（ビルボード + DynamicTexture）を描画する。
      */
     labels?: ReadonlyArray<string>;
+    /**
+     * 辺ラベル（隣接頂点間ごと）。`edgeLabels[i]` は `points[i]` → `points[i+1]` の
+     * 中点に表示される。`closed === true` のときの末尾要素 `edgeLabels[points.length-1]`
+     * は `points[points.length-1]` → `points[0]` のラベルとして扱う。
+     * 値が `undefined` または `length` 範囲外の辺にはラベルを描画しない (#185)。
+     */
+    edgeLabels?: ReadonlyArray<string | undefined>;
     /** スタイル */
     style?: PolygonStyleOptions;
     /** default true */
@@ -403,6 +410,7 @@ export type PolygonUpdate = Partial<
         | "closed"
         | "altitudeMode"
         | "labels"
+        | "edgeLabels"
         | "style"
         | "enabled"
         | "verticalsEnabled"
@@ -420,6 +428,12 @@ export interface PolygonHandle {
     readonly closed: boolean;
     readonly altitudeMode: AltitudeMode;
     readonly labels: ReadonlyArray<string | undefined> | undefined;
+    /**
+     * 辺ラベル（#185）。一度でも `edgeLabels` を指定された場合は
+     * `points` と整合する長さ（`closed ? N : N-1`）の配列を返し、
+     * 未指定要素は `undefined`。一度も指定されていない場合は `undefined`。
+     */
+    readonly edgeLabels: ReadonlyArray<string | undefined> | undefined;
     readonly style: Readonly<Required<PolygonStyleOptions>>;
     readonly enabled: boolean;
     /** 垂線の表示状態 */

--- a/src/terrain/polygon.ts
+++ b/src/terrain/polygon.ts
@@ -203,6 +203,11 @@ const createLabelMesh = (
     text: string,
     style: ResolvedStyle,
     parent: TransformNode,
+    /**
+     * mesh / material / texture 名のプレフィクス。`"label"`（点ラベル）または
+     * `"edge-label"`（#185 辺ラベル）。命名以外の挙動は共通。
+     */
+    namePrefix: "label" | "edge-label" = "label",
 ): LabelEntry => {
     const dpr =
         typeof globalThis !== "undefined" &&
@@ -222,7 +227,7 @@ const createLabelMesh = (
 
     // 文字幅を測るための probe テクスチャ。
     const probe = new DynamicTexture(
-        `polygon-${id}-label-probe-${index}`,
+        `polygon-${id}-${namePrefix}-probe-${index}`,
         { width: 16, height: 16 },
         scene,
         false,
@@ -250,7 +255,7 @@ const createLabelMesh = (
     );
 
     const texture = new DynamicTexture(
-        `polygon-${id}-label-${index}`,
+        `polygon-${id}-${namePrefix}-${index}`,
         { width: dtWidth, height: dtHeight },
         scene,
         false,
@@ -290,7 +295,7 @@ const createLabelMesh = (
     const heightWorld = dtHeight / dpr;
 
     const mesh = CreatePlane(
-        `polygon-${id}-label-${index}`,
+        `polygon-${id}-${namePrefix}-${index}`,
         { width: widthWorld, height: heightWorld },
         scene,
     );
@@ -300,7 +305,7 @@ const createLabelMesh = (
     mesh.parent = parent;
 
     const material = new StandardMaterial(
-        `polygon-${id}-label-mat-${index}`,
+        `polygon-${id}-${namePrefix}-mat-${index}`,
         scene,
     );
     material.disableLighting = true;
@@ -399,6 +404,16 @@ export const createPolygonNode = (
         options.labels ? options.labels[i] : undefined,
     );
 
+    // 辺ラベル (#185)。長さは `closed ? N : N-1`。`edgeLabels[i]` は points[i]→points[i+1] の中点に表示する。
+    // closed=true のときの末尾要素 (i = N-1) は points[N-1]→points[0] のラベル。
+    const expectedEdgeCount = (): number =>
+        closed ? points.length : Math.max(0, points.length - 1);
+    let hasEdgeLabels = options.edgeLabels !== undefined;
+    const edgeLabels: (string | undefined)[] = Array.from(
+        { length: expectedEdgeCount() },
+        (_, i) => (options.edgeLabels ? options.edgeLabels[i] : undefined),
+    );
+
     const root = new TransformNode(`polygon-${id}`, scene);
 
     // 各頂点に対応する球を 1 つだけ作る。スケールは applyTransform で更新する。
@@ -417,6 +432,22 @@ export const createPolygonNode = (
         if (text === undefined || text === null) return null;
         return createLabelMesh(scene, id, index, text, style, root);
     });
+
+    // edgeLabels[i] が指定された辺にのみ辺ラベルを作る (#185)。indexed by 辺 index。
+    const edgeLabelEntries: (LabelEntry | null)[] = edgeLabels.map(
+        (text, index) => {
+            if (text === undefined || text === null) return null;
+            return createLabelMesh(
+                scene,
+                id,
+                index,
+                text,
+                style,
+                root,
+                "edge-label",
+            );
+        },
+    );
 
     // 初期 path（仮）。applyTransform で必ず上書きされる前提だが、
     // 構築時にも有効な Tube が必要なので原点付近の placeholder を渡す。
@@ -484,6 +515,11 @@ export const createPolygonNode = (
             entry.mesh.setEnabled(visible && verticalsEnabled);
         }
         for (const entry of labelEntries) {
+            if (!entry) continue;
+            entry.mesh.setEnabled(visible && labelsEnabled);
+        }
+        // 辺ラベル (#185) も labelsEnabled を共用する。
+        for (const entry of edgeLabelEntries) {
             if (!entry) continue;
             entry.mesh.setEnabled(visible && labelsEnabled);
         }
@@ -583,6 +619,14 @@ export const createPolygonNode = (
             e.material.name = `polygon-${id}-label-mat-${i}`;
             e.texture.name = `polygon-${id}-label-${i}`;
         }
+        // 辺ラベル (#185) も同様に index に合わせて再採番する。
+        for (let i = 0; i < edgeLabelEntries.length; i++) {
+            const e = edgeLabelEntries[i];
+            if (!e) continue;
+            e.mesh.name = `polygon-${id}-edge-label-${i}`;
+            e.material.name = `polygon-${id}-edge-label-mat-${i}`;
+            e.texture.name = `polygon-${id}-edge-label-${i}`;
+        }
     };
 
     /** 内部: lat/lon/altitude のバリデーション (#173)。 */
@@ -681,6 +725,20 @@ export const createPolygonNode = (
                 label.mesh.scaling.setAll(pointScale);
             }
         }
+        // 辺ラベル (#185): edgeLabels[i] は worldPoints[i] と worldPoints[(i+1) % N]
+        // の中点に配置する。closed=false の末尾辺は対象外（edgeLabelEntries の長さで吸収）。
+        const N = worldPoints.length;
+        for (let i = 0; i < edgeLabelEntries.length; i++) {
+            const entry = edgeLabelEntries[i];
+            if (!entry) continue;
+            const a = worldPoints[i];
+            const b = worldPoints[(i + 1) % N];
+            const mx = (a.x + b.x) * 0.5;
+            const my = (a.y + b.y) * 0.5;
+            const mz = (a.z + b.z) * 0.5;
+            entry.mesh.position.set(mx, my, mz);
+            entry.mesh.scaling.setAll(pointScale);
+        }
         const tubePath = buildLinePath(worldPoints, closed);
         lineMesh = CreateTube(
             `polygon-${id}-line`,
@@ -713,6 +771,7 @@ export const createPolygonNode = (
         closed,
         altitudeMode,
         labels: hasLabels ? Object.freeze([...labels]) : undefined,
+        edgeLabels: hasEdgeLabels ? Object.freeze([...edgeLabels]) : undefined,
         style: { ...style },
         enabled: logicalEnabled,
         verticalsEnabled,
@@ -739,6 +798,14 @@ export const createPolygonNode = (
             entry.mesh.dispose();
         }
         labelEntries.length = 0;
+        // 辺ラベル (#185) も dispose する。
+        for (const entry of edgeLabelEntries) {
+            if (!entry) continue;
+            entry.texture.dispose();
+            entry.material.dispose();
+            entry.mesh.dispose();
+        }
+        edgeLabelEntries.length = 0;
         lineMaterial.dispose();
         lineMesh.dispose();
         wallMaterial.dispose();
@@ -819,6 +886,10 @@ export const createPolygonNode = (
             dropEntries.splice(index, 0, drop);
             labels.splice(index, 0, undefined);
             labelEntries.splice(index, 0, null);
+            // 辺ラベル (#185): 点ラベルと同じ規則で同 index にシフト。
+            // expectedEdgeCount は points 増加で 1 増えるので 1 件挿入する。
+            edgeLabels.splice(index, 0, undefined);
+            edgeLabelEntries.splice(index, 0, null);
             renumberEntries();
             onPointCountChanged();
         },
@@ -847,6 +918,19 @@ export const createPolygonNode = (
                 lbl.texture.dispose();
                 lbl.material.dispose();
                 lbl.mesh.dispose();
+            }
+            // 辺ラベル (#185): 点ラベルと同じ規則で同 index を 1 件削除する。
+            // 開ポリゴンで末尾頂点を削除する場合、edgeLabels.length === points.length-1
+            // なので index を `length-1` にクランプして末尾の辺ラベルを削除する。
+            if (edgeLabels.length > 0) {
+                const ei = Math.min(index, edgeLabels.length - 1);
+                edgeLabels.splice(ei, 1);
+                const elbl = edgeLabelEntries.splice(ei, 1)[0];
+                if (elbl) {
+                    elbl.texture.dispose();
+                    elbl.material.dispose();
+                    elbl.mesh.dispose();
+                }
             }
             renumberEntries();
             onPointCountChanged();
@@ -922,6 +1006,16 @@ export const createPolygonNode = (
             labelEntries.length = 0;
             labels.length = 0;
             hasLabels = false;
+            // 辺ラベル (#185): replacePolygonPoints 後は全 undefined で再構成する。
+            for (const entry of edgeLabelEntries) {
+                if (!entry) continue;
+                entry.texture.dispose();
+                entry.material.dispose();
+                entry.mesh.dispose();
+            }
+            edgeLabelEntries.length = 0;
+            edgeLabels.length = 0;
+            hasEdgeLabels = false;
             points.length = 0;
             for (let i = 0; i < newPoints.length; i++) {
                 const p = newPoints[i];
@@ -936,6 +1030,12 @@ export const createPolygonNode = (
                 dropEntries.push(createDropLine(scene, id, i, style, root));
                 labels.push(undefined);
                 labelEntries.push(null);
+            }
+            // 辺ラベルは expectedEdgeCount に合わせて全 undefined で再生成。
+            const newEdgeCount = expectedEdgeCount();
+            for (let i = 0; i < newEdgeCount; i++) {
+                edgeLabels.push(undefined);
+                edgeLabelEntries.push(null);
             }
             onPointCountChanged();
         },

--- a/tests/polygon.unit.spec.ts
+++ b/tests/polygon.unit.spec.ts
@@ -345,6 +345,146 @@ describe("createPolygonNode 構築", () => {
         });
         expect(planeCalls.length).toBe(0);
     });
+
+    // 辺ラベル (#185)
+    it("edgeLabels[i] が指定された辺にのみ辺ラベル平面を生成する (open)", () => {
+        createPolygonNode(sceneStub, "pE1", {
+            points: [
+                { lat: 35.0, lon: 139.0, altitude: 0 },
+                { lat: 35.1, lon: 139.1, altitude: 0 },
+                { lat: 35.2, lon: 139.2, altitude: 0 },
+            ],
+            altitudeMode: "absolute",
+            // open: 辺数 = N-1 = 2。1 件目だけラベルを付ける。
+            edgeLabels: ["e0", undefined],
+        });
+        // 1 plane のみ生成され、edge-label プレフィクスを持つ。
+        const edgePlanes = planeCalls.filter((p) =>
+            p.name.includes("-edge-label-"),
+        );
+        expect(edgePlanes.length).toBe(1);
+        expect(edgePlanes[0].name).toBe("polygon-pE1-edge-label-0");
+    });
+
+    it("closed=true のとき edgeLabels の長さは N（最後は points[N-1]→points[0]）", () => {
+        createPolygonNode(sceneStub, "pE2", {
+            points: [
+                { lat: 35.0, lon: 139.0, altitude: 0 },
+                { lat: 35.1, lon: 139.1, altitude: 0 },
+                { lat: 35.2, lon: 139.2, altitude: 0 },
+            ],
+            altitudeMode: "absolute",
+            closed: true,
+            edgeLabels: ["e0", "e1", "e2-back-to-0"],
+        });
+        const edgePlanes = planeCalls.filter((p) =>
+            p.name.includes("-edge-label-"),
+        );
+        expect(edgePlanes.length).toBe(3);
+    });
+
+    it("edgeLabels 未指定なら handle.edgeLabels は undefined", () => {
+        const node = createPolygonNode(sceneStub, "pE3", {
+            points: [
+                { lat: 35.0, lon: 139.0, altitude: 0 },
+                { lat: 35.1, lon: 139.1, altitude: 0 },
+            ],
+            altitudeMode: "absolute",
+        });
+        expect(node.getHandle().edgeLabels).toBeUndefined();
+    });
+
+    it("edgeLabels 指定時 handle.edgeLabels は points と整合する長さで返る", () => {
+        const node = createPolygonNode(sceneStub, "pE4", {
+            points: [
+                { lat: 35.0, lon: 139.0, altitude: 0 },
+                { lat: 35.1, lon: 139.1, altitude: 0 },
+                { lat: 35.2, lon: 139.2, altitude: 0 },
+            ],
+            altitudeMode: "absolute",
+            closed: false,
+            edgeLabels: ["e0"],
+        });
+        const handle = node.getHandle();
+        expect(handle.edgeLabels).toBeDefined();
+        // open N=3 → 辺数 2。未指定要素は undefined で埋める。
+        expect(handle.edgeLabels?.length).toBe(2);
+        expect(handle.edgeLabels?.[0]).toBe("e0");
+        expect(handle.edgeLabels?.[1]).toBeUndefined();
+    });
+
+    it("insertPoint で edgeLabels 配列も同 index にシフトされる", () => {
+        const node = createPolygonNode(sceneStub, "pE5", {
+            points: [
+                { lat: 35.0, lon: 139.0, altitude: 0 },
+                { lat: 35.1, lon: 139.1, altitude: 0 },
+                { lat: 35.2, lon: 139.2, altitude: 0 },
+            ],
+            altitudeMode: "absolute",
+            closed: true,
+            edgeLabels: ["A", "B", "C"],
+        });
+        node.insertPoint(2, { lat: 35.15, lon: 139.15, altitude: 0 });
+        const labels = node.getHandle().edgeLabels;
+        // closed N=3→4: 4 件、index=2 に undefined が挿入され "C" は index=3 に。
+        expect(labels?.length).toBe(4);
+        expect(labels?.[0]).toBe("A");
+        expect(labels?.[1]).toBe("B");
+        expect(labels?.[2]).toBeUndefined();
+        expect(labels?.[3]).toBe("C");
+    });
+
+    it("removePoint で edgeLabels 配列の同 index が削除される", () => {
+        const node = createPolygonNode(sceneStub, "pE6", {
+            points: [
+                { lat: 35.0, lon: 139.0, altitude: 0 },
+                { lat: 35.1, lon: 139.1, altitude: 0 },
+                { lat: 35.2, lon: 139.2, altitude: 0 },
+            ],
+            altitudeMode: "absolute",
+            closed: true,
+            edgeLabels: ["A", "B", "C"],
+        });
+        node.removePoint(1);
+        // closed N=3→2: 2 件、index=1 が削除される。
+        expect(node.getHandle().edgeLabels).toEqual(["A", "C"]);
+    });
+
+    it("open polygon の末尾頂点削除時は末尾辺ラベルが除去される", () => {
+        const node = createPolygonNode(sceneStub, "pE7", {
+            points: [
+                { lat: 35.0, lon: 139.0, altitude: 0 },
+                { lat: 35.1, lon: 139.1, altitude: 0 },
+                { lat: 35.2, lon: 139.2, altitude: 0 },
+            ],
+            altitudeMode: "absolute",
+            closed: false,
+            edgeLabels: ["e0", "e1"],
+        });
+        node.removePoint(2);
+        // open N=3→2: 1 件、末尾辺 (e1) が削除される。
+        expect(node.getHandle().edgeLabels).toEqual(["e0"]);
+    });
+
+    it("replacePoints 後 edgeLabels は全 undefined で再構成される", () => {
+        const node = createPolygonNode(sceneStub, "pE8", {
+            points: [
+                { lat: 35.0, lon: 139.0, altitude: 0 },
+                { lat: 35.1, lon: 139.1, altitude: 0 },
+            ],
+            altitudeMode: "absolute",
+            closed: true,
+            edgeLabels: ["x", "y"],
+        });
+        // 一度 edgeLabels を指定 → hasEdgeLabels は true → replacePoints で再構成。
+        node.replacePoints([
+            { lat: 36.0, lon: 140.0, altitude: 0 },
+            { lat: 36.1, lon: 140.1, altitude: 0 },
+            { lat: 36.2, lon: 140.2, altitude: 0 },
+        ]);
+        // replacePoints は hasEdgeLabels を false に戻す → handle.edgeLabels=undefined。
+        expect(node.getHandle().edgeLabels).toBeUndefined();
+    });
 });
 
 describe("createPolygonNode applyTransform", () => {


### PR DESCRIPTION
<!-- Copilot Code Review: Follow .github/copilot-instructions.md. -->
<!-- Copilot Code Review: Follow AGENTS.md. -->
<!-- Copilot Code Review: Write all review comments in Japanese. -->

## 概要

ポリゴンの隣接点間（辺）に文字列ラベルを表示する `edgeLabels` を `PolygonOptions` / `PolygonHandle` に追加します。距離計測などのデモ（#44）で、辺ごとに「水平距離」「高低差」を表示する用途の基盤となります。

Parent: #44

## 関連 Issue

Closes #185

## 変更内容

- `src/lib/types.ts`:
  - `PolygonOptions.edgeLabels?: ReadonlyArray<string | undefined>` を追加。`edgeLabels[i]` は `points[i]` → `points[i+1]` の中点に表示。`closed === true` のとき末尾要素は `points[N-1]` → `points[0]` のラベル。
  - `PolygonHandle.edgeLabels: ReadonlyArray<string | undefined> | undefined` を追加（一度でも設定されていれば配列を返す）。
  - `PolygonUpdate` の Pick に `"edgeLabels"` を追加。
- `src/terrain/polygon.ts`:
  - `createLabelMesh` を `namePrefix: "label" | "edge-label"` で名前空間切替できるよう拡張（点ラベルと辺ラベルでメッシュ・マテリアル・テクスチャ名衝突を回避）。
  - `edgeLabels` / `edgeLabelEntries` の並行配列を保持し、長さは `closed ? N : N-1` で揃える。
  - `applyTransform` で各辺の中点（`(worldPoints[i] + worldPoints[(i+1) % N]) / 2`）にビルボード Plane を配置し、`pointScale` 連動でスクリーン安定。
  - `applyVisibility` / `renumberEntries` / `dispose` / `insertPoint` / `removePoint` / `replacePoints` を辺ラベルにも対応（`labelsEnabled` を共用）。
  - `removePoint` は open ポリゴン末尾頂点削除時に splice index を `edgeLabels.length-1` にクランプして末尾辺ラベルを除去（JS `splice` の境界挙動対応）。
  - `replacePoints` 後は `edgeLabels` を全 `undefined` で再構成、`hasEdgeLabels` を false に戻す。
- `tests/polygon.unit.spec.ts`: 辺ラベル 8 ケースを追加（生成 / closed 長さ / handle 整合 / insert / remove / open 末尾削除 / replace 再構成 / 未指定時の handle.undefined）。
- `spec/package.md` §3.3.8.1: `PolygonOptions.edgeLabels` の API 追記、#185 の仕様セクション追記（中点配置 / labelsEnabled 共用 / shift ルール / 名前空間 `polygon-${id}-edge-label-${i}` 等）。

## 動作確認方法

```shell
npm run lint
npm run typecheck
npm run test:unit
```

すべて成功すること（`Tests: 554 passed`、新規 +8）。

## 確認事項

- [x] Copilot レビューを日本語で実施し、指摘を修正した
- [x] `npm run test:visuals:update` は毎回実行していない
- [x] 画面表示の意図した変更がある場合のみ、開発者がスナップショットを更新した
