### PR TITLE
feat: QGroundControl Plan ファイル簡易表示デモ (#38)

### DIFF
--- a/examples/okutama.plan
+++ b/examples/okutama.plan
@@ -1,0 +1,290 @@
+{
+    "fileType": "Plan",
+    "geoFence": {
+        "circles": [
+            {
+                "circle": {
+                    "center": [
+                        35.79185330892785,
+                        139.04875075067923
+                    ],
+                    "radius": 148.6696453391971
+                },
+                "inclusion": true,
+                "version": 1
+            }
+        ],
+        "polygons": [
+            {
+                "inclusion": true,
+                "polygon": [
+                    [
+                        35.78119118423945,
+                        139.0155554596605
+                    ],
+                    [
+                        35.780557345975986,
+                        139.02034217849484
+                    ],
+                    [
+                        35.78289290329043,
+                        139.03542661940673
+                    ],
+                    [
+                        35.78745799934225,
+                        139.04538107075717
+                    ],
+                    [
+                        35.78710147819815,
+                        139.0474676808036
+                    ],
+                    [
+                        35.78406082046976,
+                        139.04540192053304
+                    ],
+                    [
+                        35.78097161325014,
+                        139.0364036553163
+                    ],
+                    [
+                        35.77833207231516,
+                        139.02070654713293
+                    ],
+                    [
+                        35.779336739702785,
+                        139.01491987915722
+                    ]
+                ],
+                "version": 1
+            }
+        ],
+        "version": 2
+    },
+    "groundStation": "QGroundControl",
+    "mission": {
+        "cruiseSpeed": 1,
+        "firmwareType": 3,
+        "globalPlanAltitudeMode": 1,
+        "hoverSpeed": 5,
+        "items": [
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 50,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 22,
+                "doJumpId": 1,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    0,
+                    0,
+                    50
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 50,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 2,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    35.79196971850398,
+                    139.04883949344594,
+                    50
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 75,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 3,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    35.78655862746033,
+                    139.04593844937483,
+                    75
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 90,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 4,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    35.78479187671575,
+                    139.043807961761,
+                    90
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 60,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 5,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    35.78177242,
+                    139.03606576,
+                    60
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 50,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 6,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    35.780898754866946,
+                    139.03043500185498,
+                    50
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 35,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 7,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    35.77935164,
+                    139.02038159,
+                    35
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 32,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 8,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    35.77948819,
+                    139.01944443,
+                    32
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 20,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 9,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    35.78012772190709,
+                    139.01597313549905,
+                    20
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 0,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 21,
+                "doJumpId": 10,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    35.7801385,
+                    139.01591839,
+                    0
+                ],
+                "type": "SimpleItem"
+            }
+        ],
+        "plannedHomePosition": [
+            35.79210805,
+            139.04890088,
+            522
+        ],
+        "vehicleType": 2,
+        "version": 2
+    },
+    "rallyPoints": {
+        "points": [
+            [
+                35.78970727,
+                139.04329378,
+                0
+            ],
+            [
+                35.78421729,
+                139.04349786,
+                0
+            ],
+            [
+                35.78251902,
+                139.02834407,
+                0
+            ]
+        ],
+        "version": 2
+    },
+    "version": 1
+}

--- a/public/plan.html
+++ b/public/plan.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <title>jpmap_terrain – Plan Viewer</title>
+  <meta name="description" content="QGroundControl Plan ファイルをドラッグ&ドロップでマップ上に表示するデモ (#38)">
+  <meta name="author" content="8ga3">
+  <style>
+    html, body {
+      overflow: hidden;
+      width: 100%;
+      height: 100%;
+      margin: 0;
+      padding: 0;
+    }
+
+    #root {
+      position: relative;
+      width: 100%;
+      height: 100%;
+      touch-action: none;
+    }
+
+    #plan-overlay {
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      z-index: 10;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI",
+        "Hiragino Sans", "Noto Sans JP", Meiryo, sans-serif;
+    }
+
+    #plan-overlay .back-link {
+      position: absolute;
+      top: 12px;
+      left: 12px;
+      pointer-events: auto;
+      padding: 6px 12px;
+      font-size: 13px;
+      color: #fff;
+      background: rgba(0, 0, 0, 0.45);
+      border: 1px solid rgba(255, 255, 255, 0.25);
+      border-radius: 6px;
+      text-decoration: none;
+    }
+
+    #plan-overlay .back-link:hover {
+      background: rgba(0, 0, 0, 0.6);
+    }
+
+    #plan-controls {
+      position: absolute;
+      top: 12px;
+      right: 12px;
+      pointer-events: auto;
+      padding: 10px 12px;
+      font-size: 13px;
+      color: #fff;
+      background: rgba(0, 0, 0, 0.5);
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      border-radius: 8px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      max-width: 300px;
+    }
+
+    #plan-controls strong {
+      font-size: 12px;
+      letter-spacing: 0.04em;
+      color: #c8d2e6;
+    }
+
+    #plan-status {
+      font-size: 11px;
+      line-height: 1.4;
+      color: #e2e8f0;
+      white-space: pre-line;
+    }
+
+    /* ドラッグ&ドロップ オーバーレイ */
+    #plan-drop-zone {
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      display: none;
+      align-items: center;
+      justify-content: center;
+      background: rgba(0, 0, 0, 0.6);
+      z-index: 100;
+    }
+
+    #plan-drop-zone.active {
+      display: flex;
+      pointer-events: auto;
+    }
+
+    #plan-drop-zone .drop-label {
+      font-size: 20px;
+      color: #fff;
+      padding: 32px 48px;
+      border: 3px dashed rgba(255, 255, 255, 0.6);
+      border-radius: 16px;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <div id="plan-overlay">
+    <a class="back-link" href="/">← デモ一覧へ</a>
+    <div id="plan-controls">
+      <strong>Plan Viewer (#38)</strong>
+      <div id="plan-status">.plan ファイルをドラッグ&ドロップしてください</div>
+    </div>
+  </div>
+  <div id="plan-drop-zone">
+    <div class="drop-label">ここにドロップして Plan を読み込む</div>
+  </div>
+</body>
+</html>

--- a/public/plan.html
+++ b/public/plan.html
@@ -78,6 +78,45 @@
       white-space: pre-line;
     }
 
+    /* レイヤー表示切替ボタン */
+    #plan-layer-buttons {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 5px;
+    }
+
+    #plan-layer-buttons button {
+      pointer-events: auto;
+      padding: 3px 9px;
+      font-size: 11px;
+      color: #fff;
+      background: rgba(255, 255, 255, 0.08);
+      border: 1px solid rgba(255, 255, 255, 0.3);
+      border-radius: 4px;
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+
+    #plan-layer-buttons button:hover {
+      background: rgba(255, 255, 255, 0.18);
+    }
+
+    /* 表示中: 色付きボーダーで強調、非表示時は薄暗く */
+    #plan-layer-buttons button[data-active="true"] {
+      background: rgba(255, 255, 255, 0.15);
+      border-color: rgba(255, 255, 255, 0.7);
+    }
+
+    #plan-layer-buttons button[data-active="false"] {
+      opacity: 0.45;
+    }
+
+    /* Plan 未読み込み時はボタンを無効化 */
+    #plan-layer-buttons button:disabled {
+      opacity: 0.25;
+      cursor: not-allowed;
+    }
+
     /* ドラッグ&ドロップ オーバーレイ */
     #plan-drop-zone {
       position: absolute;
