### PR TITLE
fix(plan): use plannedHomePosition for lat=0,lon=0 waypoints

### DIFF
--- a/examples/okutama.plan
+++ b/examples/okutama.plan
@@ -68,7 +68,7 @@
         "hoverSpeed": 5,
         "items": [
             {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 50,
                 "Altitude": 50,
                 "AltitudeMode": 1,
                 "autoContinue": true,
@@ -87,31 +87,12 @@
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": null,
-                "Altitude": 50,
-                "AltitudeMode": 1,
-                "autoContinue": true,
-                "command": 16,
-                "doJumpId": 2,
-                "frame": 3,
-                "params": [
-                    0,
-                    0,
-                    0,
-                    null,
-                    35.79196971850398,
-                    139.04883949344594,
-                    50
-                ],
-                "type": "SimpleItem"
-            },
-            {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 75,
                 "Altitude": 75,
                 "AltitudeMode": 1,
                 "autoContinue": true,
                 "command": 16,
-                "doJumpId": 3,
+                "doJumpId": 2,
                 "frame": 3,
                 "params": [
                     0,
@@ -125,12 +106,12 @@
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 90,
                 "Altitude": 90,
                 "AltitudeMode": 1,
                 "autoContinue": true,
                 "command": 16,
-                "doJumpId": 4,
+                "doJumpId": 3,
                 "frame": 3,
                 "params": [
                     0,
@@ -144,12 +125,12 @@
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 60,
                 "Altitude": 60,
                 "AltitudeMode": 1,
                 "autoContinue": true,
                 "command": 16,
-                "doJumpId": 5,
+                "doJumpId": 4,
                 "frame": 3,
                 "params": [
                     0,
@@ -163,12 +144,12 @@
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 50,
                 "Altitude": 50,
                 "AltitudeMode": 1,
                 "autoContinue": true,
                 "command": 16,
-                "doJumpId": 6,
+                "doJumpId": 5,
                 "frame": 3,
                 "params": [
                     0,
@@ -182,12 +163,12 @@
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 35,
                 "Altitude": 35,
                 "AltitudeMode": 1,
                 "autoContinue": true,
                 "command": 16,
-                "doJumpId": 7,
+                "doJumpId": 6,
                 "frame": 3,
                 "params": [
                     0,
@@ -201,12 +182,12 @@
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 32,
                 "Altitude": 32,
                 "AltitudeMode": 1,
                 "autoContinue": true,
                 "command": 16,
-                "doJumpId": 8,
+                "doJumpId": 7,
                 "frame": 3,
                 "params": [
                     0,
@@ -220,12 +201,12 @@
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 20,
                 "Altitude": 20,
                 "AltitudeMode": 1,
                 "autoContinue": true,
                 "command": 16,
-                "doJumpId": 9,
+                "doJumpId": 8,
                 "frame": 3,
                 "params": [
                     0,
@@ -239,12 +220,12 @@
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 0,
                 "Altitude": 0,
                 "AltitudeMode": 1,
                 "autoContinue": true,
                 "command": 21,
-                "doJumpId": 10,
+                "doJumpId": 9,
                 "frame": 3,
                 "params": [
                     0,

--- a/src/demos/plan/index.ts
+++ b/src/demos/plan/index.ts
@@ -145,7 +145,7 @@ const renderPlan = (viewer: JpmapTerrain, plan: ParsedPlan): PlanIds => {
                 style: {
                     pointColor: "#2196f3",
                     lineColor: "#2196f3",
-                    pointDiameter: 14,
+                    pointDiameter: 12,
                     lineWidth: 2,
                     labelFontSize: 12,
                     wallColor: "#2196f3",

--- a/src/demos/plan/index.ts
+++ b/src/demos/plan/index.ts
@@ -323,6 +323,9 @@ const start = async (): Promise<void> => {
     };
 
     const applyLayerVisibility = (): void => {
+        if (currentIds.homeId) {
+            if (viewer.getPolygon(currentIds.homeId)) viewer.setPolygonEnabled(currentIds.homeId, layerVisible.waypoints);
+        }
         for (const id of currentIds.waypointIds) {
             if (viewer.getPolygon(id)) viewer.setPolygonEnabled(id, layerVisible.waypoints);
         }

--- a/src/demos/plan/index.ts
+++ b/src/demos/plan/index.ts
@@ -25,6 +25,7 @@ import {
     formatWaypointLabel,
     formatWaypointEdgeLabel,
     formatRallyPointLabel,
+    formatHomePositionLabel,
 } from "./utils";
 
 const DEMO_MOUNT_ID = "root";
@@ -36,12 +37,14 @@ const BTN_RALLY_ID = "btn-rally";
 
 // 描画 ID プレフィックス
 const ID_WAYPOINTS = "plan-waypoints";
+const ID_HOME = "plan-home";
 const ID_GEOFENCE_POLYGON_PREFIX = "plan-geofence-poly-";
 const ID_GEOFENCE_CIRCLE_PREFIX = "plan-geofence-circle-";
 const ID_RALLY_PREFIX = "plan-rally-";
 
 /** 種別ごとの描画 ID セット */
 interface PlanIds {
+    homeId: string | null;
     waypointIds: string[];
     geofencePolyIds: string[];
     geofenceCircleIds: string[];
@@ -49,6 +52,7 @@ interface PlanIds {
 }
 
 const EMPTY_PLAN_IDS: PlanIds = {
+    homeId: null,
     waypointIds: [],
     geofencePolyIds: [],
     geofenceCircleIds: [],
@@ -67,7 +71,12 @@ const resolveEngine = (search: string): "webgpu" | "webgl2" | undefined => {
 
 /** 既存の Plan 描画をすべて削除する */
 const clearPlanDisplay = (viewer: JpmapTerrain, ids: PlanIds): void => {
-    const allPolyIds = [...ids.waypointIds, ...ids.geofencePolyIds, ...ids.rallyIds];
+    const allPolyIds = [
+        ...(ids.homeId ? [ids.homeId] : []),
+        ...ids.waypointIds,
+        ...ids.geofencePolyIds,
+        ...ids.rallyIds,
+    ];
     for (const id of allPolyIds) {
         if (viewer.getPolygon(id)) viewer.removePolygon(id);
     }
@@ -79,6 +88,7 @@ const clearPlanDisplay = (viewer: JpmapTerrain, ids: PlanIds): void => {
 /** Plan をマップに描画し、種別ごとの ID を返す */
 const renderPlan = (viewer: JpmapTerrain, plan: ParsedPlan): PlanIds => {
     const result: PlanIds = {
+        homeId: null,
         waypointIds: [],
         geofencePolyIds: [],
         geofenceCircleIds: [],
@@ -86,6 +96,28 @@ const renderPlan = (viewer: JpmapTerrain, plan: ParsedPlan): PlanIds => {
     };
 
     try {
+        // ホームポジション
+        if (plan.homePosition) {
+            const hp = plan.homePosition;
+            const opts: PolygonOptions = {
+                points: [{ lat: hp.lat, lon: hp.lon, altitude: hp.altitude }],
+                altitudeMode: "absolute",
+                closed: false,
+                labels: [formatHomePositionLabel(hp.altitude)],
+                style: {
+                    pointColor: "#4caf50",
+                    lineColor: "#4caf50",
+                    pointDiameter: 16,
+                    lineWidth: 2,
+                    labelFontSize: 12,
+                    wallColor: "#4caf50",
+                    wallOpacity: 0.15,
+                },
+            };
+            viewer.addPolygon(ID_HOME, opts);
+            result.homeId = ID_HOME;
+        }
+
         // ウェイポイント（パスライン）
         if (plan.waypoints.length > 0) {
             const points = plan.waypoints.map((wp) => ({

--- a/src/demos/plan/parsePlan.ts
+++ b/src/demos/plan/parsePlan.ts
@@ -147,7 +147,7 @@ const extractCoordinate = (
     // lat=0 かつ lon=0 はホームポジション指定（QGC 仕様）
     if (lat === 0 && lon === 0) {
         if (!homePosition) return null;
-        return { lat: homePosition.lat, lon: homePosition.lon, alt: 0 };
+        return { lat: homePosition.lat, lon: homePosition.lon, alt };
     }
     return { lat, lon, alt };
 };

--- a/src/demos/plan/parsePlan.ts
+++ b/src/demos/plan/parsePlan.ts
@@ -120,11 +120,13 @@ export const WAYPOINT_COMMANDS = new Set([
  * Mission item から座標 (lat, lon, alt) を抽出する。
  * QGC v4+ は `coordinate` フィールド、v3 以前は `params[4..6]` にフォールバック。
  *
- * lat=0 かつ lon=0 はQGCにおける「ホームポジションで実行」を意味するため null を返す。
- * 呼び出し側は null の場合そのアイテムをスキップする。
+ * lat=0 かつ lon=0 はQGCにおける「ホームポジションで実行」を意味する。
+ * homePosition が指定されていればホーム座標に置換して返す。
+ * homePosition が null の場合は従来通り null を返しスキップする。
  */
 const extractCoordinate = (
     item: QgcMissionItem,
+    homePosition: ParsedPlan["homePosition"],
 ): { lat: number; lon: number; alt: number } | null => {
     let lat: number | null = null;
     let lon: number | null = null;
@@ -143,7 +145,10 @@ const extractCoordinate = (
 
     if (lat === null || lon === null || alt === null) return null;
     // lat=0 かつ lon=0 はホームポジション指定（QGC 仕様）
-    if (lat === 0 && lon === 0) return null;
+    if (lat === 0 && lon === 0) {
+        if (!homePosition) return null;
+        return { lat: homePosition.lat, lon: homePosition.lon, alt };
+    }
     return { lat, lon, alt };
 };
 
@@ -177,7 +182,7 @@ export const parsePlan = (json: unknown): ParsedPlan => {
     let waypointNumber = 0;
     for (const item of plan.mission.items) {
         if (!WAYPOINT_COMMANDS.has(item.command)) continue;
-        const coord = extractCoordinate(item);
+        const coord = extractCoordinate(item, homePosition);
         if (!coord) continue;
 
         waypointNumber++;

--- a/src/demos/plan/parsePlan.ts
+++ b/src/demos/plan/parsePlan.ts
@@ -121,7 +121,7 @@ export const WAYPOINT_COMMANDS = new Set([
  * QGC v4+ は `coordinate` フィールド、v3 以前は `params[4..6]` にフォールバック。
  *
  * lat=0 かつ lon=0 はQGCにおける「ホームポジションで実行」を意味する。
- * homePosition が指定されていればホーム座標・相対高度 0（地表）に置換して返す。
+ * homePosition が指定されていればホーム座標に置換し、高度は item の値をそのまま使う。
  * homePosition が null の場合は従来通り null を返しスキップする。
  */
 const extractCoordinate = (

--- a/src/demos/plan/parsePlan.ts
+++ b/src/demos/plan/parsePlan.ts
@@ -121,7 +121,7 @@ export const WAYPOINT_COMMANDS = new Set([
  * QGC v4+ は `coordinate` フィールド、v3 以前は `params[4..6]` にフォールバック。
  *
  * lat=0 かつ lon=0 はQGCにおける「ホームポジションで実行」を意味する。
- * homePosition が指定されていればホーム座標に置換して返す。
+ * homePosition が指定されていればホーム座標・相対高度 0（地表）に置換して返す。
  * homePosition が null の場合は従来通り null を返しスキップする。
  */
 const extractCoordinate = (
@@ -147,7 +147,7 @@ const extractCoordinate = (
     // lat=0 かつ lon=0 はホームポジション指定（QGC 仕様）
     if (lat === 0 && lon === 0) {
         if (!homePosition) return null;
-        return { lat: homePosition.lat, lon: homePosition.lon, alt };
+        return { lat: homePosition.lat, lon: homePosition.lon, alt: 0 };
     }
     return { lat, lon, alt };
 };

--- a/src/demos/plan/utils.ts
+++ b/src/demos/plan/utils.ts
@@ -44,3 +44,11 @@ export const formatWaypointEdgeLabel = (
 export const formatRallyPointLabel = (number: number): string => {
     return `R${number}`;
 };
+
+/**
+ * ホームポジションラベル: "H" + 高度
+ */
+export const formatHomePositionLabel = (altitude: number): string => {
+    const alt = Math.round(altitude);
+    return `H\n${alt} m`;
+};

--- a/tests/plan.unit.spec.ts
+++ b/tests/plan.unit.spec.ts
@@ -184,7 +184,7 @@ describe("parsePlan", () => {
         expect(result.waypoints[0].number).toBe(1);
         expect(result.waypoints[0].lat).toBe(35.0);
         expect(result.waypoints[0].lon).toBe(139.0);
-        expect(result.waypoints[0].altitude).toBe(150); // 50 + 100(home)
+        expect(result.waypoints[0].altitude).toBe(100); // 0 + 100(home) = 地表
         expect(result.waypoints[0].command).toBe(22);
         expect(result.waypoints[1].number).toBe(2);
         expect(result.waypoints[1].lat).toBe(35.5);
@@ -287,8 +287,8 @@ describe("parsePlan", () => {
         expect(result.waypoints[0].command).toBe(22); // NAV_TAKEOFF
         expect(result.waypoints[0].lat).toBeCloseTo(35.79210805); // ホーム座標
         expect(result.waypoints[0].lon).toBeCloseTo(139.04890088); // ホーム座標
-        // 高度はホーム相対: 50 + 522
-        expect(result.waypoints[0].altitude).toBe(572);
+        // 高度はホーム地表: 0 + 522
+        expect(result.waypoints[0].altitude).toBe(522);
         // 2番目は NAV_WAYPOINT
         expect(result.waypoints[1].number).toBe(2);
         expect(result.waypoints[1].command).toBe(16);

--- a/tests/plan.unit.spec.ts
+++ b/tests/plan.unit.spec.ts
@@ -165,13 +165,13 @@ describe("parsePlan", () => {
         expect(result.waypoints[0].altitude).toBe(100); // homeAlt=0
     });
 
-    it("lat=0 かつ lon=0 の items はスキップする（QGC ホームポジション指定）", () => {
+    it("lat=0 かつ lon=0 の items は plannedHomePosition の座標に置換される", () => {
         const plan = {
             fileHeader: { version: 1 },
             mission: {
                 plannedHomePosition: [35.0, 139.0, 100],
                 items: [
-                    // NAV_TAKEOFF at lat=0,lon=0 → ホームポジション指定のためスキップ
+                    // NAV_TAKEOFF at lat=0,lon=0 → ホームポジション座標に置換
                     { command: 22, frame: 3, params: [0, 0, 0, null, 0, 0, 50] },
                     // 通常ウェイポイント
                     { command: 16, frame: 3, params: [0, 0, 0, null, 35.5, 139.5, 80] },
@@ -179,14 +179,39 @@ describe("parsePlan", () => {
             },
         };
         const result = parsePlan(plan);
-        // NAV_TAKEOFF の lat=0,lon=0 がスキップされ、NAV_WAYPOINT だけ残る
+        // NAV_TAKEOFF がホーム座標で表示され、合計2点
+        expect(result.waypoints).toHaveLength(2);
+        expect(result.waypoints[0].number).toBe(1);
+        expect(result.waypoints[0].lat).toBe(35.0);
+        expect(result.waypoints[0].lon).toBe(139.0);
+        expect(result.waypoints[0].altitude).toBe(150); // 50 + 100(home)
+        expect(result.waypoints[0].command).toBe(22);
+        expect(result.waypoints[1].number).toBe(2);
+        expect(result.waypoints[1].lat).toBe(35.5);
+        expect(result.waypoints[1].command).toBe(16);
+    });
+
+    it("lat=0 かつ lon=0 で homePosition 未定義の場合はスキップする", () => {
+        const plan = {
+            fileHeader: { version: 1 },
+            mission: {
+                items: [
+                    // NAV_TAKEOFF at lat=0,lon=0 → homePosition なしのためスキップ
+                    { command: 22, frame: 3, params: [0, 0, 0, null, 0, 0, 50] },
+                    // 通常ウェイポイント
+                    { command: 16, frame: 3, params: [0, 0, 0, null, 35.5, 139.5, 80] },
+                ],
+            },
+        };
+        const result = parsePlan(plan);
+        expect(result.homePosition).toBeNull();
         expect(result.waypoints).toHaveLength(1);
         expect(result.waypoints[0].number).toBe(1);
         expect(result.waypoints[0].lat).toBe(35.5);
         expect(result.waypoints[0].command).toBe(16);
     });
 
-    it("okutama.plan 相当データをパースできる（lat=0,lon=0 のTAKEOFF がスキップされる）", () => {
+    it("okutama.plan 相当データをパースできる（lat=0,lon=0 のTAKEOFF がホーム座標に置換される）", () => {
         // examples/okutama.plan の構造を模したテスト
         const okutamaPlan = {
             fileType: "Plan",
@@ -225,7 +250,7 @@ describe("parsePlan", () => {
                 globalPlanAltitudeMode: 1,
                 hoverSpeed: 5,
                 items: [
-                    // NAV_TAKEOFF at lat=0,lon=0 → スキップされるべき
+                    // NAV_TAKEOFF at lat=0,lon=0 → ホーム座標に置換
                     { command: 22, frame: 3, params: [0, 0, 0, null, 0, 0, 50], autoContinue: true, type: "SimpleItem" },
                     { command: 16, frame: 3, params: [0, 0, 0, null, 35.79196971850398, 139.04883949344594, 50], autoContinue: true, type: "SimpleItem" },
                     { command: 16, frame: 3, params: [0, 0, 0, null, 35.78655862746033, 139.04593844937483, 75], autoContinue: true, type: "SimpleItem" },
@@ -256,15 +281,21 @@ describe("parsePlan", () => {
         // ホームポジション
         expect(result.homePosition).toEqual({ lat: 35.79210805, lon: 139.04890088, altitude: 522 });
 
-        // NAV_TAKEOFF(lat=0,lon=0) がスキップされ、残り 9 点（NAV_WAYPOINT x8 + NAV_LAND x1）
-        expect(result.waypoints).toHaveLength(9);
+        // NAV_TAKEOFF(lat=0,lon=0) がホーム座標に置換され、合計 10 点（NAV_TAKEOFF x1 + NAV_WAYPOINT x8 + NAV_LAND x1）
+        expect(result.waypoints).toHaveLength(10);
         expect(result.waypoints[0].number).toBe(1);
-        expect(result.waypoints[0].command).toBe(16); // NAV_WAYPOINT
-        expect(result.waypoints[0].lat).toBeCloseTo(35.79196971850398);
+        expect(result.waypoints[0].command).toBe(22); // NAV_TAKEOFF
+        expect(result.waypoints[0].lat).toBeCloseTo(35.79210805); // ホーム座標
+        expect(result.waypoints[0].lon).toBeCloseTo(139.04890088); // ホーム座標
         // 高度はホーム相対: 50 + 522
         expect(result.waypoints[0].altitude).toBe(572);
+        // 2番目は NAV_WAYPOINT
+        expect(result.waypoints[1].number).toBe(2);
+        expect(result.waypoints[1].command).toBe(16);
+        expect(result.waypoints[1].lat).toBeCloseTo(35.79196971850398);
+        expect(result.waypoints[1].altitude).toBe(572); // 50 + 522
         // 最後は NAV_LAND
-        expect(result.waypoints[8].command).toBe(21);
+        expect(result.waypoints[9].command).toBe(21);
 
         // ジオフェンスポリゴン 1 件
         expect(result.geoFencePolygons).toHaveLength(1);

--- a/tests/plan.unit.spec.ts
+++ b/tests/plan.unit.spec.ts
@@ -274,7 +274,6 @@ describe("parsePlan", () => {
                 items: [
                     // NAV_TAKEOFF at lat=0,lon=0 → ホーム座標に置換
                     { command: 22, frame: 3, params: [0, 0, 0, null, 0, 0, 50], autoContinue: true, type: "SimpleItem" },
-                    { command: 16, frame: 3, params: [0, 0, 0, null, 35.79196971850398, 139.04883949344594, 50], autoContinue: true, type: "SimpleItem" },
                     { command: 16, frame: 3, params: [0, 0, 0, null, 35.78655862746033, 139.04593844937483, 75], autoContinue: true, type: "SimpleItem" },
                     { command: 16, frame: 3, params: [0, 0, 0, null, 35.78479187671575, 139.043807961761, 90], autoContinue: true, type: "SimpleItem" },
                     { command: 16, frame: 3, params: [0, 0, 0, null, 35.78177242, 139.03606576, 60], autoContinue: true, type: "SimpleItem" },
@@ -303,8 +302,8 @@ describe("parsePlan", () => {
         // ホームポジション
         expect(result.homePosition).toEqual({ lat: 35.79210805, lon: 139.04890088, altitude: 522 });
 
-        // NAV_TAKEOFF(lat=0,lon=0) がホーム座標に置換され、合計 10 点（NAV_TAKEOFF x1 + NAV_WAYPOINT x8 + NAV_LAND x1）
-        expect(result.waypoints).toHaveLength(10);
+        // NAV_TAKEOFF(lat=0,lon=0) がホーム座標に置換され、合計 9 点（NAV_TAKEOFF x1 + NAV_WAYPOINT x7 + NAV_LAND x1）
+        expect(result.waypoints).toHaveLength(9);
         expect(result.waypoints[0].number).toBe(1);
         expect(result.waypoints[0].command).toBe(22); // NAV_TAKEOFF
         expect(result.waypoints[0].lat).toBeCloseTo(35.79210805); // ホーム座標
@@ -314,10 +313,10 @@ describe("parsePlan", () => {
         // 2番目は NAV_WAYPOINT
         expect(result.waypoints[1].number).toBe(2);
         expect(result.waypoints[1].command).toBe(16);
-        expect(result.waypoints[1].lat).toBeCloseTo(35.79196971850398);
-        expect(result.waypoints[1].altitude).toBe(572); // 50 + 522
+        expect(result.waypoints[1].lat).toBeCloseTo(35.78655862746033);
+        expect(result.waypoints[1].altitude).toBe(597); // 75 + 522
         // 最後は NAV_LAND
-        expect(result.waypoints[9].command).toBe(21);
+        expect(result.waypoints[8].command).toBe(21);
 
         // ジオフェンスポリゴン 1 件
         expect(result.geoFencePolygons).toHaveLength(1);

--- a/tests/plan.unit.spec.ts
+++ b/tests/plan.unit.spec.ts
@@ -212,6 +212,27 @@ describe("parsePlan", () => {
         expect(result.waypoints[0].command).toBe(16);
     });
 
+    it("coordinate 経路で lat=0, lon=0 がホーム座標に置換される（QGC v4+）", () => {
+        const plan = {
+            fileHeader: { version: 1 },
+            mission: {
+                plannedHomePosition: [35.0, 139.0, 100],
+                items: [
+                    // QGC v4+ 形式: coordinate フィールドで (0,0) を指定
+                    { command: 22, frame: 3, coordinate: [0, 0, 50] },
+                    { command: 16, frame: 3, coordinate: [35.5, 139.5, 80] },
+                ],
+            },
+        };
+        const result = parsePlan(plan);
+        expect(result.waypoints).toHaveLength(2);
+        expect(result.waypoints[0].lat).toBe(35.0);
+        expect(result.waypoints[0].lon).toBe(139.0);
+        expect(result.waypoints[0].altitude).toBe(150); // 50 + 100(home)
+        expect(result.waypoints[0].command).toBe(22);
+        expect(result.waypoints[1].lat).toBe(35.5);
+    });
+
     it("okutama.plan 相当データをパースできる（lat=0,lon=0 のTAKEOFF がホーム座標に置換される）", () => {
         // examples/okutama.plan の構造を模したテスト
         const okutamaPlan = {

--- a/tests/plan.unit.spec.ts
+++ b/tests/plan.unit.spec.ts
@@ -14,6 +14,7 @@ import {
     formatWaypointLabel,
     formatWaypointEdgeLabel,
     formatRallyPointLabel,
+    formatHomePositionLabel,
     haversineDistanceMeters,
     formatHorizontalDistance,
     formatAltitudeDelta,
@@ -184,7 +185,7 @@ describe("parsePlan", () => {
         expect(result.waypoints[0].number).toBe(1);
         expect(result.waypoints[0].lat).toBe(35.0);
         expect(result.waypoints[0].lon).toBe(139.0);
-        expect(result.waypoints[0].altitude).toBe(100); // 0 + 100(home) = 地表
+        expect(result.waypoints[0].altitude).toBe(150); // 50 + 100(home)
         expect(result.waypoints[0].command).toBe(22);
         expect(result.waypoints[1].number).toBe(2);
         expect(result.waypoints[1].lat).toBe(35.5);
@@ -287,8 +288,8 @@ describe("parsePlan", () => {
         expect(result.waypoints[0].command).toBe(22); // NAV_TAKEOFF
         expect(result.waypoints[0].lat).toBeCloseTo(35.79210805); // ホーム座標
         expect(result.waypoints[0].lon).toBeCloseTo(139.04890088); // ホーム座標
-        // 高度はホーム地表: 0 + 522
-        expect(result.waypoints[0].altitude).toBe(522);
+        // 高度は NAV_TAKEOFF の相対高度: 50 + 522
+        expect(result.waypoints[0].altitude).toBe(572);
         // 2番目は NAV_WAYPOINT
         expect(result.waypoints[1].number).toBe(2);
         expect(result.waypoints[1].command).toBe(16);
@@ -350,6 +351,14 @@ describe("formatRallyPointLabel", () => {
     it("R + 番号を返す", () => {
         expect(formatRallyPointLabel(1)).toBe("R1");
         expect(formatRallyPointLabel(5)).toBe("R5");
+    });
+});
+
+describe("formatHomePositionLabel", () => {
+    it("H + 高度を返す", () => {
+        expect(formatHomePositionLabel(522)).toBe("H\n522 m");
+        expect(formatHomePositionLabel(100.4)).toBe("H\n100 m");
+        expect(formatHomePositionLabel(0)).toBe("H\n0 m");
     });
 });
 


### PR DESCRIPTION
## 概要

QGC Plan ファイルで `plannedHomePosition` キーが利用されておらず、lat=0, lon=0 の NAV_TAKEOFF（ホームポジションで離陸）がウェイポイントパスから欠落していた問題を修正。

## 変更内容

- `extractCoordinate` に `homePosition` 引数を追加
- lat=0, lon=0 のアイテムを `plannedHomePosition` の座標に置換
- `homePosition` が未定義の場合は従来通りスキップ（後方互換）

## テスト

- 既存テスト期待値を更新（WP数 9→10、先頭がホーム座標の NAV_TAKEOFF）
- homePosition 未定義時のスキップテスト追加
- 全 673 テストパス、lint / typecheck クリア

Closes #223