### PR TITLE
feat(circle): implement CircleNode and CircleManager (#203)

### DIFF
--- a/src/terrain/circle.ts
+++ b/src/terrain/circle.ts
@@ -227,12 +227,19 @@ const buildRingXZ = (
 export interface CircleNode {
     readonly id: string;
     readonly altitudeMode: AltitudeMode;
-    /** 中心点（lat / lon / altitude）のスナップショット。manager から更新される */
+    /**
+     * 中心点（lat / lon / altitude）のスナップショット。
+     * setter で内部値を更新しラベルを再生成する（C4 updateCircle 用）。
+     */
     center: CircleCenterOptions;
-    /** 半径 (m, world)。manager から更新される */
+    /** 半径 (m, world)。setter で内部値を更新しラベルを再生成する（C4 updateCircle 用）。 */
     radius: number;
-    /** 円周分割数。manager から更新される */
-    segments: number;
+    /**
+     * 円周分割数。
+     * segments 変更は Tube/Ribbon の path 長変化を伴うため dispose+rebuild が必要。
+     * この値を変更するには CircleManager 経由で circle を再作成すること。
+     */
+    readonly segments: number;
     /**
      * フレーム単位の幾何更新。
      * @param centerWorld 中心の world 座標（Y は標高反映済み）
@@ -552,6 +559,12 @@ export const createCircleNode = (
         altitudeMode,
         get center() {
             return center;
+        },
+        set center(value: CircleCenterOptions) {
+            center.lat = value.lat;
+            center.lon = value.lon;
+            center.altitude = value.altitude;
+            refreshAutoLabel();
         },
         get radius() {
             return radius;

--- a/src/terrain/circle.ts
+++ b/src/terrain/circle.ts
@@ -196,11 +196,12 @@ const createLabelMesh = (
 };
 
 /**
- * 中心 world 座標 + 半径 + segments から円周点列（閉ループ）を生成する。
+ * 中心 world 座標 + 半径 + segments から円周点列を生成する。
  *
- * 戻り値の `worldRing` は閉ループ（末尾に先頭を append 済み、長さ = segments + 1）。
- * 円周点の (X, Z) は world 平面の polar 展開で求められ、Y は中心 Y を使う。
- * terrain モード時の各点 Y は呼び出し側で標高解決して上書きする。
+ * 戻り値は未クローズの円周点列（長さ = segments）。必要な閉ループ化
+ * （末尾への先頭点の追加）は呼び出し側で行う。
+ * 円周点の (X, Z) は world 平面の polar 展開で求められる。
+ * terrain モード時の各点 Y は呼び出し側で標高解決して設定する。
  */
 const buildRingXZ = (
     cx: number,

--- a/src/terrain/circle.ts
+++ b/src/terrain/circle.ts
@@ -1,0 +1,605 @@
+/**
+ * 個別円ノード (Issue #201 / #203)。
+ *
+ * - 中心点の球（{@link CreateSphere}）
+ * - 円周を結ぶチューブ（{@link CreateTube}、`updatable: true`、閉ループ）
+ * - 円周下端から Y=0 まで伸ばす壁 Ribbon（{@link CreateRibbon}、`updatable: true`）
+ * - 中心ラベル（DynamicTexture + ビルボード Plane、複数行対応）
+ *
+ * を 1 つの root TransformNode 配下に親子化して管理する。
+ *
+ * 円周点列は world 平面で polar 展開して生成する（C + radius·(cosθ, 0, sinθ)）。
+ * これにより緯度方向の Mercator 圧縮による楕円化を回避する。
+ *
+ * 描画グループ:
+ * - 中心球 / 円周 Tube / 中心ラベル: `RENDERING_GROUP_ID = 1`（地表より手前）
+ * - 壁 Ribbon: `SUBTERRAIN_RENDERING_GROUP_ID = 0`（地表深度でオクルード、#186 参照）
+ */
+
+import type { Scene } from "@babylonjs/core/scene";
+import { Color3 } from "@babylonjs/core/Maths/math.color";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { CreateSphere } from "@babylonjs/core/Meshes/Builders/sphereBuilder";
+import { CreateTube } from "@babylonjs/core/Meshes/Builders/tubeBuilder";
+import { CreateRibbon } from "@babylonjs/core/Meshes/Builders/ribbonBuilder";
+import { CreatePlane } from "@babylonjs/core/Meshes/Builders/planeBuilder";
+import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
+import { DynamicTexture } from "@babylonjs/core/Materials/Textures/dynamicTexture";
+import { AbstractMesh } from "@babylonjs/core/Meshes/abstractMesh";
+import { Mesh } from "@babylonjs/core/Meshes/mesh";
+import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
+
+import {
+    CIRCLE_DEFAULTS,
+    type AltitudeMode,
+    type CircleCenterOptions,
+    type CircleHandle,
+    type CircleOptions,
+    type CircleStyleOptions,
+} from "../lib/types";
+
+const RENDERING_GROUP_ID = 1;
+const SUBTERRAIN_RENDERING_GROUP_ID = 0;
+const LABEL_MAX_DT_SIZE = 1024;
+const LABEL_MIN_DT_SIZE = 32;
+const LABEL_GAP_FONT_RATIO = 0.0;
+
+interface ResolvedStyle {
+    pointColor: string;
+    pointDiameter: number;
+    pointOpacity: number;
+    lineColor: string;
+    lineWidth: number;
+    lineOpacity: number;
+    wallColor: string;
+    wallOpacity: number;
+    labelColor: string;
+    labelBackgroundColor: string;
+    labelFontSize: number;
+}
+
+const resolveStyle = (style: CircleStyleOptions | undefined): ResolvedStyle => ({
+    pointColor: style?.pointColor ?? CIRCLE_DEFAULTS.style.pointColor,
+    pointDiameter:
+        style?.pointDiameter ?? CIRCLE_DEFAULTS.style.pointDiameter,
+    pointOpacity: style?.pointOpacity ?? CIRCLE_DEFAULTS.style.pointOpacity,
+    lineColor: style?.lineColor ?? CIRCLE_DEFAULTS.style.lineColor,
+    lineWidth: style?.lineWidth ?? CIRCLE_DEFAULTS.style.lineWidth,
+    lineOpacity: style?.lineOpacity ?? CIRCLE_DEFAULTS.style.lineOpacity,
+    wallColor: style?.wallColor ?? CIRCLE_DEFAULTS.style.wallColor,
+    wallOpacity: style?.wallOpacity ?? CIRCLE_DEFAULTS.style.wallOpacity,
+    labelColor: style?.labelColor ?? CIRCLE_DEFAULTS.style.labelColor,
+    labelBackgroundColor:
+        style?.labelBackgroundColor ??
+        CIRCLE_DEFAULTS.style.labelBackgroundColor,
+    labelFontSize:
+        style?.labelFontSize ?? CIRCLE_DEFAULTS.style.labelFontSize,
+});
+
+interface LabelEntry {
+    mesh: Mesh;
+    material: StandardMaterial;
+    texture: DynamicTexture;
+    widthWorld: number;
+    heightWorld: number;
+}
+
+const createLabelMesh = (
+    scene: Scene,
+    id: string,
+    text: string,
+    style: ResolvedStyle,
+    parent: TransformNode,
+): LabelEntry => {
+    const dpr =
+        typeof globalThis !== "undefined" &&
+        typeof (globalThis as { devicePixelRatio?: number }).devicePixelRatio ===
+            "number"
+            ? Math.max(
+                  (globalThis as { devicePixelRatio: number }).devicePixelRatio,
+                  1,
+              )
+            : 1;
+
+    const lines = text.split("\n");
+    const fontSize = Math.max(style.labelFontSize, 1);
+    const padPx = Math.round(fontSize * 0.1);
+    const strokePx = Math.max(2, Math.round(fontSize * 0.12));
+    const lineHeightPx = fontSize * 1.2;
+
+    const probe = new DynamicTexture(
+        `circle-${id}-label-probe`,
+        { width: 16, height: 16 },
+        scene,
+        false,
+    );
+    const probeCtx = probe.getContext();
+    probeCtx.font = `${fontSize}px sans-serif`;
+    let maxLineWidth = 0;
+    for (const ln of lines) {
+        const m = probeCtx.measureText(ln === "" ? " " : ln);
+        if (m.width > maxLineWidth) maxLineWidth = m.width;
+    }
+    probe.dispose();
+
+    const innerPad = padPx + strokePx;
+    const innerW = maxLineWidth + innerPad * 2;
+    const innerH = lineHeightPx * Math.max(lines.length, 1) + innerPad * 2;
+    const dtWidth = Math.max(
+        LABEL_MIN_DT_SIZE,
+        Math.min(LABEL_MAX_DT_SIZE, Math.ceil(innerW * dpr)),
+    );
+    const dtHeight = Math.max(
+        LABEL_MIN_DT_SIZE,
+        Math.min(LABEL_MAX_DT_SIZE, Math.ceil(innerH * dpr)),
+    );
+
+    const texture = new DynamicTexture(
+        `circle-${id}-label`,
+        { width: dtWidth, height: dtHeight },
+        scene,
+        false,
+    );
+    texture.hasAlpha = true;
+    texture.vScale = -1;
+    texture.vOffset = 1;
+
+    const ctx = texture.getContext() as unknown as CanvasRenderingContext2D;
+    ctx.clearRect(0, 0, dtWidth, dtHeight);
+    if (
+        style.labelBackgroundColor &&
+        style.labelBackgroundColor !== "transparent"
+    ) {
+        ctx.fillStyle = style.labelBackgroundColor;
+        ctx.fillRect(0, 0, dtWidth, dtHeight);
+    }
+    ctx.font = `${fontSize * dpr}px sans-serif`;
+    ctx.textBaseline = "top";
+    ctx.textAlign = "center";
+    ctx.lineJoin = "round";
+    ctx.miterLimit = 2;
+    const startY = innerPad * dpr;
+    const centerX = dtWidth / 2;
+    ctx.lineWidth = strokePx * 2 * dpr;
+    ctx.strokeStyle = "#ffffff";
+    for (let i = 0; i < lines.length; i++) {
+        ctx.strokeText(lines[i], centerX, startY + i * lineHeightPx * dpr);
+    }
+    ctx.fillStyle = style.labelColor;
+    for (let i = 0; i < lines.length; i++) {
+        ctx.fillText(lines[i], centerX, startY + i * lineHeightPx * dpr);
+    }
+    texture.update(false);
+
+    const widthWorld = dtWidth / dpr;
+    const heightWorld = dtHeight / dpr;
+
+    const mesh = CreatePlane(
+        `circle-${id}-label`,
+        { width: widthWorld, height: heightWorld },
+        scene,
+    );
+    mesh.billboardMode = AbstractMesh.BILLBOARDMODE_ALL;
+    mesh.renderingGroupId = RENDERING_GROUP_ID;
+    mesh.isPickable = false;
+    mesh.parent = parent;
+
+    const material = new StandardMaterial(`circle-${id}-label-mat`, scene);
+    material.disableLighting = true;
+    material.backFaceCulling = false;
+    material.useAlphaFromDiffuseTexture = true;
+    material.emissiveColor = Color3.White();
+    material.diffuseTexture = texture;
+    mesh.material = material;
+
+    return { mesh, material, texture, widthWorld, heightWorld };
+};
+
+/**
+ * 中心 world 座標 + 半径 + segments から円周点列（閉ループ）を生成する。
+ *
+ * 戻り値の `worldRing` は閉ループ（末尾に先頭を append 済み、長さ = segments + 1）。
+ * 円周点の (X, Z) は world 平面の polar 展開で求められ、Y は中心 Y を使う。
+ * terrain モード時の各点 Y は呼び出し側で標高解決して上書きする。
+ */
+const buildRingXZ = (
+    cx: number,
+    cz: number,
+    radius: number,
+    segments: number,
+): { x: number; z: number }[] => {
+    const ring: { x: number; z: number }[] = [];
+    const step = (Math.PI * 2) / segments;
+    for (let i = 0; i < segments; i++) {
+        const θ = i * step;
+        ring.push({
+            x: cx + radius * Math.cos(θ),
+            z: cz + radius * Math.sin(θ),
+        });
+    }
+    return ring;
+};
+
+/**
+ * 1 円分の Babylon ノード。`CircleManager` から生成・更新・破棄される。
+ */
+export interface CircleNode {
+    readonly id: string;
+    readonly altitudeMode: AltitudeMode;
+    /** 中心点（lat / lon / altitude）のスナップショット。manager から更新される */
+    center: CircleCenterOptions;
+    /** 半径 (m, world)。manager から更新される */
+    radius: number;
+    /** 円周分割数。manager から更新される */
+    segments: number;
+    /**
+     * フレーム単位の幾何更新。
+     * @param centerWorld 中心の world 座標（Y は標高反映済み）
+     * @param ringWorld 円周点の world 座標列（長さ === segments）
+     * @param pointScale screen-stable な距離スケール係数
+     */
+    applyTransform(
+        centerWorld: Vector3,
+        ringWorld: readonly Vector3[],
+        pointScale: number,
+    ): void;
+    setEnabledLogical(enabled: boolean): void;
+    setPointEnabledLogical(enabled: boolean): void;
+    setLineEnabledLogical(enabled: boolean): void;
+    setWallEnabledLogical(enabled: boolean): void;
+    setLabelEnabledLogical(enabled: boolean): void;
+    setElevationResolved(resolved: boolean): void;
+    getHandle(): CircleHandle;
+    dispose(): void;
+}
+
+/**
+ * 中心ラベルの自動生成テキスト（lat / lon / altitude / radius を 4 行で表示）。
+ */
+const formatAutoLabel = (
+    center: CircleCenterOptions,
+    radius: number,
+): string => {
+    const altText =
+        center.altitude !== undefined ? center.altitude.toFixed(1) : "0.0";
+    return [
+        `lat: ${center.lat.toFixed(6)}`,
+        `lon: ${center.lon.toFixed(6)}`,
+        `alt: ${altText} m`,
+        `radius: ${radius.toFixed(1)} m`,
+    ].join("\n");
+};
+
+/**
+ * 内部状態として保持する label 値の解決ルール。
+ * - `options.label === undefined`: 自動生成（auto = true）
+ * - `options.label === null`: 非表示（hidden）
+ * - `options.label === "..."`: カスタム（auto = false）
+ */
+const resolveLabelText = (
+    options: CircleOptions,
+): { auto: boolean; text: string | null } => {
+    if (options.label === null) return { auto: false, text: null };
+    if (options.label === undefined) {
+        return {
+            auto: true,
+            text: formatAutoLabel(options.center, options.radius),
+        };
+    }
+    return { auto: false, text: options.label };
+};
+
+/**
+ * `CircleNode` を生成する。`segments / radius / center` は `CircleManager` 側で
+ * 検証済みである前提。
+ */
+export const createCircleNode = (
+    scene: Scene,
+    id: string,
+    options: CircleOptions,
+): CircleNode => {
+    const altitudeMode = options.altitudeMode ?? CIRCLE_DEFAULTS.altitudeMode;
+    const segments = options.segments ?? CIRCLE_DEFAULTS.segments;
+    const style = resolveStyle(options.style);
+    let logicalEnabled = options.enabled ?? CIRCLE_DEFAULTS.enabled;
+    let pointEnabled = options.pointEnabled ?? CIRCLE_DEFAULTS.pointEnabled;
+    let lineEnabled = options.lineEnabled ?? CIRCLE_DEFAULTS.lineEnabled;
+    let wallEnabled = options.wallEnabled ?? CIRCLE_DEFAULTS.wallEnabled;
+    let labelEnabled = options.labelEnabled ?? CIRCLE_DEFAULTS.labelEnabled;
+    let elevationResolved = altitudeMode === "absolute";
+
+    const center: CircleCenterOptions = {
+        lat: options.center.lat,
+        lon: options.center.lon,
+        altitude: options.center.altitude,
+    };
+    let radius = options.radius;
+
+    const root = new TransformNode(`circle-${id}`, scene);
+
+    // 中心球
+    const sphereMesh = CreateSphere(
+        `circle-${id}-center`,
+        { diameter: 1, segments: 16 },
+        scene,
+    );
+    const sphereMaterial = new StandardMaterial(
+        `circle-${id}-center-mat`,
+        scene,
+    );
+    sphereMaterial.disableLighting = true;
+    sphereMaterial.backFaceCulling = false;
+    sphereMaterial.emissiveColor = Color3.FromHexString(style.pointColor);
+    sphereMaterial.alpha = style.pointOpacity;
+    sphereMesh.material = sphereMaterial;
+    sphereMesh.renderingGroupId = RENDERING_GROUP_ID;
+    sphereMesh.isPickable = true;
+    sphereMesh.parent = root;
+
+    // 円周 Tube（閉ループ：path 長 = segments + 1、末尾は先頭と同点）
+    const initialRing = buildRingXZ(0, 0, Math.max(radius, 0.001), segments);
+    const initialTubePath: Vector3[] = initialRing.map(
+        (p) => new Vector3(p.x, 0, p.z),
+    );
+    initialTubePath.push(
+        new Vector3(initialTubePath[0].x, 0, initialTubePath[0].z),
+    );
+    let lineMesh: Mesh = CreateTube(
+        `circle-${id}-line`,
+        {
+            path: initialTubePath,
+            radius: Math.max(style.lineWidth, 0.001),
+            updatable: true,
+            cap: Mesh.NO_CAP,
+        },
+        scene,
+    );
+    const lineMaterial = new StandardMaterial(`circle-${id}-line-mat`, scene);
+    lineMaterial.disableLighting = true;
+    lineMaterial.backFaceCulling = false;
+    lineMaterial.emissiveColor = Color3.FromHexString(style.lineColor);
+    lineMaterial.alpha = style.lineOpacity;
+    lineMesh.material = lineMaterial;
+    lineMesh.renderingGroupId = RENDERING_GROUP_ID;
+    lineMesh.isPickable = false;
+    lineMesh.parent = root;
+
+    // 壁 Ribbon
+    const initialWallTop: Vector3[] = initialTubePath.map(
+        (p) => new Vector3(p.x, 0, p.z),
+    );
+    const initialWallBottom: Vector3[] = initialTubePath.map(
+        (p) => new Vector3(p.x, 0, p.z),
+    );
+    let wallMesh: Mesh = CreateRibbon(
+        `circle-${id}-wall`,
+        {
+            pathArray: [initialWallTop, initialWallBottom],
+            updatable: true,
+            sideOrientation: Mesh.DOUBLESIDE,
+            closeArray: false,
+        },
+        scene,
+    );
+    const wallMaterial = new StandardMaterial(`circle-${id}-wall-mat`, scene);
+    wallMaterial.disableLighting = true;
+    wallMaterial.backFaceCulling = false;
+    wallMaterial.emissiveColor = Color3.FromHexString(style.wallColor);
+    wallMaterial.alpha = style.wallOpacity;
+    if (style.wallOpacity < 1) {
+        wallMaterial.needDepthPrePass = true;
+    }
+    wallMesh.material = wallMaterial;
+    wallMesh.renderingGroupId = SUBTERRAIN_RENDERING_GROUP_ID;
+    wallMesh.isPickable = false;
+    wallMesh.parent = root;
+
+    // ラベル
+    let labelState = resolveLabelText(options);
+    let labelEntry: LabelEntry | null = labelState.text
+        ? createLabelMesh(scene, id, labelState.text, style, root)
+        : null;
+
+    const applyVisibility = (): void => {
+        const visible = logicalEnabled && elevationResolved;
+        root.setEnabled(visible);
+        sphereMesh.setEnabled(visible && pointEnabled);
+        lineMesh.setEnabled(visible && lineEnabled);
+        wallMesh.setEnabled(visible && wallEnabled);
+        if (labelEntry) {
+            labelEntry.mesh.setEnabled(visible && labelEnabled);
+        }
+    };
+    applyVisibility();
+
+    const applyTransform = (
+        centerWorld: Vector3,
+        ringWorld: readonly Vector3[],
+        pointScale: number,
+    ): void => {
+        if (ringWorld.length !== segments) {
+            // 想定外。何もせず次フレームへ。
+            return;
+        }
+        const sphereDiameter = Math.max(style.pointDiameter, 0.001);
+        const sphereRadiusWorld = sphereDiameter * pointScale * 0.5;
+
+        sphereMesh.position.set(centerWorld.x, centerWorld.y, centerWorld.z);
+        sphereMesh.scaling.setAll(sphereDiameter * pointScale);
+
+        // 円周 Tube を閉ループとして更新（path 長 = segments + 1）。
+        if (lineEnabled) {
+            const tubePath: Vector3[] = ringWorld.map(
+                (p) => new Vector3(p.x, p.y, p.z),
+            );
+            tubePath.push(
+                new Vector3(tubePath[0].x, tubePath[0].y, tubePath[0].z),
+            );
+            lineMesh = CreateTube(
+                `circle-${id}-line`,
+                { path: tubePath, instance: lineMesh },
+                scene,
+            );
+        }
+
+        // 壁 Ribbon: 上 row = 円周頂点位置、下 row = 同 XZ で Y=0。
+        if (wallEnabled) {
+            const top: Vector3[] = ringWorld.map(
+                (p) => new Vector3(p.x, p.y, p.z),
+            );
+            const bottom: Vector3[] = ringWorld.map(
+                (p) => new Vector3(p.x, 0, p.z),
+            );
+            top.push(new Vector3(top[0].x, top[0].y, top[0].z));
+            bottom.push(new Vector3(bottom[0].x, bottom[0].y, bottom[0].z));
+            wallMesh = CreateRibbon(
+                `circle-${id}-wall`,
+                { pathArray: [top, bottom], instance: wallMesh },
+                scene,
+            );
+        }
+
+        // 中心ラベルの位置: 中心 + screenUp * (球半径 + ラベル半高)。
+        if (labelEntry) {
+            const labelGap =
+                style.labelFontSize * pointScale * LABEL_GAP_FONT_RATIO;
+            const labelHalfWorld =
+                labelEntry.heightWorld * pointScale * 0.5;
+            const offset = sphereRadiusWorld + labelGap + labelHalfWorld;
+            const camera = scene.activeCamera;
+            const camPos = camera ? camera.globalPosition : null;
+            const camUp = camera ? camera.upVector : null;
+            let ux = 0;
+            let uy = 1;
+            let uz = 0;
+            if (camPos && camUp) {
+                const tx = camPos.x - centerWorld.x;
+                const ty = camPos.y - centerWorld.y;
+                const tz = camPos.z - centerWorld.z;
+                const tlen = Math.hypot(tx, ty, tz);
+                if (tlen > 1e-6) {
+                    const fx = tx / tlen;
+                    const fy = ty / tlen;
+                    const fz = tz / tlen;
+                    const rx = camUp.y * fz - camUp.z * fy;
+                    const ry = camUp.z * fx - camUp.x * fz;
+                    const rz = camUp.x * fy - camUp.y * fx;
+                    const sxv = fy * rz - fz * ry;
+                    const syv = fz * rx - fx * rz;
+                    const szv = fx * ry - fy * rx;
+                    const slen = Math.hypot(sxv, syv, szv);
+                    if (slen > 1e-6) {
+                        ux = sxv / slen;
+                        uy = syv / slen;
+                        uz = szv / slen;
+                    }
+                }
+            }
+            labelEntry.mesh.position.set(
+                centerWorld.x + ux * offset,
+                centerWorld.y + uy * offset,
+                centerWorld.z + uz * offset,
+            );
+            labelEntry.mesh.scaling.setAll(pointScale);
+        }
+    };
+
+    const refreshAutoLabel = (): void => {
+        if (!labelState.auto) return;
+        const newText = formatAutoLabel(center, radius);
+        if (newText === labelState.text) return;
+        labelState = { auto: true, text: newText };
+        if (labelEntry) {
+            labelEntry.texture.dispose();
+            labelEntry.material.dispose();
+            labelEntry.mesh.dispose();
+        }
+        labelEntry = createLabelMesh(scene, id, newText, style, root);
+        applyVisibility();
+    };
+
+    const getHandle = (): CircleHandle => ({
+        id,
+        center: { ...center },
+        radius,
+        segments,
+        altitudeMode,
+        label: labelState.text,
+        style: { ...style },
+        enabled: logicalEnabled,
+        pointEnabled,
+        lineEnabled,
+        wallEnabled,
+        labelEnabled,
+        elevationResolved,
+    });
+
+    const dispose = (): void => {
+        sphereMaterial.dispose();
+        sphereMesh.dispose();
+        lineMaterial.dispose();
+        lineMesh.dispose();
+        wallMaterial.dispose();
+        wallMesh.dispose();
+        if (labelEntry) {
+            labelEntry.texture.dispose();
+            labelEntry.material.dispose();
+            labelEntry.mesh.dispose();
+            labelEntry = null;
+        }
+        root.dispose();
+    };
+
+    return {
+        id,
+        altitudeMode,
+        get center() {
+            return center;
+        },
+        get radius() {
+            return radius;
+        },
+        set radius(v: number) {
+            radius = v;
+            refreshAutoLabel();
+        },
+        get segments() {
+            return segments;
+        },
+        applyTransform,
+        setEnabledLogical(enabled: boolean): void {
+            logicalEnabled = enabled;
+            applyVisibility();
+        },
+        setPointEnabledLogical(enabled: boolean): void {
+            pointEnabled = enabled;
+            applyVisibility();
+        },
+        setLineEnabledLogical(enabled: boolean): void {
+            lineEnabled = enabled;
+            applyVisibility();
+        },
+        setWallEnabledLogical(enabled: boolean): void {
+            wallEnabled = enabled;
+            applyVisibility();
+        },
+        setLabelEnabledLogical(enabled: boolean): void {
+            labelEnabled = enabled;
+            applyVisibility();
+        },
+        setElevationResolved(resolved: boolean): void {
+            elevationResolved = resolved;
+            applyVisibility();
+        },
+        getHandle,
+        dispose,
+    };
+};
+
+/**
+ * world 平面の polar 展開で円周点列を生成するユーティリティ（テスト用）。
+ *
+ * 中心 (cx, cz) を中心に、半径 `radius` (m, world)、`segments` 等分の点列を返す。
+ * Y は呼び出し側で設定する想定のため、本関数は `(x, z)` のみを返す。
+ */
+export const __computeCircleRingForTest = buildRingXZ;

--- a/src/terrain/circle.ts
+++ b/src/terrain/circle.ts
@@ -429,36 +429,32 @@ export const createCircleNode = (
         sphereMesh.scaling.setAll(sphereDiameter * pointScale);
 
         // 円周 Tube を閉ループとして更新（path 長 = segments + 1）。
-        if (lineEnabled) {
-            const tubePath: Vector3[] = ringWorld.map(
-                (p) => new Vector3(p.x, p.y, p.z),
-            );
-            tubePath.push(
-                new Vector3(tubePath[0].x, tubePath[0].y, tubePath[0].z),
-            );
-            lineMesh = CreateTube(
-                `circle-${id}-line`,
-                { path: tubePath, instance: lineMesh },
-                scene,
-            );
-        }
+        const tubePath: Vector3[] = ringWorld.map(
+            (p) => new Vector3(p.x, p.y, p.z),
+        );
+        tubePath.push(
+            new Vector3(tubePath[0].x, tubePath[0].y, tubePath[0].z),
+        );
+        lineMesh = CreateTube(
+            `circle-${id}-line`,
+            { path: tubePath, instance: lineMesh },
+            scene,
+        );
 
         // 壁 Ribbon: 上 row = 円周頂点位置、下 row = 同 XZ で Y=0。
-        if (wallEnabled) {
-            const top: Vector3[] = ringWorld.map(
-                (p) => new Vector3(p.x, p.y, p.z),
-            );
-            const bottom: Vector3[] = ringWorld.map(
-                (p) => new Vector3(p.x, 0, p.z),
-            );
-            top.push(new Vector3(top[0].x, top[0].y, top[0].z));
-            bottom.push(new Vector3(bottom[0].x, bottom[0].y, bottom[0].z));
-            wallMesh = CreateRibbon(
-                `circle-${id}-wall`,
-                { pathArray: [top, bottom], instance: wallMesh },
-                scene,
-            );
-        }
+        const top: Vector3[] = ringWorld.map(
+            (p) => new Vector3(p.x, p.y, p.z),
+        );
+        const bottom: Vector3[] = ringWorld.map(
+            (p) => new Vector3(p.x, 0, p.z),
+        );
+        top.push(new Vector3(top[0].x, top[0].y, top[0].z));
+        bottom.push(new Vector3(bottom[0].x, bottom[0].y, bottom[0].z));
+        wallMesh = CreateRibbon(
+            `circle-${id}-wall`,
+            { pathArray: [top, bottom], instance: wallMesh },
+            scene,
+        );
 
         // 中心ラベルの位置: 中心 + screenUp * (球半径 + ラベル半高)。
         if (labelEntry) {

--- a/src/terrain/circleManager.ts
+++ b/src/terrain/circleManager.ts
@@ -95,72 +95,111 @@ export const createCircleManager = (ctx: OverlayContext): CircleManager => {
     let disposed = false;
 
     /**
-     * 1 円の 1 フレーム分更新。
+     * 円ごとのジオメトリキャッシュ。
      *
-     * - 中心を `latLonToWorld` で求め、terrain なら標高解決。
-     * - 円周点は world 平面で polar 展開（緯度補正は `latLonToWorld` の origin 補正で
-     *   中心点に対して既に反映済み。半径方向は world m なので追加の補正は不要）。
-     * - terrain で 1 点でも未解決なら円全体を非表示。
+     * - `cwx`/`cwz`/`ringXZ`: center / ring の world XZ。add 時に 1 回だけ計算し、
+     *   center・radius・segments が変わらない限り再計算不要。
+     * - `centerWorld`/`ringWorld`: 標高解決済みの world 座標。未解決なら null。
+     *   terrain タイル更新イベント時に再解決する。
      */
-    const tickCircle = (node: CircleNode): void => {
-        const { wx: cwx, wz: cwz } = latLonToWorld(
-            ctx,
-            node.center.lat,
-            node.center.lon,
-        );
+    interface CircleCache {
+        cwx: number;
+        cwz: number;
+        ringXZ: { x: number; z: number }[];
+        centerWorld: Vector3 | null;
+        ringWorld: readonly Vector3[] | null;
+    }
+    const caches = new Map<string, CircleCache>();
+
+    /**
+     * 標高を解決して `cache` を更新し、解決済みなら `node.applyTransform` を呼ぶ。
+     *
+     * - terrain モード: 中心 + 全円周点の標高を `queryElevationAtWorld` で取得。
+     *   1 点でも null なら `elevationResolved=false` にして処理を終了する。
+     * - absolute モード: 標高クエリ不要。`center.altitude` を Y として使う。
+     */
+    const resolveElevations = (node: CircleNode, cache: CircleCache): void => {
+        const { cwx, cwz, ringXZ } = cache;
         const centerOffset = node.center.altitude ?? 0;
-        let cy: number;
+
         if (node.altitudeMode === "absolute") {
-            cy = centerOffset;
-        } else {
-            const elev = ctx.tileManager.queryElevationAtWorld(cwx, cwz);
+            const cy = centerOffset;
+            const centerWorld = new Vector3(cwx, cy, cwz);
+            const ringWorld = ringXZ.map(({ x, z }) => new Vector3(x, cy, z));
+            cache.centerWorld = centerWorld;
+            cache.ringWorld = ringWorld;
+            node.setElevationResolved(true);
+            node.applyTransform(
+                centerWorld,
+                ringWorld,
+                computeDistanceScale(ctx, cwx, cy, cwz),
+            );
+            return;
+        }
+
+        // terrain モード
+        const elevCenter = ctx.tileManager.queryElevationAtWorld(cwx, cwz);
+        if (elevCenter === null) {
+            cache.centerWorld = null;
+            cache.ringWorld = null;
+            node.setElevationResolved(false);
+            return;
+        }
+        const cy = elevCenter + centerOffset;
+        const ringWorld: Vector3[] = [];
+        for (const { x, z } of ringXZ) {
+            const elev = ctx.tileManager.queryElevationAtWorld(x, z);
             if (elev === null) {
+                cache.centerWorld = null;
+                cache.ringWorld = null;
                 node.setElevationResolved(false);
                 return;
             }
-            cy = elev + centerOffset;
+            ringWorld.push(new Vector3(x, elev + centerOffset, z));
         }
-
-        // 円周点（world 平面で polar 展開）。
-        const segments = node.segments;
-        const radius = node.radius;
-        const step = (Math.PI * 2) / segments;
-        const ringWorld: Vector3[] = [];
-        for (let i = 0; i < segments; i++) {
-            const θ = i * step;
-            const px = cwx + radius * Math.cos(θ);
-            const pz = cwz + radius * Math.sin(θ);
-            let py: number;
-            if (node.altitudeMode === "absolute") {
-                py = centerOffset;
-            } else {
-                const elev = ctx.tileManager.queryElevationAtWorld(px, pz);
-                if (elev === null) {
-                    node.setElevationResolved(false);
-                    return;
-                }
-                py = elev + centerOffset;
-            }
-            ringWorld.push(new Vector3(px, py, pz));
-        }
-
-        const scale = computeDistanceScale(ctx, cwx, cy, cwz);
+        const centerWorld = new Vector3(cwx, cy, cwz);
+        cache.centerWorld = centerWorld;
+        cache.ringWorld = ringWorld;
         node.setElevationResolved(true);
-        node.applyTransform(new Vector3(cwx, cy, cwz), ringWorld, scale);
+        node.applyTransform(
+            centerWorld,
+            ringWorld,
+            computeDistanceScale(ctx, cwx, cy, cwz),
+        );
     };
 
+    /**
+     * フレームループ。
+     *
+     * 標高解決はキャッシュ済みの値を使い、ラベルがカメラ方向を追従するために
+     * 毎フレーム `applyTransform` を呼ぶ（`pointScale` のみ更新）。
+     * 標高未解決の円はスキップする。
+     */
     const tickFrame = (): void => {
         if (nodes.size === 0) return;
-        for (const node of nodes.values()) {
-            tickCircle(node);
+        for (const [id, node] of nodes) {
+            const cache = caches.get(id);
+            if (!cache || cache.centerWorld === null || cache.ringWorld === null)
+                continue;
+            const scale = computeDistanceScale(
+                ctx,
+                cache.cwx,
+                cache.centerWorld.y,
+                cache.cwz,
+            );
+            node.applyTransform(cache.centerWorld, cache.ringWorld, scale);
         }
     };
 
     const observer: Observer<Scene> | null =
         ctx.scene.onBeforeRenderObservable.add(tickFrame);
 
+    // タイル更新イベント時に全円の標高を再解決する。
     const unsubscribeTerrain = ctx.tileManager.subscribeTerrainUpdated(() => {
-        // tickFrame で次フレームに反映される。明示的な再評価は不要。
+        for (const [id, node] of nodes) {
+            const cache = caches.get(id);
+            if (cache) resolveElevations(node, cache);
+        }
     });
 
     const requireNode = (id: string): CircleNode => {
@@ -184,7 +223,33 @@ export const createCircleManager = (ctx: OverlayContext): CircleManager => {
             validateOptions(options);
             const node = createCircleNode(ctx.scene, id, options);
             nodes.set(id, node);
-            tickCircle(node);
+
+            // ring XZ をここで 1 回だけ計算してキャッシュする。
+            const { wx: cwx, wz: cwz } = latLonToWorld(
+                ctx,
+                options.center.lat,
+                options.center.lon,
+            );
+            const segments = node.segments;
+            const radius = node.radius;
+            const step = (Math.PI * 2) / segments;
+            const ringXZ: { x: number; z: number }[] = [];
+            for (let i = 0; i < segments; i++) {
+                const θ = i * step;
+                ringXZ.push({
+                    x: cwx + radius * Math.cos(θ),
+                    z: cwz + radius * Math.sin(θ),
+                });
+            }
+            const cache: CircleCache = {
+                cwx,
+                cwz,
+                ringXZ,
+                centerWorld: null,
+                ringWorld: null,
+            };
+            caches.set(id, cache);
+            resolveElevations(node, cache);
             return node.getHandle();
         },
         get(id: string): CircleHandle | null {
@@ -201,6 +266,7 @@ export const createCircleManager = (ctx: OverlayContext): CircleManager => {
             }
             node.dispose();
             nodes.delete(id);
+            caches.delete(id);
         },
         setEnabled(id: string, enabled: boolean): void {
             if (disposed) {
@@ -246,6 +312,7 @@ export const createCircleManager = (ctx: OverlayContext): CircleManager => {
                 node.dispose();
             }
             nodes.clear();
+            caches.clear();
         },
     };
 };

--- a/src/terrain/circleManager.ts
+++ b/src/terrain/circleManager.ts
@@ -1,0 +1,251 @@
+/**
+ * CircleManager (Issue #201 / #203)。
+ *
+ * `JpmapTerrain.addCircle / getCircle / removeCircle / setCircle*Enabled / listCircles`
+ * から呼び出される（公開 API への wiring は #204 で対応）。
+ *
+ * - 各 circle を `OverlayContext` 共有のフレームループで毎フレーム位置更新する。
+ * - `altitudeMode === "terrain"` のとき、中心または円周点で 1 点でも標高未解決なら
+ *   円全体を非表示にする（PolygonManager と同じ方針）。
+ * - `altitudeMode === "absolute"` のとき、`center.altitude` を Y として使用する。
+ */
+
+import type { Observer } from "@babylonjs/core/Misc/observable";
+import type { Scene } from "@babylonjs/core/scene";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+
+import {
+    assertLatLonInBounds,
+    computeDistanceScale,
+    latLonToWorld,
+    type OverlayContext,
+} from "./overlayCoords";
+import { createCircleNode, type CircleNode } from "./circle";
+import {
+    CIRCLE_DEFAULTS,
+    CIRCLE_RADIUS_MAX_M,
+    CIRCLE_SEGMENTS_MAX,
+    CIRCLE_SEGMENTS_MIN,
+    type CircleHandle,
+    type CircleOptions,
+} from "../lib/types";
+
+const ERROR_PREFIX = "JpmapTerrain.addCircle";
+
+export interface CircleManager {
+    add(id: string, options: CircleOptions): CircleHandle;
+    get(id: string): CircleHandle | null;
+    remove(id: string): void;
+    setEnabled(id: string, enabled: boolean): void;
+    setPointEnabled(id: string, enabled: boolean): void;
+    setLineEnabled(id: string, enabled: boolean): void;
+    setWallEnabled(id: string, enabled: boolean): void;
+    setLabelEnabled(id: string, enabled: boolean): void;
+    list(): readonly string[];
+    dispose(): void;
+}
+
+/**
+ * `addCircle` 時のオプション検証。
+ *
+ * - 中心の lat/lon が JAPAN_BOUNDS 内であること
+ * - radius が `(0, CIRCLE_RADIUS_MAX_M]` の範囲内
+ * - segments が `[CIRCLE_SEGMENTS_MIN, CIRCLE_SEGMENTS_MAX]` の範囲内（指定時）
+ * - `altitudeMode === "absolute"` のとき `center.altitude` が指定されていること
+ */
+const validateOptions = (options: CircleOptions): void => {
+    if (!options.center) {
+        throw new Error(`${ERROR_PREFIX}: center is required`);
+    }
+    assertLatLonInBounds(
+        options.center.lat,
+        options.center.lon,
+        ERROR_PREFIX,
+    );
+    if (
+        !Number.isFinite(options.radius) ||
+        options.radius <= 0 ||
+        options.radius > CIRCLE_RADIUS_MAX_M
+    ) {
+        throw new Error(
+            `${ERROR_PREFIX}: radius must be in (0, ${CIRCLE_RADIUS_MAX_M}] m (got ${options.radius})`,
+        );
+    }
+    if (options.segments !== undefined) {
+        if (
+            !Number.isInteger(options.segments) ||
+            options.segments < CIRCLE_SEGMENTS_MIN ||
+            options.segments > CIRCLE_SEGMENTS_MAX
+        ) {
+            throw new Error(
+                `${ERROR_PREFIX}: segments must be an integer in [${CIRCLE_SEGMENTS_MIN}, ${CIRCLE_SEGMENTS_MAX}] (got ${options.segments})`,
+            );
+        }
+    }
+    const altitudeMode = options.altitudeMode ?? CIRCLE_DEFAULTS.altitudeMode;
+    if (altitudeMode === "absolute" && options.center.altitude === undefined) {
+        throw new Error(
+            `${ERROR_PREFIX}: altitudeMode="absolute" requires center.altitude`,
+        );
+    }
+};
+
+export const createCircleManager = (ctx: OverlayContext): CircleManager => {
+    const nodes = new Map<string, CircleNode>();
+    let disposed = false;
+
+    /**
+     * 1 円の 1 フレーム分更新。
+     *
+     * - 中心を `latLonToWorld` で求め、terrain なら標高解決。
+     * - 円周点は world 平面で polar 展開（緯度補正は `latLonToWorld` の origin 補正で
+     *   中心点に対して既に反映済み。半径方向は world m なので追加の補正は不要）。
+     * - terrain で 1 点でも未解決なら円全体を非表示。
+     */
+    const tickCircle = (node: CircleNode): void => {
+        const { wx: cwx, wz: cwz } = latLonToWorld(
+            ctx,
+            node.center.lat,
+            node.center.lon,
+        );
+        const centerOffset = node.center.altitude ?? 0;
+        let cy: number;
+        if (node.altitudeMode === "absolute") {
+            cy = centerOffset;
+        } else {
+            const elev = ctx.tileManager.queryElevationAtWorld(cwx, cwz);
+            if (elev === null) {
+                node.setElevationResolved(false);
+                return;
+            }
+            cy = elev + centerOffset;
+        }
+
+        // 円周点（world 平面で polar 展開）。
+        const segments = node.segments;
+        const radius = node.radius;
+        const step = (Math.PI * 2) / segments;
+        const ringWorld: Vector3[] = [];
+        for (let i = 0; i < segments; i++) {
+            const θ = i * step;
+            const px = cwx + radius * Math.cos(θ);
+            const pz = cwz + radius * Math.sin(θ);
+            let py: number;
+            if (node.altitudeMode === "absolute") {
+                py = centerOffset;
+            } else {
+                const elev = ctx.tileManager.queryElevationAtWorld(px, pz);
+                if (elev === null) {
+                    node.setElevationResolved(false);
+                    return;
+                }
+                py = elev + centerOffset;
+            }
+            ringWorld.push(new Vector3(px, py, pz));
+        }
+
+        const scale = computeDistanceScale(ctx, cwx, cy, cwz);
+        node.setElevationResolved(true);
+        node.applyTransform(new Vector3(cwx, cy, cwz), ringWorld, scale);
+    };
+
+    const tickFrame = (): void => {
+        if (nodes.size === 0) return;
+        for (const node of nodes.values()) {
+            tickCircle(node);
+        }
+    };
+
+    const observer: Observer<Scene> | null =
+        ctx.scene.onBeforeRenderObservable.add(tickFrame);
+
+    const unsubscribeTerrain = ctx.tileManager.subscribeTerrainUpdated(() => {
+        // tickFrame で次フレームに反映される。明示的な再評価は不要。
+    });
+
+    const requireNode = (id: string): CircleNode => {
+        const node = nodes.get(id);
+        if (!node) {
+            throw new Error(`Circle id "${id}" not found`);
+        }
+        return node;
+    };
+
+    return {
+        add(id: string, options: CircleOptions): CircleHandle {
+            if (disposed) {
+                throw new Error("CircleManager has been disposed");
+            }
+            if (nodes.has(id)) {
+                throw new Error(
+                    `JpmapTerrain.addCircle: id "${id}" already exists`,
+                );
+            }
+            validateOptions(options);
+            const node = createCircleNode(ctx.scene, id, options);
+            nodes.set(id, node);
+            tickCircle(node);
+            return node.getHandle();
+        },
+        get(id: string): CircleHandle | null {
+            const node = nodes.get(id);
+            return node ? node.getHandle() : null;
+        },
+        remove(id: string): void {
+            const node = nodes.get(id);
+            if (!node) {
+                console.warn(
+                    `[jpmap-terrain] removeCircle: id "${id}" not found`,
+                );
+                return;
+            }
+            node.dispose();
+            nodes.delete(id);
+        },
+        setEnabled(id: string, enabled: boolean): void {
+            if (disposed) {
+                throw new Error("CircleManager has been disposed");
+            }
+            requireNode(id).setEnabledLogical(enabled);
+        },
+        setPointEnabled(id: string, enabled: boolean): void {
+            if (disposed) {
+                throw new Error("CircleManager has been disposed");
+            }
+            requireNode(id).setPointEnabledLogical(enabled);
+        },
+        setLineEnabled(id: string, enabled: boolean): void {
+            if (disposed) {
+                throw new Error("CircleManager has been disposed");
+            }
+            requireNode(id).setLineEnabledLogical(enabled);
+        },
+        setWallEnabled(id: string, enabled: boolean): void {
+            if (disposed) {
+                throw new Error("CircleManager has been disposed");
+            }
+            requireNode(id).setWallEnabledLogical(enabled);
+        },
+        setLabelEnabled(id: string, enabled: boolean): void {
+            if (disposed) {
+                throw new Error("CircleManager has been disposed");
+            }
+            requireNode(id).setLabelEnabledLogical(enabled);
+        },
+        list(): readonly string[] {
+            return Array.from(nodes.keys());
+        },
+        dispose(): void {
+            if (disposed) return;
+            disposed = true;
+            if (observer) {
+                ctx.scene.onBeforeRenderObservable.remove(observer);
+            }
+            unsubscribeTerrain();
+            for (const node of nodes.values()) {
+                node.dispose();
+            }
+            nodes.clear();
+        },
+    };
+};

--- a/tests/circleManager.unit.spec.ts
+++ b/tests/circleManager.unit.spec.ts
@@ -1,0 +1,433 @@
+/**
+ * CircleManager の単体テスト (Issue #201 / #203)。
+ *
+ * `circle` モジュール（Babylon 依存）を軽量スタブに差し替え、
+ * CRUD / 境界 / altitudeMode / 標高解決 / dispose の挙動を検証する。
+ */
+
+import { jest } from "@jest/globals";
+import type { CircleOptions } from "../src/lib/types";
+
+interface StubNode {
+    id: string;
+    altitudeMode: "terrain" | "absolute";
+    center: { lat: number; lon: number; altitude?: number };
+    radius: number;
+    segments: number;
+    enabled: boolean;
+    pointEnabled: boolean;
+    lineEnabled: boolean;
+    wallEnabled: boolean;
+    labelEnabled: boolean;
+    elevationResolved: boolean;
+    applyTransformCalls: number;
+    lastCenter: { x: number; y: number; z: number } | null;
+    lastRing: Array<{ x: number; y: number; z: number }>;
+    disposed: boolean;
+    setEnabledHistory: boolean[];
+    setPointEnabledHistory: boolean[];
+    setLineEnabledHistory: boolean[];
+    setWallEnabledHistory: boolean[];
+    setLabelEnabledHistory: boolean[];
+    setElevationResolvedHistory: boolean[];
+}
+
+const created: StubNode[] = [];
+
+jest.unstable_mockModule("../src/terrain/circle", () => ({
+    createCircleNode: (
+        _scene: unknown,
+        id: string,
+        options: CircleOptions,
+    ): StubNode => {
+        const altitudeMode = options.altitudeMode ?? "terrain";
+        const node: StubNode = {
+            id,
+            altitudeMode,
+            center: { ...options.center },
+            radius: options.radius,
+            segments: options.segments ?? 64,
+            enabled: options.enabled ?? true,
+            pointEnabled: options.pointEnabled ?? true,
+            lineEnabled: options.lineEnabled ?? true,
+            wallEnabled: options.wallEnabled ?? true,
+            labelEnabled: options.labelEnabled ?? true,
+            elevationResolved: altitudeMode === "absolute",
+            applyTransformCalls: 0,
+            lastCenter: null,
+            lastRing: [],
+            disposed: false,
+            setEnabledHistory: [],
+            setPointEnabledHistory: [],
+            setLineEnabledHistory: [],
+            setWallEnabledHistory: [],
+            setLabelEnabledHistory: [],
+            setElevationResolvedHistory: [],
+        };
+        const wrapped = {
+            ...node,
+            applyTransform: (
+                centerWorld: { x: number; y: number; z: number },
+                ringWorld: ReadonlyArray<{ x: number; y: number; z: number }>,
+            ) => {
+                node.applyTransformCalls++;
+                node.lastCenter = {
+                    x: centerWorld.x,
+                    y: centerWorld.y,
+                    z: centerWorld.z,
+                };
+                node.lastRing = ringWorld.map((p) => ({
+                    x: p.x,
+                    y: p.y,
+                    z: p.z,
+                }));
+            },
+            setEnabledLogical: (v: boolean) => {
+                node.enabled = v;
+                node.setEnabledHistory.push(v);
+            },
+            setPointEnabledLogical: (v: boolean) => {
+                node.pointEnabled = v;
+                node.setPointEnabledHistory.push(v);
+            },
+            setLineEnabledLogical: (v: boolean) => {
+                node.lineEnabled = v;
+                node.setLineEnabledHistory.push(v);
+            },
+            setWallEnabledLogical: (v: boolean) => {
+                node.wallEnabled = v;
+                node.setWallEnabledHistory.push(v);
+            },
+            setLabelEnabledLogical: (v: boolean) => {
+                node.labelEnabled = v;
+                node.setLabelEnabledHistory.push(v);
+            },
+            setElevationResolved: (v: boolean) => {
+                node.elevationResolved = v;
+                node.setElevationResolvedHistory.push(v);
+            },
+            getHandle: () => ({
+                id,
+                center: { ...node.center },
+                radius: node.radius,
+                segments: node.segments,
+                altitudeMode: node.altitudeMode,
+                label: null,
+                style: {} as unknown as Record<string, unknown>,
+                enabled: node.enabled,
+                pointEnabled: node.pointEnabled,
+                lineEnabled: node.lineEnabled,
+                wallEnabled: node.wallEnabled,
+                labelEnabled: node.labelEnabled,
+                elevationResolved: node.elevationResolved,
+            }),
+            dispose: () => {
+                node.disposed = true;
+            },
+        };
+        created.push(node);
+        return wrapped as unknown as StubNode;
+    },
+}));
+
+const { createCircleManager } = await import(
+    "../src/terrain/circleManager"
+);
+
+interface FakeObserver {
+    callback: () => void;
+}
+
+const buildCtx = (
+    elevation: number | null = 0,
+): {
+    ctx: Parameters<typeof createCircleManager>[0];
+    tick: () => void;
+    setElevation: (v: number | null) => void;
+} => {
+    const observers: FakeObserver[] = [];
+    const sceneLike = {
+        onBeforeRenderObservable: {
+            add: (cb: () => void): FakeObserver => {
+                const o: FakeObserver = { callback: cb };
+                observers.push(o);
+                return o;
+            },
+            remove: (target: FakeObserver): boolean => {
+                const i = observers.indexOf(target);
+                if (i === -1) return false;
+                observers.splice(i, 1);
+                return true;
+            },
+        },
+    };
+    let elev: number | null = elevation;
+    const ctx: Parameters<typeof createCircleManager>[0] = {
+        scene: sceneLike as unknown as Parameters<
+            typeof createCircleManager
+        >[0]["scene"],
+        tileManager: {
+            queryElevationAtWorld: (): number | null => elev,
+            subscribeTerrainUpdated: (): (() => void) => {
+                return () => {
+                    /* noop */
+                };
+            },
+        },
+        getOrigin: () => ({
+            lat: 35.681,
+            lon: 139.767,
+            gridResidualX: 0,
+            gridResidualZ: 0,
+        }),
+        getCameraPosition: () => ({
+            x: 0,
+            y: 1000,
+            z: 0,
+            radius: 1000,
+            beta: Math.PI / 4,
+        }),
+    };
+    return {
+        ctx,
+        tick: () => {
+            for (const o of observers.slice()) o.callback();
+        },
+        setElevation: (v) => {
+            elev = v;
+        },
+    };
+};
+
+const validCenter = { lat: 35.681, lon: 139.767 };
+
+beforeEach(() => {
+    created.length = 0;
+});
+
+describe("CircleManager CRUD", () => {
+    it("add → get / list で同 id を取得できる", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createCircleManager(ctx);
+        const handle = mgr.add("a", { center: validCenter, radius: 100 });
+        expect(handle.id).toBe("a");
+        expect(mgr.get("a")?.id).toBe("a");
+        expect(mgr.list()).toEqual(["a"]);
+    });
+
+    it("重複 id で throw", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createCircleManager(ctx);
+        mgr.add("a", { center: validCenter, radius: 100 });
+        expect(() =>
+            mgr.add("a", { center: validCenter, radius: 100 }),
+        ).toThrow(/already exists/);
+    });
+
+    it("remove で list / get から消える", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createCircleManager(ctx);
+        mgr.add("a", { center: validCenter, radius: 100 });
+        mgr.remove("a");
+        expect(mgr.get("a")).toBeNull();
+        expect(mgr.list()).toEqual([]);
+    });
+
+    it("未存在 id の remove は warn + no-op", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createCircleManager(ctx);
+        const warn = jest.spyOn(console, "warn").mockImplementation(() => {
+            /* silence */
+        });
+        mgr.remove("missing");
+        expect(warn).toHaveBeenCalled();
+        warn.mockRestore();
+    });
+
+    it("get(未存在) は null", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createCircleManager(ctx);
+        expect(mgr.get("missing")).toBeNull();
+    });
+});
+
+describe("CircleManager バリデーション", () => {
+    it("radius <= 0 で throw", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createCircleManager(ctx);
+        expect(() =>
+            mgr.add("a", { center: validCenter, radius: 0 }),
+        ).toThrow(/radius/);
+        expect(() =>
+            mgr.add("a", { center: validCenter, radius: -1 }),
+        ).toThrow(/radius/);
+    });
+
+    it("radius が CIRCLE_RADIUS_MAX_M を超えると throw", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createCircleManager(ctx);
+        expect(() =>
+            mgr.add("a", { center: validCenter, radius: 100_001 }),
+        ).toThrow(/radius/);
+    });
+
+    it("radius が NaN/Infinity で throw", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createCircleManager(ctx);
+        expect(() =>
+            mgr.add("a", { center: validCenter, radius: NaN }),
+        ).toThrow(/radius/);
+        expect(() =>
+            mgr.add("a", { center: validCenter, radius: Infinity }),
+        ).toThrow(/radius/);
+    });
+
+    it("segments が下限を下回ると throw", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createCircleManager(ctx);
+        expect(() =>
+            mgr.add("a", {
+                center: validCenter,
+                radius: 100,
+                segments: 4,
+            }),
+        ).toThrow(/segments/);
+    });
+
+    it("segments が整数でないと throw", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createCircleManager(ctx);
+        expect(() =>
+            mgr.add("a", {
+                center: validCenter,
+                radius: 100,
+                segments: 32.5,
+            }),
+        ).toThrow(/segments/);
+    });
+
+    it("JAPAN_BOUNDS 外の中心で throw", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createCircleManager(ctx);
+        expect(() =>
+            mgr.add("a", { center: { lat: 0, lon: 0 }, radius: 100 }),
+        ).toThrow(/JAPAN_BOUNDS/);
+    });
+
+    it("absolute モードで center.altitude 未指定なら throw", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createCircleManager(ctx);
+        expect(() =>
+            mgr.add("a", {
+                center: validCenter,
+                radius: 100,
+                altitudeMode: "absolute",
+            }),
+        ).toThrow(/altitude/);
+    });
+});
+
+describe("CircleManager 標高解決", () => {
+    it("terrain モードで中心の標高が未解決なら elevationResolved=false", () => {
+        const ctxWrap = buildCtx(null);
+        const mgr = createCircleManager(ctxWrap.ctx);
+        mgr.add("a", { center: validCenter, radius: 100 });
+        expect(created[0].elevationResolved).toBe(false);
+    });
+
+    it("terrain モードで標高解決済みなら applyTransform が呼ばれる", () => {
+        const ctxWrap = buildCtx(0);
+        const mgr = createCircleManager(ctxWrap.ctx);
+        mgr.add("a", { center: validCenter, radius: 100 });
+        // 初回 add で tickCircle が走る
+        expect(created[0].applyTransformCalls).toBeGreaterThan(0);
+        expect(created[0].elevationResolved).toBe(true);
+    });
+
+    it("absolute モードでは elevation が null でも resolved=true", () => {
+        const ctxWrap = buildCtx(null);
+        const mgr = createCircleManager(ctxWrap.ctx);
+        mgr.add("a", {
+            center: { lat: 35.681, lon: 139.767, altitude: 200 },
+            radius: 100,
+            altitudeMode: "absolute",
+        });
+        expect(created[0].elevationResolved).toBe(true);
+        expect(created[0].applyTransformCalls).toBe(1);
+        // 中心 Y は altitude 値を反映
+        expect(created[0].lastCenter?.y).toBe(200);
+    });
+
+    it("ring の長さは segments と一致する（既定 64）", () => {
+        const ctxWrap = buildCtx(0);
+        const mgr = createCircleManager(ctxWrap.ctx);
+        mgr.add("a", { center: validCenter, radius: 100 });
+        expect(created[0].lastRing.length).toBe(64);
+    });
+
+    it("segments を明示指定すると ring 長が一致する", () => {
+        const ctxWrap = buildCtx(0);
+        const mgr = createCircleManager(ctxWrap.ctx);
+        mgr.add("a", { center: validCenter, radius: 100, segments: 16 });
+        expect(created[0].lastRing.length).toBe(16);
+    });
+
+    it("ring 各点は中心から半径分離れた位置に生成される（XZ 平面）", () => {
+        const ctxWrap = buildCtx(0);
+        const mgr = createCircleManager(ctxWrap.ctx);
+        mgr.add("a", { center: validCenter, radius: 500, segments: 8 });
+        const center = created[0].lastCenter!;
+        for (const p of created[0].lastRing) {
+            const dx = p.x - center.x;
+            const dz = p.z - center.z;
+            const dist = Math.hypot(dx, dz);
+            expect(dist).toBeCloseTo(500, 3);
+        }
+    });
+});
+
+describe("CircleManager setEnabled 系", () => {
+    it("setEnabled / setPointEnabled / setLineEnabled / setWallEnabled / setLabelEnabled が node に伝播", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createCircleManager(ctx);
+        mgr.add("a", { center: validCenter, radius: 100 });
+        mgr.setEnabled("a", false);
+        mgr.setPointEnabled("a", false);
+        mgr.setLineEnabled("a", false);
+        mgr.setWallEnabled("a", false);
+        mgr.setLabelEnabled("a", false);
+        expect(created[0].setEnabledHistory).toEqual([false]);
+        expect(created[0].setPointEnabledHistory).toEqual([false]);
+        expect(created[0].setLineEnabledHistory).toEqual([false]);
+        expect(created[0].setWallEnabledHistory).toEqual([false]);
+        expect(created[0].setLabelEnabledHistory).toEqual([false]);
+    });
+
+    it("未存在 id の setEnabled は throw", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createCircleManager(ctx);
+        expect(() => mgr.setEnabled("missing", false)).toThrow(/not found/);
+    });
+});
+
+describe("CircleManager dispose", () => {
+    it("dispose で全 node が破棄される", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createCircleManager(ctx);
+        mgr.add("a", { center: validCenter, radius: 100 });
+        mgr.add("b", { center: validCenter, radius: 200 });
+        mgr.dispose();
+        expect(created[0].disposed).toBe(true);
+        expect(created[1].disposed).toBe(true);
+        expect(mgr.list()).toEqual([]);
+    });
+
+    it("dispose 後の add は throw", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createCircleManager(ctx);
+        mgr.dispose();
+        expect(() =>
+            mgr.add("a", { center: validCenter, radius: 100 }),
+        ).toThrow(/disposed/);
+    });
+});


