### PR TITLE
fix(#228): タイル中心とオーバーレイ座標系のズレを修正

### DIFF
--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -429,10 +429,11 @@ export class DefaultScene implements CreateSceneClass {
                 JAPAN_BOUNDS.minLon,
                 JAPAN_BOUNDS.maxLon
             );
-            await tileManager.setCenter(currentLat, currentLon, 0);
 
             // センタータイルの地理的中心と currentLat/currentLon のメートル差を
-            // gridResidual に反映し、オーバーレイ座標系とタイルメッシュ配置を一致させる
+            // gridResidual に反映し、オーバーレイ座標系とタイルメッシュ配置を一致させる。
+            // setCenter より前に更新することで、可視タイル計算が正しい camera.target を参照し、
+            // target 変更による二重リフレッシュを防ぐ。
             const centerTile = toTileXY(currentLat, currentLon, MAX_ZOOM);
             const { lat: tileCenterLat, lon: tileCenterLon } = tileCenterLatLon(
                 centerTile.x,
@@ -446,6 +447,8 @@ export class DefaultScene implements CreateSceneClass {
             gridResidualZ = (currentLat - tileCenterLat) * METERS_PER_DEGREE_LAT;
             camera.target.x = gridResidualX;
             camera.target.z = gridResidualZ;
+
+            await tileManager.setCenter(currentLat, currentLon, 0);
         };
 
         // ---------- カメラターゲットオフセット → 緯度経度変換 ----------

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -13,7 +13,7 @@ import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
 import { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Ray } from "@babylonjs/core/Culling/ray";
 import { CreateSceneClass } from "../createScene";
-import { clamp, toTileXY, tileEdgeMeters, JAPAN_BOUNDS } from "../terrain/gsiTile";
+import { clamp, toTileXY, tileEdgeMeters, tileCenterLatLon, JAPAN_BOUNDS } from "../terrain/gsiTile";
 import { createControlPanel, snapScale, formatScale, showToast } from "../terrain/controlPanel";
 import { attachResizeRefresh } from "../terrain/resizeRefresh";
 import { createTileManager } from "../terrain/tileManager";
@@ -430,13 +430,28 @@ export class DefaultScene implements CreateSceneClass {
                 JAPAN_BOUNDS.maxLon
             );
             await tileManager.setCenter(currentLat, currentLon, 0);
+
+            // センタータイルの地理的中心と currentLat/currentLon のメートル差を
+            // gridResidual に反映し、オーバーレイ座標系とタイルメッシュ配置を一致させる
+            const centerTile = toTileXY(currentLat, currentLon, MAX_ZOOM);
+            const { lat: tileCenterLat, lon: tileCenterLon } = tileCenterLatLon(
+                centerTile.x,
+                centerTile.y,
+                MAX_ZOOM
+            );
+            const metersPerDegLon =
+                METERS_PER_DEGREE_LAT *
+                Math.cos((currentLat * Math.PI) / 180);
+            gridResidualX = (currentLon - tileCenterLon) * metersPerDegLon;
+            gridResidualZ = (currentLat - tileCenterLat) * METERS_PER_DEGREE_LAT;
+            camera.target.x = gridResidualX;
+            camera.target.z = gridResidualZ;
         };
 
         // ---------- カメラターゲットオフセット → 緯度経度変換 ----------
         const commitPanOffset = (): void => {
             const tx = camera.target.x;
             const tz = camera.target.z;
-            if (tx === 0 && tz === 0) return;
 
             // 新規オフセット = 全体 - 既知のグリッド残差
             const newOffsetX = tx - gridResidualX;

--- a/src/terrain/gsiTile.ts
+++ b/src/terrain/gsiTile.ts
@@ -32,6 +32,20 @@ export const toTileXY = (
     return { x, y };
 };
 
+/** タイル中心の緯度経度を返す（Web メルカトル逆変換） */
+export const tileCenterLatLon = (
+    x: number,
+    y: number,
+    zoom: number
+): { lat: number; lon: number } => {
+    const n = 2 ** zoom;
+    const lon = ((x + 0.5) / n) * 360 - 180;
+    const lat =
+        (Math.atan(Math.sinh(Math.PI * (1 - (2 * (y + 0.5)) / n))) * 180) /
+        Math.PI;
+    return { lat, lon };
+};
+
 /** タイル1辺の実距離[m] */
 export const tileEdgeMeters = (lat: number, zoom: number): number => {
     const latClamped = clamp(lat, -85.05112878, 85.05112878);

--- a/tests/gsiTile.unit.spec.ts
+++ b/tests/gsiTile.unit.spec.ts
@@ -4,6 +4,7 @@ import {
     JAPAN_BOUNDS,
     clamp,
     toTileXY,
+    tileCenterLatLon,
     tileEdgeMeters,
     decodeGsiElevation,
     isAllNaN,
@@ -469,5 +470,44 @@ describe("loadElevationTile", () => {
 
         // 3 レイヤー全て試行
         expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+});
+
+describe("tileCenterLatLon", () => {
+    it("zoom=0 の唯一のタイル中心は (0, 0) である", () => {
+        const { lat, lon } = tileCenterLatLon(0, 0, 0);
+        expect(lon).toBeCloseTo(0, 5);
+        expect(lat).toBeCloseTo(0, 1);
+    });
+
+    it("toTileXY で得たタイルの中心は元の座標に近い（zoom=18, 奥多摩）", () => {
+        const inputLat = 35.79210805;
+        const inputLon = 139.04890088;
+        const zoom = 18;
+        const { x, y } = toTileXY(inputLat, inputLon, zoom);
+        const { lat, lon } = tileCenterLatLon(x, y, zoom);
+
+        // タイル1辺 ≈ 124m → 中心と端の最大差 ≈ 62m ≈ 0.00056°
+        expect(Math.abs(lat - inputLat)).toBeLessThan(0.001);
+        expect(Math.abs(lon - inputLon)).toBeLessThan(0.001);
+    });
+
+    it("lon は (x+0.5)/2^zoom*360-180 の計算式と一致する", () => {
+        const zoom = 14;
+        const x = 14552;
+        const y = 6451;
+        const { lon } = tileCenterLatLon(x, y, zoom);
+        const expected = ((x + 0.5) / 2 ** zoom) * 360 - 180;
+        expect(lon).toBeCloseTo(expected, 10);
+    });
+
+    it("toTileXY との往復でタイル中心が同一タイルに属する", () => {
+        const zoom = 18;
+        const x = 232500;
+        const y = 103000;
+        const { lat, lon } = tileCenterLatLon(x, y, zoom);
+        const back = toTileXY(lat, lon, zoom);
+        expect(back.x).toBe(x);
+        expect(back.y).toBe(y);
     });
 });


### PR DESCRIPTION
## 概要
Closes #228

zoom=18 のタイルメッシュはタイルの地理的中心をワールド (0,0) に配置しますが、
`gridResidualX/Z = 0` の初期状態では `latLonToWorld` が `currentLat/currentLon` を
ワールド (0,0) に置いていました。この不一致により、ウェイポイントなどのオーバーレイが
地形テクスチャに対して最大 ±62m（単軸）ずれて表示されていました。

## 修正内容

### `src/terrain/gsiTile.ts`
- `tileCenterLatLon(x, y, zoom)` 関数を追加（タイル整数座標 → 地理的中心の緯度経度）

### `src/scenes/default.ts`
- `refreshTerrain` にてセンタータイルの地理的中心と `currentLat/currentLon` のメートル差を `gridResidualX/Z` として初期化
- `commitPanOffset` の `tx === 0 && tz === 0` 早期リターンを削除（非ゼロ初期残差で誤動作するため。0.01m デッドバンドチェックで代替）

### `tests/gsiTile.unit.spec.ts`
- `tileCenterLatLon` のテスト 4 件を追加

## テスト
- 全 677 テスト通過
- lint / typecheck クリーン