@@ -111,6 +150,11 @@
     <a class="back-link" href="/">← デモ一覧へ</a>
     <div id="plan-controls">
       <strong>Plan Viewer (#38)</strong>
+      <div id="plan-layer-buttons">
+        <button type="button" id="btn-waypoints" data-active="true" disabled>ウェイポイント</button>
+        <button type="button" id="btn-geofence" data-active="true" disabled>ジオフェンス</button>
+        <button type="button" id="btn-rally" data-active="true" disabled>ラリーポイント</button>
+      </div>
       <div id="plan-status">.plan ファイルをドラッグ&ドロップしてください</div>
     </div>
   </div>

--- a/spec/demos.md
+++ b/spec/demos.md
@@ -3,7 +3,7 @@
 `jpmap_terrain` の開発デモは複数のエントリポイントを持ち、`/`（ポータル）から各デモへ遷移できます。
 本ドキュメントはデモポータルの方針・URL 規約・新規デモの追加手順をまとめます。
 
-## デモ一覧（2026-04 時点）
+## デモ一覧（2026-05 時点）
 
 | デモ | URL | エントリ | 説明 |
 |---|---|---|---|
@@ -13,6 +13,7 @@
 | ポリゴン | `/polygon.html` | `src/demos/polygon/index.ts` | `JpmapTerrain` のポリゴン公開 API（terrain / absolute / closed の 3 種・点編集 API）の動作確認 |
 | サークル | `/circle.html` | `src/demos/circle/index.ts` | `JpmapTerrain` のサークル公開 API（terrain / absolute / custom-segments の 3 種・updateCircle デモ）の動作確認 (#201 / #206) |
 | 距離計測 | `/distance.html` | `src/demos/distance/index.ts` | 地形クリックで頂点を追加し、辺ごとに水平距離・高低差を表示する。`onTerrainClick` (#183) / `onPolygonPoint*` (#184) / `edgeLabels` (#185) の統合動作確認デモ (#186) |
+| Plan Viewer | `/plan.html` | `src/demos/plan/index.ts` | QGroundControl の `.plan` ファイルをドラッグ&ドロップで表示するビューア (#38)。ウェイポイント・ジオフェンス・ラリーポイントを描画 |
 
 ## 設計方針
 
@@ -86,6 +87,31 @@
 
 - 水平距離は `haversineDistanceMeters`（WGS84 平均半径）で算出。浮動小数誤差で `h` が 1 を僅かに超えるケース（対蹠点付近）に備え、`h` を `[0, 1]` にクランプしてから `Math.atan2` に渡す。
 - 編集モードのドラッグ時は `pointermove` ごとに `removePolygon` → `addPolygon` を行うと負荷が高いため、`requestAnimationFrame` で 1 フレーム 1 回に集約する。`dragEnd` で保留中の rAF を即時 flush し、最終位置が確実に反映されるようにする (#191)。
+
+### plan (`/plan.html`)
+
+QGroundControl の `.plan` ファイルをドラッグ&ドロップでマップ上に表示するビューア（#38）。編集機能は持たない。
+
+**ファイル入力:** デスクトップからのドラッグ&ドロップ。再ドロップ時は前回表示をクリアし新しい Plan のみ表示する。
+
+**ウェイポイント（Mission）:**
+
+- パスライン（`addPolygon`, `altitudeMode: "absolute"`, `closed: false`）で描画。
+- 各頂点ラベル: `#番号\n高度 m`（1 始まり、スキップ MAV_CMD は数えない）。
+- エッジラベル: `水平距離\n高度差`。
+- 対応 MAV_CMD: `NAV_WAYPOINT`(16) / `NAV_LAND`(21) / `NAV_TAKEOFF`(22)。その他はスキップ。
+- 高度はホームポジションからの相対高度として絶対高度に変換。
+
+**ジオフェンス:**
+
+- ポリゴン: `addPolygon`（`closed: true`, `altitudeMode: "terrain"`）。ラベルなし。
+- 円: `addCircle`（`altitudeMode: "terrain"`, `pointEnabled: false`, `label: null`）。壁付き。
+
+**ラリーポイント:**
+
+- 1 点ポリゴン（`addPolygon`）でマーカー表示。ラベルは `R番号`。
+
+**URL:** `engine` / カメラ系は他デモと共通（`parseCameraStateFromUrl` / `parseMapTypeFromUrl` を共用）。
 
 ## 新規デモの追加手順
 

--- a/spec/demos.md
+++ b/spec/demos.md
@@ -104,8 +104,8 @@ QGroundControl の `.plan` ファイルをドラッグ&ドロップでマップ�
 
 **ジオフェンス:**
 
-- ポリゴン: `addPolygon`（`closed: true`, `altitudeMode: "terrain"`）。ラベルなし。
-- 円: `addCircle`（`altitudeMode: "terrain"`, `pointEnabled: false`, `label: null`）。壁付き。
+- ポリゴン: `addPolygon`（`closed: true`, `altitudeMode: "absolute"`）。ホーム高度 +10m で描画（遠方タイル未ロード時も即時表示のため）。ラベルなし。
+- 円: `addCircle`（`altitudeMode: "absolute"`, `pointEnabled: false`, `label: null`）。ホーム高度 +10m で描画。壁付き。
 
 **ラリーポイント:**
 

--- a/src/demos/distance/utils.ts
+++ b/src/demos/distance/utils.ts
@@ -1,69 +1,24 @@
 /**
  * 距離計測デモのための純粋関数群 (#186)。
  *
- * - `haversineDistanceMeters`: 2 点の lat/lon から水平距離 (m) を計算する。
- * - `formatHorizontalDistance`: m / km の単位を切替えて整形する。
- * - `formatAltitudeDelta`: 高低差 (m) を整形する（符号付き）。
  * - `formatPointLabel`: 頂点ラベル（lat / lon / altitude）を整形する。
+ * - `formatEdgeLabel`: 辺ラベル（水平距離 + 高低差）を整形する。
  *
- * ロジックを demo 本体から分離することでユニットテスト対象を明確化する。
+ * haversine 距離計算・距離/高低差フォーマットは共通ユーティリティ
+ * `../shared/geoUtils` に移動した。
  */
 
-/** 地球半径 (m)。WGS84 平均半径。 */
-const EARTH_RADIUS_M = 6_371_008.8;
+export {
+    haversineDistanceMeters,
+    formatHorizontalDistance,
+    formatAltitudeDelta,
+} from "../shared/geoUtils";
 
-const toRadians = (deg: number): number => (deg * Math.PI) / 180;
-
-/**
- * 2 点の (lat, lon) から大圏距離 (m) を haversine 法で算出する。
- *
- * 小数点以下の round/floor は呼び出し側で行い、本関数は double 精度のままを返す。
- * 同一点なら 0 を返す。
- */
-export const haversineDistanceMeters = (
-    a: { lat: number; lon: number },
-    b: { lat: number; lon: number },
-): number => {
-    const lat1 = toRadians(a.lat);
-    const lat2 = toRadians(b.lat);
-    const dLat = toRadians(b.lat - a.lat);
-    const dLon = toRadians(b.lon - a.lon);
-    const sinDLat = Math.sin(dLat / 2);
-    const sinDLon = Math.sin(dLon / 2);
-    const h =
-        sinDLat * sinDLat +
-        Math.cos(lat1) * Math.cos(lat2) * sinDLon * sinDLon;
-    // 浮動小数誤差で h が 1 を僅かに超えると Math.sqrt(1 - h) が NaN に
-    // なり得る（ほぼ対蹠点）。安定のため [0, 1] にクランプする。
-    const hClamped = Math.min(1, Math.max(0, h));
-    const c = 2 * Math.atan2(Math.sqrt(hClamped), Math.sqrt(1 - hClamped));
-    return EARTH_RADIUS_M * c;
-};
-
-/**
- * 水平距離を m / km の単位を自動切替で整形する。
- * - 1000 m 未満: `<整数> m`（小数なし、四捨五入）
- * - 1000 m 以上: `<小数 2 桁> km`
- */
-export const formatHorizontalDistance = (meters: number): string => {
-    if (!Number.isFinite(meters) || meters < 0) return "-";
-    if (meters < 1000) {
-        return `${Math.round(meters)} m`;
-    }
-    return `${(meters / 1000).toFixed(2)} km`;
-};
-
-/**
- * 高低差を m で整形する。常に符号 (+/-) を付ける。
- * 絶対値 < 0.5 m は `±0 m` として扱う（四捨五入後 0 になるケースを明示）。
- */
-export const formatAltitudeDelta = (deltaM: number): string => {
-    if (!Number.isFinite(deltaM)) return "-";
-    const rounded = Math.round(deltaM);
-    if (rounded === 0) return "±0 m";
-    const sign = rounded > 0 ? "+" : "";
-    return `${sign}${rounded} m`;
-};
+import {
+    haversineDistanceMeters,
+    formatHorizontalDistance,
+    formatAltitudeDelta,
+} from "../shared/geoUtils";
 
 /**
  * 頂点ラベル（複数行）。lat/lon は小数 5 桁、altitude は m 整数。

--- a/src/demos/plan/index.ts
+++ b/src/demos/plan/index.ts
@@ -85,119 +85,125 @@ const renderPlan = (viewer: JpmapTerrain, plan: ParsedPlan): PlanIds => {
         rallyIds: [],
     };
 
-    // ウェイポイント（パスライン）
-    if (plan.waypoints.length > 0) {
-        const points = plan.waypoints.map((wp) => ({
-            lat: wp.lat,
-            lon: wp.lon,
-            altitude: wp.altitude,
-        }));
-        const labels = plan.waypoints.map((wp) => formatWaypointLabel(wp));
-        const edgeLabels: (string | undefined)[] = [];
-        for (let i = 0; i < plan.waypoints.length - 1; i++) {
-            edgeLabels.push(
-                formatWaypointEdgeLabel(
-                    plan.waypoints[i],
-                    plan.waypoints[i + 1],
-                ),
-            );
+    try {
+        // ウェイポイント（パスライン）
+        if (plan.waypoints.length > 0) {
+            const points = plan.waypoints.map((wp) => ({
+                lat: wp.lat,
+                lon: wp.lon,
+                altitude: wp.altitude,
+            }));
+            const labels = plan.waypoints.map((wp) => formatWaypointLabel(wp));
+            const edgeLabels: (string | undefined)[] = [];
+            for (let i = 0; i < plan.waypoints.length - 1; i++) {
+                edgeLabels.push(
+                    formatWaypointEdgeLabel(
+                        plan.waypoints[i],
+                        plan.waypoints[i + 1],
+                    ),
+                );
+            }
+
+            const opts: PolygonOptions = {
+                points,
+                altitudeMode: "absolute",
+                closed: false,
+                labels,
+                edgeLabels,
+                style: {
+                    pointColor: "#2196f3",
+                    lineColor: "#2196f3",
+                    pointDiameter: 14,
+                    lineWidth: 2,
+                    labelFontSize: 12,
+                    wallColor: "#2196f3",
+                    wallOpacity: 0.15,
+                },
+            };
+            viewer.addPolygon(ID_WAYPOINTS, opts);
+            result.waypointIds.push(ID_WAYPOINTS);
         }
 
-        const opts: PolygonOptions = {
-            points,
-            altitudeMode: "absolute",
-            closed: false,
-            labels,
-            edgeLabels,
-            style: {
-                pointColor: "#2196f3",
-                lineColor: "#2196f3",
-                pointDiameter: 14,
-                lineWidth: 2,
-                labelFontSize: 12,
-                wallColor: "#2196f3",
-                wallOpacity: 0.15,
-            },
-        };
-        viewer.addPolygon(ID_WAYPOINTS, opts);
-        result.waypointIds.push(ID_WAYPOINTS);
+        // ジオフェンスポリゴン
+        // absolute モードで描画する。terrain モードだと遠方頂点のタイル未ロード時に
+        // 描画されないため、ホーム高度を基準にした絶対高度で即時表示する。
+        const geofenceAlt = (plan.homePosition?.altitude ?? 0) + 10;
+        plan.geoFencePolygons.forEach((poly, i) => {
+            const id = `${ID_GEOFENCE_POLYGON_PREFIX}${i}`;
+            const color = poly.inclusion ? "#4caf50" : "#f44336";
+            const opts: PolygonOptions = {
+                points: poly.points.map((p) => ({
+                    lat: p.lat,
+                    lon: p.lon,
+                    altitude: geofenceAlt,
+                })),
+                altitudeMode: "absolute",
+                closed: true,
+                style: {
+                    pointColor: color,
+                    lineColor: color,
+                    pointDiameter: 0,
+                    lineWidth: 2,
+                    wallColor: color,
+                    wallOpacity: 0.2,
+                },
+            };
+            viewer.addPolygon(id, opts);
+            result.geofencePolyIds.push(id);
+        });
+
+        // ジオフェンス円
+        plan.geoFenceCircles.forEach((circ, i) => {
+            const id = `${ID_GEOFENCE_CIRCLE_PREFIX}${i}`;
+            const color = circ.inclusion ? "#4caf50" : "#f44336";
+            const radius = Math.min(circ.radius, CIRCLE_RADIUS_MAX_M);
+            const opts: CircleOptions = {
+                center: {
+                    lat: circ.center.lat,
+                    lon: circ.center.lon,
+                    altitude: geofenceAlt,
+                },
+                radius,
+                altitudeMode: "absolute",
+                label: null,
+                pointEnabled: false,
+                style: {
+                    lineColor: color,
+                    lineWidth: 2,
+                    wallColor: color,
+                    wallOpacity: 0.2,
+                },
+            };
+            viewer.addCircle(id, opts);
+            result.geofenceCircleIds.push(id);
+        });
+
+        // ラリーポイント
+        plan.rallyPoints.forEach((rp) => {
+            const id = `${ID_RALLY_PREFIX}${rp.number}`;
+            const opts: PolygonOptions = {
+                points: [{ lat: rp.lat, lon: rp.lon, altitude: rp.altitude }],
+                altitudeMode: "absolute",
+                closed: false,
+                labels: [formatRallyPointLabel(rp.number)],
+                style: {
+                    pointColor: "#ff9800",
+                    lineColor: "#ff9800",
+                    pointDiameter: 16,
+                    lineWidth: 2,
+                    labelFontSize: 12,
+                    wallColor: "#ff9800",
+                    wallOpacity: 0.15,
+                },
+            };
+            viewer.addPolygon(id, opts);
+            result.rallyIds.push(id);
+        });
+    } catch (err) {
+        // 描画途中で例外が発生した場合、追加済みオブジェクトをロールバック削除して再スロー
+        clearPlanDisplay(viewer, result);
+        throw err;
     }
-
-    // ジオフェンスポリゴン
-    // absolute モードで描画する。terrain モードだと遠方頂点のタイル未ロード時に
-    // 描画されないため、ホーム高度を基準にした絶対高度で即時表示する。
-    const geofenceAlt = (plan.homePosition?.altitude ?? 0) + 10;
-    plan.geoFencePolygons.forEach((poly, i) => {
-        const id = `${ID_GEOFENCE_POLYGON_PREFIX}${i}`;
-        const color = poly.inclusion ? "#4caf50" : "#f44336";
-        const opts: PolygonOptions = {
-            points: poly.points.map((p) => ({
-                lat: p.lat,
-                lon: p.lon,
-                altitude: geofenceAlt,
-            })),
-            altitudeMode: "absolute",
-            closed: true,
-            style: {
-                pointColor: color,
-                lineColor: color,
-                pointDiameter: 0,
-                lineWidth: 2,
-                wallColor: color,
-                wallOpacity: 0.2,
-            },
-        };
-        viewer.addPolygon(id, opts);
-        result.geofencePolyIds.push(id);
-    });
-
-    // ジオフェンス円
-    plan.geoFenceCircles.forEach((circ, i) => {
-        const id = `${ID_GEOFENCE_CIRCLE_PREFIX}${i}`;
-        const color = circ.inclusion ? "#4caf50" : "#f44336";
-        const radius = Math.min(circ.radius, CIRCLE_RADIUS_MAX_M);
-        const opts: CircleOptions = {
-            center: {
-                lat: circ.center.lat,
-                lon: circ.center.lon,
-                altitude: geofenceAlt,
-            },
-            radius,
-            altitudeMode: "absolute",
-            label: null,
-            pointEnabled: false,
-            style: {
-                lineColor: color,
-                lineWidth: 2,
-                wallColor: color,
-                wallOpacity: 0.2,
-            },
-        };
-        viewer.addCircle(id, opts);
-        result.geofenceCircleIds.push(id);
-    });
-
-    // ラリーポイント
-    plan.rallyPoints.forEach((rp) => {
-        const id = `${ID_RALLY_PREFIX}${rp.number}`;
-        const opts: PolygonOptions = {
-            points: [{ lat: rp.lat, lon: rp.lon, altitude: rp.altitude }],
-            altitudeMode: "absolute",
-            closed: false,
-            labels: [formatRallyPointLabel(rp.number)],
-            style: {
-                pointColor: "#ff9800",
-                lineColor: "#ff9800",
-                pointDiameter: 16,
-                lineWidth: 2,
-                labelFontSize: 12,
-                wallColor: "#ff9800",
-                wallOpacity: 0.15,
-            },
-        };
-        viewer.addPolygon(id, opts);
-        result.rallyIds.push(id);
-    });
 
     return result;
 };

--- a/src/demos/plan/index.ts
+++ b/src/demos/plan/index.ts
@@ -124,6 +124,9 @@ const renderPlan = (viewer: JpmapTerrain, plan: ParsedPlan): PlanIds => {
     }
 
     // ジオフェンスポリゴン
+    // absolute モードで描画する。terrain モードだと遠方頂点のタイル未ロード時に
+    // 描画されないため、ホーム高度を基準にした絶対高度で即時表示する。
+    const geofenceAlt = (plan.homePosition?.altitude ?? 0) + 10;
     plan.geoFencePolygons.forEach((poly, i) => {
         const id = `${ID_GEOFENCE_POLYGON_PREFIX}${i}`;
         const color = poly.inclusion ? "#4caf50" : "#f44336";
@@ -131,9 +134,9 @@ const renderPlan = (viewer: JpmapTerrain, plan: ParsedPlan): PlanIds => {
             points: poly.points.map((p) => ({
                 lat: p.lat,
                 lon: p.lon,
-                altitude: 10,
+                altitude: geofenceAlt,
             })),
-            altitudeMode: "terrain",
+            altitudeMode: "absolute",
             closed: true,
             style: {
                 pointColor: color,
@@ -154,9 +157,13 @@ const renderPlan = (viewer: JpmapTerrain, plan: ParsedPlan): PlanIds => {
         const color = circ.inclusion ? "#4caf50" : "#f44336";
         const radius = Math.min(circ.radius, CIRCLE_RADIUS_MAX_M);
         const opts: CircleOptions = {
-            center: { lat: circ.center.lat, lon: circ.center.lon },
+            center: {
+                lat: circ.center.lat,
+                lon: circ.center.lon,
+                altitude: geofenceAlt,
+            },
             radius,
-            altitudeMode: "terrain",
+            altitudeMode: "absolute",
             label: null,
             pointEnabled: false,
             style: {

--- a/src/demos/plan/index.ts
+++ b/src/demos/plan/index.ts
@@ -1,0 +1,318 @@
+/**
+ * Plan Viewer デモ (#38)
+ *
+ * QGroundControl の `.plan` ファイルをドラッグ&ドロップで読み込み、
+ * ウェイポイント・ジオフェンス・ラリーポイントをマップ上に表示する。
+ *
+ * - ビューア専用（編集なし）
+ * - 再ドロップで前回表示をクリアし、新しい Plan のみ表示
+ * - 描画は distance デモと同じ addPolygon / addCircle API を使用
+ */
+import { JpmapTerrain } from "../../lib/jpmapTerrain";
+import type {
+    JpmapTerrainOptions,
+    PolygonOptions,
+    CircleOptions,
+} from "../../lib/types";
+import { CIRCLE_RADIUS_MAX_M } from "../../lib/types";
+import {
+    parseCameraStateFromUrl,
+    parseMapTypeFromUrl,
+} from "../../terrain/urlState";
+import { parsePlan } from "./parsePlan";
+import type { ParsedPlan } from "./parsePlan";
+import {
+    formatWaypointLabel,
+    formatWaypointEdgeLabel,
+    formatRallyPointLabel,
+} from "./utils";
+
+const DEMO_MOUNT_ID = "root";
+const STATUS_ID = "plan-status";
+const DROP_ZONE_ID = "plan-drop-zone";
+
+// 描画 ID プレフィックス
+const ID_WAYPOINTS = "plan-waypoints";
+const ID_GEOFENCE_POLYGON_PREFIX = "plan-geofence-poly-";
+const ID_GEOFENCE_CIRCLE_PREFIX = "plan-geofence-circle-";
+const ID_RALLY_PREFIX = "plan-rally-";
+
+/**
+ * `?engine=` クエリ文字列から描画エンジン種別を解決する。
+ */
+const resolveEngine = (search: string): "webgpu" | "webgl2" | undefined => {
+    const value = new URLSearchParams(search).get("engine");
+    if (value === "webgpu") return "webgpu";
+    if (value === "webgl" || value === "webgl2") return "webgl2";
+    return undefined;
+};
+
+/** 既存の Plan 描画をすべて削除する */
+const clearPlanDisplay = (viewer: JpmapTerrain, ids: string[]): void => {
+    for (const id of ids) {
+        if (viewer.getPolygon(id)) {
+            viewer.removePolygon(id);
+        }
+        if (viewer.getCircle(id)) {
+            viewer.removeCircle(id);
+        }
+    }
+};
+
+/** Plan をマップに描画し、使用した ID リストを返す */
+const renderPlan = (viewer: JpmapTerrain, plan: ParsedPlan): string[] => {
+    const usedIds: string[] = [];
+
+    // ウェイポイント（パスライン）
+    if (plan.waypoints.length > 0) {
+        const points = plan.waypoints.map((wp) => ({
+            lat: wp.lat,
+            lon: wp.lon,
+            altitude: wp.altitude,
+        }));
+        const labels = plan.waypoints.map((wp) => formatWaypointLabel(wp));
+        const edgeLabels: (string | undefined)[] = [];
+        for (let i = 0; i < plan.waypoints.length - 1; i++) {
+            edgeLabels.push(
+                formatWaypointEdgeLabel(
+                    plan.waypoints[i],
+                    plan.waypoints[i + 1],
+                ),
+            );
+        }
+
+        const opts: PolygonOptions = {
+            points,
+            altitudeMode: "absolute",
+            closed: false,
+            labels,
+            edgeLabels,
+            style: {
+                pointColor: "#2196f3",
+                lineColor: "#2196f3",
+                pointDiameter: 14,
+                lineWidth: 2,
+                labelFontSize: 12,
+                wallColor: "#2196f3",
+                wallOpacity: 0.15,
+            },
+        };
+        viewer.addPolygon(ID_WAYPOINTS, opts);
+        usedIds.push(ID_WAYPOINTS);
+    }
+
+    // ジオフェンスポリゴン
+    plan.geoFencePolygons.forEach((poly, i) => {
+        const id = `${ID_GEOFENCE_POLYGON_PREFIX}${i}`;
+        const color = poly.inclusion ? "#4caf50" : "#f44336";
+        const opts: PolygonOptions = {
+            points: poly.points.map((p) => ({
+                lat: p.lat,
+                lon: p.lon,
+            })),
+            altitudeMode: "terrain",
+            closed: true,
+            style: {
+                pointColor: color,
+                lineColor: color,
+                pointDiameter: 0,
+                lineWidth: 2,
+                wallColor: color,
+                wallOpacity: 0.2,
+            },
+        };
+        viewer.addPolygon(id, opts);
+        usedIds.push(id);
+    });
+
+    // ジオフェンス円
+    plan.geoFenceCircles.forEach((circ, i) => {
+        const id = `${ID_GEOFENCE_CIRCLE_PREFIX}${i}`;
+        const color = circ.inclusion ? "#4caf50" : "#f44336";
+        const radius = Math.min(circ.radius, CIRCLE_RADIUS_MAX_M);
+        const opts: CircleOptions = {
+            center: { lat: circ.center.lat, lon: circ.center.lon },
+            radius,
+            altitudeMode: "terrain",
+            label: null,
+            pointEnabled: false,
+            style: {
+                lineColor: color,
+                lineWidth: 2,
+                wallColor: color,
+                wallOpacity: 0.2,
+            },
+        };
+        viewer.addCircle(id, opts);
+        usedIds.push(id);
+    });
+
+    // ラリーポイント
+    plan.rallyPoints.forEach((rp) => {
+        const id = `${ID_RALLY_PREFIX}${rp.number}`;
+        const opts: PolygonOptions = {
+            points: [{ lat: rp.lat, lon: rp.lon, altitude: rp.altitude }],
+            altitudeMode: "absolute",
+            closed: false,
+            labels: [formatRallyPointLabel(rp.number)],
+            style: {
+                pointColor: "#ff9800",
+                lineColor: "#ff9800",
+                pointDiameter: 16,
+                lineWidth: 2,
+                labelFontSize: 12,
+                wallColor: "#ff9800",
+                wallOpacity: 0.15,
+            },
+        };
+        viewer.addPolygon(id, opts);
+        usedIds.push(id);
+    });
+
+    return usedIds;
+};
+
+const updateStatus = (
+    statusEl: HTMLElement | null,
+    plan: ParsedPlan | null,
+    error?: string,
+): void => {
+    if (!statusEl) return;
+    if (error) {
+        statusEl.textContent = `エラー: ${error}`;
+        return;
+    }
+    if (!plan) {
+        statusEl.textContent = ".plan ファイルをドラッグ&ドロップしてください";
+        return;
+    }
+    const lines: string[] = [];
+    lines.push(`ウェイポイント: ${plan.waypoints.length} 点`);
+    if (plan.geoFencePolygons.length > 0) {
+        lines.push(`ジオフェンス(ポリゴン): ${plan.geoFencePolygons.length}`);
+    }
+    if (plan.geoFenceCircles.length > 0) {
+        lines.push(`ジオフェンス(円): ${plan.geoFenceCircles.length}`);
+    }
+    if (plan.rallyPoints.length > 0) {
+        lines.push(`ラリーポイント: ${plan.rallyPoints.length}`);
+    }
+    statusEl.textContent = lines.join("\n");
+};
+
+const start = async (): Promise<void> => {
+    const mount = document.getElementById(DEMO_MOUNT_ID);
+    if (!mount) {
+        throw new Error(`#${DEMO_MOUNT_ID} mount element not found`);
+    }
+
+    const engine = resolveEngine(location.search);
+    const cameraState = parseCameraStateFromUrl(location.href) ?? undefined;
+    const mapType = parseMapTypeFromUrl(location.href);
+    const defaultCamera = {
+        lat: 35.6242625,
+        lon: 139.5148162,
+        altitude: 1500,
+        azimuth: 0,
+        tilt: 55,
+    };
+
+    const opts: JpmapTerrainOptions = {
+        ...(engine ? { engine } : {}),
+        ...(cameraState ?? defaultCamera),
+        ...(mapType !== null ? { mapType } : {}),
+        showViewModeButton: false,
+    };
+
+    const viewer = await JpmapTerrain.create(mount, opts);
+
+    const statusEl = document.getElementById(STATUS_ID);
+    const dropZone = document.getElementById(DROP_ZONE_ID);
+
+    let currentIds: string[] = [];
+
+    const loadPlan = (fileContent: string): void => {
+        // 前回表示をクリア
+        clearPlanDisplay(viewer, currentIds);
+        currentIds = [];
+
+        try {
+            const json = JSON.parse(fileContent) as unknown;
+            const plan = parsePlan(json);
+            currentIds = renderPlan(viewer, plan);
+            updateStatus(statusEl, plan);
+
+            // ウェイポイントがある場合、最初のウェイポイント位置にカメラを移動
+            if (plan.waypoints.length > 0) {
+                const first = plan.waypoints[0];
+                void viewer.flyTo({ lat: first.lat, lon: first.lon });
+            } else if (plan.rallyPoints.length > 0) {
+                const first = plan.rallyPoints[0];
+                void viewer.flyTo({ lat: first.lat, lon: first.lon });
+            }
+        } catch (e) {
+            const msg = e instanceof Error ? e.message : "不明なエラー";
+            updateStatus(statusEl, null, msg);
+        }
+    };
+
+    // ドラッグ&ドロップ
+    let dragCounter = 0;
+
+    document.addEventListener("dragenter", (e: DragEvent) => {
+        e.preventDefault();
+        dragCounter++;
+        if (dragCounter === 1) {
+            dropZone?.classList.add("active");
+        }
+    });
+
+    document.addEventListener("dragleave", (e: DragEvent) => {
+        e.preventDefault();
+        dragCounter--;
+        if (dragCounter <= 0) {
+            dragCounter = 0;
+            dropZone?.classList.remove("active");
+        }
+    });
+
+    document.addEventListener("dragover", (e: DragEvent) => {
+        e.preventDefault();
+    });
+
+    document.addEventListener("drop", (e: DragEvent) => {
+        e.preventDefault();
+        dragCounter = 0;
+        dropZone?.classList.remove("active");
+
+        const files = e.dataTransfer?.files;
+        if (!files || files.length === 0) return;
+
+        const file = files[0];
+        const reader = new FileReader();
+        reader.onload = () => {
+            if (typeof reader.result === "string") {
+                loadPlan(reader.result);
+            }
+        };
+        reader.onerror = () => {
+            updateStatus(statusEl, null, "ファイルの読み込みに失敗しました");
+        };
+        reader.readAsText(file);
+    });
+
+    updateStatus(statusEl, null);
+
+    if (process.env.NODE_ENV !== "production") {
+        (window as unknown as { viewer: JpmapTerrain }).viewer = viewer;
+    }
+};
+
+if (
+    typeof document !== "undefined" &&
+    document.getElementById(DEMO_MOUNT_ID) !== null
+) {
+    start().catch((err) => {
+        console.error("[jpmap-terrain plan demo] failed to start:", err);
+    });
+}

--- a/src/demos/plan/index.ts
+++ b/src/demos/plan/index.ts
@@ -30,12 +30,30 @@ import {
 const DEMO_MOUNT_ID = "root";
 const STATUS_ID = "plan-status";
 const DROP_ZONE_ID = "plan-drop-zone";
+const BTN_WAYPOINTS_ID = "btn-waypoints";
+const BTN_GEOFENCE_ID = "btn-geofence";
+const BTN_RALLY_ID = "btn-rally";
 
 // 描画 ID プレフィックス
 const ID_WAYPOINTS = "plan-waypoints";
 const ID_GEOFENCE_POLYGON_PREFIX = "plan-geofence-poly-";
 const ID_GEOFENCE_CIRCLE_PREFIX = "plan-geofence-circle-";
 const ID_RALLY_PREFIX = "plan-rally-";
+
+/** 種別ごとの描画 ID セット */
+interface PlanIds {
+    waypointIds: string[];
+    geofencePolyIds: string[];
+    geofenceCircleIds: string[];
+    rallyIds: string[];
+}
+
+const EMPTY_PLAN_IDS: PlanIds = {
+    waypointIds: [],
+    geofencePolyIds: [],
+    geofenceCircleIds: [],
+    rallyIds: [],
+};
 
 /**
  * `?engine=` クエリ文字列から描画エンジン種別を解決する。
@@ -48,20 +66,24 @@ const resolveEngine = (search: string): "webgpu" | "webgl2" | undefined => {
 };
 
 /** 既存の Plan 描画をすべて削除する */
-const clearPlanDisplay = (viewer: JpmapTerrain, ids: string[]): void => {
-    for (const id of ids) {
-        if (viewer.getPolygon(id)) {
-            viewer.removePolygon(id);
-        }
-        if (viewer.getCircle(id)) {
-            viewer.removeCircle(id);
-        }
+const clearPlanDisplay = (viewer: JpmapTerrain, ids: PlanIds): void => {
+    const allPolyIds = [...ids.waypointIds, ...ids.geofencePolyIds, ...ids.rallyIds];
+    for (const id of allPolyIds) {
+        if (viewer.getPolygon(id)) viewer.removePolygon(id);
+    }
+    for (const id of ids.geofenceCircleIds) {
+        if (viewer.getCircle(id)) viewer.removeCircle(id);
     }
 };
 
-/** Plan をマップに描画し、使用した ID リストを返す */
-const renderPlan = (viewer: JpmapTerrain, plan: ParsedPlan): string[] => {
-    const usedIds: string[] = [];
+/** Plan をマップに描画し、種別ごとの ID を返す */
+const renderPlan = (viewer: JpmapTerrain, plan: ParsedPlan): PlanIds => {
+    const result: PlanIds = {
+        waypointIds: [],
+        geofencePolyIds: [],
+        geofenceCircleIds: [],
+        rallyIds: [],
+    };
 
     // ウェイポイント（パスライン）
     if (plan.waypoints.length > 0) {
@@ -98,7 +120,7 @@ const renderPlan = (viewer: JpmapTerrain, plan: ParsedPlan): string[] => {
             },
         };
         viewer.addPolygon(ID_WAYPOINTS, opts);
-        usedIds.push(ID_WAYPOINTS);
+        result.waypointIds.push(ID_WAYPOINTS);
     }
 
     // ジオフェンスポリゴン
@@ -122,7 +144,7 @@ const renderPlan = (viewer: JpmapTerrain, plan: ParsedPlan): string[] => {
             },
         };
         viewer.addPolygon(id, opts);
-        usedIds.push(id);
+        result.geofencePolyIds.push(id);
     });
 
     // ジオフェンス円
@@ -144,7 +166,7 @@ const renderPlan = (viewer: JpmapTerrain, plan: ParsedPlan): string[] => {
             },
         };
         viewer.addCircle(id, opts);
-        usedIds.push(id);
+        result.geofenceCircleIds.push(id);
     });
 
     // ラリーポイント
@@ -166,10 +188,10 @@ const renderPlan = (viewer: JpmapTerrain, plan: ParsedPlan): string[] => {
             },
         };
         viewer.addPolygon(id, opts);
-        usedIds.push(id);
+        result.rallyIds.push(id);
     });
 
