### PR TITLE
feat(circle): updateCircle 編集API (#205)

### DIFF
--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -26,6 +26,7 @@ import {
     MapTypeChangeListener,
     CircleHandle,
     CircleOptions,
+    CircleUpdate,
     MarkerHandle,
     MarkerOptions,
     MarkerUpdate,
@@ -1079,6 +1080,11 @@ export class JpmapTerrain {
     public addCircle(id: string, options: CircleOptions): CircleHandle {
         this._assertAlive();
         return this._requireCircleManager().add(id, options);
+    }
+
+    public updateCircle(id: string, partial: CircleUpdate): CircleHandle {
+        this._assertAlive();
+        return this._requireCircleManager().update(id, partial);
     }
 
     public getCircle(id: string): CircleHandle | null {

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -1074,7 +1074,7 @@ export class JpmapTerrain {
 
     /**
      * dispose 後の円 API はマーカー・ポリゴンと同方針:
-     * - 戻り値が `CircleHandle`（非 null）の API（`addCircle`）は throw。
+     * - 戻り値が `CircleHandle`（非 null）の API（`addCircle` / `updateCircle`）は throw。
      * - 戻り値が void / `CircleHandle | null` / `readonly string[]` の API は no-op として扱う。
      */
     public addCircle(id: string, options: CircleOptions): CircleHandle {

--- a/src/terrain/circleManager.ts
+++ b/src/terrain/circleManager.ts
@@ -335,7 +335,8 @@ export const createCircleManager = (ctx: OverlayContext): CircleManager => {
                     partial.segments !== oldNode.segments) ||
                 (partial.altitudeMode !== undefined &&
                     partial.altitudeMode !== oldNode.altitudeMode) ||
-                partial.style !== undefined ||
+                (partial.style !== undefined &&
+                    Object.keys(partial.style).length > 0) ||
                 partial.label !== undefined;
 
             // マージ済み options を構築する。

--- a/src/terrain/circleManager.ts
+++ b/src/terrain/circleManager.ts
@@ -28,12 +28,15 @@ import {
     CIRCLE_SEGMENTS_MIN,
     type CircleHandle,
     type CircleOptions,
+    type CircleUpdate,
 } from "../lib/types";
 
 const ERROR_PREFIX = "JpmapTerrain.addCircle";
+const UPDATE_ERROR_PREFIX = "JpmapTerrain.updateCircle";
 
 export interface CircleManager {
     add(id: string, options: CircleOptions): CircleHandle;
+    update(id: string, partial: CircleUpdate): CircleHandle;
     get(id: string): CircleHandle | null;
     remove(id: string): void;
     setEnabled(id: string, enabled: boolean): void;
@@ -92,6 +95,8 @@ const validateOptions = (options: CircleOptions): void => {
 
 export const createCircleManager = (ctx: OverlayContext): CircleManager => {
     const nodes = new Map<string, CircleNode>();
+    /** add 時に渡された完全な CircleOptions（update 時の差分マージ元）。 */
+    const storedOptions = new Map<string, CircleOptions>();
     let disposed = false;
 
     /**
@@ -210,6 +215,86 @@ export const createCircleManager = (ctx: OverlayContext): CircleManager => {
         return node;
     };
 
+    /**
+     * center / radius / segments から ring XZ キャッシュを構築し、標高解決を行う。
+     * `add` と `update`（ジオメトリ変化時）の共通処理。
+     */
+    const buildCacheAndResolve = (id: string, node: CircleNode): void => {
+        const { wx: cwx, wz: cwz } = latLonToWorld(
+            ctx,
+            node.center.lat,
+            node.center.lon,
+        );
+        const segments = node.segments;
+        const radius = node.radius;
+        const step = (Math.PI * 2) / segments;
+        const ringXZ: { x: number; z: number }[] = [];
+        for (let i = 0; i < segments; i++) {
+            const θ = i * step;
+            ringXZ.push({
+                x: cwx + radius * Math.cos(θ),
+                z: cwz + radius * Math.sin(θ),
+            });
+        }
+        const cache: CircleCache = {
+            cwx,
+            cwz,
+            ringXZ,
+            centerWorld: null,
+            ringWorld: null,
+        };
+        caches.set(id, cache);
+        resolveElevations(node, cache);
+    };
+
+    /**
+     * `CircleUpdate` で指定されたフィールドのバリデーション。
+     * `addCircle` と同一のルールを適用するが、未指定のフィールドはスキップする。
+     */
+    const validatePartial = (
+        partial: CircleUpdate,
+        currentNode: CircleNode,
+    ): void => {
+        if (partial.center !== undefined) {
+            assertLatLonInBounds(
+                partial.center.lat,
+                partial.center.lon,
+                UPDATE_ERROR_PREFIX,
+            );
+        }
+        if (partial.radius !== undefined) {
+            if (
+                !Number.isFinite(partial.radius) ||
+                partial.radius <= 0 ||
+                partial.radius > CIRCLE_RADIUS_MAX_M
+            ) {
+                throw new Error(
+                    `${UPDATE_ERROR_PREFIX}: radius must be in (0, ${CIRCLE_RADIUS_MAX_M}] m (got ${partial.radius})`,
+                );
+            }
+        }
+        if (partial.segments !== undefined) {
+            if (
+                !Number.isInteger(partial.segments) ||
+                partial.segments < CIRCLE_SEGMENTS_MIN ||
+                partial.segments > CIRCLE_SEGMENTS_MAX
+            ) {
+                throw new Error(
+                    `${UPDATE_ERROR_PREFIX}: segments must be an integer in [${CIRCLE_SEGMENTS_MIN}, ${CIRCLE_SEGMENTS_MAX}] (got ${partial.segments})`,
+                );
+            }
+        }
+        // altitudeMode → absolute 切替時に center.altitude が必要
+        const nextMode =
+            partial.altitudeMode ?? currentNode.altitudeMode;
+        const nextCenter = partial.center ?? currentNode.center;
+        if (nextMode === "absolute" && nextCenter.altitude === undefined) {
+            throw new Error(
+                `${UPDATE_ERROR_PREFIX}: altitudeMode="absolute" requires center.altitude`,
+            );
+        }
+    };
+
     return {
         add(id: string, options: CircleOptions): CircleHandle {
             if (disposed) {
@@ -223,34 +308,103 @@ export const createCircleManager = (ctx: OverlayContext): CircleManager => {
             validateOptions(options);
             const node = createCircleNode(ctx.scene, id, options);
             nodes.set(id, node);
-
-            // ring XZ をここで 1 回だけ計算してキャッシュする。
-            const { wx: cwx, wz: cwz } = latLonToWorld(
-                ctx,
-                options.center.lat,
-                options.center.lon,
-            );
-            const segments = node.segments;
-            const radius = node.radius;
-            const step = (Math.PI * 2) / segments;
-            const ringXZ: { x: number; z: number }[] = [];
-            for (let i = 0; i < segments; i++) {
-                const θ = i * step;
-                ringXZ.push({
-                    x: cwx + radius * Math.cos(θ),
-                    z: cwz + radius * Math.sin(θ),
-                });
-            }
-            const cache: CircleCache = {
-                cwx,
-                cwz,
-                ringXZ,
-                centerWorld: null,
-                ringWorld: null,
-            };
-            caches.set(id, cache);
-            resolveElevations(node, cache);
+            storedOptions.set(id, { ...options, center: { ...options.center } });
+            buildCacheAndResolve(id, node);
             return node.getHandle();
+        },
+        update(id: string, partial: CircleUpdate): CircleHandle {
+            if (disposed) {
+                throw new Error("CircleManager has been disposed");
+            }
+            const oldNode = requireNode(id);
+            const prev = storedOptions.get(id);
+            if (!prev) {
+                throw new Error(
+                    `${UPDATE_ERROR_PREFIX}: stored options for "${id}" missing`,
+                );
+            }
+            validatePartial(partial, oldNode);
+
+            // segments / altitudeMode / style / label の変更は node 再構築が必要。
+            const needsRebuild =
+                (partial.segments !== undefined &&
+                    partial.segments !== oldNode.segments) ||
+                (partial.altitudeMode !== undefined &&
+                    partial.altitudeMode !== oldNode.altitudeMode) ||
+                partial.style !== undefined ||
+                partial.label !== undefined;
+
+            // マージ済み options を構築する。
+            const merged: CircleOptions = {
+                ...prev,
+                center: { ...prev.center },
+            };
+            if (partial.center !== undefined) {
+                merged.center = { ...partial.center };
+            }
+            if (partial.radius !== undefined) merged.radius = partial.radius;
+            if (partial.segments !== undefined)
+                merged.segments = partial.segments;
+            if (partial.altitudeMode !== undefined)
+                merged.altitudeMode = partial.altitudeMode;
+            if (partial.label !== undefined) merged.label = partial.label;
+            if (partial.style !== undefined)
+                merged.style = { ...prev.style, ...partial.style };
+            if (partial.enabled !== undefined) merged.enabled = partial.enabled;
+            if (partial.pointEnabled !== undefined)
+                merged.pointEnabled = partial.pointEnabled;
+            if (partial.lineEnabled !== undefined)
+                merged.lineEnabled = partial.lineEnabled;
+            if (partial.wallEnabled !== undefined)
+                merged.wallEnabled = partial.wallEnabled;
+            if (partial.labelEnabled !== undefined)
+                merged.labelEnabled = partial.labelEnabled;
+
+            storedOptions.set(id, {
+                ...merged,
+                center: { ...merged.center },
+            });
+
+            if (needsRebuild) {
+                // Tube/Ribbon の path 長やマテリアルが変わるため dispose → 再構築。
+                oldNode.dispose();
+                const newNode = createCircleNode(ctx.scene, id, merged);
+                nodes.set(id, newNode);
+                buildCacheAndResolve(id, newNode);
+                return newNode.getHandle();
+            }
+
+            // 再構築不要なケース: setter 経由で差分適用。
+            let geometryChanged = false;
+            if (partial.center !== undefined) {
+                oldNode.center = partial.center;
+                geometryChanged = true;
+            }
+            if (partial.radius !== undefined) {
+                oldNode.radius = partial.radius;
+                geometryChanged = true;
+            }
+            if (partial.enabled !== undefined) {
+                oldNode.setEnabledLogical(partial.enabled);
+            }
+            if (partial.pointEnabled !== undefined) {
+                oldNode.setPointEnabledLogical(partial.pointEnabled);
+            }
+            if (partial.lineEnabled !== undefined) {
+                oldNode.setLineEnabledLogical(partial.lineEnabled);
+            }
+            if (partial.wallEnabled !== undefined) {
+                oldNode.setWallEnabledLogical(partial.wallEnabled);
+            }
+            if (partial.labelEnabled !== undefined) {
+                oldNode.setLabelEnabledLogical(partial.labelEnabled);
+            }
+
+            // center / radius が変わった場合は ring XZ キャッシュを再構築する。
+            if (geometryChanged) {
+                buildCacheAndResolve(id, oldNode);
+            }
+            return oldNode.getHandle();
         },
         get(id: string): CircleHandle | null {
             const node = nodes.get(id);
@@ -267,6 +421,7 @@ export const createCircleManager = (ctx: OverlayContext): CircleManager => {
             node.dispose();
             nodes.delete(id);
             caches.delete(id);
+            storedOptions.delete(id);
         },
         setEnabled(id: string, enabled: boolean): void {
             if (disposed) {
@@ -313,6 +468,7 @@ export const createCircleManager = (ctx: OverlayContext): CircleManager => {
             }
             nodes.clear();
             caches.clear();
+            storedOptions.clear();
         },
     };
 };

--- a/src/terrain/circleManager.ts
+++ b/src/terrain/circleManager.ts
@@ -308,7 +308,11 @@ export const createCircleManager = (ctx: OverlayContext): CircleManager => {
             validateOptions(options);
             const node = createCircleNode(ctx.scene, id, options);
             nodes.set(id, node);
-            storedOptions.set(id, { ...options, center: { ...options.center } });
+            storedOptions.set(id, {
+                ...options,
+                center: { ...options.center },
+                style: options.style ? { ...options.style } : undefined,
+            });
             buildCacheAndResolve(id, node);
             return node.getHandle();
         },
@@ -363,6 +367,7 @@ export const createCircleManager = (ctx: OverlayContext): CircleManager => {
             storedOptions.set(id, {
                 ...merged,
                 center: { ...merged.center },
+                style: merged.style ? { ...merged.style } : undefined,
             });
 
             if (needsRebuild) {

--- a/tests/circleManager.unit.spec.ts
+++ b/tests/circleManager.unit.spec.ts
@@ -392,6 +392,15 @@ describe("CircleManager update", () => {
         expect(created.length).toBe(2);
     });
 
+    it("空 style {} は再構築しない", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createCircleManager(ctx);
+        mgr.add("a", { center: validCenter, radius: 100 });
+        mgr.update("a", { style: {} });
+        expect(created.length).toBe(1); // 再構築なし
+        expect(created[0].disposed).toBe(false);
+    });
+
     it("enabled フラグの変更は node 再構築なしで反映される", () => {
         const { ctx } = buildCtx(0);
         const mgr = createCircleManager(ctx);

--- a/tests/circleManager.unit.spec.ts
+++ b/tests/circleManager.unit.spec.ts
@@ -14,6 +14,7 @@ interface StubNode {
     center: { lat: number; lon: number; altitude?: number };
     radius: number;
     segments: number;
+    label: string | null | undefined;
     enabled: boolean;
     pointEnabled: boolean;
     lineEnabled: boolean;
@@ -47,6 +48,7 @@ jest.unstable_mockModule("../src/terrain/circle", () => ({
             center: { ...options.center },
             radius: options.radius,
             segments: options.segments ?? 64,
+            label: options.label,
             enabled: options.enabled ?? true,
             pointEnabled: options.pointEnabled ?? true,
             lineEnabled: options.lineEnabled ?? true,
@@ -124,7 +126,7 @@ jest.unstable_mockModule("../src/terrain/circle", () => ({
                 radius: node.radius,
                 segments: node.segments,
                 altitudeMode: node.altitudeMode,
-                label: null,
+                label: node.label ?? null,
                 style: {} as unknown as Record<string, unknown>,
                 enabled: node.enabled,
                 pointEnabled: node.pointEnabled,
@@ -398,6 +400,28 @@ describe("CircleManager update", () => {
         expect(created.length).toBe(1); // 再構築なし
         expect(created[0].setEnabledHistory).toEqual([false]);
         expect(created[0].setPointEnabledHistory).toEqual([false]);
+    });
+
+    it("label を文字列に変更すると node が再構築され getHandle に反映される", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createCircleManager(ctx);
+        mgr.add("a", { center: validCenter, radius: 100 });
+        expect(created.length).toBe(1);
+        const handle = mgr.update("a", { label: "テスト" });
+        expect(created[0].disposed).toBe(true);
+        expect(created.length).toBe(2);
+        expect(handle.label).toBe("テスト");
+    });
+
+    it("label を null に変更すると node が再構築される（非表示）", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createCircleManager(ctx);
+        mgr.add("a", { center: validCenter, radius: 100, label: "初期" });
+        expect(created.length).toBe(1);
+        const handle = mgr.update("a", { label: null });
+        expect(created[0].disposed).toBe(true);
+        expect(created.length).toBe(2);
+        expect(handle.label).toBeNull();
     });
 
     it("未存在 id の update は throw", () => {

--- a/tests/circleManager.unit.spec.ts
+++ b/tests/circleManager.unit.spec.ts
@@ -66,6 +66,18 @@ jest.unstable_mockModule("../src/terrain/circle", () => ({
         };
         const wrapped = {
             ...node,
+            get center() {
+                return node.center;
+            },
+            set center(v: { lat: number; lon: number; altitude?: number }) {
+                node.center = { ...v };
+            },
+            get radius() {
+                return node.radius;
+            },
+            set radius(v: number) {
+                node.radius = v;
+            },
             applyTransform: (
                 centerWorld: { x: number; y: number; z: number },
                 ringWorld: ReadonlyArray<{ x: number; y: number; z: number }>,
@@ -324,6 +336,122 @@ describe("CircleManager バリデーション", () => {
                 altitudeMode: "absolute",
             }),
         ).toThrow(/altitude/);
+    });
+});
+
+describe("CircleManager update", () => {
+    it("center を変更すると getHandle に反映され、ring が再計算される", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createCircleManager(ctx);
+        mgr.add("a", { center: validCenter, radius: 500 });
+        const prevCenter = created[0].lastCenter;
+        const newCenter = { lat: 35.690, lon: 139.770 };
+        const handle = mgr.update("a", { center: newCenter });
+        expect(handle.center.lat).toBe(35.690);
+        expect(handle.center.lon).toBe(139.770);
+        // ring 再計算されたので applyTransform が追加で呼ばれている
+        expect(created[0].applyTransformCalls).toBeGreaterThan(1);
+        // center world 座標が変わっている
+        expect(created[0].lastCenter).not.toEqual(prevCenter);
+    });
+
+    it("radius を変更すると ring 各点の距離が新半径になる", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createCircleManager(ctx);
+        mgr.add("a", { center: validCenter, radius: 100, segments: 8 });
+        mgr.update("a", { radius: 300 });
+        const center = created[0].lastCenter!;
+        for (const p of created[0].lastRing) {
+            const dist = Math.hypot(p.x - center.x, p.z - center.z);
+            expect(dist).toBeCloseTo(300, 3);
+        }
+    });
+
+    it("segments を変更すると node が再構築される（created 配列に新 node 追加）", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createCircleManager(ctx);
+        mgr.add("a", { center: validCenter, radius: 100, segments: 16 });
+        expect(created.length).toBe(1);
+        expect(created[0].disposed).toBe(false);
+        mgr.update("a", { segments: 32 });
+        // 旧 node が dispose され、新 node が作られる
+        expect(created[0].disposed).toBe(true);
+        expect(created.length).toBe(2);
+        expect(created[1].lastRing.length).toBe(32);
+    });
+
+    it("style を変更すると node が再構築される", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createCircleManager(ctx);
+        mgr.add("a", { center: validCenter, radius: 100 });
+        expect(created.length).toBe(1);
+        mgr.update("a", { style: { lineColor: "#00ff00" } });
+        expect(created[0].disposed).toBe(true);
+        expect(created.length).toBe(2);
+    });
+
+    it("enabled フラグの変更は node 再構築なしで反映される", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createCircleManager(ctx);
+        mgr.add("a", { center: validCenter, radius: 100 });
+        mgr.update("a", { enabled: false, pointEnabled: false });
+        expect(created.length).toBe(1); // 再構築なし
+        expect(created[0].setEnabledHistory).toEqual([false]);
+        expect(created[0].setPointEnabledHistory).toEqual([false]);
+    });
+
+    it("未存在 id の update は throw", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createCircleManager(ctx);
+        expect(() => mgr.update("missing", { radius: 200 })).toThrow(
+            /not found/,
+        );
+    });
+
+    it("update 時も radius バリデーションが効く", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createCircleManager(ctx);
+        mgr.add("a", { center: validCenter, radius: 100 });
+        expect(() => mgr.update("a", { radius: -1 })).toThrow(/radius/);
+        expect(() => mgr.update("a", { radius: 200_000 })).toThrow(/radius/);
+    });
+
+    it("update 時も segments バリデーションが効く", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createCircleManager(ctx);
+        mgr.add("a", { center: validCenter, radius: 100 });
+        expect(() => mgr.update("a", { segments: 3 })).toThrow(/segments/);
+    });
+
+    it("update 時も JAPAN_BOUNDS バリデーションが効く", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createCircleManager(ctx);
+        mgr.add("a", { center: validCenter, radius: 100 });
+        expect(() =>
+            mgr.update("a", { center: { lat: 0, lon: 0 } }),
+        ).toThrow(/JAPAN_BOUNDS/);
+    });
+
+    it("absolute 切替時に altitude 未指定なら throw", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createCircleManager(ctx);
+        mgr.add("a", { center: validCenter, radius: 100 });
+        expect(() => mgr.update("a", { altitudeMode: "absolute" })).toThrow(
+            /altitude/,
+        );
+    });
+
+    it("altitudeMode 変更は node 再構築", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createCircleManager(ctx);
+        mgr.add("a", {
+            center: { ...validCenter, altitude: 100 },
+            radius: 100,
+        });
+        expect(created.length).toBe(1);
+        mgr.update("a", { altitudeMode: "absolute" });
+        expect(created[0].disposed).toBe(true);
+        expect(created.length).toBe(2);
     });
 });
 

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -174,19 +174,18 @@ jest.unstable_mockModule("../src/terrain/circle", () => ({
         let enabled = options.enabled ?? true;
         const altitudeMode = options.altitudeMode ?? "terrain";
         let elevationResolved = altitudeMode === "absolute";
-        const center = { ...options.center };
-        const radius = options.radius;
+        let _center = { ...options.center };
+        let _radius = options.radius;
         const segments = options.segments ?? 64;
         return {
             id,
             altitudeMode,
-            get center() { return center; },
+            get center() { return _center; },
             set center(v: { lat: number; lon: number; altitude?: number }) {
-                center.lat = v.lat;
-                center.lon = v.lon;
-                center.altitude = v.altitude;
+                _center = { ...v };
             },
-            get radius() { return radius; },
+            get radius() { return _radius; },
+            set radius(v: number) { _radius = v; },
             get segments() { return segments; },
             applyTransform: () => { /* no-op */ },
             setEnabledLogical: (v: boolean) => { enabled = v; },
@@ -197,8 +196,8 @@ jest.unstable_mockModule("../src/terrain/circle", () => ({
             setElevationResolved: (v: boolean) => { elevationResolved = v; },
             getHandle: () => ({
                 id,
-                center: { ...center },
-                radius,
+                center: { ..._center },
+                radius: _radius,
                 segments,
                 altitudeMode,
                 label: null,
@@ -2285,6 +2284,7 @@ describe("JpmapTerrain (skeleton)", () => {
             const viewer = await create(createMountElement());
             viewer.dispose();
             expect(() => viewer.addCircle("c1", { center: validCenter, radius: 100 })).toThrow();
+            expect(() => viewer.updateCircle("c1", { radius: 200 })).toThrow();
             expect(viewer.getCircle("c1")).toBeNull();
             expect(viewer.listCircles()).toEqual([]);
             expect(() => viewer.removeCircle("c1")).not.toThrow();
@@ -2293,6 +2293,14 @@ describe("JpmapTerrain (skeleton)", () => {
             expect(() => viewer.setCircleLineEnabled("c1", false)).not.toThrow();
             expect(() => viewer.setCircleWallEnabled("c1", false)).not.toThrow();
             expect(() => viewer.setCircleLabelEnabled("c1", false)).not.toThrow();
+        });
+
+        it("updateCircle で既存円の radius を変更できる", async () => {
+            const viewer = await create(createMountElement());
+            viewer.addCircle("c1", { center: validCenter, radius: 100 });
+            const updated = viewer.updateCircle("c1", { radius: 300 });
+            expect(updated.radius).toBe(300);
+            viewer.dispose();
         });
     });
 });


### PR DESCRIPTION
## 概要

Issue #205 の実装。Circle API に `updateCircle` 編集メソッドを追加する。

## 変更内容

### CircleManager（src/terrain/circleManager.ts）
- `update(id, partial)` メソッド追加
  - **再構築パス**: segments / altitudeMode / style / label 変更時 → dispose + createCircleNode
  - **setter パス**: center / radius / enabled フラグ変更時 → setter + キャッシュ再構築
- `storedOptions` Map で full options を保持し、partial merge で更新
- `validatePartial()` ヘルパー: update 固有のバリデーション
- `buildCacheAndResolve()` ヘルパー: ring XZ キャッシュ構築 + 標高解決
- `dispose()` に `storedOptions.clear()` 追加
- `remove()` に `storedOptions.delete()` 追加

### JpmapTerrain（src/lib/jpmapTerrain.ts）
- `CircleUpdate` 型 import 追加
- `updateCircle(id, partial)` 公開メソッド追加

### テスト
- circleManager.unit.spec.ts: update テスト 12 件追加（center/radius/segments/style/enabled/バリデーション）
- jpmapTerrain.unit.spec.ts: updateCircle 統合テスト追加、dispose 後の updateCircle throw 確認追加
- mock に center/radius setter 追加（update 経路を正しくテスト可能に）

## テスト結果
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run test:unit` ✅（28 suites / 631 tests）

Closes #205