### PR TITLE
docs(circle): spec/package.md §3.3.9 Circle API & demos.md 追記 (Issue #208)

### DIFF
--- a/spec/demos.md
+++ b/spec/demos.md
@@ -11,6 +11,7 @@
 | 3D 地形ビューア | `/viewer.html` | `src/demos/viewer/index.ts` | 既存の 3D 地形可視化（`/@lat,lon` URL ・カメラ・地図種別連動） |
 | タイムラプス | `/timelapse.html` | `src/demos/timelapse/index.ts` | 24 時間を 1 分に圧縮した太陽位置・陰影アニメ＋アナログ時計オーバーレイ |
 | ポリゴン | `/polygon.html` | `src/demos/polygon/index.ts` | `JpmapTerrain` のポリゴン公開 API（terrain / absolute / closed の 3 種・点編集 API）の動作確認 |
+| サークル | `/circle.html` | `src/demos/circle/index.ts` | `JpmapTerrain` のサークル公開 API（terrain / absolute / custom-segments の 3 種・updateCircle デモ）の動作確認 (#201 / #206) |
 | 距離計測 | `/distance.html` | `src/demos/distance/index.ts` | 地形クリックで頂点を追加し、辺ごとに水平距離・高低差を表示する。`onTerrainClick` (#183) / `onPolygonPoint*` (#184) / `edgeLabels` (#185) の統合動作確認デモ (#186) |
 
 ## 設計方針
@@ -43,6 +44,22 @@
 | `engine` / カメラ系 | viewer と同じ | — | `parseCameraStateFromUrl` を共用 |
 
 実装上、タイムラプス側では `autoSunPosition` を強制 OFF にし、`viewer.dateTime` を `requestAnimationFrame` ループで更新します（`UPDATE_INTERVAL_MS = 200ms` で setter 連打を抑制）。アナログ時計と時刻ラベルは画面下部中央に縦積みで配置し、表示は日本標準時（JST = UTC+9）を使用します。
+
+### circle (`/circle.html`)
+
+`JpmapTerrain` のサークル公開 API（§3.3.9）の動作確認デモ（#201 / #206）。
+
+**デモ構成（3 サークル）:**
+
+| id | altitudeMode | 概要 |
+|---|---|---|
+| `yomiuri-terrain` | `terrain` | 地表追従円（半径 500m、標準スタイル） |
+| `yomiuri-absolute` | `absolute` | 絶対標高円（半径 300m、altitude=200m、青色） |
+| `yomiuri-custom` | `terrain` | カスタムセグメント円（半径 400m、segments=16） |
+
+**コントロール:** 各サークルの enabled / point / line / wall / label トグルと、`updateCircle` による半径・中心・スタイル変更のデモ UI を右パネルに配置する。
+
+**URL:** `engine` に加えてカメラ初期位置（`/@lat,lon[,...]` のパス形式および `?lat=&lon=` クエリ形式）と `?mapType=standard|photo` を受け付ける（`parseCameraStateFromUrl` / `parseMapTypeFromUrl` を共用）。
 
 ### distance (`/distance.html`)
 

--- a/spec/demos.md
+++ b/spec/demos.md
@@ -53,9 +53,9 @@
 
 | id | altitudeMode | 概要 |
 |---|---|---|
-| `yomiuri-terrain` | `terrain` | 地表追従円（半径 500m、標準スタイル） |
-| `yomiuri-absolute` | `absolute` | 絶対標高円（半径 300m、altitude=200m、青色） |
-| `yomiuri-custom` | `terrain` | カスタムセグメント円（半径 400m、segments=16） |
+| `yomiuri-terrain` | `terrain` | 地表追従円（半径 300m、altitude=50m、赤色） |
+| `yomiuri-absolute` | `absolute` | 絶対標高円（半径 200m、altitude=400m、青色） |
+| `yomiuri-custom` | `absolute` | カスタムセグメント円（半径 150m、altitude=300m、segments=16、黄色） |
 
 **コントロール:** 各サークルの enabled / point / line / wall / label トグルと、`updateCircle` による半径・中心・スタイル変更のデモ UI を右パネルに配置する。
 

--- a/spec/package.md
+++ b/spec/package.md
@@ -536,7 +536,153 @@ interface JpmapTerrain {
 - `insertPolygonPoint` / `removePolygonPoint` は labels 配列の対応 index をシフトする（隣接ラベルとの整合を保つ）。
 - `replacePolygonPoints` は新しい点数に合わせ labels を全 undefined で再構成する（明示的にラベルを再付与するには `updatePolygonPoint` を呼び出す）。
 
-#### 3.3.9 地形クリック通知 (Issue #183)
+#### 3.3.9 サークル (Issue #201)
+
+中心点（緯度・経度）と半径 (m) を指定して円を地形上に描画する API。中心球 / 円周 Tube / 壁 Ribbon / 中心ラベルを組み合わせて描画する。
+
+##### 3.3.9.1 公開 API（Issue #202〜#205）
+
+```typescript
+interface JpmapTerrain {
+  /** サークル追加。同 id 重複は throw、バリデーション失敗は throw */
+  addCircle(id: string, options: CircleOptions): CircleHandle;
+  /** 取得。未存在は null */
+  getCircle(id: string): CircleHandle | null;
+  /** 差分更新。未存在 id は throw */
+  updateCircle(id: string, partial: CircleUpdate): CircleHandle;
+  /** 削除。未存在は no-op + warn */
+  removeCircle(id: string): void;
+  /** enabled の薄いショートカット */
+  setCircleEnabled(id: string, enabled: boolean): void;
+  /** 中心球表示切替 */
+  setCirclePointEnabled(id: string, enabled: boolean): void;
+  /** 円周 Tube 表示切替 */
+  setCircleLineEnabled(id: string, enabled: boolean): void;
+  /** 壁 Ribbon 表示切替 */
+  setCircleWallEnabled(id: string, enabled: boolean): void;
+  /** 中心ラベル表示切替 */
+  setCircleLabelEnabled(id: string, enabled: boolean): void;
+  /** 全 id を生成順で返す */
+  listCircles(): readonly string[];
+}
+
+type AltitudeMode = "absolute" | "terrain";
+
+interface CircleCenterOptions {
+  lat: number;
+  lon: number;
+  /** `altitudeMode === "absolute"` のとき必須 (m)。`"terrain"` のときは地表からのオフセット (m)、未指定時は 0 */
+  altitude?: number;
+}
+
+interface CircleStyleOptions {
+  // 中心球
+  pointColor?: string;        // CSS color (default "#ff0000")
+  pointDiameter?: number;     // m (default 20, distScale 適用)
+  pointOpacity?: number;      // 0..1 (default 1)
+  // 円周 Tube
+  lineColor?: string;         // CSS color (default "#ff0000")
+  lineWidth?: number;         // m (Tube 半径, default 2)
+  lineOpacity?: number;       // 0..1 (default 1)
+  // 壁 Ribbon
+  wallColor?: string;         // CSS color (default "#ff0000")
+  wallOpacity?: number;       // 0..1 (default 0.3)
+  // 中心ラベル
+  labelColor?: string;            // CSS color (default "#000000")
+  labelBackgroundColor?: string;  // CSS color (default "transparent")
+  labelFontSize?: number;         // px (default 14)
+}
+
+interface CircleOptions {
+  center: CircleCenterOptions;
+  /** 半径 (m, world)。> 0 かつ 100000 以下 */
+  radius: number;
+  /** 円周分割数。既定 64。範囲 [8, 512] */
+  segments?: number;
+  altitudeMode?: AltitudeMode;    // default "terrain"
+  /**
+   * 中心ラベル文言。未指定時は「lat / lon / alt / radius」を自動生成。
+   * 明示 string で上書き、null で非表示
+   */
+  label?: string | null;
+  style?: CircleStyleOptions;
+  enabled?: boolean;              // default true
+  pointEnabled?: boolean;         // default true
+  lineEnabled?: boolean;          // default true
+  wallEnabled?: boolean;          // default true
+  labelEnabled?: boolean;         // default true
+}
+
+type CircleUpdate = Partial<Pick<CircleOptions,
+  | "center" | "radius" | "segments" | "altitudeMode"
+  | "label" | "style" | "enabled"
+  | "pointEnabled" | "lineEnabled" | "wallEnabled" | "labelEnabled">>;
+
+interface CircleHandle {
+  readonly id: string;
+  readonly center: Readonly<CircleCenterOptions>;
+  readonly radius: number;
+  readonly segments: number;
+  readonly altitudeMode: AltitudeMode;
+  readonly label: string | null;
+  readonly style: Readonly<Required<CircleStyleOptions>>;
+  readonly enabled: boolean;
+  readonly pointEnabled: boolean;
+  readonly lineEnabled: boolean;
+  readonly wallEnabled: boolean;
+  readonly labelEnabled: boolean;
+  /**
+   * `terrain` モード時、中心点の地表標高が解決済みなら true。
+   * 円は平面円として描画されるため、中心の標高のみが必要。
+   * `absolute` モード時は常に true。
+   */
+  readonly elevationResolved: boolean;
+}
+```
+
+**仕様:**
+
+- `center.lat/lon` が JAPAN_BOUNDS 外、`radius <= 0` または `radius > 100000`、`segments < 8` または `segments > 512`、`altitudeMode === "absolute"` で `center.altitude` 未指定の場合は throw。
+- 同 id の重複追加は throw。`removeCircle` の未存在 id は `console.warn` + no-op。`updateCircle` / `setCircle*Enabled` の未存在 id は throw。
+- 円周点列は world 座標で `P_i = center + (radius × cos θ_i, 0, radius × sin θ_i)` として `segments` 等分に生成する（Mercator 楕円化回避）。
+- `terrain` モードでは中心点の地表標高のみ解決し、その値 + `center.altitude` を全円周点に均一適用する（平面円）。標高未解決の間は全体を非表示にし、`onTerrainUpdated` 後に自動表示する。
+- `absolute` モードでは `center.altitude` をそのまま Y に採用する。
+- 各コンポーネントの `renderingGroupId`: 中心球 / 円周 Tube / 中心ラベルは `1`（地表より手前）。壁 Ribbon は `0` + `needDepthPrePass=true`（半透明時の z-fight 緩和）。
+- `dispose()` で全 Circle リソース（Mesh / Material / TransformNode）を解放する。
+
+**差分更新の保証範囲（updateCircle）:**
+
+| 変更フィールド | 挙動 |
+|---|---|
+| `center` のみ | TransformNode 位置更新、メッシュ再生成なし |
+| `radius` のみ | 円周点列再計算、Tube / Ribbon の path 差分更新 |
+| `segments` 変更 | Tube / Ribbon を dispose + 再生成 |
+| `altitudeMode` 変更 | 標高解決リセット + 即時 tick |
+| `style`（空でない場合） | Material プロパティ更新 |
+| `*Enabled` フラグ | `setEnabled` でメッシュ可視性切替 |
+| `label` | DynamicTexture 再描画 or Plane dispose / 再生成 |
+
+**利用例:**
+
+```typescript
+import { JpmapTerrain } from "jpmap-terrain";
+
+const circle = viewer.addCircle("range-ring", {
+  center: { lat: 35.6895, lon: 139.6917 },
+  radius: 500,
+  altitudeMode: "terrain",
+  label: "500m 圏内",
+  style: { lineColor: "#0000ff", wallOpacity: 0.2 },
+});
+
+// 半径を動的に変更
+viewer.updateCircle("range-ring", { radius: 1000 });
+
+// 壁を非表示
+viewer.setCircleWallEnabled("range-ring", false);
+```
+
+#### 3.3.10 地形クリック通知 (Issue #183)
 
 地形タイル上でのマウス／タッチによるクリックを購読するイベント API。距離計測など「クリックで地点を確定する」系デモ（#44）の基盤。
 
@@ -586,7 +732,7 @@ const unsubscribe = viewer.onTerrainClick((e) => {
 unsubscribe();
 ```
 
-#### 3.3.10 ポリゴン頂点インタラクション (Issue #184)
+#### 3.3.11 ポリゴン頂点インタラクション (Issue #184)
 
 ポリゴンの頂点（球体メッシュ）に対する hover / click / drag を購読するイベント API。距離計測などのデモ（#44）で頂点の編集 UI を構築するための基盤。
 
@@ -680,7 +826,7 @@ viewer.onPolygonPointDragEnd(() => {
 });
 ```
 
-#### 3.3.11 辺ラベル (Issue #185)
+#### 3.3.12 辺ラベル (Issue #185)
 
 `PolygonOptions.edgeLabels` で各辺の中点に文字列ラベルを表示する。距離計測デモ（#186）のように動的に距離・高低差を反映する用途に使う。
 

--- a/spec/package.md
+++ b/spec/package.md
@@ -647,7 +647,7 @@ interface CircleHandle {
 - 円周点列は world 座標で `P_i = center + (radius × cos θ_i, 0, radius × sin θ_i)` として `segments` 等分に生成する（Mercator 楕円化回避）。
 - `terrain` モードでは中心点の地表標高のみ解決し、その値 + `center.altitude` を全円周点に均一適用する（平面円）。標高未解決の間は全体を非表示にし、`onTerrainUpdated` 後に自動表示する。
 - `absolute` モードでは `center.altitude` をそのまま Y に採用する。
-- 各コンポーネントの `renderingGroupId`: 中心球 / 円周 Tube / 中心ラベルは `1`（地表より手前）。壁 Ribbon は `0` + `needDepthPrePass=true`（半透明時の z-fight 緩和）。
+- 各コンポーネントの `renderingGroupId`: 中心球 / 円周 Tube / 中心ラベルは `1`（地表より手前）。壁 Ribbon は `0`。`wallOpacity < 1`（半透明）の場合のみ `needDepthPrePass=true` で z-fight を緩和する。
 - `dispose()` で全 Circle リソース（Mesh / Material / TransformNode）を解放する。
 
 **差分更新の保証範囲（updateCircle）:**

--- a/spec/package.md
+++ b/spec/package.md
@@ -656,11 +656,11 @@ interface CircleHandle {
 |---|---|
 | `center` のみ | TransformNode 位置更新、メッシュ再生成なし |
 | `radius` のみ | 円周点列再計算、Tube / Ribbon の path 差分更新 |
-| `segments` 変更 | Tube / Ribbon を dispose + 再生成 |
-| `altitudeMode` 変更 | 標高解決リセット + 即時 tick |
-| `style`（空でない場合） | Material プロパティ更新 |
+| `segments` 変更 | CircleNode を dispose + 再生成（path 長が変わるため） |
+| `altitudeMode` 変更 | CircleNode を dispose + 再生成（標高解決リセット + 即時 tick） |
+| `style`（空でない場合） | CircleNode を dispose + 再生成（Material 再構築） |
 | `*Enabled` フラグ | `setEnabled` でメッシュ可視性切替 |
-| `label` | DynamicTexture 再描画 or Plane dispose / 再生成 |
+| `label` | CircleNode を dispose + 再生成（DynamicTexture 再構築） |
 
 **利用例:**
 


### PR DESCRIPTION
## 概要

Circle API (#201) の仕様書更新。

closes #208

## 変更内容

### spec/package.md

- **§3.3.9 サークル (Issue #201)** を新規追加
  - `§3.3.9.1 公開 API（Issue #202〜#205）`: 全型定義・バリデーション・描画仕様・差分更新保証範囲・利用例
  - `elevationResolved` の定義: 「中心点の地表標高が解決済みなら true」（平面円のため中心のみ必要）
- 既存セクションのリナンバー: §3.3.9→§3.3.10、§3.3.10→§3.3.11、§3.3.11→§3.3.12

### spec/demos.md

- デモ一覧テーブルに「サークル」行を追加（`/circle.html`）
- `### circle (/circle.html)` セクションを追加（3 サークル構成・コントロール・URL 規約）

## 確認事項

- AGENTS.md の仕様整合性観点に沿って内容を確認済み
- 実装の `elevationResolved` コメント（6b5a771）と一致