### PR TITLE
fix(#224): 湖面タイル高度乖離 — elevation ベース反復補間 + sentinel 修正

### DIFF
--- a/src/terrain/gsiTile.ts
+++ b/src/terrain/gsiTile.ts
@@ -198,11 +198,13 @@ export const loadElevationTile = async (
                     img.data[i + 2]
                 );
             }
-            // 全NaNのタイルはこのレイヤーでは使えない → 次のレイヤーへ
-            if (isAllNaN(elev)) {
-                lastErr = new Error(`All NaN tile: ${url}`);
-                continue;
-            }
+            // HTTP 成功 = このレイヤーが当該領域をカバーしているとみなす。
+            // 全 NaN（湖面など no-data 領域）でも次レイヤーへフォールバックしない。
+            // 下位レイヤー（dem5b など）は同じ場所に水面標高を返すことがあり、
+            // それを使うと湖面が押し上がる（issue #224）。
+            // all-NaN の場合は同レイヤー隣接タイルから後段（refineAllNaNTiles）の
+            // NaN 埋めで補間させる。
+            // フォールバックは HTTP 取得失敗（404 等：このレイヤー範囲外）でのみ発動。
             return elev;
         } catch (e) {
             lastErr = e;

--- a/src/terrain/gsiTile.ts
+++ b/src/terrain/gsiTile.ts
@@ -41,10 +41,30 @@ export const tileEdgeMeters = (lat: number, zoom: number): number => {
     return metersPerPixel * TILE_SIZE;
 };
 
-/** 全ピクセルが NaN かどうか判定する */
+/**
+ * 標高データの「無効値」を表す番兵値。
+ *
+ * `fillInvalidPixels` が周囲に有効値を一切見つけられず BFS でも埋められなかった
+ * ピクセルに書き込まれる。実標高で -100m に達することは現実的にない（海岸線で
+ * 観測される負値はせいぜい -数 m 程度）ため、後段の処理で「埋め残し」を一意に
+ * 識別できる。
+ *
+ * このセンチネルが残ったタイルは：
+ * - メッシュに直接適用された場合、地表より十分下に沈む（視覚的な凹みではあるが
+ *   湖面が押し上げられるよりはマシ）
+ * - 隣接タイルのステッチ参照では NaN と同等に扱われ、平均から除外される
+ *   （`tileStitching` の `nanMean` 等を参照）
+ */
+export const NO_DATA_SENTINEL = -100;
+
+/** NaN または NO_DATA_SENTINEL を「無効」とみなす */
+export const isInvalidElev = (v: number): boolean =>
+    Number.isNaN(v) || v === NO_DATA_SENTINEL;
+
+/** 全ピクセルが無効値（NaN または NO_DATA_SENTINEL）かどうか判定する */
 export const isAllNaN = (data: Float32Array): boolean => {
     for (let i = 0; i < data.length; i++) {
-        if (!Number.isNaN(data[i])) return false;
+        if (!isInvalidElev(data[i])) return false;
     }
     return true;
 };
@@ -60,7 +80,7 @@ export const decodeGsiElevation = (
     return raw < 2 ** 23 ? raw * 0.01 : (raw - 2 ** 24) * 0.01;
 };
 
-/** 無効値(NaN)を周囲の有効ピクセルからBFS(フロンティア)方式で補間する */
+/** 無効値(NaN/NO_DATA_SENTINEL)を周囲の有効ピクセルからBFS(フロンティア)方式で補間する */
 export const fillInvalidPixels = (
     elev: Float32Array,
     width: number,
@@ -73,21 +93,21 @@ export const fillInvalidPixels = (
         [-1,  1], [0,  1], [1,  1],
     ];
 
-    // BFS: 有効ピクセルに隣接する NaN をキューに入れ、波状に埋める。
+    // BFS: 有効ピクセルに隣接する無効ピクセルをキューに入れ、波状に埋める。
     // 同一ピクセルが複数回キューに入る場合があるが、処理時に埋め済みならスキップする。
     // 各ピクセルの隣接は最大8なので総キュー操作は O(width * height)。
 
-    // フロンティア初期化: NaN で、かつ隣に有効値があるピクセルを収集
+    // フロンティア初期化: 無効値で、かつ隣に有効値があるピクセルを収集
     let frontier: number[] = [];
     for (let i = 0; i < size; i++) {
-        if (!Number.isNaN(elev[i])) continue;
+        if (!isInvalidElev(elev[i])) continue;
         const x = i % width;
         const y = (i - x) / width;
         for (const [dx, dy] of offsets) {
             const nx = x + dx;
             const ny = y + dy;
             if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
-            if (!Number.isNaN(elev[ny * width + nx])) {
+            if (!isInvalidElev(elev[ny * width + nx])) {
                 frontier.push(i);
                 break;
             }
@@ -98,7 +118,7 @@ export const fillInvalidPixels = (
     while (frontier.length > 0) {
         const next: number[] = [];
         for (const idx of frontier) {
-            if (!Number.isNaN(elev[idx])) continue; // 既に埋まった
+            if (!isInvalidElev(elev[idx])) continue; // 既に埋まった
             const x = idx % width;
             const y = (idx - x) / width;
             let sum = 0;
@@ -108,20 +128,20 @@ export const fillInvalidPixels = (
                 const ny = y + dy;
                 if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
                 const v = elev[ny * width + nx];
-                if (!Number.isNaN(v)) {
+                if (!isInvalidElev(v)) {
                     sum += v;
                     count++;
                 }
             }
             if (count > 0) {
                 elev[idx] = sum / count;
-                // 新たに埋まったピクセルの隣の NaN を次のフロンティアに追加
+                // 新たに埋まったピクセルの隣の無効値を次のフロンティアに追加
                 for (const [dx, dy] of offsets) {
                     const nx = x + dx;
                     const ny = y + dy;
                     if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
                     const ni = ny * width + nx;
-                    if (Number.isNaN(elev[ni])) {
+                    if (isInvalidElev(elev[ni])) {
                         next.push(ni);
                     }
                 }
@@ -130,9 +150,12 @@ export const fillInvalidPixels = (
         frontier = next;
     }
 
-    // 全ピクセル無効等で残った NaN は 0 にフォールバック
+    // 全ピクセル無効等で残った無効値は NO_DATA_SENTINEL にフォールバック。
+    // 0 にすると後段の `isAllNaN` 判定で「有効」と誤認されてしまうため、
+    // 後で再ステッチ→再 fill が走った際に再度埋め直し対象にできるよう
+    // センチネル値で残しておく。
     for (let i = 0; i < size; i++) {
-        if (Number.isNaN(elev[i])) elev[i] = 0;
+        if (Number.isNaN(elev[i])) elev[i] = NO_DATA_SENTINEL;
     }
 };
 

--- a/src/terrain/tileCache.ts
+++ b/src/terrain/tileCache.ts
@@ -14,6 +14,11 @@ export interface TileCacheEntry {
      * wasAllNaN かつ unblocked=false なら隣接データとして利用しない。
      */
     unblocked?: boolean;
+    /**
+     * refineAllNaNTiles のレスキューパス（代表標高による平坦化）で filled を設定した場合に true。
+     * 次の refineAllNaNTiles 呼び出しで BFS 補間による上書きを試みるためリセット対象とする。
+     */
+    isRescue?: boolean;
 }
 
 export interface TileCache {

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -753,13 +753,19 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         }
         if (allNanTiles.length === 0) return;
 
-        // Step 1: wasAllNaN タイルをリセット（前回の rescue 値も含めて毎回やり直す）
+        // Step 1: まだ解決していないタイル（未解決 or レスキュー経由）のみリセット。
+        // BFS 補間で解決済みのタイルはスキップし、再計算コストを抑える。
         for (const [key] of allNanTiles) {
             const entry = cache.get(key);
-            if (entry) { entry.filled = undefined; entry.unblocked = false; }
+            if (entry && (!entry.unblocked || entry.isRescue)) {
+                entry.filled = undefined;
+                entry.unblocked = false;
+                entry.isRescue = false;
+            }
         }
 
         // Step 2: 反復ステッチ + NaN 埋め
+        const resolvedInThisCall = new Set<TileKey>();
         for (let iter = 0; iter < ALL_NAN_REFINE_MAX_ITER; iter++) {
             let resolvedThisIter = 0;
             let remainingCount = 0;
@@ -792,16 +798,18 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
                     entry.unblocked = true;
                     resolvedThisIter++;
                     remainingCount--;
+                    resolvedInThisCall.add(key);
                 }
             }
 
             if (remainingCount === 0 || resolvedThisIter === 0) break;
         }
 
-        // Step 3: メッシュ適用（解決済みタイルのみ）
+        // Step 3: メッシュ適用（今回新たに解決したタイルのみ）
         let progressed = false;
-        for (const [, tile] of allNanTiles) {
-            const entry = cache.get(toTileKey(tile.coord));
+        for (const [key, tile] of allNanTiles) {
+            if (!resolvedInThisCall.has(key)) continue;
+            const entry = cache.get(key);
             if (!entry?.filled) continue;
             applyElevationDataToMesh(tile.mesh, entry.filled);
             progressed = true;
@@ -832,6 +840,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
                     const filled = new Float32Array(TILE_SIZE * TILE_SIZE).fill(fallbackElev);
                     entry.filled = filled;
                     entry.unblocked = true;
+                    entry.isRescue = true;
                     applyElevationDataToMesh(tile.mesh, filled);
                 }
                 progressed = true;

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -25,6 +25,7 @@ import {
     fillInvalidPixels,
     isAllNaN,
     isInvalidElev,
+    NO_DATA_SENTINEL,
 } from "./gsiTile";
 import { stitchTileEdges, stitchTileEdgesCrossLevel } from "./tileStitching";
 import type { CoarseEdgeNeighbor } from "./tileStitching";
@@ -650,7 +651,17 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         const { stitched, hasSeed } = stitchAndCheckSeed(elevation, coord, crossLevel);
 
         // NaN を埋める（BFS）
-        fillInvalidPixels(stitched, TILE_SIZE, TILE_SIZE);
+        // wasAllNaN でシードなしの場合、フロンティアが空で BFS は進まず
+        // 全ピクセル走査だけが発生する（256×256 で無駄）。
+        // この場合は fillInvalidPixels をスキップし sentinel で直接埋める。
+        const isAllNanNoSeed = !!cacheEntryPre?.wasAllNaN && !hasSeed;
+        if (!isAllNanNoSeed) {
+            fillInvalidPixels(stitched, TILE_SIZE, TILE_SIZE);
+        } else {
+            for (let i = 0; i < stitched.length; i++) {
+                if (isInvalidElev(stitched[i])) stitched[i] = NO_DATA_SENTINEL;
+            }
+        }
 
         // メッシュに適用:
         // - シードあり: 今回のステッチ結果を使用

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -819,7 +819,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
             let count = 0;
             for (const [, tile] of activeTiles) {
                 const entry = cache.get(toTileKey(tile.coord));
-                if (!entry || entry.wasAllNaN) continue;
+                if (!entry || (entry.wasAllNaN && !entry.unblocked)) continue;
                 const data = entry.filled ?? entry.elevation;
                 const v = data[(TILE_SIZE >> 1) * TILE_SIZE + (TILE_SIZE >> 1)];
                 if (!isInvalidElev(v)) { sum += v; count++; }

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -24,6 +24,7 @@ import {
     MapType,
     fillInvalidPixels,
     isAllNaN,
+    isInvalidElev,
 } from "./gsiTile";
 import { stitchTileEdges, stitchTileEdgesCrossLevel } from "./tileStitching";
 import type { CoarseEdgeNeighbor } from "./tileStitching";
@@ -632,17 +633,17 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
             }
         }
 
-        // wasAllNaN タイルのシード判定（ステッチ後、辺に非 NaN が 1 つでもあるか）
+        // wasAllNaN タイルのシード判定（ステッチ後、辺に有効値が 1 つでもあるか）
         let hasSeed = false;
         if (cacheEntryPre?.wasAllNaN) {
             const last = TILE_SIZE - 1;
             for (let i = 0; i < TILE_SIZE && !hasSeed; i++) {
                 // 上辺・下辺
-                if (!Number.isNaN(stitched[i])) { hasSeed = true; break; }
-                if (!Number.isNaN(stitched[last * TILE_SIZE + i])) { hasSeed = true; break; }
+                if (!isInvalidElev(stitched[i])) { hasSeed = true; break; }
+                if (!isInvalidElev(stitched[last * TILE_SIZE + i])) { hasSeed = true; break; }
                 // 左辺・右辺
-                if (!Number.isNaN(stitched[i * TILE_SIZE])) { hasSeed = true; break; }
-                if (!Number.isNaN(stitched[i * TILE_SIZE + last])) { hasSeed = true; break; }
+                if (!isInvalidElev(stitched[i * TILE_SIZE])) { hasSeed = true; break; }
+                if (!isInvalidElev(stitched[i * TILE_SIZE + last])) { hasSeed = true; break; }
             }
         }
 
@@ -766,10 +767,10 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
                 const last = TILE_SIZE - 1;
                 let hasSeed = false;
                 for (let i = 0; i < TILE_SIZE && !hasSeed; i++) {
-                    if (!Number.isNaN(stitched[i])) { hasSeed = true; break; }
-                    if (!Number.isNaN(stitched[last * TILE_SIZE + i])) { hasSeed = true; break; }
-                    if (!Number.isNaN(stitched[i * TILE_SIZE])) { hasSeed = true; break; }
-                    if (!Number.isNaN(stitched[i * TILE_SIZE + last])) { hasSeed = true; break; }
+                    if (!isInvalidElev(stitched[i])) { hasSeed = true; break; }
+                    if (!isInvalidElev(stitched[last * TILE_SIZE + i])) { hasSeed = true; break; }
+                    if (!isInvalidElev(stitched[i * TILE_SIZE])) { hasSeed = true; break; }
+                    if (!isInvalidElev(stitched[i * TILE_SIZE + last])) { hasSeed = true; break; }
                 }
 
                 if (hasSeed) {
@@ -808,7 +809,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
                 if (!entry || entry.wasAllNaN) continue;
                 const data = entry.filled ?? entry.elevation;
                 const v = data[(TILE_SIZE >> 1) * TILE_SIZE + (TILE_SIZE >> 1)];
-                if (!Number.isNaN(v)) { sum += v; count++; }
+                if (!isInvalidElev(v)) { sum += v; count++; }
             }
             if (count > 0) {
                 const fallbackElev = sum / count;
@@ -855,10 +856,10 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
             const px = Math.min(TILE_SIZE - 1, Math.max(0, Math.round(fx * (TILE_SIZE - 1))));
             const py = Math.min(TILE_SIZE - 1, Math.max(0, Math.round(fy * (TILE_SIZE - 1))));
             const val = data[py * TILE_SIZE + px];
-            if (!Number.isNaN(val)) {
+            if (!isInvalidElev(val)) {
                 return (val + currentAltitudeOffset) * heightScale;
             }
-            // NaN の場合は近傍8ピクセルから補間（fillInvalidPixels と同等の方針）。
+            // 無効値の場合は近傍8ピクセルから補間（fillInvalidPixels と同等の方針）。
             // 近傍にも有効値がなければ低 zoom へフォールバックする。
             let sum = 0;
             let count = 0;
@@ -869,7 +870,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
                     const ny = py + dy;
                     if (nx < 0 || nx >= TILE_SIZE || ny < 0 || ny >= TILE_SIZE) continue;
                     const nv = data[ny * TILE_SIZE + nx];
-                    if (!Number.isNaN(nv)) {
+                    if (!isInvalidElev(nv)) {
                         sum += nv;
                         count++;
                     }

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -590,26 +590,31 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         return result;
     };
 
+    /** 補間済み標高データをメッシュ頂点・法線に反映する */
+    const applyElevationDataToMesh = (mesh: Mesh, filled: Float32Array): void => {
+        const pos = mesh.getVerticesData(VertexBuffer.PositionKind);
+        const idx = mesh.getIndices();
+        if (!pos || !idx) return;
+        const typed = pos instanceof Float32Array ? pos : new Float32Array(pos);
+        applyElevation(typed, filled, currentAltitudeOffset, heightScale, subdivisions);
+        mesh.updateVerticesData(VertexBuffer.PositionKind, typed);
+        const normals = new Float32Array(typed.length);
+        VertexData.ComputeNormals(typed, idx, normals);
+        mesh.updateVerticesData(VertexBuffer.NormalKind, normals);
+        mesh.refreshBoundingInfo();
+    };
+
     /** タイルの標高データをステッチ＋NaN埋めしてメッシュに適用 */
     const applyStitchedElevation = (
         mesh: Mesh,
         elevation: Float32Array,
         coord: TileCoord,
     ): void => {
-        const pos = mesh.getVerticesData(VertexBuffer.PositionKind);
-        const idx = mesh.getIndices();
-        if (!pos || !idx) return;
-
-        const typed = pos instanceof Float32Array ? pos : new Float32Array(pos);
-
-        // wasAllNaN かつ既に unblocked なタイルは filled を再ステッチのベースに使い状態を保持
         const cacheEntryPre = cache.get(toTileKey(coord));
-        const base = (cacheEntryPre?.wasAllNaN && cacheEntryPre.unblocked && cacheEntryPre.filled)
-            ? cacheEntryPre.filled
-            : elevation;
 
-        // 標高データのコピーを作成（キャッシュの元データを保持するため）
-        const stitched = new Float32Array(base);
+        // 常に元データ(elevation)からコピー。
+        // 再ステッチ時に古い filled を引き継がないことで、隣接ズーム変更後も正しい値に収束する。
+        const stitched = new Float32Array(elevation);
 
         // 隣接タイルと辺を縫い合わせ（同 zoom）
         const neighbors = getNeighborElevations(coord);
@@ -627,10 +632,9 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
             }
         }
 
-        // BFS シードが存在するか（縫い合わせ後に非 NaN が1つでもあるか）を判定。
-        // all-NaN だったタイルのみ判定が必要。シードは辺に入るため外周のみ走査。
+        // wasAllNaN タイルのシード判定（ステッチ後、辺に非 NaN が 1 つでもあるか）
         let hasSeed = false;
-        if (cacheEntryPre?.wasAllNaN && !cacheEntryPre.unblocked) {
+        if (cacheEntryPre?.wasAllNaN) {
             const last = TILE_SIZE - 1;
             for (let i = 0; i < TILE_SIZE && !hasSeed; i++) {
                 // 上辺・下辺
@@ -642,23 +646,21 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
             }
         }
 
-        // NaN を埋める
+        // NaN を埋める（BFS）
         fillInvalidPixels(stitched, TILE_SIZE, TILE_SIZE);
 
-        // メッシュに適用
-        applyElevation(typed, stitched, currentAltitudeOffset, heightScale, subdivisions);
-        mesh.updateVerticesData(VertexBuffer.PositionKind, typed);
-        const normals = new Float32Array(typed.length);
-        VertexData.ComputeNormals(typed, idx, normals);
-        mesh.updateVerticesData(VertexBuffer.NormalKind, normals);
-        mesh.refreshBoundingInfo();
+        // メッシュに適用:
+        // - シードあり: 今回のステッチ結果を使用
+        // - シードなし（wasAllNaN）: 旧 filled があれば維持（Y=0 凹み防止）
+        const meshData = (cacheEntryPre?.wasAllNaN && !hasSeed && cacheEntryPre.filled)
+            ? cacheEntryPre.filled
+            : stitched;
+        applyElevationDataToMesh(mesh, meshData);
 
-        // キャッシュに補間結果を記録（後続の反復補間で隣接データとして利用される）
-        if (cacheEntryPre) {
-            if (cacheEntryPre.wasAllNaN) {
-                cacheEntryPre.filled = stitched;
-                cacheEntryPre.unblocked = cacheEntryPre.unblocked || hasSeed;
-            }
+        // キャッシュ更新: シードが得られた場合のみ filled/unblocked を更新
+        if (cacheEntryPre?.wasAllNaN && hasSeed) {
+            cacheEntryPre.filled = stitched;
+            cacheEntryPre.unblocked = true;
         }
     };
 
@@ -717,54 +719,96 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
     };
 
     /**
-     * 元データが all-NaN だったタイルを反復的に再ステッチして補間する。
-     * 1 回目で隣接が all-NaN でシードが得られなかったタイルでも、
-     * 隣接が他の有効値タイルから順次補間されることで段階的にエッジが埋まる。
-     * 進展が無くなるか上限回数に達するまで繰り返す。
-     * 反復後も解決しないタイルは、活性タイルの代表標高で平坦に埋める（湖中央の凹み防止）。
+     * 元データが all-NaN だったタイルを反復的に補間する。
+     *
+     * アルゴリズム:
+     * 1. wasAllNaN タイルをリセット（filled/unblocked をクリア）
+     *    ※非 wasAllNaN タイルは loadTile/flushRestitch で filled 設定済み（NaN 埋め済み）
+     * 2. 反復: elevation ベース（all-NaN）でステッチ → 辺シード有りなら NaN 埋め
+     *    隣接に解決済みタイルが増えるたびに波状に補間が進む
+     * 3. 解決済みタイルのみメッシュ適用（反復中は適用しない）
+     * 4. 到達不能タイルはレスキューパス（代表標高で平坦化）
      */
-    const ALL_NAN_REFINE_MAX_ITER = 16;
+    const ALL_NAN_REFINE_MAX_ITER = 32;
     const refineAllNaNTiles = (): void => {
-        let progressed = false;
-        for (let iter = 0; iter < ALL_NAN_REFINE_MAX_ITER; iter++) {
-            let progress = false;
-            for (const [key, tile] of activeTiles) {
-                const entry = cache.get(key);
-                if (!entry?.wasAllNaN) continue;
-                if (entry.unblocked) continue;
-                applyStitchedElevation(tile.mesh, entry.elevation, tile.coord);
-                if (entry.unblocked) {
-                    progress = true;
-                    progressed = true;
-                }
-            }
-            if (!progress) break;
-        }
-
-        // レスキューパス: まだ解決できない all-NaN タイルがあれば、
-        // 活性タイルの代表標高（中央値近似: 平均）で平坦に埋めて Y=0 凹みを防ぐ。
-        const stillBlocked: Array<[string, ActiveTile]> = [];
+        // wasAllNaN タイルを収集
+        const allNanTiles: Array<[TileKey, ActiveTile]> = [];
         for (const [key, tile] of activeTiles) {
             const entry = cache.get(key);
-            if (entry?.wasAllNaN && !entry.unblocked) {
-                stillBlocked.push([key, tile]);
+            if (entry?.wasAllNaN) allNanTiles.push([key, tile]);
+        }
+        if (allNanTiles.length === 0) return;
+
+        // Step 1: wasAllNaN タイルをリセット（前回の rescue 値も含めて毎回やり直す）
+        for (const [key] of allNanTiles) {
+            const entry = cache.get(key);
+            if (entry) { entry.filled = undefined; entry.unblocked = false; }
+        }
+
+        // Step 2: 反復ステッチ + NaN 埋め
+        for (let iter = 0; iter < ALL_NAN_REFINE_MAX_ITER; iter++) {
+            let resolvedThisIter = 0;
+            let remainingCount = 0;
+
+            for (const [key, tile] of allNanTiles) {
+                const entry = cache.get(key);
+                if (!entry || entry.unblocked) continue; // 解決済みはスキップ
+
+                remainingCount++;
+
+                // elevation ベース（all-NaN）でステッチ
+                const stitched = new Float32Array(entry.elevation);
+                stitchTileEdges(stitched, getNeighborElevations(tile.coord), TILE_SIZE);
+                const coarse = getCoarseEdgeNeighbors(tile.coord);
+                if (coarse.length > 0) stitchTileEdgesCrossLevel(stitched, coarse, TILE_SIZE);
+
+                // 辺シード判定
+                const last = TILE_SIZE - 1;
+                let hasSeed = false;
+                for (let i = 0; i < TILE_SIZE && !hasSeed; i++) {
+                    if (!Number.isNaN(stitched[i])) { hasSeed = true; break; }
+                    if (!Number.isNaN(stitched[last * TILE_SIZE + i])) { hasSeed = true; break; }
+                    if (!Number.isNaN(stitched[i * TILE_SIZE])) { hasSeed = true; break; }
+                    if (!Number.isNaN(stitched[i * TILE_SIZE + last])) { hasSeed = true; break; }
+                }
+
+                if (hasSeed) {
+                    fillInvalidPixels(stitched, TILE_SIZE, TILE_SIZE);
+                    entry.filled = stitched;
+                    entry.unblocked = true;
+                    resolvedThisIter++;
+                    remainingCount--;
+                }
             }
+
+            if (remainingCount === 0 || resolvedThisIter === 0) break;
+        }
+
+        // Step 3: メッシュ適用（解決済みタイルのみ）
+        let progressed = false;
+        for (const [, tile] of allNanTiles) {
+            const entry = cache.get(toTileKey(tile.coord));
+            if (!entry?.filled) continue;
+            applyElevationDataToMesh(tile.mesh, entry.filled);
+            progressed = true;
+        }
+
+        // Step 4: レスキューパス（反復で到達できなかったタイルを代表標高で平坦化）
+        const stillBlocked: Array<[string, ActiveTile]> = [];
+        for (const [key, tile] of allNanTiles) {
+            const entry = cache.get(key);
+            if (entry?.wasAllNaN && !entry.unblocked) stillBlocked.push([key, tile]);
         }
         if (stillBlocked.length > 0) {
-            // 代表標高: 解決済みタイル（filled or elevation）からサンプリング
+            // 解決済みタイルの代表標高（中央値近似: 平均）
             let sum = 0;
             let count = 0;
             for (const [, tile] of activeTiles) {
                 const entry = cache.get(toTileKey(tile.coord));
-                if (!entry) continue;
-                if (entry.wasAllNaN && !entry.unblocked) continue;
+                if (!entry || entry.wasAllNaN) continue;
                 const data = entry.filled ?? entry.elevation;
-                // タイル中心1点をサンプリング（コスト抑制）
                 const v = data[(TILE_SIZE >> 1) * TILE_SIZE + (TILE_SIZE >> 1)];
-                if (!Number.isNaN(v)) {
-                    sum += v;
-                    count++;
-                }
+                if (!Number.isNaN(v)) { sum += v; count++; }
             }
             if (count > 0) {
                 const fallbackElev = sum / count;
@@ -774,17 +818,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
                     const filled = new Float32Array(TILE_SIZE * TILE_SIZE).fill(fallbackElev);
                     entry.filled = filled;
                     entry.unblocked = true;
-                    // メッシュに直接適用
-                    const pos = tile.mesh.getVerticesData(VertexBuffer.PositionKind);
-                    const idx = tile.mesh.getIndices();
-                    if (!pos || !idx) continue;
-                    const typed = pos instanceof Float32Array ? pos : new Float32Array(pos);
-                    applyElevation(typed, filled, currentAltitudeOffset, heightScale, subdivisions);
-                    tile.mesh.updateVerticesData(VertexBuffer.PositionKind, typed);
-                    const normals = new Float32Array(typed.length);
-                    VertexData.ComputeNormals(typed, idx, normals);
-                    tile.mesh.updateVerticesData(VertexBuffer.NormalKind, normals);
-                    tile.mesh.refreshBoundingInfo();
+                    applyElevationDataToMesh(tile.mesh, filled);
                 }
                 progressed = true;
             }

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -605,6 +605,34 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         mesh.refreshBoundingInfo();
     };
 
+    /**
+     * elevation をコピーしてステッチ（同zoom + cross-level）を適用し、
+     * 辺に有効値（シード）があるかを判定する共通ヘルパー。
+     */
+    const stitchAndCheckSeed = (
+        elevation: Float32Array,
+        coord: TileCoord,
+        crossLevel: boolean,
+    ): { stitched: Float32Array; hasSeed: boolean } => {
+        const stitched = new Float32Array(elevation);
+        stitchTileEdges(stitched, getNeighborElevations(coord), TILE_SIZE);
+        if (crossLevel) {
+            const coarse = getCoarseEdgeNeighbors(coord);
+            if (coarse.length > 0) stitchTileEdgesCrossLevel(stitched, coarse, TILE_SIZE);
+        }
+
+        const last = TILE_SIZE - 1;
+        let hasSeed = false;
+        for (let i = 0; i < TILE_SIZE && !hasSeed; i++) {
+            if (!isInvalidElev(stitched[i])) { hasSeed = true; break; }
+            if (!isInvalidElev(stitched[last * TILE_SIZE + i])) { hasSeed = true; break; }
+            if (!isInvalidElev(stitched[i * TILE_SIZE])) { hasSeed = true; break; }
+            if (!isInvalidElev(stitched[i * TILE_SIZE + last])) { hasSeed = true; break; }
+        }
+
+        return { stitched, hasSeed };
+    };
+
     /** タイルの標高データをステッチ＋NaN埋めしてメッシュに適用 */
     const applyStitchedElevation = (
         mesh: Mesh,
@@ -613,39 +641,13 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
     ): void => {
         const cacheEntryPre = cache.get(toTileKey(coord));
 
-        // 常に元データ(elevation)からコピー。
-        // 再ステッチ時に古い filled を引き継がないことで、隣接ズーム変更後も正しい値に収束する。
-        const stitched = new Float32Array(elevation);
-
-        // 隣接タイルと辺を縫い合わせ（同 zoom）
-        const neighbors = getNeighborElevations(coord);
-        stitchTileEdges(stitched, neighbors, TILE_SIZE);
-
         // 異 zoom 隣接（粗タイル）と縫い合わせ。
         // - 通常タイルはカメラ近傍のみ対象（再適用時の計算コスト抑制）
         // - all-NaN タイルは同 zoom 近傍からシードが得られない場合があるため
         //   カメラ距離に関わらず常に試行する
         const tileSize = tileSizeForZoom(coord.zoom);
-        if (cacheEntryPre?.wasAllNaN || isTileNearCamera(coord, tileSize)) {
-            const coarse = getCoarseEdgeNeighbors(coord);
-            if (coarse.length > 0) {
-                stitchTileEdgesCrossLevel(stitched, coarse, TILE_SIZE);
-            }
-        }
-
-        // wasAllNaN タイルのシード判定（ステッチ後、辺に有効値が 1 つでもあるか）
-        let hasSeed = false;
-        if (cacheEntryPre?.wasAllNaN) {
-            const last = TILE_SIZE - 1;
-            for (let i = 0; i < TILE_SIZE && !hasSeed; i++) {
-                // 上辺・下辺
-                if (!isInvalidElev(stitched[i])) { hasSeed = true; break; }
-                if (!isInvalidElev(stitched[last * TILE_SIZE + i])) { hasSeed = true; break; }
-                // 左辺・右辺
-                if (!isInvalidElev(stitched[i * TILE_SIZE])) { hasSeed = true; break; }
-                if (!isInvalidElev(stitched[i * TILE_SIZE + last])) { hasSeed = true; break; }
-            }
-        }
+        const crossLevel = !!cacheEntryPre?.wasAllNaN || isTileNearCamera(coord, tileSize);
+        const { stitched, hasSeed } = stitchAndCheckSeed(elevation, coord, crossLevel);
 
         // NaN を埋める（BFS）
         fillInvalidPixels(stitched, TILE_SIZE, TILE_SIZE);
@@ -776,21 +778,8 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
 
                 remainingCount++;
 
-                // elevation ベース（all-NaN）でステッチ
-                const stitched = new Float32Array(entry.elevation);
-                stitchTileEdges(stitched, getNeighborElevations(tile.coord), TILE_SIZE);
-                const coarse = getCoarseEdgeNeighbors(tile.coord);
-                if (coarse.length > 0) stitchTileEdgesCrossLevel(stitched, coarse, TILE_SIZE);
-
-                // 辺シード判定
-                const last = TILE_SIZE - 1;
-                let hasSeed = false;
-                for (let i = 0; i < TILE_SIZE && !hasSeed; i++) {
-                    if (!isInvalidElev(stitched[i])) { hasSeed = true; break; }
-                    if (!isInvalidElev(stitched[last * TILE_SIZE + i])) { hasSeed = true; break; }
-                    if (!isInvalidElev(stitched[i * TILE_SIZE])) { hasSeed = true; break; }
-                    if (!isInvalidElev(stitched[i * TILE_SIZE + last])) { hasSeed = true; break; }
-                }
+                // wasAllNaN → 常に cross-level stitch を実行
+                const { stitched, hasSeed } = stitchAndCheckSeed(entry.elevation, tile.coord, true);
 
                 if (hasSeed) {
                     fillInvalidPixels(stitched, TILE_SIZE, TILE_SIZE);

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -808,7 +808,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         }
 
         // Step 4: レスキューパス（反復で到達できなかったタイルを代表標高で平坦化）
-        const stillBlocked: Array<[string, ActiveTile]> = [];
+        const stillBlocked: Array<[TileKey, ActiveTile]> = [];
         for (const [key, tile] of allNanTiles) {
             const entry = cache.get(key);
             if (entry?.wasAllNaN && !entry.unblocked) stillBlocked.push([key, tile]);

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -658,10 +658,23 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
             : stitched;
         applyElevationDataToMesh(mesh, meshData);
 
-        // キャッシュ更新: シードが得られた場合のみ filled/unblocked を更新
-        if (cacheEntryPre?.wasAllNaN && hasSeed) {
-            cacheEntryPre.filled = stitched;
-            cacheEntryPre.unblocked = true;
+        // キャッシュ更新:
+        // - wasAllNaN + シードあり: filled/unblocked を更新
+        // - 通常タイル: filled を常に更新。
+        //   NaN 埋め済みデータ（entry.filled）を保存しておくことで、
+        //   後から refineAllNaNTiles が隣接参照する際に岸タイルの
+        //   lake 側エッジ NaN が補間済みの値を返せるようになる。
+        //   これがないと getNeighborElevations が生 elevation（エッジ NaN あり）を
+        //   返し、all-NaN タイルへシードが伝搬せずレスキューパスが誤った高度を適用する。
+        if (cacheEntryPre) {
+            if (cacheEntryPre.wasAllNaN) {
+                if (hasSeed) {
+                    cacheEntryPre.filled = stitched;
+                    cacheEntryPre.unblocked = true;
+                }
+            } else {
+                cacheEntryPre.filled = stitched;
+            }
         }
     };
 

--- a/src/terrain/tileStitching.ts
+++ b/src/terrain/tileStitching.ts
@@ -1,5 +1,7 @@
 /** 隣接タイルの標高データを辺・頂点で縫い合わせるユーティリティ */
 
+import { isInvalidElev } from "./gsiTile";
+
 /** 隣接タイルの標高データ（同一zoomレベルのみ） */
 export interface StitchNeighbors {
     top?: Float32Array;
@@ -12,12 +14,12 @@ export interface StitchNeighbors {
     bottomRight?: Float32Array;
 }
 
-/** NaN を除外した平均値を返す。すべて NaN なら NaN */
+/** 無効値(NaN/NO_DATA_SENTINEL)を除外した平均値を返す。すべて無効なら NaN */
 export const nanMean = (values: readonly number[]): number => {
     let sum = 0;
     let count = 0;
     for (const v of values) {
-        if (!Number.isNaN(v)) {
+        if (!isInvalidElev(v)) {
             sum += v;
             count++;
         }
@@ -206,8 +208,8 @@ export const stitchTileEdgesCrossLevel = (
             const a = n.elevation[coarseIdxLo];
             const b = n.elevation[coarseIdxHi];
             let v: number;
-            const aNaN = Number.isNaN(a);
-            const bNaN = Number.isNaN(b);
+            const aNaN = isInvalidElev(a);
+            const bNaN = isInvalidElev(b);
             if (aNaN && bNaN) continue;
             else if (aNaN) v = b;
             else if (bNaN) v = a;

--- a/tests/gsiTile.unit.spec.ts
+++ b/tests/gsiTile.unit.spec.ts
@@ -411,7 +411,7 @@ describe("loadElevationTile", () => {
         const allNanImageData = makeImageDataResult(128, 0, 0);
         setupLoadImageMocks(allNanImageData);
 
-        const fetchMock = jest.fn(() =>
+        const fetchMock = jest.fn<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>(() =>
             Promise.resolve({ ok: true, blob: () => Promise.resolve(new Blob()) } as Response)
         );
         globalThis.fetch = fetchMock;
@@ -434,7 +434,7 @@ describe("loadElevationTile", () => {
         setupLoadImageMocks(validImageData);
 
         let callCount = 0;
-        const fetchMock = jest.fn(() => {
+        const fetchMock = jest.fn<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>(() => {
             callCount++;
             if (callCount === 1) {
                 // dem5a: HTTP 失敗

--- a/tests/gsiTile.unit.spec.ts
+++ b/tests/gsiTile.unit.spec.ts
@@ -261,10 +261,10 @@ describe("fillInvalidPixels", () => {
         expect(data[4]).toBe(10);
     });
 
-    it("全 NaN の場合は 0 にフォールバックする", () => {
+    it("全 NaN の場合は NO_DATA_SENTINEL (-100) にフォールバックする", () => {
         const data = new Float32Array([NaN, NaN, NaN, NaN]);
         fillInvalidPixels(data, 2, 2);
-        expect(Array.from(data)).toEqual([0, 0, 0, 0]);
+        expect(Array.from(data)).toEqual([-100, -100, -100, -100]);
     });
 
     it("大きな NaN 領域を完全に埋める（旧16パスでは届かない距離）", () => {

--- a/tests/gsiTile.unit.spec.ts
+++ b/tests/gsiTile.unit.spec.ts
@@ -1,3 +1,4 @@
+import { jest } from "@jest/globals";
 import {
     TILE_SIZE,
     JAPAN_BOUNDS,
@@ -11,6 +12,7 @@ import {
     photoTextureUrl,
     textureUrl,
     NO_DATA_SENTINEL,
+    loadElevationTile,
 } from "../src/terrain/gsiTile";
 
 describe("TILE_SIZE", () => {
@@ -357,5 +359,115 @@ describe("fillInvalidPixels", () => {
         for (let y = 0; y < H; y++) {
             expect(data[y * W]).toBe(30);
         }
+    });
+});
+
+// ---------- loadElevationTile ----------
+// loadImageData (module-private) が fetch → createImageBitmap → Canvas を使うため
+// ブラウザ API をモックして loadElevationTile のフォールバック挙動をテストする。
+
+/** 指定 RGBA を返す最小 ImageData 風オブジェクト (1×1) を作るヘルパー */
+const makeImageDataResult = (r: number, g: number, b: number): ImageData => ({
+    width: 1,
+    height: 1,
+    data: new Uint8ClampedArray([r, g, b, 255]),
+    colorSpace: "srgb",
+});
+
+/** loadImageData 内部で使われるブラウザ API をモックするセットアップ */
+const setupLoadImageMocks = (imageData: ImageData) => {
+    const mockCtx = {
+        drawImage: jest.fn(),
+        getImageData: jest.fn(() => imageData),
+    };
+    const mockCanvas = {
+        width: 0,
+        height: 0,
+        getContext: jest.fn(() => mockCtx),
+    };
+    // node 環境では document が存在しない場合があるため globalThis にセット
+    (globalThis as Record<string, unknown>).document = {
+        createElement: jest.fn(() => mockCanvas),
+    };
+    (globalThis as Record<string, unknown>).createImageBitmap = jest.fn(() =>
+        Promise.resolve({ width: imageData.width, height: imageData.height, close: jest.fn() })
+    );
+};
+
+describe("loadElevationTile", () => {
+    const originalFetch = globalThis.fetch;
+    const originalCreateImageBitmap = (globalThis as Record<string, unknown>).createImageBitmap;
+    const originalDocument = (globalThis as Record<string, unknown>).document;
+
+    afterEach(() => {
+        globalThis.fetch = originalFetch;
+        (globalThis as Record<string, unknown>).createImageBitmap = originalCreateImageBitmap;
+        (globalThis as Record<string, unknown>).document = originalDocument;
+        jest.restoreAllMocks();
+    });
+
+    it("HTTP 成功で all-NaN でも次レイヤーへフォールバックしない", async () => {
+        // dem5a が all-NaN (R=128,G=0,B=0) を返す → そのまま返すべき
+        const allNanImageData = makeImageDataResult(128, 0, 0);
+        setupLoadImageMocks(allNanImageData);
+
+        const fetchMock = jest.fn(() =>
+            Promise.resolve({ ok: true, blob: () => Promise.resolve(new Blob()) } as Response)
+        );
+        globalThis.fetch = fetchMock;
+
+        const elev = await loadElevationTile(15, 100, 200);
+
+        // dem5a のみ呼ばれ、dem5b/dem には行かない
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock.mock.calls[0][0]).toContain("dem5a_png");
+
+        // 返却値は all-NaN
+        expect(elev).toBeInstanceOf(Float32Array);
+        expect(elev.length).toBe(1);
+        expect(Number.isNaN(elev[0])).toBe(true);
+    });
+
+    it("HTTP 失敗時のみ次レイヤーへフォールバックする", async () => {
+        // dem5a → 404, dem5b → 有効データ (R=0, G=100, B=0 → 25600*0.01 = 256.0)
+        const validImageData = makeImageDataResult(0, 100, 0);
+        setupLoadImageMocks(validImageData);
+
+        let callCount = 0;
+        const fetchMock = jest.fn(() => {
+            callCount++;
+            if (callCount === 1) {
+                // dem5a: HTTP 失敗
+                return Promise.resolve({ ok: false, status: 404 } as Response);
+            }
+            // dem5b: HTTP 成功
+            return Promise.resolve({ ok: true, blob: () => Promise.resolve(new Blob()) } as Response);
+        });
+        globalThis.fetch = fetchMock;
+
+        const elev = await loadElevationTile(15, 100, 200);
+
+        // dem5a → 失敗, dem5b → 成功 で 2 回呼ばれる
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(fetchMock.mock.calls[0][0]).toContain("dem5a_png");
+        expect(fetchMock.mock.calls[1][0]).toContain("dem5b_png");
+
+        // dem5b の有効値が返る
+        expect(elev).toBeInstanceOf(Float32Array);
+        expect(Number.isNaN(elev[0])).toBe(false);
+    });
+
+    it("全レイヤー HTTP 失敗時はエラーを投げる", async () => {
+        const fetchMock = jest.fn(() =>
+            Promise.resolve({ ok: false, status: 404 } as Response)
+        );
+        globalThis.fetch = fetchMock;
+
+        await expect(loadElevationTile(15, 100, 200)).rejects.toThrow(
+            /No elevation tile available/
+        );
+
+        // 3 レイヤー全て試行
+        expect(fetchMock).toHaveBeenCalledTimes(3);
     });
 });

--- a/tests/gsiTile.unit.spec.ts
+++ b/tests/gsiTile.unit.spec.ts
@@ -10,6 +10,7 @@ import {
     stdTextureUrl,
     photoTextureUrl,
     textureUrl,
+    NO_DATA_SENTINEL,
 } from "../src/terrain/gsiTile";
 
 describe("TILE_SIZE", () => {
@@ -261,10 +262,11 @@ describe("fillInvalidPixels", () => {
         expect(data[4]).toBe(10);
     });
 
-    it("全 NaN の場合は NO_DATA_SENTINEL (-100) にフォールバックする", () => {
+    it("全 NaN の場合は NO_DATA_SENTINEL にフォールバックする", () => {
         const data = new Float32Array([NaN, NaN, NaN, NaN]);
         fillInvalidPixels(data, 2, 2);
-        expect(Array.from(data)).toEqual([-100, -100, -100, -100]);
+        const expected = Array.from({ length: 4 }, () => NO_DATA_SENTINEL);
+        expect(Array.from(data)).toEqual(expected);
     });
 
     it("大きな NaN 領域を完全に埋める（旧16パスでは届かない距離）", () => {

--- a/tests/tileManager.unit.spec.ts
+++ b/tests/tileManager.unit.spec.ts
@@ -142,10 +142,12 @@ jest.unstable_mockModule("../src/terrain/gsiTile", () => ({
     ),
     isAllNaN: jest.fn((data: Float32Array) => {
         for (let i = 0; i < data.length; i++) {
-            if (!Number.isNaN(data[i])) return false;
+            if (!Number.isNaN(data[i]) && data[i] !== -100) return false;
         }
         return true;
     }),
+    isInvalidElev: jest.fn((v: number) => Number.isNaN(v) || v === -100),
+    NO_DATA_SENTINEL: -100,
     stdTextureUrl: jest.fn(() => "https://example.com/tile.png"),
     photoTextureUrl: jest.fn(() => "https://example.com/photo.jpg"),
     textureUrl: jest.fn(() => "https://example.com/tile.png"),


### PR DESCRIPTION
## 概要

Closes #224

ズームイン時に湖面（all-NaN タイル）の高度が周囲の地形と乖離する問題を修正する。

---

## 原因の連鎖

1. **レイヤーフォールバックの誤り**: `loadElevationTile` が all-NaN タイルで次レイヤー(dem5b)にフォールバックし、dem5b が水面に誤った標高(695m 等)を返していた
2. **NaN→0 フォールバックの誤り**: `fillInvalidPixels` が残存 NaN を `0` に変換していたため、`isAllNaN` が「有効データあり」と誤認し、再ステッチ時にシードが再評価できなかった
3. **岸タイルの filled 未保存**: `applyStitchedElevation` が通常タイルの `entry.filled` を保存しておらず、`getNeighborElevations` が生 elevation（湖側エッジ = NaN）を返すため、`refineAllNaNTiles` のシード検出が失敗してレスキューパスが誤った高度を適用していた

---

## 修正内容

### 1. アルゴリズム刷新（elevation ベース + 反復リセット方式）
- `applyStitchedElevation`: 常に生 `elevation` からコピーし、古い `filled` を引き継がない
- `refineAllNaNTiles`: 毎回 all-NaN タイルをリセット → 反復(stitch → fill)でシード波及 → 収束後にメッシュ適用

### 2. NO_DATA_SENTINEL 導入（0 フォールバック廃止）
- `fillInvalidPixels` の残存 NaN フォールバックを `0` → `-100`（`NO_DATA_SENTINEL`）に変更
- `isAllNaN` / `nanMean` / `stitchTileEdgesCrossLevel` / hasSeed 判定を NaN と同等に `-100` を無効値として扱うよう更新

### 3. all-NaN タイルでレイヤーフォールバックしない
- HTTP 成功 = レイヤーが当該領域をカバーとみなし、all-NaN でも次レイヤーへフォールバックしない
- フォールバックは HTTP 取得失敗（404 等）でのみ発動

### 4. 通常タイルの filled を常に保存
- `applyStitchedElevation` で通常タイルも `entry.filled`（NaN 埋め済み）を保存
- `refineAllNaNTiles` が隣接参照する際、岸タイルの湖側エッジに補間値が返りシードが正しく伝搬する

---

## 影響範囲

| ファイル | 変更内容 |
|---|---|
| `src/terrain/gsiTile.ts` | `NO_DATA_SENTINEL`/`isInvalidElev` 追加、`fillInvalidPixels` 更新、レイヤーフォールバック廃止 |
| `src/terrain/tileManager.ts` | `applyStitchedElevation`・`refineAllNaNTiles` 刷新、filled 保存ロジック修正 |
| `src/terrain/tileStitching.ts` | `nanMean`・`stitchTileEdgesCrossLevel` を `isInvalidElev` 対応 |

---

## 検証

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run test:unit` ✅ (669 tests)