### PR TITLE
feat(viewer): add 3D/2D view mode switching (#193)

### DIFF
--- a/spec/package.md
+++ b/spec/package.md
@@ -278,6 +278,7 @@ interface JpmapTerrain {
 - `tilt` setter / `flyTo({ tilt })` は `camera.beta` に反映されない（保存値だけ更新され、3D 復帰時に復元される）。
 - Ctrl/Cmd + ドラッグの tilt 操作、コンパスボタンによる tilt リセットは無効。
 - `lat` / `lon` / `altitude` / `azimuth` の操作は通常通り動作する。
+- 3D → 2D 切替時は `camera.beta` が 0 にリセットされるため、`onCameraChange` は viewMode 変化単独でも `tilt` の差分により発火する。
 
 #### 3.3.6 太陽位置（時間による明るさ変化）
 

--- a/spec/package.md
+++ b/spec/package.md
@@ -51,6 +51,8 @@ const viewer = await JpmapTerrain.create(document.getElementById("map")!, {
 | `azimuth` | `number` | `0` | 方位角（度、Babylon.js camera alpha に対応） |
 | `tilt` | `number` | `45` | チルト角（度、Babylon.js camera beta に対応） |
 | `mapType` | `"standard" \| "photo"` | `"standard"` | 地図種類（標準地図 / 航空写真） |
+| `viewMode` | `"3d" \| "2d"` | `"3d"` | カメラ視点モード（Issue #193）。`"2d"` は平行投影で `tilt = 0` 固定、tilt 操作無効 |
+| `showViewModeButton` | `boolean` | `true` | ライブラリ内蔵の 3D/2D 切替ボタンを表示するか（Issue #193） |
 | `dateTime` | `Date \| null` | `null` | 太陽位置計算に使う日時。`null` の場合は内部の決定的なフォールバック時刻（夏至日本時間正午）を使用 |
 | `autoSunPosition` | `boolean` | `false` | `true` で実時刻に追従して内部更新（60 秒周期）、`false` で `dateTime` を固定値として使用 |
 | `showSunShadows` | `boolean` | `false` | 太陽 DirectionalLight による地形への影描画を有効化する。GPU 負荷が大きいため既定 OFF |
@@ -83,6 +85,16 @@ interface JpmapTerrain {
   /** カメラチルト角・度（get / set） */
   get tilt(): number;
   set tilt(value: number);
+
+  /**
+   * カメラ視点モード（Issue #193）。
+   * - `"3d"`: 透視投影（既定）。`tilt` 有効。
+   * - `"2d"`: 平行投影。`tilt = 0` 固定、tilt 操作（setter / `flyTo` / Ctrl+ドラッグ / コンパスボタン）は無効。
+   *   3D へ復帰すると、2D 切替直前の `tilt` が復元される。
+   * - 同値の再 set は no-op。
+   */
+  get viewMode(): ViewMode;
+  set viewMode(value: ViewMode);
 
   /**
    * 指定座標にカメラを移動する。
@@ -134,6 +146,10 @@ interface JpmapTerrain {
   /** 地図種類切替ボタンの表示・非表示（get / set） */
   get showMapToggle(): boolean;
   set showMapToggle(value: boolean);
+
+  /** 3D/2D 視点モード切替ボタンの表示・非表示（get / set, Issue #193） */
+  get showViewModeButton(): boolean;
+  set showViewModeButton(value: boolean);
 
   /** コピーライト（出典表記）の表示・非表示（get / set） */
   get showAttribution(): boolean;
@@ -231,6 +247,37 @@ const unsubscribe = viewer.onMapTypeChange((mapType) => {
 });
 unsubscribe();
 ```
+
+#### 3.3.5.1 viewMode 変化イベント (Issue #193)
+
+カメラ視点モード（`viewMode`）の変化を購読する。`onMapTypeChange` と対称な API。
+
+```typescript
+interface JpmapTerrain {
+  /**
+   * viewMode 変化リスナーを登録する。
+   *
+   * @param listener viewMode 変化を受け取るリスナー
+   * @returns 登録解除関数（unsubscribe）
+   */
+  onViewModeChange(listener: ViewModeChangeListener): () => void;
+}
+```
+
+**仕様:**
+
+- 戻り値は登録解除関数。呼び出すと当該リスナーのみが解除される。
+- **発火条件**: `viewMode` が実際に変化したタイミングのみ通知する（同値の再 set は通知しない）。UI の視点切替ボタン操作・プログラム経由の `viewer.viewMode = ...` の双方で発火する。
+- **初回登録時は即時発火しない**（変化があった次回以降のみ）。
+- リスナーが throw した場合でも、内部で例外を捕捉して `console.error` でログ出力し、他リスナーの処理は継続する。
+- `dispose()` 後に `onViewModeChange` を呼び出した場合は登録されず、no-op の unsubscribe 関数を返す。
+
+**2D モード時の制約:**
+
+- `tilt` getter は常に `0` を返す。
+- `tilt` setter / `flyTo({ tilt })` は `camera.beta` に反映されない（保存値だけ更新され、3D 復帰時に復元される）。
+- Ctrl/Cmd + ドラッグの tilt 操作、コンパスボタンによる tilt リセットは無効。
+- `lat` / `lon` / `altitude` / `azimuth` の操作は通常通り動作する。
 
 #### 3.3.6 太陽位置（時間による明るさ変化）
 
@@ -340,6 +387,13 @@ interface MarkerOptions {
 - 値は大小文字無視で受理する（例: `?mapType=Photo` も `"photo"` として解釈）。書き戻し時は小文字に正規化する。
 - 不正値・欠落・URL 解析失敗時は `JPMAP_TERRAIN_DEFAULTS.mapType`（= `"standard"`）にフォールバックする（例外は投げない）。
 - `viewer.mapType` の変化（UI 切替ボタン / プログラム set）は `onMapTypeChange` 経由でデモ層が `history.replaceState` により URL の `?mapType=` を更新する。パス（`/@lat,lon[,...]`）と他クエリ（`engine`, `dateTime` 等）・ハッシュは保持される。
+
+**`viewMode` URL クエリ仕様 (Issue #193):**
+
+- URL クエリ `?viewMode=3d|2d` で初期値を上書きできる（デモ層）。
+- 値は大小文字無視で受理する。書き戻し時は小文字に正規化する。
+- 不正値・欠落・URL 解析失敗時は `JPMAP_TERRAIN_DEFAULTS.viewMode`（= `"3d"`）にフォールバックする。
+- `viewer.viewMode` の変化は `onViewModeChange` 経由でデモ層が `history.replaceState` により URL の `?viewMode=` を更新する。パス・他クエリ・ハッシュは保持される。
 
 #### 3.3.8 ポリゴン (Issue #169)
 
@@ -687,6 +741,8 @@ interface CameraChangeEvent {
   readonly altitude: number;
   readonly azimuth: number;
   readonly tilt: number;
+  /** 現在の視点モード（Issue #193）。`"2d"` のとき `tilt` は常に `0`。 */
+  readonly viewMode: ViewMode;
 }
 
 /** `JpmapTerrain.onCameraChange` リスナー */
@@ -694,6 +750,12 @@ type CameraChangeListener = (event: CameraChangeEvent) => void;
 
 /** `JpmapTerrain.onMapTypeChange` リスナー (Issue #149) */
 type MapTypeChangeListener = (mapType: MapType) => void;
+
+/** カメラ視点モード (Issue #193) */
+type ViewMode = "3d" | "2d";
+
+/** `JpmapTerrain.onViewModeChange` リスナー (Issue #193) */
+type ViewModeChangeListener = (viewMode: ViewMode) => void;
 ```
 
 ```typescript
@@ -702,6 +764,8 @@ import type {
   CameraChangeListener,
   MapType,
   MapTypeChangeListener,
+  ViewMode,
+  ViewModeChangeListener,
   // ポリゴン (Issue #170)
   AltitudeMode,
   PolygonPointOptions,
@@ -758,8 +822,9 @@ import type {
 
 | パラメータ | 型 | 説明 |
 |---|---|---|
-| `projection` | `"perspective" \| "orthographic"` | 射影投影 / 平行投影の切り替え |
 | `fov` | `number` | 視野角（度） |
+
+> `projection` は §3.2 の `viewMode` (`"3d"` / `"2d"`) として実装済み (Issue #193)。
 
 ### 4.2 追加 API
 

--- a/src/demos/distance/index.ts
+++ b/src/demos/distance/index.ts
@@ -236,6 +236,8 @@ const start = async (): Promise<void> => {
         ...(engine ? { engine } : {}),
         ...(cameraState ?? defaultCamera),
         ...(mapType !== null ? { mapType } : {}),
+        // ライブラリ内蔵の視点モード切替ボタンは非表示。デモ独自の UI を提供する (Issue #193)。
+        showViewModeButton: false,
     };
 
     const viewer = await JpmapTerrain.create(mount, opts);
@@ -282,6 +284,21 @@ const start = async (): Promise<void> => {
     const toolbar = document.getElementById(TOOLBAR_ID);
     if (toolbar instanceof HTMLElement) {
         buildToolbar(toolbar, state, onStateChange);
+        // 3D / 2D 視点モード切替 (Issue #193)
+        // ライブラリ内蔵ボタンは showViewModeButton:false で非表示。
+        const viewModeBtn = document.createElement("button");
+        viewModeBtn.type = "button";
+        viewModeBtn.dataset.distanceAction = "viewMode";
+        const refreshViewModeBtn = (): void => {
+            viewModeBtn.textContent =
+                viewer.viewMode === "3d" ? "2D 表示" : "3D 表示";
+        };
+        viewModeBtn.addEventListener("click", () => {
+            viewer.viewMode = viewer.viewMode === "3d" ? "2d" : "3d";
+        });
+        viewer.onViewModeChange(() => refreshViewModeBtn());
+        refreshViewModeBtn();
+        toolbar.appendChild(viewModeBtn);
     }
 
     // モード別のカーソル表示 (#186)。

--- a/src/demos/polygon/index.ts
+++ b/src/demos/polygon/index.ts
@@ -194,6 +194,23 @@ const buildControls = (
         }),
     );
 
+    // 3D / 2D 視点モード切替 (Issue #193)
+    // ライブラリ内蔵ボタンは showViewModeButton:false で非表示にしているため、
+    // ここに同等機能のボタンを置いて API 経由で切替する。
+    {
+        const btn = document.createElement("button");
+        btn.type = "button";
+        const refresh = (): void => {
+            btn.textContent = viewer.viewMode === "3d" ? "2D 表示" : "3D 表示";
+        };
+        btn.addEventListener("click", () => {
+            viewer.viewMode = viewer.viewMode === "3d" ? "2d" : "3d";
+        });
+        viewer.onViewModeChange(() => refresh());
+        refresh();
+        container.appendChild(btn);
+    }
+
     // 点編集 API デモ (Issue #173)。`yomiuri-closed` を編集対象とする。
     const editTargetId = "yomiuri-closed";
     let insertCounter = 0;
@@ -316,6 +333,8 @@ const start = async (): Promise<void> => {
         ...(engine ? { engine } : {}),
         ...(cameraState ?? defaultCamera),
         ...(mapType !== null ? { mapType } : {}),
+        // ライブラリ内蔵の視点モード切替ボタンは非表示。デモ独自の UI を提供する (Issue #193)。
+        showViewModeButton: false,
     };
 
     const viewer = await JpmapTerrain.create(mount, opts);

--- a/src/demos/viewer/index.ts
+++ b/src/demos/viewer/index.ts
@@ -20,6 +20,8 @@ import {
     createUrlUpdater,
     parseMapTypeFromUrl,
     updateMapTypeInUrl,
+    parseViewModeFromUrl,
+    updateViewModeInUrl,
     type CameraUrlState,
 } from "../../terrain/urlState";
 
@@ -138,6 +140,7 @@ const start = async (): Promise<void> => {
     const autoSunPosition = resolveAutoSunPosition(location.search);
     const showSunShadows = resolveShowSunShadows(location.search);
     const mapType = parseMapTypeFromUrl(location.href);
+    const viewMode = parseViewModeFromUrl(location.href);
     const opts: JpmapTerrainOptions = {
         ...(engine ? { engine } : {}),
         ...(cameraState ?? {}),
@@ -145,6 +148,7 @@ const start = async (): Promise<void> => {
         ...(autoSunPosition !== undefined ? { autoSunPosition } : {}),
         ...(showSunShadows !== undefined ? { showSunShadows } : {}),
         ...(mapType !== null ? { mapType } : {}),
+        ...(viewMode !== null ? { viewMode } : {}),
     };
     const viewer = await JpmapTerrain.create(mount, opts);
 
@@ -164,6 +168,10 @@ const start = async (): Promise<void> => {
     viewer.onMapTypeChange((next) => updateMapTypeInUrl(next));
     // 起動完了直後に一度書き込み、`?mapType=Photo` のような大小混在の値を小文字に揃える。
     updateMapTypeInUrl(viewer.mapType);
+
+    // URL 同期: viewMode 変化のたびに `?viewMode=` を反映する (Issue #193)。
+    viewer.onViewModeChange((next) => updateViewModeInUrl(next));
+    updateViewModeInUrl(viewer.viewMode);
 
     // デモ用マーカー: 東京駅・皇居・都庁 (Issue #167)
     // マーカーはカメラ距離に応じてスクリーン空間サイズが一定になるよう自動スケールされる。

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -15,6 +15,8 @@ export type {
     JpmapTerrainOptions,
     MapType,
     MapTypeChangeListener,
+    ViewMode,
+    ViewModeChangeListener,
     MarkerHandle,
     MarkerIconOptions,
     MarkerLineOptions,

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -36,6 +36,8 @@ import {
     PolygonPointHoverListener,
     PolygonPointClickListener,
     PolygonPointDragListener,
+    ViewMode,
+    ViewModeChangeListener,
 } from "./types";
 import { createMarkerManager, type MarkerManager } from "../terrain/markerManager";
 import { createPolygonManager, type PolygonManager } from "../terrain/polygonManager";
@@ -54,11 +56,13 @@ export class JpmapTerrain {
     private _azimuth: number;
     private _tilt: number;
     private _mapType: MapType;
+    private _viewMode: ViewMode;
 
     private _showCompass = true;
     private _showZoomButtons = true;
     private _showScaleBar = true;
     private _showMapToggle = true;
+    private _showViewModeButton = true;
     private _showAttribution = true;
 
     /** 太陽位置計算用の保持日時。`null` の場合は内部フォールバックを使用する */
@@ -90,6 +94,8 @@ export class JpmapTerrain {
     private _lastCameraSnapshot: CameraChangeEvent | null = null;
     /** `onMapTypeChange` で登録されたリスナー一覧 (Issue #149) */
     private _mapTypeListeners: MapTypeChangeListener[] = [];
+    /** `onViewModeChange` で登録されたリスナー一覧 (Issue #193) */
+    private _viewModeListeners: ViewModeChangeListener[] = [];
 
     /** マーカー管理 (Issue #167)。`onReady` で初期化される */
     private _markerManager: MarkerManager | null = null;
@@ -105,6 +111,10 @@ export class JpmapTerrain {
         this._azimuth = options.azimuth ?? JPMAP_TERRAIN_DEFAULTS.azimuth;
         this._tilt = options.tilt ?? JPMAP_TERRAIN_DEFAULTS.tilt;
         this._mapType = options.mapType ?? JPMAP_TERRAIN_DEFAULTS.mapType;
+        this._viewMode = options.viewMode ?? JPMAP_TERRAIN_DEFAULTS.viewMode;
+        this._showViewModeButton =
+            options.showViewModeButton ??
+            JPMAP_TERRAIN_DEFAULTS.showViewModeButton;
         // 太陽位置 (Issue #35)。`Invalid Date` は `console.warn` のうえ null に倒す。
         this._dateTime = JpmapTerrain._sanitizeDateTimeOption(options.dateTime);
         this._autoSunPosition =
@@ -184,6 +194,8 @@ export class JpmapTerrain {
                 tilt: this._tilt,
                 mapType: this._mapType,
                 onMapTypeChange: (next) => this._handleMapTypeChange(next),
+                viewMode: this._viewMode,
+                onViewModeChange: (next) => this._handleViewModeChange(next),
                 onReady: (controller) => {
                     this._controller = controller;
                     // T6: 初期表示状態を controller に反映する
@@ -202,6 +214,10 @@ export class JpmapTerrain {
                     controller.setUiVisibility(
                         "mapToggle",
                         this._showMapToggle,
+                    );
+                    controller.setUiVisibility(
+                        "viewModeButton",
+                        this._showViewModeButton,
                     );
                     controller.setUiVisibility(
                         "attribution",
@@ -476,6 +492,14 @@ export class JpmapTerrain {
         this._controller?.setUiVisibility("mapToggle", value);
     }
 
+    public get showViewModeButton(): boolean {
+        return this._showViewModeButton;
+    }
+    public set showViewModeButton(value: boolean) {
+        this._showViewModeButton = value;
+        this._controller?.setUiVisibility("viewModeButton", value);
+    }
+
     public get showAttribution(): boolean {
         return this._showAttribution;
     }
@@ -490,6 +514,63 @@ export class JpmapTerrain {
     public set mapType(value: MapType) {
         this._mapType = value;
         this._controller?.setMapType(value);
+    }
+
+    /**
+     * 現在のカメラ視点モード (Issue #193)。
+     * `"3d"` (透視投影) / `"2d"` (平行投影、tilt=0 固定)。
+     */
+    public get viewMode(): ViewMode {
+        return this._controller?.getViewMode() ?? this._viewMode;
+    }
+    public set viewMode(value: ViewMode) {
+        this._viewMode = value;
+        this._controller?.setViewMode(value);
+    }
+
+    /**
+     * `viewMode` が変化した際に呼ばれるリスナーを登録する (Issue #193)。
+     *
+     * `onMapTypeChange` と対称な API。UI ボタン操作・`viewMode` setter のいずれの
+     * 経路でも、値が変化したフレームのみ通知する。同値再 set では通知しない。
+     * 戻り値の関数で登録解除（複数回呼んでも安全）。リスナーが throw しても他リスナー
+     * へ伝播し、`console.error` で握りつぶす。`dispose()` 後の呼び出しは何もせず、
+     * no-op の unsubscribe を返す。
+     */
+    public onViewModeChange(listener: ViewModeChangeListener): () => void {
+        if (this._disposed) {
+            return () => {
+                /* no-op: viewer is already disposed */
+            };
+        }
+        this._viewModeListeners.push(listener);
+        let removed = false;
+        return (): void => {
+            if (removed) return;
+            removed = true;
+            const idx = this._viewModeListeners.indexOf(listener);
+            if (idx !== -1) {
+                this._viewModeListeners.splice(idx, 1);
+            }
+        };
+    }
+
+    /**
+     * controller から伝播される `viewMode` 変化を受け取り、
+     * 内部状態の更新と登録リスナーへの通知を行う (Issue #193)。
+     * controller 側で同値再 set はフィルタ済みのため、ここでは無条件に通知する。
+     */
+    private _handleViewModeChange(next: ViewMode): void {
+        if (this._disposed) return;
+        this._viewMode = next;
+        const listeners = this._viewModeListeners.slice();
+        for (const listener of listeners) {
+            try {
+                listener(next);
+            } catch (err) {
+                console.error("[JpmapTerrain] onViewModeChange listener threw:", err);
+            }
+        }
     }
 
     /**
@@ -778,6 +859,7 @@ export class JpmapTerrain {
             altitude: this.altitude,
             azimuth: this.azimuth,
             tilt: this.tilt,
+            viewMode: this.viewMode,
         };
         const prev = this._lastCameraSnapshot;
         if (prev === null) {
@@ -790,7 +872,8 @@ export class JpmapTerrain {
             Math.abs(snapshot.lon - prev.lon) > eps ||
             Math.abs(snapshot.altitude - prev.altitude) > eps ||
             Math.abs(snapshot.azimuth - prev.azimuth) > eps ||
-            Math.abs(snapshot.tilt - prev.tilt) > eps;
+            Math.abs(snapshot.tilt - prev.tilt) > eps ||
+            snapshot.viewMode !== prev.viewMode;
         if (!changed) return;
         this._lastCameraSnapshot = snapshot;
         // iterate 中の add/remove 安全のためスナップショットを取って iterate
@@ -986,6 +1069,7 @@ export class JpmapTerrain {
         this._cameraListeners = [];
         this._lastCameraSnapshot = null;
         this._mapTypeListeners = [];
+        this._viewModeListeners = [];
         if (this._resizeObserver) {
             this._resizeObserver.disconnect();
             this._resizeObserver = null;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,6 +11,15 @@ export type EngineType = "webgpu" | "webgl2";
 export type MapType = "standard" | "photo";
 
 /**
+ * カメラ視点モード (Issue #193)。
+ *
+ * - `"3d"`: 透視投影（既定）。`tilt` が有効で、地形の起伏が立体的に見える。
+ * - `"2d"`: 平行投影。`tilt = 0`（真下視点）に固定され、tilt 操作は無効化される。
+ *   3D へ復帰した際は、2D 切替直前の `tilt` 値が復元される。
+ */
+export type ViewMode = "3d" | "2d";
+
+/**
  * `JpmapTerrain.create` 初期化オプション。
  * すべて任意指定で、未指定時は spec/package.md §3.2 のデフォルト値が適用される。
  */
@@ -29,6 +38,17 @@ export interface JpmapTerrainOptions {
     tilt?: number;
     /** 地図種類 */
     mapType?: MapType;
+    /**
+     * カメラ視点モード (Issue #193)。
+     * - `"3d"` (既定): 透視投影。`tilt` 有効。
+     * - `"2d"`: 平行投影。`tilt = 0` 固定で tilt 操作は無効。
+     */
+    viewMode?: ViewMode;
+    /**
+     * ライブラリ内蔵の 3D/2D 切替ボタンを表示するかどうか (Issue #193)。
+     * 既定 `true`。デモ側で独自の UI を用意する場合に `false` を指定する。
+     */
+    showViewModeButton?: boolean;
     /**
      * 太陽位置計算に使う日時（UTC として扱う）。
      * 未指定 / `null` の場合は内部の決定的フォールバック（{@link SUN_FALLBACK_DATETIME_ISO}）を使用する。
@@ -80,6 +100,8 @@ export const JPMAP_TERRAIN_DEFAULTS = {
     azimuth: 0,
     tilt: 45,
     mapType: "standard" as MapType,
+    viewMode: "3d" as ViewMode,
+    showViewModeButton: true as boolean,
     dateTime: null as Date | null,
     autoSunPosition: false as boolean,
     showSunShadows: false as boolean,
@@ -109,6 +131,11 @@ export interface CameraChangeEvent {
     readonly altitude: number;
     readonly azimuth: number;
     readonly tilt: number;
+    /**
+     * 現在のカメラ視点モード (Issue #193)。
+     * `"2d"` のとき `tilt` は常に `0` を返す。
+     */
+    readonly viewMode: ViewMode;
 }
 
 /** `JpmapTerrain.onCameraChange` リスナー */
@@ -119,6 +146,12 @@ export type CameraChangeListener = (event: CameraChangeEvent) => void;
  * `mapType` が実際に変化したタイミングのみ呼ばれる。
  */
 export type MapTypeChangeListener = (mapType: MapType) => void;
+
+/**
+ * `JpmapTerrain.onViewModeChange` リスナー (Issue #193)。
+ * `viewMode` が実際に変化したタイミングのみ呼ばれる。
+ */
+export type ViewModeChangeListener = (viewMode: ViewMode) => void;
 
 // ---- 地形クリック通知 (Issue #183) ----
 

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -1,5 +1,6 @@
 import { Scene } from "@babylonjs/core/scene";
 import { ArcRotateCamera } from "@babylonjs/core/Cameras/arcRotateCamera";
+import { Camera } from "@babylonjs/core/Cameras/camera";
 import { Matrix, Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { Color3 } from "@babylonjs/core/Maths/math.color";
 import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight";
@@ -32,6 +33,7 @@ import {
     type PolygonPointHoverListener,
     type PolygonPointClickListener,
     type PolygonPointDragListener,
+    type ViewMode,
 } from "../lib/types";
 
 const TERRAIN_SUBDIVISIONS = 128;
@@ -146,6 +148,20 @@ export interface DefaultSceneController {
     getMapType(): "standard" | "photo";
     /** 地図種類を切り替える。ボタン表示も一緒に追従させる */
     setMapType(value: "standard" | "photo"): void;
+
+    // ---- 視点モード (Issue #193) ----
+
+    /** 現在のカメラ視点モードを返す */
+    getViewMode(): ViewMode;
+    /**
+     * 視点モードを切り替える。
+     * - `"2d"`: `camera.beta` を 0 に固定し、`Camera.ORTHOGRAPHIC_CAMERA` に切替。
+     *   現在の `tilt` を保存し、3D 復帰時に復元する。
+     * - `"3d"`: 透視投影に戻し、保存していた `tilt` を復元する。
+     * - 同値再呼び出しは no-op。
+     */
+    setViewMode(value: ViewMode): void;
+
     /**
      * コントロールパネル要素の表示・非表示を切り替える (spec §3.3.2)。
      */
@@ -155,6 +171,7 @@ export interface DefaultSceneController {
             | "zoomButtons"
             | "scaleBar"
             | "mapToggle"
+            | "viewModeButton"
             | "attribution",
         visible: boolean,
     ): void;
@@ -263,6 +280,16 @@ export interface DefaultSceneInitOptions {
      * - 同値再 set では発火しない。
      */
     onMapTypeChange?: (mapType: "standard" | "photo") => void;
+    /** 初期視点モード (Issue #193)。未指定時は `"3d"`。 */
+    viewMode?: ViewMode;
+    /**
+     * `viewMode` が実際に変化した際に呼ばれるコールバック (Issue #193)。
+     *
+     * - `controller.setViewMode` 経由・UI ボタンクリック経由のいずれの変化でも発火する。
+     * - 起動時の初期値設定では発火しない（呼び出し側との重複通知防止）。
+     * - 同値再 set では発火しない。
+     */
+    onViewModeChange?: (viewMode: ViewMode) => void;
     /**
      * シーン構築完了時に外部操作用コントローラを受け取るコールバック (T5)。
      * `JpmapTerrain` の get/set/flyTo はこのコントローラ経由でカメラ・位置を更新する。
@@ -296,6 +323,14 @@ export class DefaultScene implements CreateSceneClass {
         camera.upperRadiusLimit = CAMERA_UPPER_RADIUS;
         camera.minZ = 1;
         camera.maxZ = CAMERA_FAR_CLIP;
+
+        // ---- 視点モード切替 (Issue #193) ----
+        // 「カメラの本当の状態」は ArcRotateCamera.mode / beta、
+        // 「論理 viewMode」と「3D 復帰時に戻す tilt」は本クロージャに閉じる。
+        // 宣言だけ camera 直後に hoist し、操作ロジック（UI 連携・初期反映）は
+        // tileManager / mapToggle 構築後に行う。
+        let currentViewMode: ViewMode = options?.viewMode ?? "3d";
+        let savedTiltDeg: number = tiltDeg;
 
         // チルト制限（地面から15° = beta上限 5π/12）
         camera.upperBetaLimit = Math.PI / 2 - Math.PI / 12;
@@ -1000,6 +1035,11 @@ export class DefaultScene implements CreateSceneClass {
                 lastPointerX = e.clientX;
                 lastPointerY = e.clientY;
                 camera.alpha -= dx * 0.003;
+                // 2D モード時は tilt 操作を無効化する (Issue #193)。
+                // alpha（方位回転）は 2D でも有効。
+                if (currentViewMode === "2d") {
+                    return;
+                }
                 const prevBeta = camera.beta;
                 camera.beta -= dy * 0.003;
                 camera.beta = clamp(
@@ -1501,7 +1541,11 @@ export class DefaultScene implements CreateSceneClass {
             }
 
             const targetAlpha = -Math.PI / 2; // 北向き
-            const targetBeta = camera.lowerBetaLimit ?? 0.1; // ほぼ真下
+            // 2D モード時は tilt を変更しない（既に beta=0 固定） (Issue #193)。
+            const targetBeta =
+                currentViewMode === "2d"
+                    ? camera.beta
+                    : (camera.lowerBetaLimit ?? 0.1); // ほぼ真下
             const duration = 400;             // ms
             const startAlpha = camera.alpha;
             const startBeta = camera.beta;
@@ -1605,6 +1649,83 @@ export class DefaultScene implements CreateSceneClass {
             applyMapTypeChange(next);
         });
 
+        // ---- 視点モード切替 (Issue #193) ----
+        // 宣言は camera 初期化直後に hoist 済み。ここでは UI 連携・初期反映を行う。
+        const applyOrthoFrustum = (): void => {
+            const w = engine.getRenderWidth();
+            const h = engine.getRenderHeight();
+            if (w <= 0 || h <= 0) return;
+            const aspect = w / h;
+            // 画面に「カメラ高度 ≒ 1 画面分」が映るよう半径ベースで設定する。
+            const halfH = camera.radius;
+            const halfW = halfH * aspect;
+            camera.orthoTop = halfH;
+            camera.orthoBottom = -halfH;
+            camera.orthoLeft = -halfW;
+            camera.orthoRight = halfW;
+        };
+
+        const updateViewModeToggleLabel = (mode: ViewMode): void => {
+            // 「次に切り替える先」をラベルに表示する（3D 中は "2D"、2D 中は "3D"）。
+            ui.viewModeToggle.textContent = mode === "3d" ? "2D" : "3D";
+            ui.viewModeToggle.setAttribute(
+                "aria-label",
+                mode === "3d" ? "視点切替: 2D に変更" : "視点切替: 3D に変更",
+            );
+            ui.viewModeToggle.setAttribute(
+                "aria-pressed",
+                mode === "2d" ? "true" : "false",
+            );
+        };
+
+        const applyViewModeInternal = (
+            next: ViewMode,
+            opts?: { silent?: boolean },
+        ): void => {
+            if (next === currentViewMode) return;
+            if (next === "2d") {
+                // 現在の tilt を保存（3D 復帰時に復元するため）
+                savedTiltDeg = (camera.beta * 180) / Math.PI;
+                camera.beta = 0;
+                camera.mode = Camera.ORTHOGRAPHIC_CAMERA;
+                applyOrthoFrustum();
+            } else {
+                camera.mode = Camera.PERSPECTIVE_CAMERA;
+                const lower = camera.lowerBetaLimit ?? 0.1;
+                const upper = camera.upperBetaLimit ?? Math.PI;
+                camera.beta = clamp(
+                    (savedTiltDeg * Math.PI) / 180,
+                    lower,
+                    upper,
+                );
+            }
+            currentViewMode = next;
+            updateViewModeToggleLabel(next);
+            if (!opts?.silent) {
+                options?.onViewModeChange?.(next);
+            }
+        };
+
+        // 初期反映: ラベルは現在モードに合わせる。`silent: true` で初期 listener は発火させない。
+        updateViewModeToggleLabel(currentViewMode);
+        if (currentViewMode === "2d") {
+            // applyViewModeInternal は同値で no-op になるため一時的に "3d" に戻して再適用する。
+            currentViewMode = "3d";
+            applyViewModeInternal("2d", { silent: true });
+        }
+
+        // 2D の間は radius / リサイズで ortho frustum を追従させる必要がある。
+        // 毎フレーム更新は安価（4 つの数値設定）なので onBeforeRender で常時走らせる。
+        scene.onBeforeRenderObservable.add(() => {
+            if (currentViewMode === "2d") {
+                applyOrthoFrustum();
+            }
+        });
+
+        ui.viewModeToggle.addEventListener("click", () => {
+            applyViewModeInternal(currentViewMode === "3d" ? "2d" : "3d");
+        });
+
         // カメラ-地形衝突回避: 地面にめり込まないよう radius を補正してストップ
         const clampCameraAboveTerrain = (): void => {
             const minR = terrainMinRadius();
@@ -1680,7 +1801,7 @@ export class DefaultScene implements CreateSceneClass {
             if (values.azimuth !== undefined) {
                 camera.alpha = alphaFromAzimuthDeg(values.azimuth);
             }
-            if (values.tilt !== undefined) {
+            if (values.tilt !== undefined && currentViewMode === "3d") {
                 const lower = camera.lowerBetaLimit ?? 0;
                 const upper = camera.upperBetaLimit ?? Math.PI;
                 camera.beta = clamp(
@@ -1688,6 +1809,15 @@ export class DefaultScene implements CreateSceneClass {
                     lower,
                     upper,
                 );
+                // 3D 中の tilt 変更は、以後 2D に切り替えたときに復元される値となる。
+                savedTiltDeg = (camera.beta * 180) / Math.PI;
+            } else if (values.tilt !== undefined) {
+                // 2D 中は tilt を camera.beta に反映せず、復帰時の値だけ更新する (Issue #193)。
+                const lowerDeg =
+                    ((camera.lowerBetaLimit ?? 0) * 180) / Math.PI;
+                const upperDeg =
+                    ((camera.upperBetaLimit ?? Math.PI) * 180) / Math.PI;
+                savedTiltDeg = clamp(values.tilt, lowerDeg, upperDeg);
             }
             // 中心座標が変わったときのみ refresh する。
             // altitude/azimuth/tilt はタイル中心に影響しないため refresh 不要。
@@ -1853,7 +1983,10 @@ export class DefaultScene implements CreateSceneClass {
             getLon: () => currentLon,
             getAltitude: () => camera.radius,
             getAzimuth: () => azimuthDegFromAlpha(camera.alpha),
-            getTilt: () => (camera.beta * 180) / Math.PI,
+            getTilt: () =>
+                currentViewMode === "2d"
+                    ? 0
+                    : (camera.beta * 180) / Math.PI,
             setLat: (value) => applyView({ lat: value }, true),
             setLon: (value) => applyView({ lon: value }, true),
             setAltitude: (value) => applyView({ altitude: value }, true),
@@ -1868,6 +2001,9 @@ export class DefaultScene implements CreateSceneClass {
                 const internal = value === "standard" ? "std" : "photo";
                 applyMapTypeChange(internal);
             },
+            // ---- 視点モード (Issue #193) ----
+            getViewMode: () => currentViewMode,
+            setViewMode: (value) => applyViewModeInternal(value),
             setUiVisibility: createUiVisibilityController({
                 compass: ui.compass,
                 locateMe: ui.locateMe,
@@ -1876,6 +2012,7 @@ export class DefaultScene implements CreateSceneClass {
                 scaleBarBar: ui.scaleBar.bar,
                 scaleBarLabel: ui.scaleBar.label,
                 mapToggle: ui.mapToggle,
+                viewModeToggle: ui.viewModeToggle,
                 attribution: ui.scaleBar.attribution,
             }),
             setSunState: (dateTime) => {
@@ -1923,6 +2060,7 @@ export class DefaultScene implements CreateSceneClass {
                 };
                 removeFromParent(ui.compass);
                 removeFromParent(ui.mapToggle);
+                removeFromParent(ui.viewModeToggle);
                 // ズームボタン等は同一の親 container にまとまっているため、
                 // 親をまとめて remove することで全要素を除去する。
                 const zoomContainer = ui.zoomIn.parentElement;

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -1721,15 +1721,13 @@ export class DefaultScene implements CreateSceneClass {
         };
 
         const updateViewModeToggleLabel = (mode: ViewMode): void => {
-            // 「次に切り替える先」をラベルに表示する（3D 中は "2D"、2D 中は "3D"）。
+            // 「次に切り替える先」を示すアクションボタンとしてラベルを表示する。
+            // textContent / aria-label を「次に切り替える先」で揃えるため、
+            // 「現在の状態」を意味する aria-pressed は付与しない（混在を避ける）。
             ui.viewModeButton.textContent = mode === "3d" ? "2D" : "3D";
             ui.viewModeButton.setAttribute(
                 "aria-label",
                 mode === "3d" ? "視点切替: 2D に変更" : "視点切替: 3D に変更",
-            );
-            ui.viewModeButton.setAttribute(
-                "aria-pressed",
-                mode === "2d" ? "true" : "false",
             );
         };
 

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -1061,14 +1061,38 @@ export class DefaultScene implements CreateSceneClass {
                 // Ctrl/Cmd + ドラッグ: 水平=パン(alpha)、垂直=チルト(beta)
                 const dx = e.clientX - lastPointerX;
                 const dy = e.clientY - lastPointerY;
+                if (currentViewMode === "2d") {
+                    // 2D 中の Ctrl+drag は「画面中心を軸とする twist 回転」。
+                    // カーソルが中心を見る角度（atan2）の差分を camera.alpha に加える。
+                    // 例: 中心の少し上から右へドラッグ → 角度が時計回りに増加 → 画面が右回り。
+                    const rect = canvas.getBoundingClientRect();
+                    const cx = rect.left + rect.width / 2;
+                    const cy = rect.top + rect.height / 2;
+                    const px0 = lastPointerX - cx;
+                    const py0 = lastPointerY - cy;
+                    const px1 = e.clientX - cx;
+                    const py1 = e.clientY - cy;
+                    // 中心近傍は角度が不安定なため一定距離未満では回転しない。
+                    const minR = 8; // px
+                    if (
+                        Math.hypot(px0, py0) >= minR &&
+                        Math.hypot(px1, py1) >= minR
+                    ) {
+                        const a0 = Math.atan2(py0, px0);
+                        const a1 = Math.atan2(py1, px1);
+                        let delta = a1 - a0;
+                        if (delta > Math.PI) delta -= 2 * Math.PI;
+                        else if (delta < -Math.PI) delta += 2 * Math.PI;
+                        camera.alpha += delta;
+                    }
+                    lastPointerX = e.clientX;
+                    lastPointerY = e.clientY;
+                    // 2D ではチルト操作は無効、衝突判定も不要
+                    return;
+                }
                 lastPointerX = e.clientX;
                 lastPointerY = e.clientY;
                 camera.alpha -= dx * 0.003;
-                // 2D モード時は tilt 操作を無効化する (Issue #193)。
-                // alpha（方位回転）は 2D でも有効。
-                if (currentViewMode === "2d") {
-                    return;
-                }
                 const prevBeta = camera.beta;
                 camera.beta -= dy * 0.003;
                 camera.beta = clamp(

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -1656,8 +1656,10 @@ export class DefaultScene implements CreateSceneClass {
             const h = engine.getRenderHeight();
             if (w <= 0 || h <= 0) return;
             const aspect = w / h;
-            // 画面に「カメラ高度 ≒ 1 画面分」が映るよう半径ベースで設定する。
-            const halfH = camera.radius;
+            // perspective でターゲット平面に映る範囲と一致させるため、
+            // 半画角 fov/2 と radius から halfH を導出する。
+            // 前提: camera.fovMode は既定の FOVMODE_VERTICAL_FIXED（fov は鉛直方向）。
+            const halfH = camera.radius * Math.tan(camera.fov / 2);
             const halfW = halfH * aspect;
             camera.orthoTop = halfH;
             camera.orthoBottom = -halfH;
@@ -1680,9 +1682,9 @@ export class DefaultScene implements CreateSceneClass {
 
         const applyViewModeInternal = (
             next: ViewMode,
-            opts?: { silent?: boolean },
+            opts?: { silent?: boolean; force?: boolean },
         ): void => {
-            if (next === currentViewMode) return;
+            if (next === currentViewMode && !opts?.force) return;
             if (next === "2d") {
                 // 現在の tilt を保存（3D 復帰時に復元するため）
                 savedTiltDeg = (camera.beta * 180) / Math.PI;
@@ -1709,14 +1711,13 @@ export class DefaultScene implements CreateSceneClass {
         // 初期反映: ラベルは現在モードに合わせる。`silent: true` で初期 listener は発火させない。
         updateViewModeToggleLabel(currentViewMode);
         if (currentViewMode === "2d") {
-            // applyViewModeInternal は同値で no-op になるため一時的に "3d" に戻して再適用する。
-            currentViewMode = "3d";
-            applyViewModeInternal("2d", { silent: true });
+            // 同値だが初期化のため force で適用する（camera.mode / ortho frustum を確定させる）。
+            applyViewModeInternal("2d", { silent: true, force: true });
         }
 
         // 2D の間は radius / リサイズで ortho frustum を追従させる必要がある。
         // 毎フレーム更新は安価（4 つの数値設定）なので onBeforeRender で常時走らせる。
-        scene.onBeforeRenderObservable.add(() => {
+        const orthoFrustumObserver = scene.onBeforeRenderObservable.add(() => {
             if (currentViewMode === "2d") {
                 applyOrthoFrustum();
             }
@@ -2035,6 +2036,8 @@ export class DefaultScene implements CreateSceneClass {
             dispose: () => {
                 // ShadowGenerator が残っていれば確実に解放する (Issue #39)。
                 disableSunShadows();
+                // 視点モード追従の onBeforeRender observer を解除 (Issue #193)。
+                scene.onBeforeRenderObservable.remove(orthoFrustumObserver);
                 // 地形クリックリスナー (Issue #183) も dispose 時に解放する。
                 // 解除関数を呼ばないまま dispose されたケースで、クロージャに
                 // 残ったリスナー参照経由で外部オブジェクトが解放されないのを防ぐ。

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -57,6 +57,14 @@ const CAMERA_UPPER_RADIUS = 75000;
 /** 遠クリッピング面（メートル） */
 const CAMERA_FAR_CLIP = 400000;
 
+/**
+ * 2D モード時の camera.beta 固定値（ラジアン）。
+ * beta=0 だとジンバルロックで alpha（方位）変化がカメラ位置に反映されず、
+ * かつ camera.lowerBetaLimit によるクランプで意図通りにならないため、
+ * 実質 0 の極小値を使用する。論理 tilt は 0 として扱う。
+ */
+const BETA_2D = 1e-7;
+
 /** Phase 2（垂直移動）に切り替えるカメラ高度の閾値（メートル） */
 const SKY_ZOOM_ALTITUDE_THRESHOLD = 1000;
 
@@ -155,7 +163,7 @@ export interface DefaultSceneController {
     getViewMode(): ViewMode;
     /**
      * 視点モードを切り替える。
-     * - `"2d"`: `camera.beta` を 0 に固定し、`Camera.ORTHOGRAPHIC_CAMERA` に切替。
+     * - `"2d"`: `camera.beta` を極小値（BETA_2D）に固定し、`Camera.ORTHOGRAPHIC_CAMERA` に切替。
      *   現在の `tilt` を保存し、3D 復帰時に復元する。
      * - `"3d"`: 透視投影に戻し、保存していた `tilt` を復元する。
      * - 同値再呼び出しは no-op。
@@ -331,11 +339,13 @@ export class DefaultScene implements CreateSceneClass {
         // tileManager / mapToggle 構築後に行う。
         let currentViewMode: ViewMode = options?.viewMode ?? "3d";
         let savedTiltDeg: number = tiltDeg;
+        // 2D モード中は lowerBetaLimit を 0 に変更するため、3D 復帰用に元の値を保持する。
+        const lowerBetaLimit3d = 0.1;
 
         // チルト制限（地面から15° = beta上限 5π/12）
         camera.upperBetaLimit = Math.PI / 2 - Math.PI / 12;
         // beta=0（真下視点）はArcRotateCameraのジンバルロック・数値不安定を招くため最小値を設定
-        camera.lowerBetaLimit = 0.1;
+        camera.lowerBetaLimit = lowerBetaLimit3d;
 
         // デフォルト入力をすべて無効化（カスタムハンドラで制御）
         camera.inputs.removeByType("ArcRotateCameraPointersInput");
@@ -1541,11 +1551,11 @@ export class DefaultScene implements CreateSceneClass {
             }
 
             const targetAlpha = -Math.PI / 2; // 北向き
-            // 2D モード時は tilt を変更しない（既に beta=0 固定） (Issue #193)。
+            // 2D モード時は tilt を変更しない（既に BETA_2D 固定） (Issue #193)。
             const targetBeta =
                 currentViewMode === "2d"
                     ? camera.beta
-                    : (camera.lowerBetaLimit ?? 0.1); // ほぼ真下
+                    : (camera.lowerBetaLimit ?? lowerBetaLimit3d); // ほぼ真下
             const duration = 400;             // ms
             const startAlpha = camera.alpha;
             const startBeta = camera.beta;
@@ -1688,16 +1698,22 @@ export class DefaultScene implements CreateSceneClass {
             if (next === "2d") {
                 // 現在の tilt を保存（3D 復帰時に復元するため）
                 savedTiltDeg = (camera.beta * 180) / Math.PI;
-                camera.beta = 0;
+                // ArcRotateCamera は beta=0 でジンバルロックが生じ alpha（方位）変化がカメラ位置に
+                // 反映されなくなる。また lowerBetaLimit=0.1 のままでは 0 付近にクランプされてしまう。
+                // そのため 2D 中は lowerBetaLimit を 0 に緩め、実質 0 の極小値（BETA_2D）で固定する。
+                // この値は論理 tilt=0 として扱い、getTilt() は常に 0 を返す。
+                camera.lowerBetaLimit = 0;
+                camera.beta = BETA_2D;
                 camera.mode = Camera.ORTHOGRAPHIC_CAMERA;
                 applyOrthoFrustum();
             } else {
                 camera.mode = Camera.PERSPECTIVE_CAMERA;
-                const lower = camera.lowerBetaLimit ?? 0.1;
+                // 3D 復帰時に元の lowerBetaLimit を戻してから beta を復元する。
+                camera.lowerBetaLimit = lowerBetaLimit3d;
                 const upper = camera.upperBetaLimit ?? Math.PI;
                 camera.beta = clamp(
                     (savedTiltDeg * Math.PI) / 180,
-                    lower,
+                    lowerBetaLimit3d,
                     upper,
                 );
             }
@@ -1803,7 +1819,7 @@ export class DefaultScene implements CreateSceneClass {
                 camera.alpha = alphaFromAzimuthDeg(values.azimuth);
             }
             if (values.tilt !== undefined && currentViewMode === "3d") {
-                const lower = camera.lowerBetaLimit ?? 0;
+                const lower = camera.lowerBetaLimit ?? lowerBetaLimit3d;
                 const upper = camera.upperBetaLimit ?? Math.PI;
                 camera.beta = clamp(
                     (values.tilt * Math.PI) / 180,
@@ -1814,8 +1830,7 @@ export class DefaultScene implements CreateSceneClass {
                 savedTiltDeg = (camera.beta * 180) / Math.PI;
             } else if (values.tilt !== undefined) {
                 // 2D 中は tilt を camera.beta に反映せず、復帰時の値だけ更新する (Issue #193)。
-                const lowerDeg =
-                    ((camera.lowerBetaLimit ?? 0) * 180) / Math.PI;
+                const lowerDeg = (lowerBetaLimit3d * 180) / Math.PI;
                 const upperDeg =
                     ((camera.upperBetaLimit ?? Math.PI) * 180) / Math.PI;
                 savedTiltDeg = clamp(values.tilt, lowerDeg, upperDeg);

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -1679,12 +1679,12 @@ export class DefaultScene implements CreateSceneClass {
 
         const updateViewModeToggleLabel = (mode: ViewMode): void => {
             // 「次に切り替える先」をラベルに表示する（3D 中は "2D"、2D 中は "3D"）。
-            ui.viewModeToggle.textContent = mode === "3d" ? "2D" : "3D";
-            ui.viewModeToggle.setAttribute(
+            ui.viewModeButton.textContent = mode === "3d" ? "2D" : "3D";
+            ui.viewModeButton.setAttribute(
                 "aria-label",
                 mode === "3d" ? "視点切替: 2D に変更" : "視点切替: 3D に変更",
             );
-            ui.viewModeToggle.setAttribute(
+            ui.viewModeButton.setAttribute(
                 "aria-pressed",
                 mode === "2d" ? "true" : "false",
             );
@@ -1739,7 +1739,7 @@ export class DefaultScene implements CreateSceneClass {
             }
         });
 
-        ui.viewModeToggle.addEventListener("click", () => {
+        ui.viewModeButton.addEventListener("click", () => {
             applyViewModeInternal(currentViewMode === "3d" ? "2d" : "3d");
         });
 
@@ -2028,7 +2028,7 @@ export class DefaultScene implements CreateSceneClass {
                 scaleBarBar: ui.scaleBar.bar,
                 scaleBarLabel: ui.scaleBar.label,
                 mapToggle: ui.mapToggle,
-                viewModeToggle: ui.viewModeToggle,
+                viewModeButton: ui.viewModeButton,
                 attribution: ui.scaleBar.attribution,
             }),
             setSunState: (dateTime) => {
@@ -2078,7 +2078,7 @@ export class DefaultScene implements CreateSceneClass {
                 };
                 removeFromParent(ui.compass);
                 removeFromParent(ui.mapToggle);
-                removeFromParent(ui.viewModeToggle);
+                removeFromParent(ui.viewModeButton);
                 // ズームボタン等は同一の親 container にまとまっているため、
                 // 親をまとめて remove することで全要素を除去する。
                 const zoomContainer = ui.zoomIn.parentElement;

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -629,9 +629,20 @@ export class DefaultScene implements CreateSceneClass {
                 return;
             }
 
-            // 先にカメラ位置を反映してから setTarget で alpha/beta/radius を再計算させる
-            camera.setPosition(new Vector3(camX, camY, camZ));
-            camera.setTarget(new Vector3(targetX, targetY, targetZ));
+            // 先にカメラ位置を反映してから setTarget で alpha/beta/radius を再計算させる。
+            // ただし 2D モードではカメラがターゲット直上（beta=BETA_2D で sin≈0）にあるため、
+            // setTarget の atan2 ベースの alpha 再計算が浮動小数点誤差で不安定になり、
+            // 画面が意図せず回転してしまう。2D 中はユーザーの alpha と固定値の beta を保護する。
+            if (currentViewMode === "2d") {
+                const prevAlpha = camera.alpha;
+                camera.setPosition(new Vector3(camX, camY, camZ));
+                camera.setTarget(new Vector3(targetX, targetY, targetZ));
+                camera.alpha = prevAlpha;
+                camera.beta = BETA_2D;
+            } else {
+                camera.setPosition(new Vector3(camX, camY, camZ));
+                camera.setTarget(new Vector3(targetX, targetY, targetZ));
+            }
         };
 
         // ---------- カスタムマウスハンドラ ----------
@@ -903,7 +914,15 @@ export class DefaultScene implements CreateSceneClass {
                     m.name.startsWith("tile-ground-")
                 );
                 if (centerPick?.hit && centerPick.pickedPoint) {
-                    camera.setTarget(centerPick.pickedPoint);
+                    if (currentViewMode === "2d") {
+                        // 2D 中の setTarget も alpha 再計算で不安定化するため alpha/beta を保護する。
+                        const prevAlpha = camera.alpha;
+                        camera.setTarget(centerPick.pickedPoint);
+                        camera.alpha = prevAlpha;
+                        camera.beta = BETA_2D;
+                    } else {
+                        camera.setTarget(centerPick.pickedPoint);
+                    }
                     // ターゲット差分を緯度経度へ折り込み、Marker/Polygon の位置基準
                     // (currentLat/Lon と gridResidualX/Z) を新ターゲットと整合させる。
                     // これを行わずに gridResidualX/Z だけ更新すると、currentLat/Lon

--- a/src/terrain/controlPanel.ts
+++ b/src/terrain/controlPanel.ts
@@ -273,7 +273,6 @@ const createViewModeToggleButton = (): HTMLButtonElement => {
     btn.textContent = "2D";
     btn.tabIndex = 0;
     btn.setAttribute("aria-label", "視点切替: 2D に変更");
-    btn.setAttribute("aria-pressed", "false");
     css(btn, {
         position: "absolute",
         top: "60px",

--- a/src/terrain/controlPanel.ts
+++ b/src/terrain/controlPanel.ts
@@ -13,6 +13,7 @@ export interface ControlPanelElements {
     zoomIn: HTMLButtonElement;
     zoomOut: HTMLButtonElement;
     mapToggle: HTMLButtonElement;
+    viewModeToggle: HTMLButtonElement;
     scaleBar: ScaleBarElement;
 }
 
@@ -260,6 +261,46 @@ const createMapToggleButton = (): HTMLButtonElement => {
     return btn;
 };
 
+/**
+ * 3D / 2D 視点モード切替ボタン (Issue #193)。
+ *
+ * コンパスボタン（top:12px right:12px の 40×40 円形）の直下に同幅・同色系で配置する。
+ * ラベルは「次に切り替える先」を表示する（3D 表示中は `2D`、2D 表示中は `3D`）。
+ */
+const createViewModeToggleButton = (): HTMLButtonElement => {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.textContent = "2D";
+    btn.tabIndex = 0;
+    btn.setAttribute("aria-label", "視点切替: 2D に変更");
+    btn.setAttribute("aria-pressed", "false");
+    css(btn, {
+        position: "absolute",
+        top: "60px",
+        right: "12px",
+        width: "40px",
+        height: "40px",
+        border: "none",
+        borderRadius: "50%",
+        background: "rgba(9,18,32,0.72)",
+        backdropFilter: "blur(6px)",
+        color: "#f2f7ff",
+        fontSize: "13px",
+        fontWeight: "bold",
+        lineHeight: "1",
+        cursor: "pointer",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        outline: "none",
+        padding: "0",
+        zIndex: "10",
+    });
+    btn.classList.add("cp-btn");
+    document.body.appendChild(btn);
+    return btn;
+};
+
 /** きれいな数値にスナップ */
 export const SCALE_STEPS = [
     1, 2, 5, 10, 20, 50, 100, 200, 500,
@@ -363,7 +404,10 @@ export const createControlPanel = (): ControlPanelElements => {
     // 地図切替ボタン（画面左下に配置）
     const mapToggle = createMapToggleButton();
 
+    // 視点モード切替ボタン（コンパス直下に配置） (Issue #193)
+    const viewModeToggle = createViewModeToggleButton();
+
     // スケールバー（ズームボタンコンテナ内に統合済み）
 
-    return { compass, locateMe, zoomIn, zoomOut, mapToggle, scaleBar };
+    return { compass, locateMe, zoomIn, zoomOut, mapToggle, viewModeToggle, scaleBar };
 };

--- a/src/terrain/controlPanel.ts
+++ b/src/terrain/controlPanel.ts
@@ -13,7 +13,7 @@ export interface ControlPanelElements {
     zoomIn: HTMLButtonElement;
     zoomOut: HTMLButtonElement;
     mapToggle: HTMLButtonElement;
-    viewModeToggle: HTMLButtonElement;
+    viewModeButton: HTMLButtonElement;
     scaleBar: ScaleBarElement;
 }
 
@@ -405,9 +405,9 @@ export const createControlPanel = (): ControlPanelElements => {
     const mapToggle = createMapToggleButton();
 
     // 視点モード切替ボタン（コンパス直下に配置） (Issue #193)
-    const viewModeToggle = createViewModeToggleButton();
+    const viewModeButton = createViewModeToggleButton();
 
     // スケールバー（ズームボタンコンテナ内に統合済み）
 
-    return { compass, locateMe, zoomIn, zoomOut, mapToggle, viewModeToggle, scaleBar };
+    return { compass, locateMe, zoomIn, zoomOut, mapToggle, viewModeButton, scaleBar };
 };

--- a/src/terrain/uiVisibility.ts
+++ b/src/terrain/uiVisibility.ts
@@ -13,6 +13,7 @@ export type UiVisibilityTarget =
     | "zoomButtons"
     | "scaleBar"
     | "mapToggle"
+    | "viewModeButton"
     | "attribution";
 
 export interface UiVisibilityElements {
@@ -23,6 +24,7 @@ export interface UiVisibilityElements {
     scaleBarBar: HTMLElement;
     scaleBarLabel: HTMLElement;
     mapToggle: HTMLElement;
+    viewModeToggle: HTMLElement;
     attribution: HTMLElement;
 }
 
@@ -42,6 +44,7 @@ export const createUiVisibilityController = (
         scaleBarBar: captureDisplay(elements.scaleBarBar),
         scaleBarLabel: captureDisplay(elements.scaleBarLabel),
         mapToggle: captureDisplay(elements.mapToggle),
+        viewModeToggle: captureDisplay(elements.viewModeToggle),
         attribution: captureDisplay(elements.attribution),
     };
     const apply = (key: keyof UiVisibilityElements, visible: boolean): void => {
@@ -63,6 +66,9 @@ export const createUiVisibilityController = (
                 break;
             case "mapToggle":
                 apply("mapToggle", visible);
+                break;
+            case "viewModeButton":
+                apply("viewModeToggle", visible);
                 break;
             case "attribution":
                 apply("attribution", visible);

--- a/src/terrain/uiVisibility.ts
+++ b/src/terrain/uiVisibility.ts
@@ -24,7 +24,7 @@ export interface UiVisibilityElements {
     scaleBarBar: HTMLElement;
     scaleBarLabel: HTMLElement;
     mapToggle: HTMLElement;
-    viewModeToggle: HTMLElement;
+    viewModeButton: HTMLElement;
     attribution: HTMLElement;
 }
 
@@ -44,7 +44,7 @@ export const createUiVisibilityController = (
         scaleBarBar: captureDisplay(elements.scaleBarBar),
         scaleBarLabel: captureDisplay(elements.scaleBarLabel),
         mapToggle: captureDisplay(elements.mapToggle),
-        viewModeToggle: captureDisplay(elements.viewModeToggle),
+        viewModeButton: captureDisplay(elements.viewModeButton),
         attribution: captureDisplay(elements.attribution),
     };
     const apply = (key: keyof UiVisibilityElements, visible: boolean): void => {
@@ -68,7 +68,7 @@ export const createUiVisibilityController = (
                 apply("mapToggle", visible);
                 break;
             case "viewModeButton":
-                apply("viewModeToggle", visible);
+                apply("viewModeButton", visible);
                 break;
             case "attribution":
                 apply("attribution", visible);

--- a/src/terrain/urlState.ts
+++ b/src/terrain/urlState.ts
@@ -2,7 +2,7 @@
 
 import { clamp, JAPAN_BOUNDS } from "./gsiTile";
 import { JPMAP_TERRAIN_DEFAULTS } from "../lib/types";
-import type { MapType } from "../lib/types";
+import type { MapType, ViewMode } from "../lib/types";
 
 export interface LatLon {
     lat: number;
@@ -280,5 +280,55 @@ export const updateMapTypeInUrl = (mapType: MapType): void => {
         return;
     }
     const next = withMapTypeInUrl(window.location.href, mapType);
+    window.history.replaceState(null, "", next);
+};
+
+// ---- viewMode クエリ (Issue #193) ----
+
+/** `?viewMode=` のクエリキー名 */
+export const VIEW_MODE_QUERY_KEY = "viewMode";
+
+const VIEW_MODE_VALUES: ReadonlyArray<ViewMode> = ["3d", "2d"];
+
+const isViewMode = (value: string): value is ViewMode =>
+    (VIEW_MODE_VALUES as ReadonlyArray<string>).includes(value);
+
+/**
+ * URL から `?viewMode=3d|2d` を読み取る (Issue #193)。
+ *
+ * - 大小文字無視（`3D`, `2D` も可）。書き出しは小文字。
+ * - 不正値・欠落・URL 解析失敗時は `null` を返す。
+ */
+export const parseViewModeFromUrl = (url: string): ViewMode | null => {
+    try {
+        const parsed = new URL(url, "http://localhost");
+        const raw = parsed.searchParams.get(VIEW_MODE_QUERY_KEY);
+        if (raw === null) return null;
+        const normalized = raw.toLowerCase();
+        return isViewMode(normalized) ? normalized : null;
+    } catch {
+        return null;
+    }
+};
+
+/**
+ * 入力 URL のクエリ部に `viewMode=<value>` をマージして返す純粋関数 (Issue #193)。
+ * パス・他クエリ・ハッシュは保持する。既存の `viewMode` パラメータは上書きする。
+ */
+export const withViewModeInUrl = (url: string, viewMode: ViewMode): string => {
+    const parsed = new URL(url, "http://localhost");
+    parsed.searchParams.set(VIEW_MODE_QUERY_KEY, viewMode);
+    return parsed.pathname + parsed.search + parsed.hash;
+};
+
+/**
+ * `history.replaceState` で現在の URL に `?viewMode=<value>` を反映する (Issue #193)。
+ * `window` / `history` が未定義な環境では何もしない。
+ */
+export const updateViewModeInUrl = (viewMode: ViewMode): void => {
+    if (typeof window === "undefined" || typeof window.history === "undefined") {
+        return;
+    }
+    const next = withViewModeInUrl(window.location.href, viewMode);
     window.history.replaceState(null, "", next);
 };

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -170,6 +170,9 @@ jest.unstable_mockModule("../src/scenes/default", () => {
     // T6: setMapType / setUiVisibility の記録もテストから検証できるよう保持する。
     let lastMapType: "standard" | "photo" = "standard";
     const setMapTypeCalls: Array<"standard" | "photo"> = [];
+    // Issue #193: viewMode の状態と setViewMode 呼び出し履歴。
+    let lastViewMode: "3d" | "2d" = "3d";
+    const setViewModeCalls: Array<"3d" | "2d"> = [];
     // T7: controller.dispose の呼び出し回数も検証する。
     let controllerDisposeCount = 0;
     // Issue #35: setSunState 呼び出し履歴を保持する。
@@ -269,12 +272,14 @@ jest.unstable_mockModule("../src/scenes/default", () => {
         | "zoomButtons"
         | "scaleBar"
         | "mapToggle"
+        | "viewModeButton"
         | "attribution";
     const uiVisibility: Record<UiTarget, boolean> = {
         compass: true,
         zoomButtons: true,
         scaleBar: true,
         mapToggle: true,
+        viewModeButton: true,
         attribution: true,
     };
     type ViewValues = {
@@ -297,6 +302,8 @@ jest.unstable_mockModule("../src/scenes/default", () => {
                     tilt?: number;
                     mapType?: "standard" | "photo";
                     onMapTypeChange?: (mapType: "standard" | "photo") => void;
+                    viewMode?: "3d" | "2d";
+                    onViewModeChange?: (viewMode: "3d" | "2d") => void;
                     onReady?: (controller: unknown) => void;
                 },
             ) => {
@@ -307,6 +314,8 @@ jest.unstable_mockModule("../src/scenes/default", () => {
                 let azimuth = opts?.azimuth ?? 0;
                 let tilt = opts?.tilt ?? 0;
                 if (opts?.mapType) lastMapType = opts.mapType;
+                if (opts?.viewMode) lastViewMode = opts.viewMode;
+                let savedTilt = tilt;
                 const refresh = (): void => {
                     refreshCallCount++;
                 };
@@ -325,7 +334,15 @@ jest.unstable_mockModule("../src/scenes/default", () => {
                     }
                     if (values.altitude !== undefined) altitude = values.altitude;
                     if (values.azimuth !== undefined) azimuth = values.azimuth;
-                    if (values.tilt !== undefined) tilt = values.tilt;
+                    if (values.tilt !== undefined) {
+                        // 2D 中は tilt を反映しない（復帰時の値だけ更新）
+                        if (lastViewMode === "3d") {
+                            tilt = values.tilt;
+                            savedTilt = values.tilt;
+                        } else {
+                            savedTilt = values.tilt;
+                        }
+                    }
                     if (shouldRefresh && centerChanged) refresh();
                 };
                 opts?.onReady?.({
@@ -333,7 +350,7 @@ jest.unstable_mockModule("../src/scenes/default", () => {
                     getLon: () => lon,
                     getAltitude: () => altitude,
                     getAzimuth: () => azimuth,
-                    getTilt: () => tilt,
+                    getTilt: () => (lastViewMode === "2d" ? 0 : tilt),
                     setLat: (v: number) => applyView({ lat: v }, true),
                     setLon: (v: number) => applyView({ lon: v }, true),
                     setAltitude: (v: number) => applyView({ altitude: v }, true),
@@ -352,10 +369,23 @@ jest.unstable_mockModule("../src/scenes/default", () => {
                             opts?.onMapTypeChange?.(value);
                         }
                     },
+                    getViewMode: () => lastViewMode,
+                    setViewMode: (value: "3d" | "2d") => {
+                        const prev = lastViewMode;
+                        if (prev === value) return;
+                        if (value === "2d") {
+                            savedTilt = tilt;
+                            tilt = 0;
+                        } else {
+                            tilt = savedTilt;
+                        }
+                        lastViewMode = value;
+                        setViewModeCalls.push(value);
+                        opts?.onViewModeChange?.(value);
+                    },
                     setUiVisibility: (target: UiTarget, visible: boolean) => {
                         uiVisibility[target] = visible;
-                    },
-                    setSunState: (_dateTime: Date | null) => {
+                    },                    setSunState: (_dateTime: Date | null) => {
                         // テスト用: 受信を記録するだけで Babylon 描画は伴わない
                         sunStateCalls.push({ dateTime: _dateTime });
                     },
@@ -438,6 +468,7 @@ jest.unstable_mockModule("../src/scenes/default", () => {
             uiVisibility.zoomButtons = true;
             uiVisibility.scaleBar = true;
             uiVisibility.mapToggle = true;
+            uiVisibility.viewModeButton = true;
             uiVisibility.attribution = true;
         },
         __getSetMapTypeCalls: (): Array<"standard" | "photo"> => [
@@ -449,6 +480,16 @@ jest.unstable_mockModule("../src/scenes/default", () => {
         __getLastMapType: (): "standard" | "photo" => lastMapType,
         __setLastMapType: (v: "standard" | "photo"): void => {
             lastMapType = v;
+        },
+        __getSetViewModeCalls: (): Array<"3d" | "2d"> => [
+            ...setViewModeCalls,
+        ],
+        __resetSetViewModeCalls: (): void => {
+            setViewModeCalls.length = 0;
+        },
+        __getLastViewMode: (): "3d" | "2d" => lastViewMode,
+        __setLastViewMode: (v: "3d" | "2d"): void => {
+            lastViewMode = v;
         },
         __getControllerDisposeCount: (): number => controllerDisposeCount,
         __resetControllerDisposeCount: (): void => {
@@ -517,6 +558,7 @@ type UiTarget =
     | "zoomButtons"
     | "scaleBar"
     | "mapToggle"
+    | "viewModeButton"
     | "attribution";
 const sceneMockModule = (await import("../src/scenes/default")) as unknown as {
     __getRefreshCount: () => number;
@@ -527,6 +569,10 @@ const sceneMockModule = (await import("../src/scenes/default")) as unknown as {
     __resetSetMapTypeCalls: () => void;
     __getLastMapType: () => "standard" | "photo";
     __setLastMapType: (v: "standard" | "photo") => void;
+    __getSetViewModeCalls: () => Array<"3d" | "2d">;
+    __resetSetViewModeCalls: () => void;
+    __getLastViewMode: () => "3d" | "2d";
+    __setLastViewMode: (v: "3d" | "2d") => void;
     __getControllerDisposeCount: () => number;
     __resetControllerDisposeCount: () => void;
     __getSunStateCalls: () => Array<{ dateTime: Date | null }>;
@@ -955,6 +1001,7 @@ describe("JpmapTerrain (skeleton)", () => {
                 zoomButtons: true,
                 scaleBar: true,
                 mapToggle: true,
+                viewModeButton: true,
                 attribution: true,
             });
         });
@@ -966,6 +1013,7 @@ describe("JpmapTerrain (skeleton)", () => {
             viewer.showZoomButtons = false;
             viewer.showScaleBar = false;
             viewer.showMapToggle = false;
+            viewer.showViewModeButton = false;
             viewer.showAttribution = false;
 
             expect(sceneMockModule.__getUiVisibility()).toEqual({
@@ -973,6 +1021,7 @@ describe("JpmapTerrain (skeleton)", () => {
                 zoomButtons: false,
                 scaleBar: false,
                 mapToggle: false,
+                viewModeButton: false,
                 attribution: false,
             });
 
@@ -981,6 +1030,7 @@ describe("JpmapTerrain (skeleton)", () => {
             expect(viewer.showZoomButtons).toBe(false);
             expect(viewer.showScaleBar).toBe(false);
             expect(viewer.showMapToggle).toBe(false);
+            expect(viewer.showViewModeButton).toBe(false);
             expect(viewer.showAttribution).toBe(false);
 
             viewer.showCompass = true;
@@ -1434,6 +1484,162 @@ describe("JpmapTerrain (skeleton)", () => {
             viewer.mapType = "standard";
             expect(listener).toHaveBeenCalledTimes(1);
             expect(listener).toHaveBeenCalledWith("standard");
+        });
+    });
+
+    describe("viewMode (Issue #193)", () => {
+        beforeEach(() => {
+            sceneMockModule.__resetSetViewModeCalls();
+            sceneMockModule.__setLastViewMode("3d");
+        });
+
+        it("デフォルト viewMode は '3d'", async () => {
+            const viewer = await create(createMountElement());
+            expect(viewer.viewMode).toBe("3d");
+        });
+
+        it("options.viewMode === '2d' を渡すと初期から '2d' になる", async () => {
+            const viewer = await create(createMountElement(), {
+                viewMode: "2d",
+            });
+            expect(viewer.viewMode).toBe("2d");
+        });
+
+        it("setter で '2d' に切替後 getter が '2d' を返す", async () => {
+            const viewer = await create(createMountElement());
+            viewer.viewMode = "2d";
+            expect(viewer.viewMode).toBe("2d");
+            viewer.viewMode = "3d";
+            expect(viewer.viewMode).toBe("3d");
+        });
+
+        it("2D 中の tilt getter は 0、3D 復帰時に元 tilt が復元される", async () => {
+            const viewer = await create(createMountElement(), { tilt: 45 });
+            expect(viewer.tilt).toBe(45);
+
+            viewer.viewMode = "2d";
+            expect(viewer.tilt).toBe(0);
+
+            viewer.viewMode = "3d";
+            expect(viewer.tilt).toBe(45);
+        });
+
+        it("2D 中の tilt setter / flyTo({tilt}) は反映されないが lat/lon/altitude/azimuth は適用される", async () => {
+            const viewer = await create(createMountElement(), { tilt: 45 });
+            viewer.viewMode = "2d";
+
+            viewer.tilt = 60;
+            expect(viewer.tilt).toBe(0); // 2D は常に 0
+
+            await viewer.flyTo({
+                lat: 36.0,
+                lon: 138.0,
+                altitude: 3000,
+                azimuth: 90,
+                tilt: 30,
+                duration: 0,
+            });
+            expect(viewer.lat).toBe(36.0);
+            expect(viewer.lon).toBe(138.0);
+            expect(viewer.altitude).toBe(3000);
+            expect(viewer.azimuth).toBe(90);
+            expect(viewer.tilt).toBe(0); // 2D 中は tilt は 0 のまま
+
+            // 3D 復帰時に flyTo で渡された tilt 30 が復元される
+            viewer.viewMode = "3d";
+            expect(viewer.tilt).toBe(30);
+        });
+
+        it("onViewModeChange は値変化時のみ発火、同値 set は no-op", async () => {
+            const viewer = await create(createMountElement());
+            const listener = jest.fn();
+            viewer.onViewModeChange(listener);
+
+            viewer.viewMode = "3d"; // 同値
+            expect(listener).not.toHaveBeenCalled();
+
+            viewer.viewMode = "2d";
+            expect(listener).toHaveBeenCalledTimes(1);
+            expect(listener).toHaveBeenCalledWith("2d");
+
+            viewer.viewMode = "2d"; // 同値
+            expect(listener).toHaveBeenCalledTimes(1);
+
+            viewer.viewMode = "3d";
+            expect(listener).toHaveBeenCalledTimes(2);
+        });
+
+        it("onViewModeChange unsubscribe は冪等で、解除後は呼ばれない", async () => {
+            const viewer = await create(createMountElement());
+            const listener = jest.fn();
+            const unsubscribe = viewer.onViewModeChange(listener);
+            viewer.viewMode = "2d";
+            expect(listener).toHaveBeenCalledTimes(1);
+            unsubscribe();
+            unsubscribe(); // 多重呼び出しでも例外にならない
+            viewer.viewMode = "3d";
+            expect(listener).toHaveBeenCalledTimes(1);
+        });
+
+        it("リスナーが throw しても他リスナーへ伝播し console.error が記録される", async () => {
+            const viewer = await create(createMountElement());
+            const errorSpy = jest
+                .spyOn(console, "error")
+                .mockImplementation(() => {});
+            const failing = jest.fn(() => {
+                throw new Error("vm listener failure");
+            });
+            const ok = jest.fn();
+            viewer.onViewModeChange(failing);
+            viewer.onViewModeChange(ok);
+
+            viewer.viewMode = "2d";
+
+            expect(failing).toHaveBeenCalledTimes(1);
+            expect(ok).toHaveBeenCalledTimes(1);
+            expect(errorSpy).toHaveBeenCalled();
+            errorSpy.mockRestore();
+        });
+
+        it("dispose 後の onViewModeChange は no-op の unsubscribe を返す", async () => {
+            const viewer = await create(createMountElement());
+            viewer.dispose();
+            const listener = jest.fn();
+            const unsubscribe = viewer.onViewModeChange(listener);
+            expect(typeof unsubscribe).toBe("function");
+            expect(() => unsubscribe()).not.toThrow();
+            expect(listener).not.toHaveBeenCalled();
+        });
+
+        it("CameraChangeEvent.viewMode が含まれる", async () => {
+            const viewer = await create(createMountElement());
+            const events: Array<{ viewMode: "3d" | "2d" }> = [];
+            viewer.onCameraChange((e) => events.push({ viewMode: e.viewMode }));
+            // 初回スナップショット確立
+            sceneMockModule.__triggerSceneRender();
+            // 2D に切替 → 次フレームで camera change 通知（tilt 変化 + viewMode 変化）
+            viewer.viewMode = "2d";
+            sceneMockModule.__triggerSceneRender();
+
+            expect(events.length).toBeGreaterThan(0);
+            expect(events[events.length - 1].viewMode).toBe("2d");
+        });
+
+        it("showViewModeButton=false で UI が非表示になる", async () => {
+            await create(createMountElement(), {
+                showViewModeButton: false,
+            });
+            expect(
+                sceneMockModule.__getUiVisibility().viewModeButton,
+            ).toBe(false);
+        });
+
+        it("showViewModeButton 既定は true", async () => {
+            const viewer = await create(createMountElement());
+            expect(viewer.showViewModeButton).toBe(true);
+            expect(
+                sceneMockModule.__getUiVisibility().viewModeButton,
+            ).toBe(true);
         });
     });
 

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -385,7 +385,8 @@ jest.unstable_mockModule("../src/scenes/default", () => {
                     },
                     setUiVisibility: (target: UiTarget, visible: boolean) => {
                         uiVisibility[target] = visible;
-                    },                    setSunState: (_dateTime: Date | null) => {
+                    },
+                    setSunState: (_dateTime: Date | null) => {
                         // テスト用: 受信を記録するだけで Babylon 描画は伴わない
                         sunStateCalls.push({ dateTime: _dateTime });
                     },

--- a/tests/libExports.unit.spec.ts
+++ b/tests/libExports.unit.spec.ts
@@ -66,6 +66,7 @@ describe("package entry exports (T8)", () => {
             altitude: 2000,
             azimuth: 0,
             tilt: 45,
+            viewMode: "3d",
         };
         let received: CameraChangeEvent | null = null;
         const listener: CameraChangeListener = (e) => {

--- a/tests/uiVisibility.unit.spec.ts
+++ b/tests/uiVisibility.unit.spec.ts
@@ -31,6 +31,7 @@ describe("createUiVisibilityController (T6)", () => {
             scaleBarBar: make(""),
             scaleBarLabel: make(""),
             mapToggle: make("flex"),
+            viewModeToggle: make("flex"),
             attribution: make(""),
         };
     };

--- a/tests/uiVisibility.unit.spec.ts
+++ b/tests/uiVisibility.unit.spec.ts
@@ -31,7 +31,7 @@ describe("createUiVisibilityController (T6)", () => {
             scaleBarBar: make(""),
             scaleBarLabel: make(""),
             mapToggle: make("flex"),
-            viewModeToggle: make("flex"),
+            viewModeButton: make("flex"),
             attribution: make(""),
         };
     };

--- a/tests/urlState.unit.spec.ts
+++ b/tests/urlState.unit.spec.ts
@@ -14,6 +14,10 @@ import {
     parseMapTypeFromUrl,
     withMapTypeInUrl,
     updateMapTypeInUrl,
+    VIEW_MODE_QUERY_KEY,
+    parseViewModeFromUrl,
+    withViewModeInUrl,
+    updateViewModeInUrl,
 } from "../src/terrain/urlState";
 
 describe("urlState", () => {
@@ -622,6 +626,74 @@ describe("urlState", () => {
                 azimuth: 90,
                 tilt: 60,
             });
+        });
+    });
+
+    describe("parseViewModeFromUrl / withViewModeInUrl (Issue #193)", () => {
+        it("?viewMode=3d / 2d を解析できる", () => {
+            expect(parseViewModeFromUrl("http://localhost/?viewMode=3d")).toBe(
+                "3d",
+            );
+            expect(parseViewModeFromUrl("http://localhost/?viewMode=2d")).toBe(
+                "2d",
+            );
+        });
+
+        it("大小文字無視で受理する", () => {
+            expect(parseViewModeFromUrl("http://localhost/?viewMode=3D")).toBe(
+                "3d",
+            );
+            expect(parseViewModeFromUrl("http://localhost/?viewMode=2D")).toBe(
+                "2d",
+            );
+        });
+
+        it("欠落 / 不正値は null", () => {
+            expect(parseViewModeFromUrl("http://localhost/")).toBeNull();
+            expect(
+                parseViewModeFromUrl("http://localhost/?viewMode=foo"),
+            ).toBeNull();
+        });
+
+        it("withViewModeInUrl はパス・他クエリ・ハッシュを保持して上書きする", () => {
+            expect(
+                withViewModeInUrl(
+                    "http://localhost/path?engine=webgl2#section",
+                    "2d",
+                ),
+            ).toBe("/path?engine=webgl2&viewMode=2d#section");
+            expect(
+                withViewModeInUrl(
+                    "http://localhost/?viewMode=3d&engine=webgl2",
+                    "2d",
+                ),
+            ).toBe("/?viewMode=2d&engine=webgl2");
+        });
+
+        it("VIEW_MODE_QUERY_KEY === 'viewMode'", () => {
+            expect(VIEW_MODE_QUERY_KEY).toBe("viewMode");
+        });
+
+        it("updateViewModeInUrl は history.replaceState に渡す", () => {
+            const originalWindow = (globalThis as { window?: unknown }).window;
+            const replaceSpy = jest.fn();
+            (globalThis as { window?: unknown }).window = {
+                history: { replaceState: replaceSpy },
+                location: { href: "http://localhost/?engine=webgl" },
+            };
+            try {
+                updateViewModeInUrl("2d");
+                expect(replaceSpy).toHaveBeenCalledTimes(1);
+                expect(replaceSpy.mock.calls[0][2]).toBe(
+                    "/?engine=webgl&viewMode=2d",
+                );
+            } finally {
+                if (originalWindow === undefined) {
+                    delete (globalThis as { window?: unknown }).window;
+                } else {
+                    (globalThis as { window?: unknown }).window = originalWindow;
+                }
+            }
         });
     });
 });


### PR DESCRIPTION
## 概要

3D地形ビューアに **3Dモード / 2Dモード** の切り替え機能を追加する。

- `viewMode` プロパティ（`"3d" | "2d"`）の get/set
- 2Dモード時: 平行投影（orthographic）、tilt=0（真下）固定、tilt操作無効、回転と移動は有効
- 3Dモード復帰時: perspective と元の tilt を復元
- `onViewModeChange` イベント
- 切替ボタン（コンパス直下）と `showViewModeButton` API
- `CameraChangeEvent` に `viewMode` フィールド追加
- URL パラメータ `?viewMode=` 対応（viewer demo）
- polygon / distance demo はデモ側ボタンから API 呼出パターンで実装

## 設計方針

- `mapType` 切替（#149）と完全対称な構造
- 「カメラの本当の状態」は `ArcRotateCamera.mode` / `beta`、「論理 viewMode」と「3D 復帰用 tilt」は scene 内クロージャに閉じる
- 2D 制約は scene 入口で集中ガード（applyView の tilt 分岐 / pointer drag / resetCompassView の3箇所）

## 検証

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test:unit` ✅ 27 suites / 592 tests pass（新規 18件追加）
- `npm run test:visuals` は CI / 手動で確認

## 互換性

- `CameraChangeEvent` に必須フィールド `viewMode` 追加（型レベル破壊的変更）。リスナー側で受信のみのコードは影響なし。

Closes #193
Closes #194
Closes #195
Closes #196
Closes #197
Closes #198
