### PR TITLE
feat(circle): wire CircleManager into JpmapTerrain public API (#204)

### DIFF
--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -280,6 +280,18 @@ export class JpmapTerrain {
             }
         } catch (error) {
             // 部分的に確保済みのリソースを解放してから再 throw
+            if (this._circleManager) {
+                try { this._circleManager.dispose(); } catch { /* best-effort */ }
+                this._circleManager = null;
+            }
+            if (this._polygonManager) {
+                try { this._polygonManager.dispose(); } catch { /* best-effort */ }
+                this._polygonManager = null;
+            }
+            if (this._markerManager) {
+                try { this._markerManager.dispose(); } catch { /* best-effort */ }
+                this._markerManager = null;
+            }
             if (this._resizeObserver) {
                 this._resizeObserver.disconnect();
                 this._resizeObserver = null;

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -24,6 +24,8 @@ import {
     JpmapTerrainOptions,
     MapType,
     MapTypeChangeListener,
+    CircleHandle,
+    CircleOptions,
     MarkerHandle,
     MarkerOptions,
     MarkerUpdate,
@@ -41,6 +43,7 @@ import {
 } from "./types";
 import { createMarkerManager, type MarkerManager } from "../terrain/markerManager";
 import { createPolygonManager, type PolygonManager } from "../terrain/polygonManager";
+import { createCircleManager, type CircleManager } from "../terrain/circleManager";
 
 /**
  * jpmap-terrain ビューア。
@@ -102,6 +105,9 @@ export class JpmapTerrain {
 
     /** ポリゴン管理 (Issue #170)。`onReady` で初期化される */
     private _polygonManager: PolygonManager | null = null;
+
+    /** 円管理 (Issue #201)。`onReady` で初期化される */
+    private _circleManager: CircleManager | null = null;
 
     private constructor(mountElement: HTMLElement, options: JpmapTerrainOptions) {
         this.mountElement = mountElement;
@@ -241,6 +247,10 @@ export class JpmapTerrain {
                     );
                     // ポリゴン (Issue #170)。MarkerContext と同一のコンテキストを共有する。
                     this._polygonManager = createPolygonManager(
+                        controller.getMarkerContext(),
+                    );
+                    // 円 (Issue #201)。MarkerContext と同一のコンテキストを共有する。
+                    this._circleManager = createCircleManager(
                         controller.getMarkerContext(),
                     );
                 },
@@ -1040,6 +1050,65 @@ export class JpmapTerrain {
         return this._requirePolygonManager().replacePoints(id, points);
     }
 
+    // ---- 円 (Issue #201) ----
+
+    private _requireCircleManager(): CircleManager {
+        if (!this._circleManager) {
+            throw new Error("JpmapTerrain circle manager is not ready yet");
+        }
+        return this._circleManager;
+    }
+
+    /**
+     * dispose 後の円 API はマーカー・ポリゴンと同方針:
+     * - 戻り値が `CircleHandle`（非 null）の API（`addCircle`）は throw。
+     * - 戻り値が void / `CircleHandle | null` / `readonly string[]` の API は no-op として扱う。
+     */
+    public addCircle(id: string, options: CircleOptions): CircleHandle {
+        this._assertAlive();
+        return this._requireCircleManager().add(id, options);
+    }
+
+    public getCircle(id: string): CircleHandle | null {
+        if (this._disposed || !this._circleManager) return null;
+        return this._circleManager.get(id);
+    }
+
+    public removeCircle(id: string): void {
+        if (this._disposed || !this._circleManager) return;
+        this._circleManager.remove(id);
+    }
+
+    public setCircleEnabled(id: string, enabled: boolean): void {
+        if (this._disposed || !this._circleManager) return;
+        this._circleManager.setEnabled(id, enabled);
+    }
+
+    public setCirclePointEnabled(id: string, enabled: boolean): void {
+        if (this._disposed || !this._circleManager) return;
+        this._circleManager.setPointEnabled(id, enabled);
+    }
+
+    public setCircleLineEnabled(id: string, enabled: boolean): void {
+        if (this._disposed || !this._circleManager) return;
+        this._circleManager.setLineEnabled(id, enabled);
+    }
+
+    public setCircleWallEnabled(id: string, enabled: boolean): void {
+        if (this._disposed || !this._circleManager) return;
+        this._circleManager.setWallEnabled(id, enabled);
+    }
+
+    public setCircleLabelEnabled(id: string, enabled: boolean): void {
+        if (this._disposed || !this._circleManager) return;
+        this._circleManager.setLabelEnabled(id, enabled);
+    }
+
+    public listCircles(): readonly string[] {
+        if (this._disposed) return [];
+        return this._circleManager?.list() ?? [];
+    }
+
     // ---- ライフサイクル (spec §3.3.3) ----
 
     /**
@@ -1095,6 +1164,15 @@ export class JpmapTerrain {
                 console.error("[JpmapTerrain] polygonManager.dispose threw:", err);
             }
             this._polygonManager = null;
+        }
+        // 円マネージャも Scene dispose 前に解放する (Issue #201)。
+        if (this._circleManager) {
+            try {
+                this._circleManager.dispose();
+            } catch (err) {
+                console.error("[JpmapTerrain] circleManager.dispose threw:", err);
+            }
+            this._circleManager = null;
         }
         // controlPanel が body に追加した UI 要素を Scene dispose 前に除去する。
         if (this._controller) {

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -163,6 +163,58 @@ jest.unstable_mockModule("../src/terrain/polygon", () => ({
     },
 }));
 
+// `circle.ts` は Babylon 実体に依存するため、Circle API テストでは
+// `createCircleNode` を軽量スタブに差し替える。
+jest.unstable_mockModule("../src/terrain/circle", () => ({
+    createCircleNode: (
+        _scene: unknown,
+        id: string,
+        options: { center: { lat: number; lon: number; altitude?: number }; radius: number; segments?: number; altitudeMode?: "terrain" | "absolute"; enabled?: boolean; pointEnabled?: boolean; lineEnabled?: boolean; wallEnabled?: boolean; labelEnabled?: boolean },
+    ) => {
+        let enabled = options.enabled ?? true;
+        const altitudeMode = options.altitudeMode ?? "terrain";
+        let elevationResolved = altitudeMode === "absolute";
+        const center = { ...options.center };
+        const radius = options.radius;
+        const segments = options.segments ?? 64;
+        return {
+            id,
+            altitudeMode,
+            get center() { return center; },
+            set center(v: { lat: number; lon: number; altitude?: number }) {
+                center.lat = v.lat;
+                center.lon = v.lon;
+                center.altitude = v.altitude;
+            },
+            get radius() { return radius; },
+            get segments() { return segments; },
+            applyTransform: () => { /* no-op */ },
+            setEnabledLogical: (v: boolean) => { enabled = v; },
+            setPointEnabledLogical: () => { /* no-op */ },
+            setLineEnabledLogical: () => { /* no-op */ },
+            setWallEnabledLogical: () => { /* no-op */ },
+            setLabelEnabledLogical: () => { /* no-op */ },
+            setElevationResolved: (v: boolean) => { elevationResolved = v; },
+            getHandle: () => ({
+                id,
+                center: { ...center },
+                radius,
+                segments,
+                altitudeMode,
+                label: null,
+                style: {} as unknown as Record<string, unknown>,
+                enabled,
+                pointEnabled: options.pointEnabled ?? true,
+                lineEnabled: options.lineEnabled ?? true,
+                wallEnabled: options.wallEnabled ?? true,
+                labelEnabled: options.labelEnabled ?? true,
+                elevationResolved,
+            }),
+            dispose: () => { /* no-op */ },
+        };
+    },
+}));
+
 jest.unstable_mockModule("../src/scenes/default", () => {
     // モック内で refreshTerrain 相当の呼び出し回数を記録し、
     // テストから検証できるよう getter を export する（T5 のバッチ refresh 検証用）。
@@ -2192,6 +2244,55 @@ describe("JpmapTerrain (skeleton)", () => {
             sceneMockModule.__triggerPolygonPointDragEnd(buildDrag());
             expect(calls.length).toBe(0);
             expect(() => offs.forEach((o) => o())).not.toThrow();
+        });
+    });
+
+    describe("Circle API (Issue #201)", () => {
+        const validCenter = { lat: 35.681, lon: 139.767 };
+
+        it("addCircle → getCircle / listCircles で参照できる", async () => {
+            const viewer = await create(createMountElement());
+            const handle = viewer.addCircle("c1", { center: validCenter, radius: 100 });
+            expect(handle.id).toBe("c1");
+            expect(viewer.getCircle("c1")?.id).toBe("c1");
+            expect(viewer.listCircles()).toEqual(["c1"]);
+        });
+
+        it("removeCircle で消える", async () => {
+            const viewer = await create(createMountElement());
+            viewer.addCircle("c1", { center: validCenter, radius: 100 });
+            viewer.removeCircle("c1");
+            expect(viewer.getCircle("c1")).toBeNull();
+            expect(viewer.listCircles()).toEqual([]);
+        });
+
+        it("setCircleEnabled は登録済み id に対して throw しない", async () => {
+            const viewer = await create(createMountElement());
+            viewer.addCircle("c1", { center: validCenter, radius: 100 });
+            expect(() => viewer.setCircleEnabled("c1", false)).not.toThrow();
+        });
+
+        it("setCircle{Point,Line,Wall,Label}Enabled は登録済み id に対して throw しない", async () => {
+            const viewer = await create(createMountElement());
+            viewer.addCircle("c1", { center: validCenter, radius: 100 });
+            expect(() => viewer.setCirclePointEnabled("c1", false)).not.toThrow();
+            expect(() => viewer.setCircleLineEnabled("c1", false)).not.toThrow();
+            expect(() => viewer.setCircleWallEnabled("c1", false)).not.toThrow();
+            expect(() => viewer.setCircleLabelEnabled("c1", false)).not.toThrow();
+        });
+
+        it("dispose 後の addCircle は throw、その他 API は no-op / null / [] を返す", async () => {
+            const viewer = await create(createMountElement());
+            viewer.dispose();
+            expect(() => viewer.addCircle("c1", { center: validCenter, radius: 100 })).toThrow();
+            expect(viewer.getCircle("c1")).toBeNull();
+            expect(viewer.listCircles()).toEqual([]);
+            expect(() => viewer.removeCircle("c1")).not.toThrow();
+            expect(() => viewer.setCircleEnabled("c1", false)).not.toThrow();
+            expect(() => viewer.setCirclePointEnabled("c1", false)).not.toThrow();
+            expect(() => viewer.setCircleLineEnabled("c1", false)).not.toThrow();
+            expect(() => viewer.setCircleWallEnabled("c1", false)).not.toThrow();
+            expect(() => viewer.setCircleLabelEnabled("c1", false)).not.toThrow();
         });
     });
 });


