### PR TITLE
feat(circle-demo): サークルデモページ追加 (#206)

### DIFF
--- a/public/circle.html
+++ b/public/circle.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>jpmap_terrain – サークルデモ</title>
-  <meta name="description" content="jpmap_terrain の Circle (CircleManager) 公開 API 動作確認デモ (Issue #201)">
+  <meta name="description" content="jpmap_terrain の Circle (CircleManager) 公開 API 動作確認デモ (Issue #201 / #206)">
   <meta name="author" content="8ga3">
   <style>
     html, body {
@@ -93,7 +93,7 @@
   <div id="circle-overlay">
     <a class="back-link" href="/">← デモ一覧へ</a>
     <div id="circle-controls">
-      <strong>サークルデモ (Issue #201)</strong>
+      <strong>サークルデモ (Issue #201 / #206)</strong>
       <div id="circle-controls-buttons"></div>
     </div>
   </div>

--- a/public/circle.html
+++ b/public/circle.html
@@ -1,0 +1,101 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <title>jpmap_terrain – サークルデモ</title>
+  <meta name="description" content="jpmap_terrain の Circle (CircleManager) 公開 API 動作確認デモ (Issue #201)">
+  <meta name="author" content="8ga3">
+  <style>
+    html, body {
+      overflow: hidden;
+      width: 100%;
+      height: 100%;
+      margin: 0;
+      padding: 0;
+    }
+
+    #root {
+      position: relative;
+      width: 100%;
+      height: 100%;
+      touch-action: none;
+    }
+
+    /* 操作 UI ルート。ポインターイベントは透過。 */
+    #circle-overlay {
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      z-index: 10;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI",
+        "Hiragino Sans", "Noto Sans JP", Meiryo, sans-serif;
+    }
+
+    #circle-overlay .back-link {
+      position: absolute;
+      top: 12px;
+      left: 12px;
+      pointer-events: auto;
+      padding: 6px 12px;
+      font-size: 13px;
+      color: #fff;
+      background: rgba(0, 0, 0, 0.45);
+      border: 1px solid rgba(255, 255, 255, 0.25);
+      border-radius: 6px;
+      text-decoration: none;
+    }
+
+    #circle-overlay .back-link:hover {
+      background: rgba(0, 0, 0, 0.6);
+    }
+
+    #circle-controls {
+      position: absolute;
+      top: 12px;
+      right: 12px;
+      pointer-events: auto;
+      padding: 10px 12px;
+      font-size: 13px;
+      color: #fff;
+      background: rgba(0, 0, 0, 0.5);
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      border-radius: 8px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      max-width: 240px;
+    }
+
+    #circle-controls strong {
+      font-size: 12px;
+      letter-spacing: 0.04em;
+      color: #c8d2e6;
+    }
+
+    #circle-controls button {
+      pointer-events: auto;
+      padding: 4px 8px;
+      font-size: 12px;
+      color: #fff;
+      background: rgba(255, 255, 255, 0.08);
+      border: 1px solid rgba(255, 255, 255, 0.25);
+      border-radius: 4px;
+      cursor: pointer;
+    }
+
+    #circle-controls button:hover {
+      background: rgba(255, 255, 255, 0.18);
+    }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <div id="circle-overlay">
+    <a class="back-link" href="/">← デモ一覧へ</a>
+    <div id="circle-controls">
+      <strong>サークルデモ (Issue #201)</strong>
+      <div id="circle-controls-buttons"></div>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/demos/circle/index.ts
+++ b/src/demos/circle/index.ts
@@ -1,0 +1,310 @@
+/**
+ * サークルデモ (Issue #201 / #206)
+ *
+ * `JpmapTerrain` の Circle 公開 API（`addCircle` / `updateCircle` /
+ * `removeCircle` / `setCircleEnabled` / `setCirclePointEnabled` /
+ * `setCircleLineEnabled` / `setCircleWallEnabled` / `setCircleLabelEnabled` /
+ * `getCircle` / `listCircles`）を目視確認するためのデモ。
+ *
+ * 仕様:
+ * - `altitudeMode: "terrain"` で地形に沿った円
+ * - `altitudeMode: "absolute"` で絶対標高の円
+ * - 各円の enabled / point / line / wall / label トグル
+ * - `updateCircle` による半径・中心・スタイルの動的更新
+ *
+ * 開発デモ層につき `src/lib/**` には依存型のみ依存し、内部実装は触らない。
+ */
+import { JpmapTerrain } from "../../lib/jpmapTerrain";
+import type { CircleOptions, JpmapTerrainOptions } from "../../lib/types";
+import {
+    parseCameraStateFromUrl,
+    parseMapTypeFromUrl,
+} from "../../terrain/urlState";
+
+const DEMO_MOUNT_ID = "root";
+const CONTROLS_ID = "circle-controls-buttons";
+
+const resolveEngine = (search: string): "webgpu" | "webgl2" | undefined => {
+    const value = new URLSearchParams(search).get("engine");
+    if (value === "webgpu") return "webgpu";
+    if (value === "webgl" || value === "webgl2") return "webgl2";
+    return undefined;
+};
+
+interface DemoCircleDef {
+    id: string;
+    label: string;
+    options: CircleOptions;
+}
+
+/**
+ * デモ用の円定義。
+ * よみうりランド付近を中心に、terrain / absolute / カスタムスタイルの 3 つを配置する。
+ */
+const buildDemoCircles = (): readonly DemoCircleDef[] => [
+    {
+        id: "yomiuri-terrain",
+        label: "terrain (地表+50m, r=300m)",
+        options: {
+            center: { lat: 35.6242, lon: 139.5100, altitude: 50 },
+            radius: 300,
+            altitudeMode: "terrain",
+            style: {
+                pointColor: "#ff5252",
+                lineColor: "#ff5252",
+                lineWidth: 3,
+                wallColor: "#ff5252",
+                wallOpacity: 0.3,
+            },
+        },
+    },
+    {
+        id: "yomiuri-absolute",
+        label: "absolute (標高400m, r=200m)",
+        options: {
+            center: { lat: 35.6242, lon: 139.5148, altitude: 400 },
+            radius: 200,
+            altitudeMode: "absolute",
+            style: {
+                pointColor: "#42a5f5",
+                lineColor: "#42a5f5",
+                lineWidth: 4,
+                wallColor: "#42a5f5",
+                wallOpacity: 0.4,
+            },
+        },
+    },
+    {
+        id: "yomiuri-custom",
+        label: "custom (segments=16, r=150m)",
+        options: {
+            center: { lat: 35.6242, lon: 139.5200, altitude: 300 },
+            radius: 150,
+            segments: 16,
+            altitudeMode: "absolute",
+            label: "16角形\nradius=150m",
+            style: {
+                pointColor: "#ffca28",
+                pointDiameter: 30,
+                lineColor: "#ffca28",
+                lineWidth: 2,
+                wallColor: "#ffca28",
+                wallOpacity: 0.5,
+            },
+        },
+    },
+];
+
+/** 操作 UI を構築する。 */
+const buildControls = (
+    container: HTMLElement,
+    viewer: JpmapTerrain,
+    circles: readonly DemoCircleDef[],
+): void => {
+    container.innerHTML = "";
+
+    // 各円の enabled トグル
+    for (const def of circles) {
+        const btn = document.createElement("button");
+        btn.type = "button";
+        btn.dataset.circleId = def.id;
+        const refreshLabel = (): void => {
+            const handle = viewer.getCircle(def.id);
+            const enabled = handle ? handle.enabled : false;
+            btn.textContent = `${enabled ? "✔" : "✕"} ${def.label}`;
+        };
+        btn.addEventListener("click", () => {
+            const handle = viewer.getCircle(def.id);
+            if (!handle) return;
+            viewer.setCircleEnabled(def.id, !handle.enabled);
+            refreshLabel();
+        });
+        container.appendChild(btn);
+        refreshLabel();
+    }
+
+    // 全体トグルヘルパー
+    const buildToggle = (
+        labelOn: string,
+        labelOff: string,
+        initial: boolean,
+        onClick: (next: boolean) => void,
+    ): HTMLButtonElement => {
+        const btn = document.createElement("button");
+        btn.type = "button";
+        let state = initial;
+        const refresh = (): void => {
+            btn.textContent = state ? labelOn : labelOff;
+        };
+        btn.addEventListener("click", () => {
+            state = !state;
+            onClick(state);
+            refresh();
+        });
+        refresh();
+        return btn;
+    };
+
+    container.appendChild(
+        buildToggle("✔ 中心点 ON", "✕ 中心点 OFF", true, (next) => {
+            for (const def of circles) {
+                viewer.setCirclePointEnabled(def.id, next);
+            }
+        }),
+    );
+    container.appendChild(
+        buildToggle("✔ 円周 ON", "✕ 円周 OFF", true, (next) => {
+            for (const def of circles) {
+                viewer.setCircleLineEnabled(def.id, next);
+            }
+        }),
+    );
+    container.appendChild(
+        buildToggle("✔ 壁 ON", "✕ 壁 OFF", true, (next) => {
+            for (const def of circles) {
+                viewer.setCircleWallEnabled(def.id, next);
+            }
+        }),
+    );
+    container.appendChild(
+        buildToggle("✔ ラベル ON", "✕ ラベル OFF", true, (next) => {
+            for (const def of circles) {
+                viewer.setCircleLabelEnabled(def.id, next);
+            }
+        }),
+    );
+
+    // 3D / 2D 視点モード切替
+    {
+        const btn = document.createElement("button");
+        btn.type = "button";
+        const refresh = (): void => {
+            btn.textContent = viewer.viewMode === "3d" ? "2D 表示" : "3D 表示";
+        };
+        btn.addEventListener("click", () => {
+            viewer.viewMode = viewer.viewMode === "3d" ? "2d" : "3d";
+        });
+        viewer.onViewModeChange(() => refresh());
+        refresh();
+        container.appendChild(btn);
+    }
+
+    // updateCircle デモ: 半径を段階的に変更
+    const editTargetId = "yomiuri-terrain";
+    let radiusStep = 0;
+    const radiusValues = [300, 500, 100, 300];
+    const buildEditButton = (
+        label: string,
+        onClick: () => void,
+    ): HTMLButtonElement => {
+        const btn = document.createElement("button");
+        btn.type = "button";
+        btn.textContent = label;
+        btn.addEventListener("click", () => {
+            try {
+                onClick();
+            } catch (err) {
+                console.warn(
+                    `[jpmap-terrain demo] circle edit "${label}" failed:`,
+                    err,
+                );
+            }
+        });
+        return btn;
+    };
+
+    container.appendChild(
+        buildEditButton("半径変更", () => {
+            radiusStep = (radiusStep + 1) % radiusValues.length;
+            viewer.updateCircle(editTargetId, {
+                radius: radiusValues[radiusStep],
+            });
+        }),
+    );
+
+    container.appendChild(
+        buildEditButton("スタイル変更", () => {
+            const handle = viewer.getCircle(editTargetId);
+            if (!handle) return;
+            const isRed = handle.style.lineColor === "#ff5252";
+            viewer.updateCircle(editTargetId, {
+                style: {
+                    pointColor: isRed ? "#4caf50" : "#ff5252",
+                    lineColor: isRed ? "#4caf50" : "#ff5252",
+                    wallColor: isRed ? "#4caf50" : "#ff5252",
+                },
+            });
+        }),
+    );
+
+    container.appendChild(
+        buildEditButton("中心移動", () => {
+            const handle = viewer.getCircle(editTargetId);
+            if (!handle) return;
+            viewer.updateCircle(editTargetId, {
+                center: {
+                    lat: handle.center.lat + 0.001,
+                    lon: handle.center.lon,
+                    altitude: handle.center.altitude,
+                },
+            });
+        }),
+    );
+};
+
+const start = async (): Promise<void> => {
+    const mount = document.getElementById(DEMO_MOUNT_ID);
+    if (!mount) {
+        throw new Error(`#${DEMO_MOUNT_ID} mount element not found`);
+    }
+
+    const engine = resolveEngine(location.search);
+    const cameraState = parseCameraStateFromUrl(location.href) ?? undefined;
+    const mapType = parseMapTypeFromUrl(location.href);
+    const defaultCamera = {
+        lat: 35.6242625,
+        lon: 139.5148162,
+        altitude: 1500,
+        azimuth: 0,
+        tilt: 55,
+    };
+
+    const opts: JpmapTerrainOptions = {
+        ...(engine ? { engine } : {}),
+        ...(cameraState ?? defaultCamera),
+        ...(mapType !== null ? { mapType } : {}),
+        showViewModeButton: false,
+    };
+
+    const viewer = await JpmapTerrain.create(mount, opts);
+    const circles = buildDemoCircles();
+    for (const def of circles) {
+        try {
+            viewer.addCircle(def.id, def.options);
+        } catch (err) {
+            console.warn(
+                `[jpmap-terrain demo] failed to add circle "${def.id}":`,
+                err,
+            );
+        }
+    }
+
+    const controls = document.getElementById(CONTROLS_ID);
+    if (controls instanceof HTMLElement) {
+        buildControls(controls, viewer, circles);
+    }
+
+    if (process.env.NODE_ENV !== "production") {
+        (window as unknown as { viewer: JpmapTerrain }).viewer = viewer;
+        (window as unknown as { scene: unknown }).scene = viewer.__debugScene;
+    }
+};
+
+if (
+    typeof document !== "undefined" &&
+    document.getElementById(DEMO_MOUNT_ID) !== null
+) {
+    start().catch((err) => {
+        console.error("[jpmap-terrain demo] failed to start:", err);
+    });
+}

--- a/src/demos/portal/index.ts
+++ b/src/demos/portal/index.ts
@@ -42,6 +42,12 @@ const DEMO_LIST: readonly DemoEntry[] = [
             "地形クリックで点を追加し、辺ごとの水平距離と高低差を表示するデモ。追加 / 削除 / 編集モードで頂点を動的に編集できます。",
         href: "distance",
     },
+    {
+        title: "サークル",
+        description:
+            "CircleManager 公開 API の動作確認デモ。terrain / absolute / カスタムセグメントの 3 種類の円を表示し、enabled や半径・スタイルの動的更新ができます。",
+        href: "circle",
+    },
 ];
 
 const PORTAL_MOUNT_ID = "root";

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -668,7 +668,8 @@ export interface CircleHandle {
     readonly wallEnabled: boolean;
     readonly labelEnabled: boolean;
     /**
-     * `terrain` モード時、中心 + 全円周点の標高解決済みなら true。
+     * `terrain` モード時、中心点の地表標高が解決済みなら true。
+     * 円は平面円として描画されるため、中心の標高のみが必要。
      * `absolute` モード時は常に true。
      */
     readonly elevationResolved: boolean;

--- a/src/terrain/circleManager.ts
+++ b/src/terrain/circleManager.ts
@@ -119,8 +119,9 @@ export const createCircleManager = (ctx: OverlayContext): CircleManager => {
     /**
      * 標高を解決して `cache` を更新し、解決済みなら `node.applyTransform` を呼ぶ。
      *
-     * - terrain モード: 中心 + 全円周点の標高を `queryElevationAtWorld` で取得。
-     *   1 点でも null なら `elevationResolved=false` にして処理を終了する。
+     * - terrain モード: 中心点の地表標高のみ `queryElevationAtWorld` で取得。
+     *   null なら `elevationResolved=false` にして処理を終了する。
+     *   円は平面円として描画するため、リング点は中心と同一 Y になる。
      * - absolute モード: 標高クエリ不要。`center.altitude` を Y として使う。
      */
     const resolveElevations = (node: CircleNode, cache: CircleCache): void => {

--- a/src/terrain/circleManager.ts
+++ b/src/terrain/circleManager.ts
@@ -142,7 +142,10 @@ export const createCircleManager = (ctx: OverlayContext): CircleManager => {
             return;
         }
 
-        // terrain モード
+        // terrain モード:
+        // 中心点の地表標高のみクエリし、リング全点を同一 Y（中心地表 + altitude）に揃える。
+        // 各リング点の位置で個別に標高クエリすると地形凹凸がリングに反映されて
+        // 別の地形の凹凸に見えるため、平面円として描画する。
         const elevCenter = ctx.tileManager.queryElevationAtWorld(cwx, cwz);
         if (elevCenter === null) {
             cache.centerWorld = null;
@@ -151,18 +154,8 @@ export const createCircleManager = (ctx: OverlayContext): CircleManager => {
             return;
         }
         const cy = elevCenter + centerOffset;
-        const ringWorld: Vector3[] = [];
-        for (const { x, z } of ringXZ) {
-            const elev = ctx.tileManager.queryElevationAtWorld(x, z);
-            if (elev === null) {
-                cache.centerWorld = null;
-                cache.ringWorld = null;
-                node.setElevationResolved(false);
-                return;
-            }
-            ringWorld.push(new Vector3(x, elev + centerOffset, z));
-        }
         const centerWorld = new Vector3(cwx, cy, cwz);
+        const ringWorld = ringXZ.map(({ x, z }) => new Vector3(x, cy, z));
         cache.centerWorld = centerWorld;
         cache.ringWorld = ringWorld;
         node.setElevationResolved(true);

--- a/src/terrain/circleManager.ts
+++ b/src/terrain/circleManager.ts
@@ -176,23 +176,40 @@ export const createCircleManager = (ctx: OverlayContext): CircleManager => {
     /**
      * フレームループ。
      *
-     * 標高解決はキャッシュ済みの値を使い、ラベルがカメラ方向を追従するために
-     * 毎フレーム `applyTransform` を呼ぶ（`pointScale` のみ更新）。
-     * 標高未解決の円はスキップする。
+     * Polygon と同様、毎フレーム中心の world XZ を `latLonToWorld` で再計算する。
+     * origin（地図中心）がドラッグで移動した場合にも正しい位置に追従するため。
+     * 標高未解決の円はスキップされる。
      */
     const tickFrame = (): void => {
         if (nodes.size === 0) return;
         for (const [id, node] of nodes) {
             const cache = caches.get(id);
-            if (!cache || cache.centerWorld === null || cache.ringWorld === null)
-                continue;
-            const scale = computeDistanceScale(
+            if (!cache) continue;
+
+            // 毎フレーム world XZ を再計算（origin 移動への追従）
+            const { wx: cwx, wz: cwz } = latLonToWorld(
                 ctx,
-                cache.cwx,
-                cache.centerWorld.y,
-                cache.cwz,
+                node.center.lat,
+                node.center.lon,
             );
-            node.applyTransform(cache.centerWorld, cache.ringWorld, scale);
+            const radius = node.radius;
+            const segments = node.segments;
+
+            // ringXZ を再計算
+            const step = (Math.PI * 2) / segments;
+            const ringXZ = cache.ringXZ;
+            for (let i = 0; i < segments; i++) {
+                const θ = i * step;
+                ringXZ[i] = {
+                    x: cwx + radius * Math.cos(θ),
+                    z: cwz + radius * Math.sin(θ),
+                };
+            }
+            cache.cwx = cwx;
+            cache.cwz = cwz;
+
+            // 標高解決
+            resolveElevations(node, cache);
         }
     };
 

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -49,6 +49,13 @@ const ENTRY_DEFINITIONS = [
         filename: "distance.html",
         title: "jpmap_terrain – 距離計測デモ",
     },
+    {
+        name: "circle",
+        entry: "src/demos/circle/index.ts",
+        template: "public/circle.html",
+        filename: "circle.html",
+        title: "jpmap_terrain – サークルデモ",
+    },
 ];
 
 const entry = Object.fromEntries(

--- a/webpack.rewrites.js
+++ b/webpack.rewrites.js
@@ -16,5 +16,7 @@ module.exports = {
         { from: /^\/polygon\.html(?:\/?@.*)?\/?$/, to: '/polygon.html' },
         { from: /^\/distance(?:\/@.*)?\/?$/, to: '/distance.html' },
         { from: /^\/distance\.html(?:\/?@.*)?\/?$/, to: '/distance.html' },
+        { from: /^\/circle(?:\/@.*)?\/?$/, to: '/circle.html' },
+        { from: /^\/circle\.html(?:\/?@.*)?\/?$/, to: '/circle.html' },
     ],
 };


### PR DESCRIPTION
## 概要

Issue #206 の実装。Circle API の動作確認用デモページを追加する。

## 変更内容

### 新規ファイル
- `public/circle.html`: デモページ HTML（polygon.html と同構造）
- `src/demos/circle/index.ts`: デモエントリポイント

### デモ内容（3つの円）
| ID | altitudeMode | 半径 | 特徴 |
|---|---|---|---|
| `yomiuri-terrain` | terrain | 300m | 地表+50m、赤色、updateCircle 編集対象 |
| `yomiuri-absolute` | absolute | 200m | 絶対標高 400m、青色 |
| `yomiuri-custom` | absolute | 150m | segments=16（16角形）、黄色、カスタムラベル |

### 操作 UI
- 各円の enabled トグル
- 中心点 / 円周 / 壁 / ラベルの全体 ON/OFF
- 3D / 2D 視点切替
- **updateCircle デモ**: 半径変更・スタイル変更・中心移動の 3 ボタン

### 設定変更
- `webpack.common.js`: circle エントリ追加
- `webpack.rewrites.js`: `/circle` URL ルーティング追加
- `src/demos/portal/index.ts`: ポータル一覧に「サークル」カード追加

## テスト結果
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run test:unit` ✅（28 suites / 634 tests）

Closes #206