### PR TITLE
test(circle): unit + Visual Regression テスト追加 (Issue #207)

### DIFF
--- a/tests/validation.spec.ts
+++ b/tests/validation.spec.ts
@@ -13,6 +13,30 @@ const applyDeterministicSunQuery = (url: URL): void => {
     url.searchParams.set("autoSunPosition", FIXED_AUTO_SUN_POSITION);
 };
 
+/**
+ * 指定フレーム数だけ requestAnimationFrame を待つ。
+ * 描画安定を保証するための共通ヘルパー。
+ */
+async function waitForFrames(
+    page: import("@playwright/test").Page,
+    frameCount: number,
+    timeout = 10000,
+): Promise<void> {
+    await page.waitForFunction(
+        (n: number) =>
+            new Promise((resolve) => {
+                let count = 0;
+                const tick = (): void => {
+                    if (++count >= n) return resolve(true);
+                    requestAnimationFrame(tick);
+                };
+                requestAnimationFrame(tick);
+            }),
+        frameCount,
+        { timeout },
+    );
+}
+
 const scenes: {
     name: string;
     url: string;
@@ -45,18 +69,7 @@ for (const scene of scenes) {
             if (scene.waitForNetworkIdle) {
                 await page.waitForLoadState("networkidle", { timeout: 30000 });
                 // タイル読み込み後の描画安定待ち（数フレーム経過で確認）
-                await page.waitForFunction(
-                    () =>
-                        new Promise((resolve) => {
-                            let count = 0;
-                            const tick = () => {
-                                if (++count >= 10) return resolve(true);
-                                requestAnimationFrame(tick);
-                            };
-                            requestAnimationFrame(tick);
-                        }),
-                    { timeout: 10000 }
-                );
+                await waitForFrames(page, 10);
             }
             if (scene.renderCount) {
                 await page.evaluate(() => {
@@ -113,18 +126,7 @@ async function waitForScene(
     // タイル読み込み完了を待つ
     await page.waitForLoadState("networkidle", { timeout: 30000 });
     // 描画安定待ち（数フレーム経過で確認）
-    await page.waitForFunction(
-        () =>
-            new Promise((resolve) => {
-                let count = 0;
-                const tick = () => {
-                    if (++count >= 10) return resolve(true);
-                    requestAnimationFrame(tick);
-                };
-                requestAnimationFrame(tick);
-            }),
-        { timeout: 10000 }
-    );
+    await waitForFrames(page, 10);
 }
 
 for (const engine of engines) {
@@ -146,18 +148,7 @@ for (const engine of engines) {
         await page.waitForLoadState("networkidle", { timeout: 30000 });
 
         // 描画安定のため数フレーム待機
-        await page.waitForFunction(
-            () =>
-                new Promise((resolve) => {
-                    let count = 0;
-                    const tick = () => {
-                        if (++count >= 5) return resolve(true);
-                        requestAnimationFrame(tick);
-                    };
-                    requestAnimationFrame(tick);
-                }),
-            { timeout: 5000 }
-        );
+        await waitForFrames(page, 5, 5000);
 
         await expect(page).toHaveScreenshot({
             timeout: 30000,
@@ -245,18 +236,7 @@ async function waitForSceneWithSkybox(
 
     // タイル再評価 + 描画安定待ち
     await page.waitForLoadState("networkidle", { timeout: 30000 });
-    await page.waitForFunction(
-        () =>
-            new Promise((resolve) => {
-                let count = 0;
-                const tick = () => {
-                    if (++count >= 15) return resolve(true);
-                    requestAnimationFrame(tick);
-                };
-                requestAnimationFrame(tick);
-            }),
-        { timeout: 10000 }
-    );
+    await waitForFrames(page, 15);
 }
 
 for (const engine of engines) {
@@ -313,18 +293,7 @@ for (const engine of engines) {
         );
 
         await page.waitForLoadState("networkidle", { timeout: 30000 });
-        await page.waitForFunction(
-            () =>
-                new Promise((resolve) => {
-                    let count = 0;
-                    const tick = () => {
-                        if (++count >= 15) return resolve(true);
-                        requestAnimationFrame(tick);
-                    };
-                    requestAnimationFrame(tick);
-                }),
-            { timeout: 10000 },
-        );
+        await waitForFrames(page, 15);
 
         await expect(page).toHaveScreenshot({
             timeout: 30000,
@@ -357,18 +326,7 @@ async function waitForPolygonScene(
         { timeout: 15000 },
     );
     await page.waitForLoadState("networkidle", { timeout: 30000 });
-    await page.waitForFunction(
-        () =>
-            new Promise((resolve) => {
-                let count = 0;
-                const tick = (): void => {
-                    if (++count >= 15) return resolve(true);
-                    requestAnimationFrame(tick);
-                };
-                requestAnimationFrame(tick);
-            }),
-        { timeout: 10000 },
-    );
+    await waitForFrames(page, 15);
 }
 
 test("Polygon point edit (initial) with WebGL2", async ({
@@ -424,18 +382,7 @@ test("Polygon point edit (after all edits) with WebGL2", async ({
         ]);
     }, POLYGON_EDIT_TARGET_ID);
 
-    await page.waitForFunction(
-        () =>
-            new Promise((resolve) => {
-                let count = 0;
-                const tick = (): void => {
-                    if (++count >= 15) return resolve(true);
-                    requestAnimationFrame(tick);
-                };
-                requestAnimationFrame(tick);
-            }),
-        { timeout: 10000 },
-    );
+    await waitForFrames(page, 15);
 
     await expect(page).toHaveScreenshot({
         timeout: 30000,
@@ -464,18 +411,7 @@ async function waitForCircleScene(
         { timeout: 15000 },
     );
     await page.waitForLoadState("networkidle", { timeout: 30000 });
-    await page.waitForFunction(
-        () =>
-            new Promise((resolve) => {
-                let count = 0;
-                const tick = (): void => {
-                    if (++count >= 15) return resolve(true);
-                    requestAnimationFrame(tick);
-                };
-                requestAnimationFrame(tick);
-            }),
-        { timeout: 10000 },
-    );
+    await waitForFrames(page, 15);
 }
 
 test("Circle demo (initial) with WebGL2", async ({ page }, testInfo) => {
@@ -504,18 +440,7 @@ test("Circle demo (after updateCircle) with WebGL2", async ({
         viewer.updateCircle("yomiuri-terrain", { radius: 600 });
     });
 
-    await page.waitForFunction(
-        () =>
-            new Promise((resolve) => {
-                let count = 0;
-                const tick = (): void => {
-                    if (++count >= 15) return resolve(true);
-                    requestAnimationFrame(tick);
-                };
-                requestAnimationFrame(tick);
-            }),
-        { timeout: 10000 },
-    );
+    await waitForFrames(page, 15);
 
     await expect(page).toHaveScreenshot({
         timeout: 30000,

--- a/tests/validation.spec.ts
+++ b/tests/validation.spec.ts
@@ -443,3 +443,83 @@ test("Polygon point edit (after all edits) with WebGL2", async ({
     });
     expect(testInfo.errors).toHaveLength(0);
 });
+
+// ---------- サークル API 視覚回帰 (Issue #201 / #207) ----------
+//
+// circle デモページ（terrain / absolute / custom-segments の 3 円）を
+// ロードし、標高解決後の初期描画スナップショットを VR baseline として取得する。
+// WebGL2 のみで実行し、時刻と autoSunPosition を固定する。
+
+async function waitForCircleScene(
+    page: import("@playwright/test").Page,
+): Promise<void> {
+    const url = new URL("/circle.html", "http://localhost");
+    url.searchParams.set("engine", "webgl");
+    applyDeterministicSunQuery(url);
+    await page.goto(`${url.pathname}${url.search}`, { timeout: 120000 });
+    await page.waitForFunction(
+        () =>
+            (window as unknown as { scene?: { isReady: () => boolean } }).scene
+                ?.isReady?.() ?? false,
+        { timeout: 15000 },
+    );
+    await page.waitForLoadState("networkidle", { timeout: 30000 });
+    await page.waitForFunction(
+        () =>
+            new Promise((resolve) => {
+                let count = 0;
+                const tick = (): void => {
+                    if (++count >= 15) return resolve(true);
+                    requestAnimationFrame(tick);
+                };
+                requestAnimationFrame(tick);
+            }),
+        { timeout: 10000 },
+    );
+}
+
+test("Circle demo (initial) with WebGL2", async ({ page }, testInfo) => {
+    await waitForCircleScene(page);
+    await expect(page).toHaveScreenshot({
+        timeout: 30000,
+        maxDiffPixelRatio: 0.02,
+    });
+    expect(testInfo.errors).toHaveLength(0);
+});
+
+test("Circle demo (after updateCircle) with WebGL2", async ({
+    page,
+}, testInfo) => {
+    await waitForCircleScene(page);
+
+    // updateCircle で半径を変更し、再描画後のスナップショットを取得する
+    await page.evaluate(() => {
+        type ViewerLike = {
+            updateCircle: (
+                id: string,
+                opts: { radius?: number },
+            ) => unknown;
+        };
+        const viewer = (window as unknown as { viewer: ViewerLike }).viewer;
+        viewer.updateCircle("yomiuri-terrain", { radius: 600 });
+    });
+
+    await page.waitForFunction(
+        () =>
+            new Promise((resolve) => {
+                let count = 0;
+                const tick = (): void => {
+                    if (++count >= 15) return resolve(true);
+                    requestAnimationFrame(tick);
+                };
+                requestAnimationFrame(tick);
+            }),
+        { timeout: 10000 },
+    );
+
+    await expect(page).toHaveScreenshot({
+        timeout: 30000,
+        maxDiffPixelRatio: 0.02,
+    });
+    expect(testInfo.errors).toHaveLength(0);
+});


### PR DESCRIPTION
## 概要

Circle API (#201) のテスト追加。

closes #207

## 変更内容

### Visual Regression テスト（新規）

`tests/validation.spec.ts` に circle デモ用テストを追加：

- **Circle demo (initial) with WebGL2**: `/circle.html` の初期描画スナップショット
- **Circle demo (after updateCircle) with WebGL2**: `updateCircle` で半径変更後のスナップショット

`waitForCircleScene` ヘルパーで polygon デモと同様に `networkidle` + 15 フレーム待機後に撮影。

### Unit テスト（既存・確認済み）

以下は #203〜#205 の実装時に追加済みで、要件を充足している：

- `tests/circleManager.unit.spec.ts`: 36 テスト（CRUD / バリデーション / update / 標高解決 / dispose）
- `tests/jpmapTerrain.unit.spec.ts`: 公開 API + dispose 後動作 + updateCircle テスト

## テスト結果

- `npm run test:unit`: 634 tests passed
- `npm run test:visuals --grep 'Circle demo'`: 2 passed
- `npm run lint`: pass
- `npm run typecheck`: pass