-    return usedIds;
+    return result;
 };
 
 const updateStatus = (
@@ -229,18 +251,83 @@ const start = async (): Promise<void> => {
     const statusEl = document.getElementById(STATUS_ID);
     const dropZone = document.getElementById(DROP_ZONE_ID);
 
-    let currentIds: string[] = [];
+    let currentIds: PlanIds = { ...EMPTY_PLAN_IDS };
+
+    // レイヤー表示状態
+    const layerVisible = { waypoints: true, geofence: true, rally: true };
+
+    // ボタン要素
+    const btnWaypoints = document.getElementById(BTN_WAYPOINTS_ID) as HTMLButtonElement | null;
+    const btnGeofence = document.getElementById(BTN_GEOFENCE_ID) as HTMLButtonElement | null;
+    const btnRally = document.getElementById(BTN_RALLY_ID) as HTMLButtonElement | null;
+
+    const refreshButtons = (hasPlan: boolean): void => {
+        if (btnWaypoints) {
+            btnWaypoints.disabled = !hasPlan;
+            btnWaypoints.dataset.active = String(layerVisible.waypoints);
+        }
+        if (btnGeofence) {
+            btnGeofence.disabled = !hasPlan;
+            btnGeofence.dataset.active = String(layerVisible.geofence);
+        }
+        if (btnRally) {
+            btnRally.disabled = !hasPlan;
+            btnRally.dataset.active = String(layerVisible.rally);
+        }
+    };
+
+    const applyLayerVisibility = (): void => {
+        for (const id of currentIds.waypointIds) {
+            if (viewer.getPolygon(id)) viewer.setPolygonEnabled(id, layerVisible.waypoints);
+        }
+        for (const id of [...currentIds.geofencePolyIds]) {
+            if (viewer.getPolygon(id)) viewer.setPolygonEnabled(id, layerVisible.geofence);
+        }
+        for (const id of currentIds.geofenceCircleIds) {
+            if (viewer.getCircle(id)) viewer.setCircleEnabled(id, layerVisible.geofence);
+        }
+        for (const id of currentIds.rallyIds) {
+            if (viewer.getPolygon(id)) viewer.setPolygonEnabled(id, layerVisible.rally);
+        }
+    };
+
+    if (btnWaypoints) {
+        btnWaypoints.addEventListener("click", () => {
+            layerVisible.waypoints = !layerVisible.waypoints;
+            applyLayerVisibility();
+            refreshButtons(true);
+        });
+    }
+    if (btnGeofence) {
+        btnGeofence.addEventListener("click", () => {
+            layerVisible.geofence = !layerVisible.geofence;
+            applyLayerVisibility();
+            refreshButtons(true);
+        });
+    }
+    if (btnRally) {
+        btnRally.addEventListener("click", () => {
+            layerVisible.rally = !layerVisible.rally;
+            applyLayerVisibility();
+            refreshButtons(true);
+        });
+    }
 
     const loadPlan = (fileContent: string): void => {
         // 前回表示をクリア
         clearPlanDisplay(viewer, currentIds);
-        currentIds = [];
+        currentIds = { ...EMPTY_PLAN_IDS };
+        // 表示状態をリセット
+        layerVisible.waypoints = true;
+        layerVisible.geofence = true;
+        layerVisible.rally = true;
 
         try {
             const json = JSON.parse(fileContent) as unknown;
             const plan = parsePlan(json);
             currentIds = renderPlan(viewer, plan);
             updateStatus(statusEl, plan);
+            refreshButtons(true);
 
             // ウェイポイントがある場合、最初のウェイポイント位置にカメラを移動
             if (plan.waypoints.length > 0) {
@@ -253,6 +340,7 @@ const start = async (): Promise<void> => {
         } catch (e) {
             const msg = e instanceof Error ? e.message : "不明なエラー";
             updateStatus(statusEl, null, msg);
+            refreshButtons(false);
         }
     };
 

--- a/src/demos/plan/index.ts
+++ b/src/demos/plan/index.ts
@@ -131,6 +131,7 @@ const renderPlan = (viewer: JpmapTerrain, plan: ParsedPlan): PlanIds => {
             points: poly.points.map((p) => ({
                 lat: p.lat,
                 lon: p.lon,
+                altitude: 10,
             })),
             altitudeMode: "terrain",
             closed: true,

--- a/src/demos/plan/parsePlan.ts
+++ b/src/demos/plan/parsePlan.ts
@@ -161,6 +161,9 @@ export const parsePlan = (json: unknown): ParsedPlan => {
     if (!plan.mission) {
         throw new Error("Invalid plan file: missing mission section");
     }
+    if (!Array.isArray(plan.mission.items)) {
+        throw new Error("Invalid plan file: mission.items is missing or not an array");
+    }
 
     // ホームポジション
     let homePosition: ParsedPlan["homePosition"] = null;

--- a/src/demos/plan/parsePlan.ts
+++ b/src/demos/plan/parsePlan.ts
@@ -10,7 +10,10 @@
 
 /** Plan ファイルトップレベル */
 export interface QgcPlanFile {
-    fileHeader: { version: number };
+    /** QGC v4.x 形式ではトップレベルに存在。v3.x 以前は version がトップレベルに直接ある場合も。 */
+    fileHeader?: { version: number };
+    /** QGC v3.x の一部バージョンではトップレベルに version が直接ある */
+    version?: number;
     mission: QgcMission;
     geoFence?: QgcGeoFence;
     rallyPoints?: QgcRallyPoints;

--- a/src/demos/plan/parsePlan.ts
+++ b/src/demos/plan/parsePlan.ts
@@ -118,7 +118,7 @@ export const WAYPOINT_COMMANDS = new Set([
  * QGC v4+ は `coordinate` フィールド、v3 以前は `params[4..6]` にフォールバック。
  *
  * lat=0 かつ lon=0 はQGCにおける「ホームポジションで実行」を意味するため null を返す。
- * 呼び出し側でホームポジションへのフォールバックを行う。
+ * 呼び出し側は null の場合そのアイテムをスキップする。
  */
 const extractCoordinate = (
     item: QgcMissionItem,

--- a/src/demos/plan/parsePlan.ts
+++ b/src/demos/plan/parsePlan.ts
@@ -116,27 +116,32 @@ export const WAYPOINT_COMMANDS = new Set([
 /**
  * Mission item から座標 (lat, lon, alt) を抽出する。
  * QGC v4+ は `coordinate` フィールド、v3 以前は `params[4..6]` にフォールバック。
+ *
+ * lat=0 かつ lon=0 はQGCにおける「ホームポジションで実行」を意味するため null を返す。
+ * 呼び出し側でホームポジションへのフォールバックを行う。
  */
 const extractCoordinate = (
     item: QgcMissionItem,
 ): { lat: number; lon: number; alt: number } | null => {
+    let lat: number | null = null;
+    let lon: number | null = null;
+    let alt: number | null = null;
+
     if (item.coordinate && item.coordinate.length >= 3) {
-        return {
-            lat: item.coordinate[0],
-            lon: item.coordinate[1],
-            alt: item.coordinate[2],
-        };
+        lat = item.coordinate[0];
+        lon = item.coordinate[1];
+        alt = item.coordinate[2];
+    } else if (item.params && item.params.length >= 7) {
+        // params fallback: [p1, p2, p3, p4, lat(x), lon(y), alt(z)]
+        lat = item.params[4];
+        lon = item.params[5];
+        alt = item.params[6];
     }
-    // params fallback: [p1, p2, p3, p4, lat(x), lon(y), alt(z)]
-    if (item.params && item.params.length >= 7) {
-        const lat = item.params[4];
-        const lon = item.params[5];
-        const alt = item.params[6];
-        if (lat !== null && lon !== null && alt !== null) {
-            return { lat, lon, alt };
-        }
-    }
-    return null;
+
+    if (lat === null || lon === null || alt === null) return null;
+    // lat=0 かつ lon=0 はホームポジション指定（QGC 仕様）
+    if (lat === 0 && lon === 0) return null;
+    return { lat, lon, alt };
 };
 
 /**

--- a/src/demos/plan/parsePlan.ts
+++ b/src/demos/plan/parsePlan.ts
@@ -1,0 +1,237 @@
+/**
+ * QGroundControl Plan ファイルパーサ (#38)
+ *
+ * `.plan` JSON を受け取り、描画に必要な Mission / GeoFence / RallyPoint 情報を抽出する。
+ * MAV_CMD のうち NAV_WAYPOINT(16) / NAV_LAND(21) / NAV_TAKEOFF(22) のみをウェイポイントとして扱い、
+ * それ以外はスキップする。高度は MAV_FRAME に基づきホームポジションからの相対高度として解決する。
+ */
+
+// ---- QGC Plan JSON スキーマ型定義 ----
+
+/** Plan ファイルトップレベル */
+export interface QgcPlanFile {
+    fileHeader: { version: number };
+    mission: QgcMission;
+    geoFence?: QgcGeoFence;
+    rallyPoints?: QgcRallyPoints;
+}
+
+/** Mission セクション */
+export interface QgcMission {
+    plannedHomePosition?: [number, number, number]; // [lat, lon, alt]
+    items: QgcMissionItem[];
+}
+
+/** Mission アイテム（個々のコマンド） */
+export interface QgcMissionItem {
+    command: number;
+    frame: number;
+    params: (number | null)[];
+    /** autoContinue */
+    autoContinue?: boolean;
+    /** MAV_CMD type label (informational) */
+    type?: string;
+    /**
+     * QGC 固有の座標フィールド。
+     * items[].coordinate = [lat, lon, alt] (QGC v4.x+)
+     * items[].params[4..6] = [lat, lon, alt] (QGC v3.x fallback)
+     */
+    coordinate?: [number, number, number];
+}
+
+/** GeoFence セクション */
+export interface QgcGeoFence {
+    polygons?: QgcGeoFencePolygon[];
+    circles?: QgcGeoFenceCircle[];
+}
+
+export interface QgcGeoFencePolygon {
+    inclusion: boolean;
+    polygon: [number, number][]; // [[lat, lon], ...]
+    version?: number;
+}
+
+export interface QgcGeoFenceCircle {
+    inclusion: boolean;
+    circle: { center: [number, number]; radius: number };
+    version?: number;
+}
+
+/** Rally Points セクション */
+export interface QgcRallyPoints {
+    points: [number, number, number][]; // [[lat, lon, alt], ...]
+    version?: number;
+}
+
+// ---- パース結果型 ----
+
+export interface ParsedWaypoint {
+    /** 1-based 表示番号（スキップ分を除く） */
+    number: number;
+    lat: number;
+    lon: number;
+    /** ホームポジション相対の絶対高度 (m) */
+    altitude: number;
+    command: number;
+}
+
+export interface ParsedGeoFencePolygon {
+    inclusion: boolean;
+    points: { lat: number; lon: number }[];
+}
+
+export interface ParsedGeoFenceCircle {
+    inclusion: boolean;
+    center: { lat: number; lon: number };
+    radius: number;
+}
+
+export interface ParsedRallyPoint {
+    /** 1-based 表示番号 */
+    number: number;
+    lat: number;
+    lon: number;
+    altitude: number;
+}
+
+export interface ParsedPlan {
+    homePosition: { lat: number; lon: number; altitude: number } | null;
+    waypoints: ParsedWaypoint[];
+    geoFencePolygons: ParsedGeoFencePolygon[];
+    geoFenceCircles: ParsedGeoFenceCircle[];
+    rallyPoints: ParsedRallyPoint[];
+}
+
+// ---- 定数 ----
+
+/** ウェイポイントとして描画する MAV_CMD */
+export const WAYPOINT_COMMANDS = new Set([
+    16, // MAV_CMD_NAV_WAYPOINT
+    21, // MAV_CMD_NAV_LAND
+    22, // MAV_CMD_NAV_TAKEOFF
+]);
+
+// ---- パースロジック ----
+
+/**
+ * Mission item から座標 (lat, lon, alt) を抽出する。
+ * QGC v4+ は `coordinate` フィールド、v3 以前は `params[4..6]` にフォールバック。
+ */
+const extractCoordinate = (
+    item: QgcMissionItem,
+): { lat: number; lon: number; alt: number } | null => {
+    if (item.coordinate && item.coordinate.length >= 3) {
+        return {
+            lat: item.coordinate[0],
+            lon: item.coordinate[1],
+            alt: item.coordinate[2],
+        };
+    }
+    // params fallback: [p1, p2, p3, p4, lat(x), lon(y), alt(z)]
+    if (item.params && item.params.length >= 7) {
+        const lat = item.params[4];
+        const lon = item.params[5];
+        const alt = item.params[6];
+        if (lat !== null && lon !== null && alt !== null) {
+            return { lat, lon, alt };
+        }
+    }
+    return null;
+};
+
+/**
+ * QGC Plan JSON をパースし、描画用データを返す。
+ *
+ * @throws JSON 構造が不正な場合 Error
+ */
+export const parsePlan = (json: unknown): ParsedPlan => {
+    if (typeof json !== "object" || json === null) {
+        throw new Error("Invalid plan file: not an object");
+    }
+    const plan = json as QgcPlanFile;
+
+    if (!plan.mission) {
+        throw new Error("Invalid plan file: missing mission section");
+    }
+
+    // ホームポジション
+    let homePosition: ParsedPlan["homePosition"] = null;
+    const hp = plan.mission.plannedHomePosition;
+    if (hp && hp.length >= 3) {
+        homePosition = { lat: hp[0], lon: hp[1], altitude: hp[2] };
+    }
+
+    // ウェイポイント
+    const waypoints: ParsedWaypoint[] = [];
+    let waypointNumber = 0;
+    for (const item of plan.mission.items) {
+        if (!WAYPOINT_COMMANDS.has(item.command)) continue;
+        const coord = extractCoordinate(item);
+        if (!coord) continue;
+
+        waypointNumber++;
+        // MAV_FRAME: ホームポジション相対 → 絶対高度
+        const homeAlt = homePosition?.altitude ?? 0;
+        const altitude = coord.alt + homeAlt;
+
+        waypoints.push({
+            number: waypointNumber,
+            lat: coord.lat,
+            lon: coord.lon,
+            altitude,
+            command: item.command,
+        });
+    }
+
+    // ジオフェンス
+    const geoFencePolygons: ParsedGeoFencePolygon[] = [];
+    const geoFenceCircles: ParsedGeoFenceCircle[] = [];
+    if (plan.geoFence) {
+        if (plan.geoFence.polygons) {
+            for (const poly of plan.geoFence.polygons) {
+                if (!poly.polygon || poly.polygon.length < 3) continue;
+                geoFencePolygons.push({
+                    inclusion: poly.inclusion,
+                    points: poly.polygon.map(([lat, lon]) => ({ lat, lon })),
+                });
+            }
+        }
+        if (plan.geoFence.circles) {
+            for (const circ of plan.geoFence.circles) {
+                if (!circ.circle) continue;
+                const center = circ.circle.center;
+                if (!center || center.length < 2) continue;
+                geoFenceCircles.push({
+                    inclusion: circ.inclusion,
+                    center: { lat: center[0], lon: center[1] },
+                    radius: circ.circle.radius,
+                });
+            }
+        }
+    }
+
+    // ラリーポイント
+    const rallyPoints: ParsedRallyPoint[] = [];
+    if (plan.rallyPoints?.points) {
+        let rallyNumber = 0;
+        for (const pt of plan.rallyPoints.points) {
+            if (!pt || pt.length < 3) continue;
+            rallyNumber++;
+            const homeAlt = homePosition?.altitude ?? 0;
+            rallyPoints.push({
+                number: rallyNumber,
+                lat: pt[0],
+                lon: pt[1],
+                altitude: pt[2] + homeAlt,
+            });
+        }
+    }
+
+    return {
+        homePosition,
+        waypoints,
+        geoFencePolygons,
+        geoFenceCircles,
+        rallyPoints,
+    };
+};

--- a/src/demos/plan/utils.ts
+++ b/src/demos/plan/utils.ts
@@ -1,0 +1,83 @@
+/**
+ * Plan Viewer デモ用ユーティリティ (#38)
+ *
+ * ウェイポイント・エッジのラベルフォーマット関数。
+ * 水平距離計算は distance デモの haversine ロジックを流用する。
+ */
+
+import type { ParsedWaypoint } from "./parsePlan";
+
+/** 地球半径 (m)。WGS84 平均半径。 */
+const EARTH_RADIUS_M = 6_371_008.8;
+
+const toRadians = (deg: number): number => (deg * Math.PI) / 180;
+
+/**
+ * 2 点の (lat, lon) から大圏距離 (m) を haversine 法で算出する。
+ */
+export const haversineDistanceMeters = (
+    a: { lat: number; lon: number },
+    b: { lat: number; lon: number },
+): number => {
+    const lat1 = toRadians(a.lat);
+    const lat2 = toRadians(b.lat);
+    const dLat = toRadians(b.lat - a.lat);
+    const dLon = toRadians(b.lon - a.lon);
+    const sinDLat = Math.sin(dLat / 2);
+    const sinDLon = Math.sin(dLon / 2);
+    const h =
+        sinDLat * sinDLat +
+        Math.cos(lat1) * Math.cos(lat2) * sinDLon * sinDLon;
+    const hClamped = Math.min(1, Math.max(0, h));
+    const c = 2 * Math.atan2(Math.sqrt(hClamped), Math.sqrt(1 - hClamped));
+    return EARTH_RADIUS_M * c;
+};
+
+/**
+ * 水平距離を m / km の単位を自動切替で整形する。
+ */
+export const formatHorizontalDistance = (meters: number): string => {
+    if (!Number.isFinite(meters) || meters < 0) return "-";
+    if (meters < 1000) {
+        return `${Math.round(meters)} m`;
+    }
+    return `${(meters / 1000).toFixed(2)} km`;
+};
+
+/**
+ * 高低差を m で整形する。常に符号 (+/-) を付ける。
+ */
+export const formatAltitudeDelta = (deltaM: number): string => {
+    if (!Number.isFinite(deltaM)) return "-";
+    const rounded = Math.round(deltaM);
+    if (rounded === 0) return "±0 m";
+    const sign = rounded > 0 ? "+" : "";
+    return `${sign}${rounded} m`;
+};
+
+/**
+ * ウェイポイントラベル: 番号 + 高度
+ */
+export const formatWaypointLabel = (wp: ParsedWaypoint): string => {
+    const alt = Math.round(wp.altitude);
+    return `#${wp.number}\n${alt} m`;
+};
+
+/**
+ * ウェイポイント間エッジラベル: 水平距離 + 高度差
+ */
+export const formatWaypointEdgeLabel = (
+    a: ParsedWaypoint,
+    b: ParsedWaypoint,
+): string => {
+    const horizontal = haversineDistanceMeters(a, b);
+    const delta = b.altitude - a.altitude;
+    return `${formatHorizontalDistance(horizontal)}\n${formatAltitudeDelta(delta)}`;
+};
+
+/**
+ * ラリーポイントラベル: 番号のみ
+ */
+export const formatRallyPointLabel = (number: number): string => {
+    return `R${number}`;
+};

--- a/src/demos/plan/utils.ts
+++ b/src/demos/plan/utils.ts
@@ -2,58 +2,21 @@
  * Plan Viewer デモ用ユーティリティ (#38)
  *
  * ウェイポイント・エッジのラベルフォーマット関数。
- * 水平距離計算は distance デモの haversine ロジックを流用する。
+ * haversine 距離計算・距離/高低差フォーマットは共通ユーティリティ
+ * `../shared/geoUtils` を使用する。
  */
 
 import type { ParsedWaypoint } from "./parsePlan";
-
-/** 地球半径 (m)。WGS84 平均半径。 */
-const EARTH_RADIUS_M = 6_371_008.8;
-
-const toRadians = (deg: number): number => (deg * Math.PI) / 180;
-
-/**
- * 2 点の (lat, lon) から大圏距離 (m) を haversine 法で算出する。
- */
-export const haversineDistanceMeters = (
-    a: { lat: number; lon: number },
-    b: { lat: number; lon: number },
-): number => {
-    const lat1 = toRadians(a.lat);
-    const lat2 = toRadians(b.lat);
-    const dLat = toRadians(b.lat - a.lat);
-    const dLon = toRadians(b.lon - a.lon);
-    const sinDLat = Math.sin(dLat / 2);
-    const sinDLon = Math.sin(dLon / 2);
-    const h =
-        sinDLat * sinDLat +
-        Math.cos(lat1) * Math.cos(lat2) * sinDLon * sinDLon;
-    const hClamped = Math.min(1, Math.max(0, h));
-    const c = 2 * Math.atan2(Math.sqrt(hClamped), Math.sqrt(1 - hClamped));
-    return EARTH_RADIUS_M * c;
-};
-
-/**
- * 水平距離を m / km の単位を自動切替で整形する。
- */
-export const formatHorizontalDistance = (meters: number): string => {
-    if (!Number.isFinite(meters) || meters < 0) return "-";
-    if (meters < 1000) {
-        return `${Math.round(meters)} m`;
-    }
-    return `${(meters / 1000).toFixed(2)} km`;
-};
-
-/**
- * 高低差を m で整形する。常に符号 (+/-) を付ける。
- */
-export const formatAltitudeDelta = (deltaM: number): string => {
-    if (!Number.isFinite(deltaM)) return "-";
-    const rounded = Math.round(deltaM);
-    if (rounded === 0) return "±0 m";
-    const sign = rounded > 0 ? "+" : "";
-    return `${sign}${rounded} m`;
-};
+export {
+    haversineDistanceMeters,
+    formatHorizontalDistance,
+    formatAltitudeDelta,
+} from "../shared/geoUtils";
+import {
+    haversineDistanceMeters,
+    formatHorizontalDistance,
+    formatAltitudeDelta,
+} from "../shared/geoUtils";
 
 /**
  * ウェイポイントラベル: 番号 + 高度

--- a/src/demos/portal/index.ts
+++ b/src/demos/portal/index.ts
@@ -48,6 +48,12 @@ const DEMO_LIST: readonly DemoEntry[] = [
             "CircleManager 公開 API の動作確認デモ。terrain / absolute / カスタムセグメントの 3 種類の円を表示し、enabled や半径・スタイルの動的更新ができます。",
         href: "circle",
     },
+    {
+        title: "Plan Viewer",
+        description:
+            "QGroundControl の Plan ファイル（.plan）をドラッグ&ドロップでマップ上に表示するビューア。ウェイポイント・ジオフェンス・ラリーポイントを描画します。",
+        href: "plan",
+    },
 ];
 
 const PORTAL_MOUNT_ID = "root";

--- a/src/demos/shared/geoUtils.ts
+++ b/src/demos/shared/geoUtils.ts
@@ -1,0 +1,63 @@
+/**
+ * デモ共通の地理計算・距離フォーマットユーティリティ。
+ *
+ * - `haversineDistanceMeters`: 2 点の lat/lon から水平距離 (m) を計算する。
+ * - `formatHorizontalDistance`: m / km の単位を切替えて整形する。
+ * - `formatAltitudeDelta`: 高低差 (m) を整形する（符号付き）。
+ */
+
+/** 地球半径 (m)。WGS84 平均半径。 */
+const EARTH_RADIUS_M = 6_371_008.8;
+
+const toRadians = (deg: number): number => (deg * Math.PI) / 180;
+
+/**
+ * 2 点の (lat, lon) から大圏距離 (m) を haversine 法で算出する。
+ *
+ * 小数点以下の round/floor は呼び出し側で行い、本関数は double 精度のままを返す。
+ * 同一点なら 0 を返す。
+ */
+export const haversineDistanceMeters = (
+    a: { lat: number; lon: number },
+    b: { lat: number; lon: number },
+): number => {
+    const lat1 = toRadians(a.lat);
+    const lat2 = toRadians(b.lat);
+    const dLat = toRadians(b.lat - a.lat);
+    const dLon = toRadians(b.lon - a.lon);
+    const sinDLat = Math.sin(dLat / 2);
+    const sinDLon = Math.sin(dLon / 2);
+    const h =
+        sinDLat * sinDLat +
+        Math.cos(lat1) * Math.cos(lat2) * sinDLon * sinDLon;
+    // 浮動小数誤差で h が 1 を僅かに超えると Math.sqrt(1 - h) が NaN に
+    // なり得る（ほぼ対蹠点）。安定のため [0, 1] にクランプする。
+    const hClamped = Math.min(1, Math.max(0, h));
+    const c = 2 * Math.atan2(Math.sqrt(hClamped), Math.sqrt(1 - hClamped));
+    return EARTH_RADIUS_M * c;
+};
+
+/**
+ * 水平距離を m / km の単位を自動切替で整形する。
+ * - 1000 m 未満: `<整数> m`（小数なし、四捨五入）
+ * - 1000 m 以上: `<小数 2 桁> km`
+ */
+export const formatHorizontalDistance = (meters: number): string => {
+    if (!Number.isFinite(meters) || meters < 0) return "-";
+    if (meters < 1000) {
+        return `${Math.round(meters)} m`;
+    }
+    return `${(meters / 1000).toFixed(2)} km`;
+};
+
+/**
+ * 高低差を m で整形する。常に符号 (+/-) を付ける。
+ * 絶対値 < 0.5 m は `±0 m` として扱う（四捨五入後 0 になるケースを明示）。
+ */
+export const formatAltitudeDelta = (deltaM: number): string => {
+    if (!Number.isFinite(deltaM)) return "-";
+    const rounded = Math.round(deltaM);
+    if (rounded === 0) return "±0 m";
+    const sign = rounded > 0 ? "+" : "";
+    return `${sign}${rounded} m`;
+};

--- a/tests/plan.unit.spec.ts
+++ b/tests/plan.unit.spec.ts
@@ -162,6 +162,123 @@ describe("parsePlan", () => {
         expect(result.homePosition).toBeNull();
         expect(result.waypoints[0].altitude).toBe(100); // homeAlt=0
     });
+
+    it("lat=0 かつ lon=0 の items はスキップする（QGC ホームポジション指定）", () => {
+        const plan = {
+            fileHeader: { version: 1 },
+            mission: {
+                plannedHomePosition: [35.0, 139.0, 100],
+                items: [
+                    // NAV_TAKEOFF at lat=0,lon=0 → ホームポジション指定のためスキップ
+                    { command: 22, frame: 3, params: [0, 0, 0, null, 0, 0, 50] },
+                    // 通常ウェイポイント
+                    { command: 16, frame: 3, params: [0, 0, 0, null, 35.5, 139.5, 80] },
+                ],
+            },
+        };
+        const result = parsePlan(plan);
+        // NAV_TAKEOFF の lat=0,lon=0 がスキップされ、NAV_WAYPOINT だけ残る
+        expect(result.waypoints).toHaveLength(1);
+        expect(result.waypoints[0].number).toBe(1);
+        expect(result.waypoints[0].lat).toBe(35.5);
+        expect(result.waypoints[0].command).toBe(16);
+    });
+
+    it("okutama.plan 相当データをパースできる（lat=0,lon=0 のTAKEOFF がスキップされる）", () => {
+        // examples/okutama.plan の構造を模したテスト
+        const okutamaPlan = {
+            fileType: "Plan",
+            version: 1,
+            groundStation: "QGroundControl",
+            geoFence: {
+                circles: [
+                    {
+                        circle: { center: [35.79185330892785, 139.04875075067923], radius: 148.6696453391971 },
+                        inclusion: true,
+                        version: 1,
+                    },
+                ],
+                polygons: [
+                    {
+                        inclusion: true,
+                        polygon: [
+                            [35.78119118423945, 139.0155554596605],
+                            [35.780557345975986, 139.02034217849484],
+                            [35.78289290329043, 139.03542661940673],
+                            [35.78745799934225, 139.04538107075717],
+                            [35.78710147819815, 139.0474676808036],
+                            [35.78406082046976, 139.04540192053304],
+                            [35.78097161325014, 139.0364036553163],
+                            [35.77833207231516, 139.02070654713293],
+                            [35.779336739702785, 139.01491987915722],
+                        ],
+                        version: 1,
+                    },
+                ],
+                version: 2,
+            },
+            mission: {
+                cruiseSpeed: 1,
+                firmwareType: 3,
+                globalPlanAltitudeMode: 1,
+                hoverSpeed: 5,
+                items: [
+                    // NAV_TAKEOFF at lat=0,lon=0 → スキップされるべき
+                    { command: 22, frame: 3, params: [0, 0, 0, null, 0, 0, 50], autoContinue: true, type: "SimpleItem" },
+                    { command: 16, frame: 3, params: [0, 0, 0, null, 35.79196971850398, 139.04883949344594, 50], autoContinue: true, type: "SimpleItem" },
+                    { command: 16, frame: 3, params: [0, 0, 0, null, 35.78655862746033, 139.04593844937483, 75], autoContinue: true, type: "SimpleItem" },
+                    { command: 16, frame: 3, params: [0, 0, 0, null, 35.78479187671575, 139.043807961761, 90], autoContinue: true, type: "SimpleItem" },
+                    { command: 16, frame: 3, params: [0, 0, 0, null, 35.78177242, 139.03606576, 60], autoContinue: true, type: "SimpleItem" },
+                    { command: 16, frame: 3, params: [0, 0, 0, null, 35.780898754866946, 139.03043500185498, 50], autoContinue: true, type: "SimpleItem" },
+                    { command: 16, frame: 3, params: [0, 0, 0, null, 35.77935164, 139.02038159, 35], autoContinue: true, type: "SimpleItem" },
+                    { command: 16, frame: 3, params: [0, 0, 0, null, 35.77948819, 139.01944443, 32], autoContinue: true, type: "SimpleItem" },
+                    { command: 16, frame: 3, params: [0, 0, 0, null, 35.78012772190709, 139.01597313549905, 20], autoContinue: true, type: "SimpleItem" },
+                    { command: 21, frame: 3, params: [0, 0, 0, null, 35.7801385, 139.01591839, 0], autoContinue: true, type: "SimpleItem" },
+                ],
+                plannedHomePosition: [35.79210805, 139.04890088, 522],
+                vehicleType: 2,
+                version: 2,
+            },
+            rallyPoints: {
+                points: [
+                    [35.78970727, 139.04329378, 0],
+                    [35.78421729, 139.04349786, 0],
+                    [35.78251902, 139.02834407, 0],
+                ],
+                version: 2,
+            },
+        };
+
+        const result = parsePlan(okutamaPlan);
+
+        // ホームポジション
+        expect(result.homePosition).toEqual({ lat: 35.79210805, lon: 139.04890088, altitude: 522 });
+
+        // NAV_TAKEOFF(lat=0,lon=0) がスキップされ、残り 9 点（NAV_WAYPOINT x8 + NAV_LAND x1）
+        expect(result.waypoints).toHaveLength(9);
+        expect(result.waypoints[0].number).toBe(1);
+        expect(result.waypoints[0].command).toBe(16); // NAV_WAYPOINT
+        expect(result.waypoints[0].lat).toBeCloseTo(35.79196971850398);
+        // 高度はホーム相対: 50 + 522
+        expect(result.waypoints[0].altitude).toBe(572);
+        // 最後は NAV_LAND
+        expect(result.waypoints[8].command).toBe(21);
+
+        // ジオフェンスポリゴン 1 件
+        expect(result.geoFencePolygons).toHaveLength(1);
+        expect(result.geoFencePolygons[0].points).toHaveLength(9);
+
+        // ジオフェンス円 1 件
+        expect(result.geoFenceCircles).toHaveLength(1);
+        expect(result.geoFenceCircles[0].center).toEqual({
+            lat: 35.79185330892785,
+            lon: 139.04875075067923,
+        });
+
+        // ラリーポイント 3 件（高度はホーム相対: 0 + 522）
+        expect(result.rallyPoints).toHaveLength(3);
+        expect(result.rallyPoints[0].altitude).toBe(522); // 0 + 522
+    });
 });
 
 describe("WAYPOINT_COMMANDS", () => {

--- a/tests/plan.unit.spec.ts
+++ b/tests/plan.unit.spec.ts
@@ -47,6 +47,8 @@ describe("parsePlan", () => {
         expect(() => parsePlan(null)).toThrow("not an object");
         expect(() => parsePlan("string")).toThrow("not an object");
         expect(() => parsePlan({})).toThrow("missing mission");
+        expect(() => parsePlan({ mission: {} })).toThrow("mission.items is missing or not an array");
+        expect(() => parsePlan({ mission: { items: "not-array" } })).toThrow("mission.items is missing or not an array");
     });
 
     it("NAV_WAYPOINT(16), NAV_TAKEOFF(22), NAV_LAND(21) をウェイポイントとして抽出する", () => {

--- a/tests/plan.unit.spec.ts
+++ b/tests/plan.unit.spec.ts
@@ -1,0 +1,256 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Plan Viewer デモの純粋関数ユニットテスト (#38)。
+ *
+ * - parsePlan: QGC plan JSON のパースとフィルタリング
+ * - formatWaypointLabel / formatWaypointEdgeLabel / formatRallyPointLabel
+ */
+import { describe, it, expect } from "@jest/globals";
+
+import { parsePlan, WAYPOINT_COMMANDS } from "../src/demos/plan/parsePlan";
+import {
+    formatWaypointLabel,
+    formatWaypointEdgeLabel,
+    formatRallyPointLabel,
+    haversineDistanceMeters,
+    formatHorizontalDistance,
+    formatAltitudeDelta,
+} from "../src/demos/plan/utils";
+
+// ---- parsePlan ----
+
+describe("parsePlan", () => {
+    const minimalPlan = {
+        fileHeader: { version: 1 },
+        mission: {
+            plannedHomePosition: [35.0, 139.0, 50],
+            items: [],
+        },
+    };
+
+    it("最小限の plan を正常にパースできる", () => {
+        const result = parsePlan(minimalPlan);
+        expect(result.homePosition).toEqual({
+            lat: 35.0,
+            lon: 139.0,
+            altitude: 50,
+        });
+        expect(result.waypoints).toHaveLength(0);
+        expect(result.geoFencePolygons).toHaveLength(0);
+        expect(result.geoFenceCircles).toHaveLength(0);
+        expect(result.rallyPoints).toHaveLength(0);
+    });
+
+    it("不正な入力で例外を投げる", () => {
+        expect(() => parsePlan(null)).toThrow("not an object");
+        expect(() => parsePlan("string")).toThrow("not an object");
+        expect(() => parsePlan({})).toThrow("missing mission");
+    });
+
+    it("NAV_WAYPOINT(16), NAV_TAKEOFF(22), NAV_LAND(21) をウェイポイントとして抽出する", () => {
+        const plan = {
+            fileHeader: { version: 1 },
+            mission: {
+                plannedHomePosition: [35.0, 139.0, 100],
+                items: [
+                    { command: 22, frame: 3, params: [0, 0, 0, 0, 35.1, 139.1, 50], coordinate: [35.1, 139.1, 50] },
+                    { command: 16, frame: 3, params: [0, 0, 0, 0, 35.2, 139.2, 80], coordinate: [35.2, 139.2, 80] },
+                    { command: 178, frame: 3, params: [0, 0, 0, 0, 0, 0, 0] }, // DO_CHANGE_SPEED - スキップ
+                    { command: 16, frame: 3, params: [0, 0, 0, 0, 35.3, 139.3, 100], coordinate: [35.3, 139.3, 100] },
+                    { command: 21, frame: 3, params: [0, 0, 0, 0, 35.4, 139.4, 0], coordinate: [35.4, 139.4, 0] },
+                ],
+            },
+        };
+        const result = parsePlan(plan);
+        expect(result.waypoints).toHaveLength(4);
+        // 番号は連番でスキップ分を含まない
+        expect(result.waypoints[0].number).toBe(1);
+        expect(result.waypoints[1].number).toBe(2);
+        expect(result.waypoints[2].number).toBe(3);
+        expect(result.waypoints[3].number).toBe(4);
+        // 高度はホーム相対 (homeAlt=100) + item alt
+        expect(result.waypoints[0].altitude).toBe(150); // 50 + 100
+        expect(result.waypoints[1].altitude).toBe(180); // 80 + 100
+    });
+
+    it("coordinate フィールドがない場合 params[4..6] にフォールバックする", () => {
+        const plan = {
+            fileHeader: { version: 1 },
+            mission: {
+                plannedHomePosition: [35.0, 139.0, 0],
+                items: [
+                    { command: 16, frame: 3, params: [0, 0, 0, 0, 35.5, 139.5, 60] },
+                ],
+            },
+        };
+        const result = parsePlan(plan);
+        expect(result.waypoints).toHaveLength(1);
+        expect(result.waypoints[0].lat).toBe(35.5);
+        expect(result.waypoints[0].lon).toBe(139.5);
+        expect(result.waypoints[0].altitude).toBe(60);
+    });
+
+    it("ジオフェンスポリゴンをパースする", () => {
+        const plan = {
+            fileHeader: { version: 1 },
+            mission: { plannedHomePosition: [35.0, 139.0, 0], items: [] },
+            geoFence: {
+                polygons: [
+                    {
+                        inclusion: true,
+                        polygon: [[35.0, 139.0], [35.1, 139.0], [35.1, 139.1], [35.0, 139.1]],
+                    },
+                ],
+                circles: [],
+            },
+        };
+        const result = parsePlan(plan);
+        expect(result.geoFencePolygons).toHaveLength(1);
+        expect(result.geoFencePolygons[0].inclusion).toBe(true);
+        expect(result.geoFencePolygons[0].points).toHaveLength(4);
+    });
+
+    it("ジオフェンス円をパースする", () => {
+        const plan = {
+            fileHeader: { version: 1 },
+            mission: { plannedHomePosition: [35.0, 139.0, 0], items: [] },
+            geoFence: {
+                polygons: [],
+                circles: [
+                    { inclusion: false, circle: { center: [35.5, 139.5], radius: 500 } },
+                ],
+            },
+        };
+        const result = parsePlan(plan);
+        expect(result.geoFenceCircles).toHaveLength(1);
+        expect(result.geoFenceCircles[0].inclusion).toBe(false);
+        expect(result.geoFenceCircles[0].center).toEqual({ lat: 35.5, lon: 139.5 });
+        expect(result.geoFenceCircles[0].radius).toBe(500);
+    });
+
+    it("ラリーポイントをパースする", () => {
+        const plan = {
+            fileHeader: { version: 1 },
+            mission: { plannedHomePosition: [35.0, 139.0, 50], items: [] },
+            rallyPoints: {
+                points: [
+                    [35.1, 139.1, 30],
+                    [35.2, 139.2, 40],
+                ],
+            },
+        };
+        const result = parsePlan(plan);
+        expect(result.rallyPoints).toHaveLength(2);
+        expect(result.rallyPoints[0].number).toBe(1);
+        expect(result.rallyPoints[0].altitude).toBe(80); // 30 + 50(home)
+        expect(result.rallyPoints[1].number).toBe(2);
+        expect(result.rallyPoints[1].altitude).toBe(90); // 40 + 50(home)
+    });
+
+    it("homePosition が未定義でも動作する", () => {
+        const plan = {
+            fileHeader: { version: 1 },
+            mission: {
+                items: [
+                    { command: 16, frame: 3, params: [0, 0, 0, 0, 35.0, 139.0, 100], coordinate: [35.0, 139.0, 100] },
+                ],
+            },
+        };
+        const result = parsePlan(plan);
+        expect(result.homePosition).toBeNull();
+        expect(result.waypoints[0].altitude).toBe(100); // homeAlt=0
+    });
+});
+
+describe("WAYPOINT_COMMANDS", () => {
+    it("16, 21, 22 を含む", () => {
+        expect(WAYPOINT_COMMANDS.has(16)).toBe(true);
+        expect(WAYPOINT_COMMANDS.has(21)).toBe(true);
+        expect(WAYPOINT_COMMANDS.has(22)).toBe(true);
+    });
+
+    it("他のコマンドを含まない", () => {
+        expect(WAYPOINT_COMMANDS.has(178)).toBe(false); // DO_CHANGE_SPEED
+        expect(WAYPOINT_COMMANDS.has(20)).toBe(false); // NAV_RETURN_TO_LAUNCH
+    });
+});
+
+// ---- utils ----
+
+describe("formatWaypointLabel", () => {
+    it("番号と高度を表示する", () => {
+        const wp = { number: 3, lat: 35.0, lon: 139.0, altitude: 150.7, command: 16 };
+        expect(formatWaypointLabel(wp)).toBe("#3\n151 m");
+    });
+});
+
+describe("formatWaypointEdgeLabel", () => {
+    it("水平距離と高度差を表示する", () => {
+        const a = { number: 1, lat: 35.0, lon: 139.0, altitude: 100, command: 16 };
+        const b = { number: 2, lat: 35.0, lon: 139.01, altitude: 150, command: 16 };
+        const label = formatWaypointEdgeLabel(a, b);
+        expect(label).toContain("m");
+        expect(label).toContain("+50 m");
+    });
+});
+
+describe("formatRallyPointLabel", () => {
+    it("R + 番号を返す", () => {
+        expect(formatRallyPointLabel(1)).toBe("R1");
+        expect(formatRallyPointLabel(5)).toBe("R5");
+    });
+});
+
+describe("haversineDistanceMeters (plan utils)", () => {
+    it("同一点は 0 を返す", () => {
+        const p = { lat: 35.0, lon: 139.0 };
+        expect(haversineDistanceMeters(p, p)).toBe(0);
+    });
+
+    it("東京-大阪は概ね 400 km 前後", () => {
+        const tokyo = { lat: 35.6812, lon: 139.7671 };
+        const osaka = { lat: 34.6937, lon: 135.5023 };
+        const d = haversineDistanceMeters(tokyo, osaka);
+        expect(d).toBeGreaterThan(380_000);
+        expect(d).toBeLessThan(420_000);
+    });
+});
+
+describe("formatHorizontalDistance", () => {
+    it("1000m 未満は m 表示", () => {
+        expect(formatHorizontalDistance(500)).toBe("500 m");
+        expect(formatHorizontalDistance(999.4)).toBe("999 m");
+    });
+
+    it("1000m 以上は km 表示", () => {
+        expect(formatHorizontalDistance(1000)).toBe("1.00 km");
+        expect(formatHorizontalDistance(12345)).toBe("12.35 km");
+    });
+
+    it("異常値は - を返す", () => {
+        expect(formatHorizontalDistance(-1)).toBe("-");
+        expect(formatHorizontalDistance(NaN)).toBe("-");
+        expect(formatHorizontalDistance(Infinity)).toBe("-");
+    });
+});
+
+describe("formatAltitudeDelta", () => {
+    it("正の値に + 符号", () => {
+        expect(formatAltitudeDelta(50)).toBe("+50 m");
+    });
+
+    it("負の値に - 符号", () => {
+        expect(formatAltitudeDelta(-30)).toBe("-30 m");
+    });
+
+    it("0 前後は ±0 m", () => {
+        expect(formatAltitudeDelta(0)).toBe("±0 m");
+        expect(formatAltitudeDelta(0.3)).toBe("±0 m");
+    });
+
+    it("NaN は -", () => {
+        expect(formatAltitudeDelta(NaN)).toBe("-");
+    });
+});

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -56,6 +56,13 @@ const ENTRY_DEFINITIONS = [
         filename: "circle.html",
         title: "jpmap_terrain – サークルデモ",
     },
+    {
+        name: "plan",
+        entry: "src/demos/plan/index.ts",
+        template: "public/plan.html",
+        filename: "plan.html",
+        title: "jpmap_terrain – Plan Viewer",
+    },
 ];
 
 const entry = Object.fromEntries(

--- a/webpack.rewrites.js
+++ b/webpack.rewrites.js
@@ -18,5 +18,7 @@ module.exports = {
         { from: /^\/distance\.html(?:\/?@.*)?\/?$/, to: '/distance.html' },
         { from: /^\/circle(?:\/@.*)?\/?$/, to: '/circle.html' },
         { from: /^\/circle\.html(?:\/?@.*)?\/?$/, to: '/circle.html' },
+        { from: /^\/plan(?:\/@.*)?\/?$/, to: '/plan.html' },
+        { from: /^\/plan\.html(?:\/?@.*)?\/?$/, to: '/plan.html' },
     ],
 };


### PR DESCRIPTION
## 概要

QGroundControl の `.plan` ファイルをドラッグ&ドロップでマップ上に表示する Plan Viewer デモを新規作成。

Closes #38

## 変更内容

### 新規ファイル
- `src/demos/plan/parsePlan.ts` — Plan JSON パーサ（型定義 + MAV_CMD フィルタ + 座標抽出）
- `src/demos/plan/utils.ts` — ラベルフォーマット関数（haversine距離, 高度差）
- `src/demos/plan/index.ts` — デモエントリ（D&D + 描画ロジック）
- `public/plan.html` — HTML テンプレート
- `tests/plan.unit.spec.ts` — ユニットテスト（24件）
- `src/demos/shared/geoUtils.ts` — 共通地理計算ユーティリティ（haversine等）

### 変更ファイル
- `webpack.common.js` — ENTRY_DEFINITIONS に plan エントリ追加
- `webpack.rewrites.js` — `/plan` → `/plan.html` の dev-server / テスト用 SPA フォールバック追加
- `src/demos/portal/index.ts` — DEMO_LIST に Plan Viewer 追加
- `spec/demos.md` — デモ一覧テーブル + plan セクション追加

## 機能

- **ウェイポイント**: パスライン表示、番号(1始まり)+高度ラベル、エッジに水平距離+高度差
- **ジオフェンスポリゴン**: クローズドループ表示（ラベルなし）
- **ジオフェンス円**: 円+壁表示（中心点非表示）
- **ラリーポイント**: マーカー+番号表示
- **レイヤー切替**: ウェイポイント/ジオフェンス/ラリーポイントの表示ON/OFF
- **再ドロップ**: 前回表示クリア → 新規 Plan のみ表示

## 影響範囲

- 新規デモページ追加（既存デモ・ライブラリ層への影響なし）
- webpack バンドル: 新エントリ `plan` 追加
- ポータル: リンク 1 件追加

## 検証

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test:unit` ✅ (658 tests)