### PR DESCRIPTION
Closes #204
Refs #201

## 概要
C2 (#203) で実装した `CircleManager` を `JpmapTerrain` クラスに wiring し、
公開 API として以下のメソッドを追加する。

### 追加メソッド
| メソッド | 説明 |
|----------|------|
| `addCircle(id, options)` | 円を追加し `CircleHandle` を返す |
| `getCircle(id)` | 円の現在のスナップショットを返す（未存在なら null） |
| `removeCircle(id)` | 円を削除 |
| `setCircleEnabled(id, enabled)` | 円全体の表示/非表示 |
| `setCirclePointEnabled(id, enabled)` | 中心点の表示/非表示 |
| `setCircleLineEnabled(id, enabled)` | 円周の表示/非表示 |
| `setCircleWallEnabled(id, enabled)` | 壁の表示/非表示 |
| `setCircleLabelEnabled(id, enabled)` | ラベルの表示/非表示 |
| `listCircles()` | 登録済み円 ID 一覧 |

### dispose 後の振る舞い
ポリゴン・マーカーと同方針:
- `addCircle` → throw
- その他 → no-op / null / `[]`

### 変更ファイル
- `src/lib/jpmapTerrain.ts`: import / field / onReady / 9 public methods / dispose
- `tests/jpmapTerrain.unit.spec.ts`: circle.ts mock + 5 integration tests

## チェック
- `npm run test:unit`: 28 suites / 619 tests pass
- `npm run lint`: clean
- `npm run typecheck`: clean

依存: C2 (#210) マージ済み。
