### PR TITLE
fix: 同zoomタイル間ステッチで raw elevation を使い対称性を保証

### DIFF
--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -485,8 +485,12 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         }
     };
 
-    /** 同じzoomの隣接タイル標高をキャッシュから取得 */
-    const getNeighborElevations = (coord: TileCoord): {
+    /**
+     * 同じzoomの隣接タイル標高をキャッシュから取得。
+     * @param useFilled true なら filled（ステッチ＋NaN埋め済み）を優先して返す。
+     *                  false なら raw elevation を返し、辺平均の対称性を保証する。
+     */
+    const getNeighborElevations = (coord: TileCoord, useFilled = false): {
         top?: Float32Array; bottom?: Float32Array;
         left?: Float32Array; right?: Float32Array;
         topLeft?: Float32Array; topRight?: Float32Array;
@@ -498,7 +502,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
             if (!e) return undefined;
             // 元データが all-NaN かつ未補間なら参照しない（誤った 0 を伝搬させない）
             if (e.wasAllNaN && !e.unblocked) return undefined;
-            return e.filled ?? e.elevation;
+            return useFilled ? (e.filled ?? e.elevation) : e.elevation;
         };
         return {
             top: get(x, y - 1),
@@ -609,14 +613,17 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
     /**
      * elevation をコピーしてステッチ（同zoom + cross-level）を適用し、
      * 辺に有効値（シード）があるかを判定する共通ヘルパー。
+     * @param useFilled true なら同 zoom ステッチで filled データを参照する
+     *                  （refineAllNaNTiles 用）。false なら raw 同士で対称平均。
      */
     const stitchAndCheckSeed = (
         elevation: Float32Array,
         coord: TileCoord,
         crossLevel: boolean,
+        useFilled = false,
     ): { stitched: Float32Array; hasSeed: boolean } => {
         const stitched = new Float32Array(elevation);
-        stitchTileEdges(stitched, getNeighborElevations(coord), TILE_SIZE);
+        stitchTileEdges(stitched, getNeighborElevations(coord, useFilled), TILE_SIZE);
         if (crossLevel) {
             const coarse = getCoarseEdgeNeighbors(coord);
             if (coarse.length > 0) stitchTileEdgesCrossLevel(stitched, coarse, TILE_SIZE);
@@ -675,10 +682,10 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         // - wasAllNaN + シードあり: filled/unblocked を更新
         // - 通常タイル: filled を常に更新。
         //   NaN 埋め済みデータ（entry.filled）を保存しておくことで、
-        //   後から refineAllNaNTiles が隣接参照する際に岸タイルの
-        //   lake 側エッジ NaN が補間済みの値を返せるようになる。
-        //   これがないと getNeighborElevations が生 elevation（エッジ NaN あり）を
-        //   返し、all-NaN タイルへシードが伝搬せずレスキューパスが誤った高度を適用する。
+        //   後から refineAllNaNTiles（useFilled=true）が隣接参照する際に
+        //   岸タイルの lake 側エッジ NaN が補間済みの値を返せるようになる。
+        //   通常のステッチ（useFilled=false）では raw elevation を参照するため
+        //   filled を保存しても辺平均の対称性には影響しない。
         if (cacheEntryPre) {
             if (cacheEntryPre.wasAllNaN) {
                 if (hasSeed) {
@@ -790,7 +797,8 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
                 remainingCount++;
 
                 // wasAllNaN → 常に cross-level stitch を実行
-                const { stitched, hasSeed } = stitchAndCheckSeed(entry.elevation, tile.coord, true);
+                // useFilled=true: 隣接 filled データからシードを取得しNaN領域を補間する
+                const { stitched, hasSeed } = stitchAndCheckSeed(entry.elevation, tile.coord, true, true);
 
                 if (hasSeed) {
                     fillInvalidPixels(stitched, TILE_SIZE, TILE_SIZE);

--- a/tests/tileManager.unit.spec.ts
+++ b/tests/tileManager.unit.spec.ts
@@ -1451,6 +1451,75 @@ describe("refineAllNaNTiles", () => {
         expect(centerElev).toBe(200);
         tm.dispose();
     });
+
+    it("useFilled=true により岸タイルの NaN 補間済みデータからシードが伝搬する（回帰テスト）", async () => {
+        // 岸タイル A(14547): 300m だが右辺(col=255)だけ NaN（湖岸の欠測）
+        // 湖タイル B(14548+): 全 NaN
+        // fillInvalidPixels が A の右辺 NaN を隣接 300m で補間 → A.filled の右辺が有効値
+        // refineAllNaNTiles の useFilled=true が A.filled を参照 → B にシード伝搬
+        // useFilled=false だと A.elevation（右辺 NaN）を参照し B は解決不能
+
+        // fillInvalidPixels を 1パス 4近傍補間に差し替え
+        (gsiTileMock.fillInvalidPixels as jest.Mock).mockImplementation(
+            (data: Float32Array, width: number, height: number) => {
+                for (let y = 0; y < height; y++) {
+                    for (let x = 0; x < width; x++) {
+                        const i = y * width + x;
+                        if (!Number.isNaN(data[i]) && data[i] !== -100) continue;
+                        const neighbors: number[] = [];
+                        if (x > 0 && !Number.isNaN(data[i - 1]) && data[i - 1] !== -100) neighbors.push(data[i - 1]);
+                        if (x < width - 1 && !Number.isNaN(data[i + 1]) && data[i + 1] !== -100) neighbors.push(data[i + 1]);
+                        if (y > 0 && !Number.isNaN(data[i - width]) && data[i - width] !== -100) neighbors.push(data[i - width]);
+                        if (y < height - 1 && !Number.isNaN(data[i + width]) && data[i + width] !== -100) neighbors.push(data[i + width]);
+                        if (neighbors.length > 0) {
+                            data[i] = neighbors.reduce((a, b) => a + b, 0) / neighbors.length;
+                        } else {
+                            data[i] = -100;
+                        }
+                    }
+                }
+            }
+        );
+
+        // 岸タイル: 右辺(col=255)だけ NaN
+        const shoreData = new Float32Array(256 * 256).fill(300);
+        for (let y = 0; y < 256; y++) shoreData[y * 256 + 255] = NaN;
+
+        // 湖タイル: 全 NaN
+        const lakeData = new Float32Array(256 * 256).fill(NaN);
+
+        (gsiTileMock.loadElevationTile as jest.Mock<(zoom: number, x: number, y: number) => Promise<Float32Array>>).mockImplementation(
+            (_zoom, x) => {
+                if (x <= 14547) return Promise.resolve(new Float32Array(shoreData));
+                return Promise.resolve(new Float32Array(lakeData));
+            }
+        );
+
+        const camera = createMockCamera();
+        const tm = createTileManager({
+            scene: createMockScene() as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 20,
+            minZoom: 14,
+            maxElevationZoom: 14,
+        });
+
+        await tm.setCenter(35.68, 139.77);
+
+        // 湖タイル B(14548) が unblocked されて filled データで標高が返る
+        // wx=1000 → tile 14548, col=0（B の左辺）
+        const lakeBorderElev = tm.queryElevationAtWorld(1000, -4);
+        expect(lakeBorderElev).not.toBeNull();
+        // 岸タイルの filled 右辺（≈300）からシードされるため 300 に近い値
+        expect(lakeBorderElev).toBeCloseTo(300, 0);
+
+        tm.dispose();
+        // fillInvalidPixels を no-op に戻す
+        (gsiTileMock.fillInvalidPixels as jest.Mock).mockImplementation(() => {});
+    });
 });
 
 describe("同zoom タイル間ステッチの対称性", () => {

--- a/tests/tileManager.unit.spec.ts
+++ b/tests/tileManager.unit.spec.ts
@@ -1452,3 +1452,75 @@ describe("refineAllNaNTiles", () => {
         tm.dispose();
     });
 });
+
+describe("同zoom タイル間ステッチの対称性", () => {
+    // flushRestitch は requestAnimationFrame 経由で実行されるが、
+    // Node.js テスト環境では rAF が未定義のため、コールバックをキューし
+    // 手動フラッシュする方式でポリフィルする
+    let origRAF: typeof globalThis.requestAnimationFrame;
+    let origCAF: typeof globalThis.cancelAnimationFrame;
+    let rafQueue: FrameRequestCallback[];
+    const flushRAF = () => {
+        let safety = 20;
+        while (rafQueue.length > 0 && safety-- > 0) {
+            const batch = rafQueue.splice(0);
+            for (const cb of batch) cb(0);
+        }
+    };
+    beforeEach(() => {
+        origRAF = globalThis.requestAnimationFrame;
+        origCAF = globalThis.cancelAnimationFrame;
+        rafQueue = [];
+        let nextId = 1;
+        globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => { rafQueue.push(cb); return nextId++; }) as typeof requestAnimationFrame;
+        globalThis.cancelAnimationFrame = (() => {}) as typeof cancelAnimationFrame;
+    });
+    afterEach(() => {
+        globalThis.requestAnimationFrame = origRAF;
+        globalThis.cancelAnimationFrame = origCAF;
+        (gsiTileMock.loadElevationTile as jest.Mock).mockImplementation(
+            () => Promise.resolve(new Float32Array(256 * 256))
+        );
+    });
+
+    it("隣接タイルの共有辺が raw 同士の平均で一致する（回帰テスト）", async () => {
+        // Tile A (x<=14547) = 100m, Tile B (x>14547) = 200m
+        // raw ステッチ後、共有辺は avg(100, 200) = 150 で両側一致すること
+        (gsiTileMock.loadElevationTile as jest.Mock<(zoom: number, x: number, y: number) => Promise<Float32Array>>).mockImplementation(
+            (_zoom, x) => {
+                const val = x <= 14547 ? 100 : 200;
+                return Promise.resolve(new Float32Array(256 * 256).fill(val));
+            }
+        );
+
+        const camera = createMockCamera();
+        const tm = createTileManager({
+            scene: createMockScene() as never,
+            camera,
+            zoom: 14,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 20,
+            minZoom: 14,
+            maxElevationZoom: 14,
+        });
+
+        await tm.setCenter(35.68, 139.77);
+        // タイルロード後に蓄積された再ステッチを実行
+        flushRAF();
+
+        // A の右辺 (col=255) と B の左辺 (col=0) を queryElevationAtWorld で取得
+        // wx=999 → tile A col=255, wx=1000 → tile B col=0, wz=-4 → row=1（辺、非角）
+        const aRightEdge = tm.queryElevationAtWorld(999, -4);
+        const bLeftEdge = tm.queryElevationAtWorld(1000, -4);
+
+        expect(aRightEdge).not.toBeNull();
+        expect(bLeftEdge).not.toBeNull();
+        // 共有辺が対称（同一値）であること
+        expect(aRightEdge).toBe(bLeftEdge);
+        // raw 平均 avg(100, 200) = 150 であること
+        expect(aRightEdge).toBe(150);
+
+        tm.dispose();
+    });
+});

--- a/tests/tileManager.unit.spec.ts
+++ b/tests/tileManager.unit.spec.ts
@@ -1460,8 +1460,8 @@ describe("refineAllNaNTiles", () => {
         // useFilled=false だと A.elevation（右辺 NaN）を参照し B は解決不能
 
         // fillInvalidPixels を 1パス 4近傍補間に差し替え
-        (gsiTileMock.fillInvalidPixels as jest.Mock).mockImplementation(
-            (data: Float32Array, width: number, height: number) => {
+        (gsiTileMock.fillInvalidPixels as jest.Mock<(data: Float32Array, width: number, height: number) => void>).mockImplementation(
+            (data, width, height) => {
                 for (let y = 0; y < height; y++) {
                     for (let x = 0; x < width; x++) {
                         const i = y * width + x;

--- a/tests/tileManager.unit.spec.ts
+++ b/tests/tileManager.unit.spec.ts
@@ -1355,6 +1355,7 @@ describe("refineAllNaNTiles", () => {
         (gsiTileMock.tileEdgeMeters as jest.Mock<(lat: number, zoom: number) => number>).mockImplementation(
             (_lat, zoom) => 1000 * Math.pow(2, 14 - zoom)
         );
+        (gsiTileMock.fillInvalidPixels as jest.Mock).mockImplementation(() => {});
     });
 
     it("隣接が段階的に unblocked になると中心タイルも最終的に unblocked になる", async () => {
@@ -1517,8 +1518,6 @@ describe("refineAllNaNTiles", () => {
         expect(lakeBorderElev).toBeCloseTo(300, 0);
 
         tm.dispose();
-        // fillInvalidPixels を no-op に戻す
-        (gsiTileMock.fillInvalidPixels as jest.Mock).mockImplementation(() => {});
     });
 });
 

--- a/tests/tileStitching.unit.spec.ts
+++ b/tests/tileStitching.unit.spec.ts
@@ -234,6 +234,47 @@ describe("stitchTileEdges", () => {
         // 内部は変わらない
         expect(target[1 * SIZE + 254]).toBe(100);
     });
+
+    it("raw 同士でステッチすると辺が対称になる（隙間なし）", () => {
+        // タイルA (値10) と タイルB (値20) を raw データでステッチ
+        const rawA = fill(S, 10);
+        const rawB = fill(S, 20);
+
+        const a = new Float32Array(rawA);
+        const b = new Float32Array(rawB);
+
+        // A の右辺 ↔ B の左辺
+        stitchTileEdges(a, { right: rawB }, S);
+        stitchTileEdges(b, { left: rawA }, S);
+
+        // 辺ピクセル（角を除く）で A.right === B.left
+        for (let row = 1; row < S - 1; row++) {
+            expect(a[row * S + (S - 1)]).toBe(b[row * S]);
+            expect(a[row * S + (S - 1)]).toBe(15); // avg(10,20)
+        }
+    });
+
+    it("filled でステッチすると辺が非対称になる（バグ再現確認）", () => {
+        // タイルA (値10) を先にステッチ→filled化 した後
+        // タイルB (値20) のステッチで A.filled を参照すると非対称になることを確認
+        const rawA = fill(S, 10);
+        const rawB = fill(S, 20);
+
+        // A を先にステッチ（right=rawB）
+        const filledA = new Float32Array(rawA);
+        stitchTileEdges(filledA, { right: rawB }, S);
+        // filledA の右辺 = avg(10,20) = 15
+
+        // B を A.filled でステッチ（left=filledA）→ 非対称
+        const filledB = new Float32Array(rawB);
+        stitchTileEdges(filledB, { left: filledA }, S);
+        // filledB の左辺 = avg(20, 15) = 17.5 ≠ 15
+
+        for (let row = 1; row < S - 1; row++) {
+            // 非対称: A の右辺(15) ≠ B の左辺(17.5) → 隙間の原因
+            expect(filledA[row * S + (S - 1)]).not.toBe(filledB[row * S]);
+        }
+    });
 });
 
 // --- stitchTileEdgesCrossLevel ---


### PR DESCRIPTION
## 概要

Closes #240

同 zoom タイル間のスティッチで `getNeighborElevations` がステッチ済み（`filled`）データを返していたため、辺の平均が非対称になり隙間が発生していた。

## 変更内容

- `getNeighborElevations` に `useFilled` パラメータ追加（default: `false`）
  - `false`: raw elevation を返し辺平均の対称性を保証
  - `true`: filled データを返し NaN 領域のシード伝搬を維持
- `stitchAndCheckSeed` に `useFilled` パラメータを転送
- `refineAllNaNTiles` で `useFilled=true` を明示指定

## 影響範囲

- **画面**: タイル境界の隙間が解消される
- **内部関数**: `getNeighborElevations`, `stitchAndCheckSeed` にオプション引数追加（いずれも `createTileManager` 内のローカル関数であり外部 API 変更なし）
- **スティッチ対象タイルの選定ロジック**: 変更なし

## テスト

- raw 同士のステッチが対称になるテスト追加
- filled 使用時の非対称性（バグ再現確認）テスト追加
- lint ✅ / typecheck ✅ / unit test ✅ (30 suites, 693 tests)

