### PR TITLE
docs(spec): #187 距離計測関連 API・デモのドキュメント整備

### DIFF
--- a/spec/demos.md
+++ b/spec/demos.md
@@ -44,6 +44,32 @@
 
 実装上、タイムラプス側では `autoSunPosition` を強制 OFF にし、`viewer.dateTime` を `requestAnimationFrame` ループで更新します（`UPDATE_INTERVAL_MS = 200ms` で setter 連打を抑制）。アナログ時計と時刻ラベルは画面下部中央に縦積みで配置し、表示は日本標準時（JST = UTC+9）を使用します。
 
+### distance (`/distance.html`)
+
+クリック / ドラッグでポリラインを編集し、頂点ごとの `lat / lon / altitude` と各辺の水平距離・高低差を実時間で表示する距離計測デモ（#186）。`onTerrainClick` (#183) / `onPolygonPoint*` (#184) / `edgeLabels` (#185) の統合動作確認を兼ねる。
+
+**URL クエリ:** `engine` のみ（viewer / timelapse と同規則）。カメラ初期位置は viewer 共通の `?@lat,lon[,...]` パスを使用しない（デモ専用 UI のため）。
+
+**操作モード（右上ツールバーで排他切替）:**
+
+| モード | 操作 | 効果 |
+|---|---|---|
+| `add`（既定） | 地形クリック | クリック地点に `altitude = 地表 + 100 m` の頂点を末尾追加。カーソルは矢印 + 「+」記号。 |
+| `remove` | 頂点クリック | 当該頂点を削除（残点 0/1 も許容）。頂点 hover 時のみ矢印 + 「−」記号カーソル。 |
+| `edit` | 頂点ドラッグ | 頂点の `lat/lon` を更新。`Shift+ドラッグ`で高度（`altitude`）を更新（地表より下にはクランプ）。頂点 hover 時のみ `move` / `ns-resize` カーソル。 |
+| 「クリア」ボタン | — | 全頂点を削除する。 |
+
+**表示:**
+
+- 各頂点に `lat / lon / altitude(m)` をラベル表示（`labels`）。
+- 各辺の中点に `水平距離(m or km) / 高低差(m, 符号付き)` をラベル表示（`edgeLabels`）。1 km 未満は `m`、それ以上は小数 2 桁の `km` で整形する。
+- ポリライン本体・球体頂点・各点からの垂線・隣接垂線間の壁を全表示（壁・垂線は地表を貫通して Y=0 まで伸び、半透明壁は地形に対して深度オクルードされる #186）。
+
+**実装メモ:**
+
+- 水平距離は `haversineDistanceMeters`（WGS84 平均半径）で算出。浮動小数誤差で `h` が 1 を僅かに超えるケース（対蹠点付近）に備え、`h` を `[0, 1]` にクランプしてから `Math.atan2` に渡す。
+- 編集モードのドラッグ時は `pointermove` ごとに `removePolygon` → `addPolygon` を行うと負荷が高いため、`requestAnimationFrame` で 1 フレーム 1 回に集約する。`dragEnd` で保留中の rAF を即時 flush し、最終位置が確実に反映されるようにする (#191)。
+
 ## 新規デモの追加手順
 
 1. `src/demos/<name>/index.ts` を新規作成し、エントリ起動コードを実装する。

--- a/spec/demos.md
+++ b/spec/demos.md
@@ -48,7 +48,7 @@
 
 クリック / ドラッグでポリラインを編集し、頂点ごとの `lat / lon / altitude` と各辺の水平距離・高低差を実時間で表示する距離計測デモ（#186）。`onTerrainClick` (#183) / `onPolygonPoint*` (#184) / `edgeLabels` (#185) の統合動作確認を兼ねる。
 
-**URL クエリ:** `engine` のみ（viewer / timelapse と同規則）。カメラ初期位置は viewer 共通の `?@lat,lon[,...]` パスを使用しない（デモ専用 UI のため）。
+**URL:** `engine` に加えて、viewer / timelapse と同様にカメラ初期位置の指定（`/@lat,lon[,...]` のパス形式、および `?lat=&lon=` 等のクエリ形式）と `?mapType=standard|photo` を受け付ける（実装上 `parseCameraStateFromUrl` / `parseMapTypeFromUrl` を共用）。
 
 **操作モード（右上ツールバーで排他切替）:**
 

--- a/spec/package.md
+++ b/spec/package.md
@@ -641,9 +641,24 @@ const points = [
   { lat: 35.70, lon: 139.76, altitude: 120 },
 ];
 
+// 水平距離 (m) を haversine 法で算出（ライブラリには含まれないので自前実装）。
+const EARTH_RADIUS_M = 6_371_008.8;
+const toRad = (deg: number) => (deg * Math.PI) / 180;
+const haversineMeters = (a: { lat: number; lon: number }, b: { lat: number; lon: number }) => {
+  const dLat = toRad(b.lat - a.lat);
+  const dLon = toRad(b.lon - a.lon);
+  const sLat = Math.sin(dLat / 2);
+  const sLon = Math.sin(dLon / 2);
+  const h = sLat * sLat + Math.cos(toRad(a.lat)) * Math.cos(toRad(b.lat)) * sLon * sLon;
+  const hh = Math.min(1, Math.max(0, h)); // 対蹠点付近で NaN を避けるためクランプ
+  return EARTH_RADIUS_M * 2 * Math.atan2(Math.sqrt(hh), Math.sqrt(1 - hh));
+};
+
 const formatEdge = (a: typeof points[number], b: typeof points[number]) => {
+  const dist = haversineMeters(a, b);
+  const distStr = dist < 1000 ? `${Math.round(dist)} m` : `${(dist / 1000).toFixed(2)} km`;
   const dAlt = (b.altitude ?? 0) - (a.altitude ?? 0);
-  return `~ m\n${dAlt >= 0 ? "+" : ""}${dAlt.toFixed(0)} m`;
+  return `${distStr}\n${dAlt >= 0 ? "+" : ""}${dAlt.toFixed(0)} m`;
 };
 
 viewer.addPolygon("dist-line", {

--- a/spec/package.md
+++ b/spec/package.md
@@ -519,6 +519,18 @@ interface JpmapTerrain {
 - `dispose()` 後の `onTerrainClick` は no-op。返される解除関数も no-op で安全に呼べる。
 - 登録解除関数は二重呼び出ししても throw しない。
 
+**利用例:**
+
+```typescript
+// 地形クリックで頂点を末尾追加するシンプルな例（distance デモ #186 と同等）
+const unsubscribe = viewer.onTerrainClick((e) => {
+  if (e.pointerEvent.shiftKey) return; // 修飾キーでアプリ独自挙動
+  console.log(`clicked: ${e.lat.toFixed(6)}, ${e.lon.toFixed(6)} (${e.altitude.toFixed(1)} m)`);
+});
+// 後で解除
+unsubscribe();
+```
+
 #### 3.3.10 ポリゴン頂点インタラクション (Issue #184)
 
 ポリゴンの頂点（球体メッシュ）に対する hover / click / drag を購読するイベント API。距離計測などのデモ（#44）で頂点の編集 UI を構築するための基盤。
@@ -573,6 +585,80 @@ interface JpmapTerrain {
 - リスナー未登録時は頂点メッシュの hit 判定 / カーソル変更コストも発生しない。
 - 各リスナーが throw しても他リスナーへ伝播せず `console.error` で握りつぶす。
 - `dispose()` 後の `onPolygonPoint*` は no-op。返される解除関数は二重呼び出ししても throw しない。
+
+**利用例:**
+
+```typescript
+// 編集デモ: 頂点ドラッグで lat/lon、Shift+ドラッグで高度を更新する (#186)
+viewer.addPolygon("line", {
+  points: [{ lat: 35.68, lon: 139.76, altitude: 100 }],
+  altitudeMode: "absolute",
+});
+
+viewer.onPolygonPointHover((e) => {
+  // hover 切替時のみ通知される。e === null で hover 解除。
+  if (e) console.log(`hovering ${e.polygonId}#${e.index}`);
+});
+
+let altitudeDragStart: number | null = null;
+viewer.onPolygonPointDragStart((e) => {
+  // Shift+ドラッグなら開始時の altitude を保持
+  altitudeDragStart = e.pointerEvent.shiftKey ? (e.pointerAltitude ?? 0) : null;
+});
+
+viewer.onPolygonPointDrag((e) => {
+  if (altitudeDragStart !== null && e.pointerAltitude !== null) {
+    // 縦線とカーソルレイの最近接点 Y を採用（地表より下にはクランプ）
+    viewer.updatePolygonPoint(e.polygonId, e.index, {
+      altitude: Math.max(e.pointerAltitude, e.groundAltitude ?? 0),
+    });
+  } else if (e.planeLat !== null && e.planeLon !== null) {
+    // 通常ドラッグ: 開始高さを保つ水平面とカーソルレイの交点を採用
+    viewer.updatePolygonPoint(e.polygonId, e.index, {
+      lat: e.planeLat, lon: e.planeLon,
+    });
+  }
+});
+
+viewer.onPolygonPointDragEnd(() => {
+  altitudeDragStart = null;
+});
+```
+
+#### 3.3.11 辺ラベル (Issue #185)
+
+`PolygonOptions.edgeLabels` で各辺の中点に文字列ラベルを表示する。距離計測デモ（#186）のように動的に距離・高低差を反映する用途に使う。
+
+**利用例:**
+
+```typescript
+import { JpmapTerrain } from "jpmap-terrain";
+
+// 各辺に "水平距離 / 高低差" を表示する
+const points = [
+  { lat: 35.68, lon: 139.76, altitude: 100 },
+  { lat: 35.69, lon: 139.77, altitude: 150 },
+  { lat: 35.70, lon: 139.76, altitude: 120 },
+];
+
+const formatEdge = (a: typeof points[number], b: typeof points[number]) => {
+  const dAlt = (b.altitude ?? 0) - (a.altitude ?? 0);
+  return `~ m\n${dAlt >= 0 ? "+" : ""}${dAlt.toFixed(0)} m`;
+};
+
+viewer.addPolygon("dist-line", {
+  points,
+  altitudeMode: "absolute",
+  // 配列長は open: points.length - 1 / closed: points.length
+  edgeLabels: [
+    formatEdge(points[0], points[1]),
+    formatEdge(points[1], points[2]),
+  ],
+});
+
+// 動的更新は edgeLabels をリセットする `replacePolygonPoints` ではなく、
+// `removePolygon` + `addPolygon` の rebuild が最も簡潔（distance デモも同方式）。
+```
 
 ### 3.4 型定義
 

--- a/spec/package.md
+++ b/spec/package.md
@@ -600,14 +600,14 @@ viewer.onPolygonPointHover((e) => {
   if (e) console.log(`hovering ${e.polygonId}#${e.index}`);
 });
 
-let altitudeDragStart: number | null = null;
+let altitudeDragWithShift = false;
 viewer.onPolygonPointDragStart((e) => {
-  // Shift+ドラッグなら開始時の altitude を保持
-  altitudeDragStart = e.pointerEvent.shiftKey ? (e.pointerAltitude ?? 0) : null;
+  // Shift+ドラッグかどうかを保持
+  altitudeDragWithShift = e.pointerEvent.shiftKey;
 });
 
 viewer.onPolygonPointDrag((e) => {
-  if (altitudeDragStart !== null && e.pointerAltitude !== null) {
+  if (altitudeDragWithShift && e.pointerAltitude !== null) {
     // 縦線とカーソルレイの最近接点 Y を採用（地表より下にはクランプ）
     viewer.updatePolygonPoint(e.polygonId, e.index, {
       altitude: Math.max(e.pointerAltitude, e.groundAltitude ?? 0),
@@ -621,7 +621,7 @@ viewer.onPolygonPointDrag((e) => {
 });
 
 viewer.onPolygonPointDragEnd(() => {
-  altitudeDragStart = null;
+  altitudeDragWithShift = false;
 });
 ```
 

--- a/spec/package.md
+++ b/spec/package.md
@@ -522,7 +522,7 @@ interface JpmapTerrain {
 **利用例:**
 
 ```typescript
-// 地形クリックで頂点を末尾追加するシンプルな例（distance デモ #186 と同等）
+// 地形クリックイベントを購読するシンプルな例
 const unsubscribe = viewer.onTerrainClick((e) => {
   if (e.pointerEvent.shiftKey) return; // 修飾キーでアプリ独自挙動
   console.log(`clicked: ${e.lat.toFixed(6)}, ${e.lon.toFixed(6)} (${e.altitude.toFixed(1)} m)`);


### PR DESCRIPTION
## 概要

Closes #187 / 関連: #44

`#44`（距離計測機能）配下で追加された公開 API・デモを spec ドキュメントへ反映する。

## 変更点

### `spec/package.md`

- §3.3.9 **`onTerrainClick`** (Issue #183): 利用例 snippet を追加
- §3.3.10 **ポリゴン頂点インタラクション** (Issue #184): 編集デモと同等の drag ハンドラ snippet（\`planeLat\` / \`planeLon\` / \`pointerAltitude\` 利用例）を追加
- §3.3.11 **辺ラベル** (Issue #185) を新設し、\`edgeLabels\` の利用例 snippet を追加

### \`spec/demos.md\`

- **distance** デモ（\`/distance.html\`）の URL クエリ・操作モード（add / remove / edit / clear）・表示内容・実装メモ（haversine クランプ / rAF コアレス）を追記

## 検証

- \`npm run lint\` ✅
- \`npm run typecheck\` ✅
- ユニットテストへの影響なし（ドキュメントのみ）

## レビュー観点

- 各セクションの記述が直近の実装（\`feature/186-distance-demo\` マージ後の振る舞い）と整合しているか
- snippet が **公開 API のみ** で完結しているか
- \`edgeLabels\` の動的更新の指針（\`replacePolygonPoints\` ではなく rebuild 方式）が読み手に伝わるか