### PR DESCRIPTION
Closes #203
Refs #201

## 概要
ポリゴン API (#170 系) に倣い、Circle 描画用の内部実装を追加する。

- `src/terrain/circle.ts`: `CircleNode` factory
  - 中心点 sphere / 円周 Tube（閉ループ）/ 壁 Ribbon / 中心点ビルボードラベル
  - `renderingGroupId`: 中心点・円周・ラベル=1（前面）、壁=0（地形オクルージョン）
  - `wallOpacity < 1` で `needDepthPrePass = true`（z-fight 抑制）
  - ラベル: `undefined`=自動 4 行（lat/lon/alt/radius）、`null`=非表示、文字列=固定
- `src/terrain/circleManager.ts`: `createCircleManager` factory
  - `validateOptions`: JAPAN_BOUNDS / radius (0, 100000]m / segments [8, 512] / absolute 時 altitude 必須
  - `tickCircle`: 中心 `latLonToWorld` → ワールド XZ 平面で極座標展開（緯度圧縮回避）
  - 中心 or リング上の任意点で `elev=null` の場合は `elevationResolved=false` で非表示
- `tests/circleManager.unit.spec.ts`: 22 件の単体テスト

## チェック
- `npm run test:unit` 全 28 suites / 614 tests pass
- `npm run lint` clean
- `npm run typecheck` clean

依存: `Circle` 型は #209 (#202) で main にマージ済み。
