### PR TITLE
feat(model): add 3D model API and demo app (#243, #244)

### DIFF
--- a/public/model.html
+++ b/public/model.html
@@ -78,7 +78,7 @@
     }
 
     #model-controls .info-row .label {
-      color: #9aa5b4;
+      color: #c0c8d4;
     }
 
     #model-controls .info-row .value {
@@ -125,11 +125,11 @@
         <span class="value" id="model-azimuth">0°</span>
       </div>
       <div>
-        <label for="azimuth-slider" style="font-size: 11px; color: #9aa5b4;">方位 (0–360°)</label>
+        <label for="azimuth-slider" style="font-size: 11px; color: #c0c8d4;">方位 (0–360°)</label>
         <input type="range" id="azimuth-slider" min="0" max="360" value="0" step="1">
       </div>
       <button id="fly-to-model">モデル位置へ移動</button>
-      <div style="font-size: 10px; color: #7a8594; margin-top: 4px;">
+      <div style="font-size: 10px; color: #a0aab6; margin-top: 4px;">
         地面をクリックするとモデルが移動します
       </div>
     </div>

--- a/public/model.html
+++ b/public/model.html
@@ -68,7 +68,7 @@
     #model-controls strong {
       font-size: 12px;
       letter-spacing: 0.04em;
-      color: #c8d2e6;
+      color: #e8ecf2;
     }
 
     #model-controls .info-row {
@@ -78,7 +78,7 @@
     }
 
     #model-controls .info-row .label {
-      color: #c0c8d4;
+      color: #e0e4ea;
     }
 
     #model-controls .info-row .value {
@@ -125,11 +125,11 @@
         <span class="value" id="model-azimuth">0°</span>
       </div>
       <div>
-        <label for="azimuth-slider" style="font-size: 11px; color: #c0c8d4;">方位 (0–360°)</label>
+        <label for="azimuth-slider" style="font-size: 11px; color: #e0e4ea;">方位 (0–360°)</label>
         <input type="range" id="azimuth-slider" min="0" max="360" value="0" step="1">
       </div>
       <button id="fly-to-model">モデル位置へ移動</button>
-      <div style="font-size: 10px; color: #a0aab6; margin-top: 4px;">
+      <div style="font-size: 10px; color: #c8cdd6; margin-top: 4px;">
         地面をクリックするとモデルが移動します
       </div>
     </div>

--- a/public/model.html
+++ b/public/model.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <title>jpmap_terrain – 3Dモデルデモ</title>
+  <meta name="description" content="jpmap_terrain の 3Dモデル (ModelManager) 公開 API 動作確認デモ (Issue #243 / #244)">
+  <meta name="author" content="8ga3">
+  <style>
+    html, body {
+      overflow: hidden;
+      width: 100%;
+      height: 100%;
+      margin: 0;
+      padding: 0;
+    }
+
+    #root {
+      position: relative;
+      width: 100%;
+      height: 100%;
+      touch-action: none;
+    }
+
+    #model-overlay {
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      z-index: 10;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI",
+        "Hiragino Sans", "Noto Sans JP", Meiryo, sans-serif;
+    }
+
+    #model-overlay .back-link {
+      position: absolute;
+      top: 12px;
+      left: 12px;
+      pointer-events: auto;
+      padding: 6px 12px;
+      font-size: 13px;
+      color: #fff;
+      background: rgba(0, 0, 0, 0.45);
+      border: 1px solid rgba(255, 255, 255, 0.25);
+      border-radius: 6px;
+      text-decoration: none;
+    }
+
+    #model-overlay .back-link:hover {
+      background: rgba(0, 0, 0, 0.6);
+    }
+
+    #model-controls {
+      position: absolute;
+      top: 12px;
+      right: 12px;
+      pointer-events: auto;
+      padding: 12px 14px;
+      font-size: 13px;
+      color: #fff;
+      background: rgba(0, 0, 0, 0.5);
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      border-radius: 8px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      min-width: 200px;
+    }
+
+    #model-controls strong {
+      font-size: 12px;
+      letter-spacing: 0.04em;
+      color: #c8d2e6;
+    }
+
+    #model-controls .info-row {
+      display: flex;
+      justify-content: space-between;
+      font-size: 12px;
+    }
+
+    #model-controls .info-row .label {
+      color: #9aa5b4;
+    }
+
+    #model-controls .info-row .value {
+      font-family: "SF Mono", "Fira Code", monospace;
+    }
+
+    #model-controls input[type="range"] {
+      width: 100%;
+      margin: 4px 0;
+    }
+
+    #model-controls button {
+      pointer-events: auto;
+      padding: 6px 10px;
+      font-size: 12px;
+      color: #fff;
+      background: rgba(255, 255, 255, 0.08);
+      border: 1px solid rgba(255, 255, 255, 0.25);
+      border-radius: 4px;
+      cursor: pointer;
+    }
+
+    #model-controls button:hover {
+      background: rgba(255, 255, 255, 0.18);
+    }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <div id="model-overlay">
+    <a class="back-link" href="/">← デモ一覧へ</a>
+    <div id="model-controls">
+      <strong>3Dモデルデモ (Issue #243 / #244)</strong>
+      <div class="info-row">
+        <span class="label">緯度</span>
+        <span class="value" id="model-lat">-</span>
+      </div>
+      <div class="info-row">
+        <span class="label">経度</span>
+        <span class="value" id="model-lon">-</span>
+      </div>
+      <div class="info-row">
+        <span class="label">方位</span>
+        <span class="value" id="model-azimuth">0°</span>
+      </div>
+      <div>
+        <label for="azimuth-slider" style="font-size: 11px; color: #9aa5b4;">方位 (0–360°)</label>
+        <input type="range" id="azimuth-slider" min="0" max="360" value="0" step="1">
+      </div>
+      <button id="fly-to-model">モデル位置へ移動</button>
+      <div style="font-size: 10px; color: #7a8594; margin-top: 4px;">
+        地面をクリックするとモデルが移動します
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/public/model.html
+++ b/public/model.html
@@ -51,7 +51,7 @@
     #model-controls {
       position: absolute;
       top: 12px;
-      right: 12px;
+      right: 64px;
       pointer-events: auto;
       padding: 12px 14px;
       font-size: 13px;

--- a/public/model.html
+++ b/public/model.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>jpmap_terrain – 3Dモデルデモ</title>
-  <meta name="description" content="jpmap_terrain の 3Dモデル (ModelManager) 公開 API 動作確認デモ (Issue #243 / #244)">
+  <meta name="description" content="jpmap_terrain の 3Dモデル (ModelManager) 公開 API 動作確認デモ">
   <meta name="author" content="8ga3">
   <style>
     html, body {
@@ -111,7 +111,7 @@
   <div id="model-overlay">
     <a class="back-link" href="/">← デモ一覧へ</a>
     <div id="model-controls">
-      <strong>3Dモデルデモ (Issue #243 / #244)</strong>
+      <strong>3Dモデルデモ</strong>
       <div class="info-row">
         <span class="label">緯度</span>
         <span class="value" id="model-lat">-</span>

--- a/public/model.html
+++ b/public/model.html
@@ -128,6 +128,13 @@
         <label for="azimuth-slider" style="font-size: 11px; color: #e0e4ea;">方位 (0–360°)</label>
         <input type="range" id="azimuth-slider" min="0" max="360" value="0" step="1">
       </div>
+      <div>
+        <div class="info-row">
+          <label for="scale-slider" style="font-size: 11px; color: #e0e4ea;">拡大率</label>
+          <span class="value" id="model-scale">50</span>
+        </div>
+        <input type="range" id="scale-slider" min="1" max="200" value="50" step="1">
+      </div>
       <button id="fly-to-model">モデル位置へ移動</button>
       <div style="font-size: 10px; color: #c8cdd6; margin-top: 4px;">
         地面をクリックするとモデルが移動します

--- a/spec/demos.md
+++ b/spec/demos.md
@@ -14,6 +14,7 @@
 | サークル | `/circle.html` | `src/demos/circle/index.ts` | `JpmapTerrain` のサークル公開 API（terrain / absolute / custom-segments の 3 種・updateCircle デモ）の動作確認 (#201 / #206) |
 | 距離計測 | `/distance.html` | `src/demos/distance/index.ts` | 地形クリックで頂点を追加し、辺ごとに水平距離・高低差を表示する。`onTerrainClick` (#183) / `onPolygonPoint*` (#184) / `edgeLabels` (#185) の統合動作確認デモ (#186) |
 | Plan Viewer | `/plan.html` | `src/demos/plan/index.ts` | QGroundControl の `.plan` ファイルをドラッグ&ドロップで表示するビューア。ウェイポイント・ジオフェンス・ラリーポイントを描画 |
+| 3Dモデル | `/model.html` | `src/demos/model/index.ts` | 地面クリックで 3D モデル（human.glb）を配置・移動するデモ。方位変更・座標表示・カメラ移動。Model API (#243) の動作確認 |
 
 ## 設計方針
 
@@ -112,6 +113,24 @@ QGroundControl の `.plan` ファイルをドラッグ&ドロップでマップ�
 - 1 点ポリゴン（`addPolygon`）でマーカー表示。ラベルは `R番号`。
 
 **URL:** `engine` / カメラ系は他デモと共通（`parseCameraStateFromUrl` / `parseMapTypeFromUrl` を共用）。
+
+### model (`/model.html`)
+
+`JpmapTerrain` の 3D モデル公開 API（§3.3.x）の動作確認デモ（#243 / #244）。
+
+**初期状態:** 東京駅（lat: 35.681236, lon: 139.767125）に `assets/human.glb` を `altitudeMode: "terrain"` で配置。
+
+**操作:**
+
+| 操作 | 効果 |
+|---|---|
+| 地面クリック | クリック地点に 3D モデルを移動（カメラから 5km 以内、地面のみ） |
+| 方位スライダー | 3D モデルの Y 軸回転（0–360°） |
+| 「モデル位置へ移動」ボタン | カメラを 3D モデルの緯度・経度に `flyTo` |
+
+**表示:** 右パネルに緯度・経度・方位を表示。方位変更用スライダーと移動ボタンを配置。
+
+**URL:** `engine` に加えてカメラ初期位置（`/@lat,lon[,...]` のパス形式および `?lat=&lon=` クエリ形式）と `?mapType=standard|photo` を受け付ける（`parseCameraStateFromUrl` / `parseMapTypeFromUrl` を共用）。
 
 ## 新規デモの追加手順
 

--- a/spec/package.md
+++ b/spec/package.md
@@ -878,7 +878,7 @@ viewer.addPolygon("dist-line", {
 
 #### 3.3.13 3Dモデル (Issue #243)
 
-Babylon.js がサポートする 3D モデルファイル（glb / gltf / obj 等）を地形上にロードして配置・操作する API。Marker / Polygon / Circle と同パターンの Manager + Handle 構成。
+Babylon.js がサポートする 3D モデルファイル（glb / gltf）を地形上にロードして配置・操作する API。ローダーは `@babylonjs/loaders` の glTF プラグインを使用し、`addModel` 呼び出し時に動的ロードする。Marker / Polygon / Circle と同パターンの Manager + Handle 構成。
 
 ##### 3.3.13.1 公開 API
 

--- a/spec/package.md
+++ b/spec/package.md
@@ -876,6 +876,87 @@ viewer.addPolygon("dist-line", {
 // `removePolygon` + `addPolygon` の rebuild が最も簡潔（distance デモも同方式）。
 ```
 
+#### 3.3.13 3Dモデル (Issue #243)
+
+Babylon.js がサポートする 3D モデルファイル（glb / gltf / obj 等）を地形上にロードして配置・操作する API。Marker / Polygon / Circle と同パターンの Manager + Handle 構成。
+
+##### 3.3.13.1 公開 API
+
+| メソッド | 戻り値 | 説明 |
+|---|---|---|
+| `addModel(id, options)` | `ModelHandle` | 3D モデルをロードして配置する。`id` 重複時は throw |
+| `getModel(id)` | `ModelHandle \| null` | 指定 id のモデル情報を取得。存在しなければ `null` |
+| `updateModel(id, partial)` | `ModelHandle` | 位置・回転・スケール等を部分更新 |
+| `removeModel(id)` | `void` | モデルを削除。存在しなければ `console.warn` で no-op |
+| `setModelEnabled(id, enabled)` | `void` | 表示 / 非表示を切替 |
+| `listModels()` | `readonly string[]` | 登録済みモデルの id 一覧 |
+| `playModelAnimation(id, name?)` | `void` | アニメーション再生。`name` 省略時は全アニメーション |
+| `stopModelAnimation(id, name?)` | `void` | アニメーション停止 |
+
+##### 3.3.13.2 ModelOptions
+
+| パラメータ | 型 | デフォルト | 説明 |
+|---|---|---|---|
+| `url` | `string` | (必須) | モデルファイルの URL |
+| `lat` | `number` | (必須) | 緯度 (度) |
+| `lon` | `number` | (必須) | 経度 (度) |
+| `altitude` | `number` | `0` | 高度 (m)。terrain 時は地表オフセット、absolute 時は海抜高度 |
+| `altitudeMode` | `AltitudeMode` | `"terrain"` | `"terrain"`: 地表追従 / `"absolute"`: 絶対高度 |
+| `rotation` | `ModelVector3` | `{x:0, y:0, z:0}` | 回転 (度)。Euler 角 |
+| `scaling` | `ModelVector3` | `{x:1, y:1, z:1}` | スケール倍率 |
+| `enabled` | `boolean` | `true` | 表示 / 非表示 |
+| `gravity` | `boolean` | `true` | 地表追従。terrain モード時のみ有効 |
+
+##### 3.3.13.3 ModelHandle
+
+| プロパティ | 型 | 説明 |
+|---|---|---|
+| `id` | `string` | モデル ID |
+| `url` | `string` | モデルファイル URL |
+| `lat` / `lon` | `number` | 緯度・経度 |
+| `altitude` | `number` | 高度 |
+| `altitudeMode` | `AltitudeMode` | 高度モード |
+| `rotation` | `Required<ModelVector3>` | 回転 (度) |
+| `scaling` | `Required<ModelVector3>` | スケール倍率 |
+| `enabled` | `boolean` | 表示状態 |
+| `gravity` | `boolean` | 地表追従状態 |
+| `loaded` | `boolean` | モデルロード完了フラグ |
+| `elevationResolved` | `boolean` | 地表標高解決済みフラグ |
+| `animationNames` | `readonly string[]` | モデルが持つアニメーション名一覧 |
+
+##### 3.3.13.4 ModelUpdate
+
+`url` を除く `ModelOptions` の全フィールドを `Partial` で受け付ける。未指定フィールドは現状維持。モデルファイルの差替えは `removeModel` → `addModel` で行う。
+
+##### 3.3.13.5 利用例
+
+```typescript
+import { JpmapTerrain } from "jpmap-terrain";
+
+const viewer = await JpmapTerrain.create(mount, { lat: 35.68, lon: 139.77 });
+
+// 3D モデルを東京駅に配置
+const handle = viewer.addModel("human", {
+  url: "assets/human.glb",
+  lat: 35.681236,
+  lon: 139.767125,
+  altitudeMode: "terrain",
+  rotation: { y: 90 },
+});
+
+// 位置を更新
+viewer.updateModel("human", { lat: 35.69, lon: 139.77 });
+
+// アニメーション再生
+viewer.playModelAnimation("human");
+
+// 向きを変える
+viewer.updateModel("human", { rotation: { y: 180 } });
+
+// 削除
+viewer.removeModel("human");
+```
+
 ### 3.4 型定義
 
 `CameraChangeEvent` および `CameraChangeListener` は、`jpmap-terrain` から import 可能である（パッケージエントリで re-export 済み）。

--- a/src/demos/model/index.ts
+++ b/src/demos/model/index.ts
@@ -19,10 +19,11 @@ import {
     parseCameraStateFromUrl,
     parseMapTypeFromUrl,
 } from "../../terrain/urlState";
+import humanGlbUrl from "../../../assets/human.glb";
 
 const DEMO_MOUNT_ID = "root";
 const MODEL_ID = "human";
-const MODEL_URL = "assets/human.glb";
+const MODEL_URL: string = humanGlbUrl;
 
 /** 東京駅 */
 const TOKYO_STATION = { lat: 35.681236, lon: 139.767125 };

--- a/src/demos/model/index.ts
+++ b/src/demos/model/index.ts
@@ -1,0 +1,133 @@
+/**
+ * 3Dモデルデモ (Issue #244)
+ *
+ * `JpmapTerrain` の Model 公開 API（`addModel` / `updateModel` /
+ * `removeModel` / `getModel` / `setModelEnabled`）を目視確認するためのデモ。
+ *
+ * 仕様:
+ * - 東京駅に `assets/human.glb` を初期配置
+ * - 地面クリックで3Dモデルを移動
+ * - 方位スライダーで向き変更
+ * - 緯度・経度・方位の表示
+ * - モデル位置へカメラ移動ボタン
+ * - クリック可能範囲はカメラから一定距離以内
+ * - 地面以外は無視
+ */
+import { JpmapTerrain } from "../../lib/jpmapTerrain";
+import type { JpmapTerrainOptions, TerrainClickEvent } from "../../lib/types";
+import {
+    parseCameraStateFromUrl,
+    parseMapTypeFromUrl,
+} from "../../terrain/urlState";
+
+const DEMO_MOUNT_ID = "root";
+const MODEL_ID = "human";
+const MODEL_URL = "assets/human.glb";
+
+/** 東京駅 */
+const TOKYO_STATION = { lat: 35.681236, lon: 139.767125 };
+
+/** クリック可能距離 (m)。カメラからこの距離以内のみクリックを受け付ける */
+const MAX_CLICK_DISTANCE_M = 5000;
+
+const resolveEngine = (search: string): "webgpu" | "webgl2" | undefined => {
+    const value = new URLSearchParams(search).get("engine");
+    if (value === "webgpu") return "webgpu";
+    if (value === "webgl" || value === "webgl2") return "webgl2";
+    return undefined;
+};
+
+const start = async (): Promise<void> => {
+    const mount = document.getElementById(DEMO_MOUNT_ID);
+    if (!mount) return;
+
+    const camera = parseCameraStateFromUrl(location.href);
+    const mapType = parseMapTypeFromUrl(location.href);
+
+    const opts: JpmapTerrainOptions = {
+        engine: resolveEngine(location.search),
+        lat: camera?.lat ?? TOKYO_STATION.lat,
+        lon: camera?.lon ?? TOKYO_STATION.lon,
+        altitude: camera?.altitude ?? 500,
+        azimuth: camera?.azimuth,
+        tilt: camera?.tilt ?? 45,
+        mapType: mapType ?? "standard",
+    };
+
+    const viewer = await JpmapTerrain.create(mount, opts);
+
+    // 開発/テスト用グローバル公開
+    if (process.env.NODE_ENV !== "production") {
+        (window as unknown as { viewer: JpmapTerrain }).viewer = viewer;
+    }
+
+    // 初期配置: 東京駅に human.glb を配置
+    let currentRotationY = 0;
+    viewer.addModel(MODEL_ID, {
+        url: MODEL_URL,
+        lat: TOKYO_STATION.lat,
+        lon: TOKYO_STATION.lon,
+        altitudeMode: "terrain",
+        altitude: 0,
+        rotation: { y: currentRotationY },
+        gravity: true,
+    });
+
+    // --- UI 要素の取得 ---
+    const latDisplay = document.getElementById("model-lat") as HTMLSpanElement;
+    const lonDisplay = document.getElementById("model-lon") as HTMLSpanElement;
+    const azimuthDisplay = document.getElementById("model-azimuth") as HTMLSpanElement;
+    const azimuthSlider = document.getElementById("azimuth-slider") as HTMLInputElement;
+    const flyToBtn = document.getElementById("fly-to-model") as HTMLButtonElement;
+
+    let modelLat = TOKYO_STATION.lat;
+    let modelLon = TOKYO_STATION.lon;
+
+    const updateDisplay = (): void => {
+        if (latDisplay) latDisplay.textContent = modelLat.toFixed(6);
+        if (lonDisplay) lonDisplay.textContent = modelLon.toFixed(6);
+        if (azimuthDisplay) azimuthDisplay.textContent = `${currentRotationY}°`;
+    };
+
+    updateDisplay();
+
+    // 方位スライダー
+    if (azimuthSlider) {
+        azimuthSlider.value = String(currentRotationY);
+        azimuthSlider.addEventListener("input", () => {
+            currentRotationY = Number(azimuthSlider.value);
+            viewer.updateModel(MODEL_ID, { rotation: { y: currentRotationY } });
+            updateDisplay();
+        });
+    }
+
+    // モデル位置へ移動ボタン
+    if (flyToBtn) {
+        flyToBtn.addEventListener("click", () => {
+            viewer.flyTo({ lat: modelLat, lon: modelLon, duration: 1500 });
+        });
+    }
+
+    // 地面クリックでモデル移動
+    viewer.onTerrainClick((event: TerrainClickEvent) => {
+        // カメラからの距離チェック
+        const cameraLat = viewer.lat;
+        const cameraLon = viewer.lon;
+        const dLat = (event.lat - cameraLat) * 111320;
+        const dLon = (event.lon - cameraLon) * 111320 * Math.cos((cameraLat * Math.PI) / 180);
+        const dist = Math.sqrt(dLat * dLat + dLon * dLon);
+        if (dist > MAX_CLICK_DISTANCE_M) return;
+
+        modelLat = event.lat;
+        modelLon = event.lon;
+        viewer.updateModel(MODEL_ID, {
+            lat: modelLat,
+            lon: modelLon,
+        });
+        updateDisplay();
+    });
+};
+
+start().catch((err) => {
+    console.error("[model-demo] Failed to start:", err);
+});

--- a/src/demos/model/index.ts
+++ b/src/demos/model/index.ts
@@ -27,6 +27,8 @@ const MODEL_URL = "assets/human.glb";
 /** 東京駅 */
 const TOKYO_STATION = { lat: 35.681236, lon: 139.767125 };
 
+/** モデルの表示スケール。human.glb は約1m なので地形上で視認できるサイズに拡大 */
+const MODEL_SCALE = 50;
 /** クリック可能距離 (m)。カメラからこの距離以内のみクリックを受け付ける */
 const MAX_CLICK_DISTANCE_M = 5000;
 
@@ -70,6 +72,7 @@ const start = async (): Promise<void> => {
         altitudeMode: "terrain",
         altitude: 0,
         rotation: { y: currentRotationY },
+        scaling: { x: MODEL_SCALE, y: MODEL_SCALE, z: MODEL_SCALE },
         gravity: true,
     });
 

--- a/src/demos/model/index.ts
+++ b/src/demos/model/index.ts
@@ -81,15 +81,19 @@ const start = async (): Promise<void> => {
     const lonDisplay = document.getElementById("model-lon") as HTMLSpanElement;
     const azimuthDisplay = document.getElementById("model-azimuth") as HTMLSpanElement;
     const azimuthSlider = document.getElementById("azimuth-slider") as HTMLInputElement;
+    const scaleDisplay = document.getElementById("model-scale") as HTMLSpanElement;
+    const scaleSlider = document.getElementById("scale-slider") as HTMLInputElement;
     const flyToBtn = document.getElementById("fly-to-model") as HTMLButtonElement;
 
     let modelLat = TOKYO_STATION.lat;
     let modelLon = TOKYO_STATION.lon;
+    let currentScale = MODEL_SCALE;
 
     const updateDisplay = (): void => {
         if (latDisplay) latDisplay.textContent = modelLat.toFixed(6);
         if (lonDisplay) lonDisplay.textContent = modelLon.toFixed(6);
         if (azimuthDisplay) azimuthDisplay.textContent = `${currentRotationY}°`;
+        if (scaleDisplay) scaleDisplay.textContent = String(currentScale);
     };
 
     updateDisplay();
@@ -100,6 +104,17 @@ const start = async (): Promise<void> => {
         azimuthSlider.addEventListener("input", () => {
             currentRotationY = Number(azimuthSlider.value);
             viewer.updateModel(MODEL_ID, { rotation: { y: currentRotationY } });
+            updateDisplay();
+        });
+    }
+
+    // 拡大率スライダー
+    if (scaleSlider) {
+        scaleSlider.value = String(currentScale);
+        scaleSlider.addEventListener("input", () => {
+            currentScale = Number(scaleSlider.value);
+            const s = currentScale;
+            viewer.updateModel(MODEL_ID, { scaling: { x: s, y: s, z: s } });
             updateDisplay();
         });
     }

--- a/src/demos/model/index.ts
+++ b/src/demos/model/index.ts
@@ -138,9 +138,15 @@ const start = async (): Promise<void> => {
 
         modelLat = event.lat;
         modelLon = event.lon;
+        // event.altitude はメッシュ表面の実際のY座標。
+        // queryElevationAtWorld は最近傍ピクセルで補間するため、
+        // 急な坂では terrain モードとズレが生じる。
+        // absolute + event.altitude でクリック位置に正確に配置する。
         viewer.updateModel(MODEL_ID, {
             lat: modelLat,
             lon: modelLon,
+            altitudeMode: "absolute",
+            altitude: event.altitude,
         });
         updateDisplay();
     });

--- a/src/demos/portal/index.ts
+++ b/src/demos/portal/index.ts
@@ -54,6 +54,12 @@ const DEMO_LIST: readonly DemoEntry[] = [
             "QGroundControl の Plan ファイル（.plan）をドラッグ&ドロップでマップ上に表示するビューア。ウェイポイント・ジオフェンス・ラリーポイントを描画します。",
         href: "plan",
     },
+    {
+        title: "3Dモデル",
+        description:
+            "地面クリックで 3D モデル（human.glb）を配置・移動するデモ。方位変更やモデル位置へのカメラ移動が可能です。",
+        href: "model",
+    },
 ];
 
 const PORTAL_MOUNT_ID = "root";

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -42,10 +42,15 @@ export type {
     CircleOptions,
     CircleUpdate,
     CircleHandle,
+    ModelVector3,
+    ModelOptions,
+    ModelUpdate,
+    ModelHandle,
 } from "./lib/types";
 export {
     CIRCLE_DEFAULTS,
     CIRCLE_SEGMENTS_MIN,
     CIRCLE_SEGMENTS_MAX,
     CIRCLE_RADIUS_MAX_M,
+    MODEL_DEFAULTS,
 } from "./lib/types";

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -30,6 +30,9 @@ import {
     MarkerHandle,
     MarkerOptions,
     MarkerUpdate,
+    ModelHandle,
+    ModelOptions,
+    ModelUpdate,
     PolygonHandle,
     PolygonOptions,
     PolygonPointOptions,
@@ -45,6 +48,7 @@ import {
 import { createMarkerManager, type MarkerManager } from "../terrain/markerManager";
 import { createPolygonManager, type PolygonManager } from "../terrain/polygonManager";
 import { createCircleManager, type CircleManager } from "../terrain/circleManager";
+import { createModelManager, type ModelManager } from "../terrain/modelManager";
 
 /**
  * jpmap-terrain ビューア。
@@ -109,6 +113,9 @@ export class JpmapTerrain {
 
     /** 円管理 (Issue #201)。`onReady` で初期化される */
     private _circleManager: CircleManager | null = null;
+
+    /** 3Dモデル管理 (Issue #243)。`onReady` で初期化される */
+    private _modelManager: ModelManager | null = null;
 
     private constructor(mountElement: HTMLElement, options: JpmapTerrainOptions) {
         this.mountElement = mountElement;
@@ -264,6 +271,10 @@ export class JpmapTerrain {
                     this._circleManager = createCircleManager(
                         controller.getMarkerContext(),
                     );
+                    // 3Dモデル (Issue #243)。MarkerContext と同一のコンテキストを共有する。
+                    this._modelManager = createModelManager(
+                        controller.getMarkerContext(),
+                    );
                 },
             });
             this._scene = scene;
@@ -294,6 +305,10 @@ export class JpmapTerrain {
             if (this._circleManager) {
                 try { this._circleManager.dispose(); } catch { /* best-effort */ }
                 this._circleManager = null;
+            }
+            if (this._modelManager) {
+                try { this._modelManager.dispose(); } catch { /* best-effort */ }
+                this._modelManager = null;
             }
             if (this._polygonManager) {
                 try { this._polygonManager.dispose(); } catch { /* best-effort */ }
@@ -1147,6 +1162,60 @@ export class JpmapTerrain {
         return this._circleManager?.list() ?? [];
     }
 
+    // ---- 3Dモデル (Issue #243) ----
+
+    private _requireModelManager(): ModelManager {
+        if (!this._modelManager) {
+            throw new Error("JpmapTerrain model manager is not ready yet");
+        }
+        return this._modelManager;
+    }
+
+    /**
+     * dispose 後の Model API はマーカーと同方針で統一する:
+     * - 戻り値が `ModelHandle`（非 null）の API（`addModel` / `updateModel`）は throw。
+     * - 戻り値が void / `ModelHandle | null` / `readonly string[]` の API は no-op として扱う。
+     */
+    public addModel(id: string, options: ModelOptions): ModelHandle {
+        this._assertAlive();
+        return this._requireModelManager().add(id, options);
+    }
+
+    public getModel(id: string): ModelHandle | null {
+        if (this._disposed || !this._modelManager) return null;
+        return this._modelManager.get(id);
+    }
+
+    public updateModel(id: string, partial: ModelUpdate): ModelHandle {
+        this._assertAlive();
+        return this._requireModelManager().update(id, partial);
+    }
+
+    public removeModel(id: string): void {
+        if (this._disposed || !this._modelManager) return;
+        this._modelManager.remove(id);
+    }
+
+    public setModelEnabled(id: string, enabled: boolean): void {
+        if (this._disposed || !this._modelManager) return;
+        this._modelManager.setEnabled(id, enabled);
+    }
+
+    public listModels(): readonly string[] {
+        if (this._disposed) return [];
+        return this._modelManager?.list() ?? [];
+    }
+
+    public playModelAnimation(id: string, name?: string): void {
+        if (this._disposed || !this._modelManager) return;
+        this._modelManager.playAnimation(id, name);
+    }
+
+    public stopModelAnimation(id: string, name?: string): void {
+        if (this._disposed || !this._modelManager) return;
+        this._modelManager.stopAnimation(id, name);
+    }
+
     // ---- ライフサイクル (spec §3.3.3) ----
 
     /**
@@ -1211,6 +1280,15 @@ export class JpmapTerrain {
                 console.error("[JpmapTerrain] circleManager.dispose threw:", err);
             }
             this._circleManager = null;
+        }
+        // 3Dモデルマネージャも Scene dispose 前に解放する (Issue #243)。
+        if (this._modelManager) {
+            try {
+                this._modelManager.dispose();
+            } catch (err) {
+                console.error("[JpmapTerrain] modelManager.dispose threw:", err);
+            }
+            this._modelManager = null;
         }
         // controlPanel が body に追加した UI 要素を Scene dispose 前に除去する。
         if (this._controller) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -709,3 +709,118 @@ export const CIRCLE_DEFAULTS = {
         labelFontSize: 14,
     },
 } as const;
+
+// ---- 3Dモデル (Issue #243) ----
+
+/**
+ * 3Dモデルの3軸値（回転・スケール共通）。
+ * 未指定軸はデフォルト値が適用される。
+ */
+export interface ModelVector3 {
+    /** X 軸値 */
+    x?: number;
+    /** Y 軸値 */
+    y?: number;
+    /** Z 軸値 */
+    z?: number;
+}
+
+/**
+ * `JpmapTerrain.addModel` のオプション (Issue #243)。
+ *
+ * Babylon.js がサポートする 3D モデルファイル (glb / gltf / obj 等) を
+ * 地形上にロードして配置する。
+ */
+export interface ModelOptions {
+    /** モデルファイルの URL（相対 / 絶対いずれも可） */
+    url: string;
+    /** 緯度 (度) */
+    lat: number;
+    /** 経度 (度) */
+    lon: number;
+    /**
+     * 高度 (m)。
+     * - `altitudeMode === "absolute"`: 海抜高度。必須。
+     * - `altitudeMode === "terrain"`: 地表からのオフセット (m)。default 0。
+     */
+    altitude?: number;
+    /** 高度モード。default `"terrain"` */
+    altitudeMode?: AltitudeMode;
+    /**
+     * 回転 (度)。各軸は Euler 回転として適用される。
+     * default `{ x: 0, y: 0, z: 0 }`
+     */
+    rotation?: ModelVector3;
+    /**
+     * スケール倍率。default `{ x: 1, y: 1, z: 1 }`
+     */
+    scaling?: ModelVector3;
+    /** 表示 / 非表示。default true */
+    enabled?: boolean;
+    /**
+     * 地表追従（重力）。default true。
+     * `true` のとき毎フレーム地表標高を取得して Y 座標を追従させる。
+     * `altitudeMode === "terrain"` のときのみ有効（`absolute` 時は無視）。
+     */
+    gravity?: boolean;
+}
+
+/**
+ * `JpmapTerrain.updateModel` の部分更新型 (Issue #243)。
+ *
+ * 未指定フィールドは現状維持される。`url` は変更不可（モデル差替えは remove → add）。
+ */
+export type ModelUpdate = Partial<
+    Pick<
+        ModelOptions,
+        | "lat"
+        | "lon"
+        | "altitude"
+        | "altitudeMode"
+        | "rotation"
+        | "scaling"
+        | "enabled"
+        | "gravity"
+    >
+>;
+
+/**
+ * `JpmapTerrain.addModel` / `getModel` / `updateModel` の戻り値 (Issue #243)。
+ * read-only スナップショット。
+ */
+export interface ModelHandle {
+    readonly id: string;
+    readonly url: string;
+    readonly lat: number;
+    readonly lon: number;
+    readonly altitude: number;
+    readonly altitudeMode: AltitudeMode;
+    readonly rotation: Readonly<Required<ModelVector3>>;
+    readonly scaling: Readonly<Required<ModelVector3>>;
+    readonly enabled: boolean;
+    readonly gravity: boolean;
+    /**
+     * モデルのロードが完了しているなら true。
+     * ロード中（非同期 SceneLoader 処理中）は false。
+     */
+    readonly loaded: boolean;
+    /**
+     * `terrain` モード時、地表標高が解決済みなら true。
+     * `absolute` モード時は常に true。
+     */
+    readonly elevationResolved: boolean;
+    /** モデルが持つアニメーション名の一覧。ロード前は空配列 */
+    readonly animationNames: readonly string[];
+}
+
+/**
+ * 3Dモデルの既定値 (Issue #243)。
+ */
+export const MODEL_DEFAULTS = {
+    altitude: 0,
+    altitudeMode: "terrain" as AltitudeMode,
+    rotation: { x: 0, y: 0, z: 0 },
+    scaling: { x: 1, y: 1, z: 1 },
+    enabled: true,
+    gravity: true,
+} as const;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -728,7 +728,7 @@ export interface ModelVector3 {
 /**
  * `JpmapTerrain.addModel` のオプション (Issue #243)。
  *
- * Babylon.js がサポートする 3D モデルファイル (glb / gltf / obj 等) を
+ * Babylon.js がサポートする 3D モデルファイル (glb / gltf) を
  * 地形上にロードして配置する。
  */
 export interface ModelOptions {

--- a/src/terrain/modelManager.ts
+++ b/src/terrain/modelManager.ts
@@ -15,7 +15,9 @@ import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import type { AbstractMesh } from "@babylonjs/core/Meshes/abstractMesh";
 import type { AnimationGroup } from "@babylonjs/core/Animations/animationGroup";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
-import "@babylonjs/loaders/glTF";
+// glTF/GLB ローダーは `addModel` 呼び出し時に動的ロードする。
+// トップレベル import にすると @babylonjs/loaders が optional peer dependency でも
+// パッケージ利用者が Model API を使わない場合に実行時エラーになるため。
 
 import {
     assertLatLonInBounds,
@@ -126,8 +128,9 @@ export const createModelManager = (ctx: OverlayContext): ModelManager => {
         const { wx, wz } = latLonToWorld(ctx, entry.lat, entry.lon);
 
         if (entry.altitudeMode === "absolute") {
-            entry.root.position = new Vector3(wx, entry.altitude, wz);
+            entry.root.position.set(wx, entry.altitude, wz);
             entry.elevationResolved = true;
+            setMeshVisibility(entry, entry.enabled);
             return;
         }
 
@@ -140,9 +143,9 @@ export const createModelManager = (ctx: OverlayContext): ModelManager => {
                 return;
             }
             entry.elevationResolved = true;
-            entry.root.position = new Vector3(wx, elev + entry.altitude, wz);
+            entry.root.position.set(wx, elev + entry.altitude, wz);
         } else {
-            entry.root.position = new Vector3(wx, entry.altitude, wz);
+            entry.root.position.set(wx, entry.altitude, wz);
             entry.elevationResolved = true;
         }
         setMeshVisibility(entry, entry.enabled);
@@ -180,6 +183,8 @@ export const createModelManager = (ctx: OverlayContext): ModelManager => {
     const loadModel = async (entry: ModelEntry): Promise<void> => {
         const { rootUrl, sceneFilename } = splitUrl(entry.url);
         try {
+            // glTF/GLB ローダーを動的ロード（optional peer dependency のため遅延）
+            await import("@babylonjs/loaders/glTF");
             const result = await SceneLoader.ImportMeshAsync(
                 "",
                 rootUrl,

--- a/src/terrain/modelManager.ts
+++ b/src/terrain/modelManager.ts
@@ -1,0 +1,452 @@
+/**
+ * ModelManager (Issue #243)。
+ *
+ * `JpmapTerrain.addModel / getModel / updateModel / removeModel / setModelEnabled /
+ *  listModels / playModelAnimation / stopModelAnimation`
+ * から呼び出される。3Dモデルの ID 管理・非同期ロード・毎フレームの位置更新を担う。
+ *
+ * Marker / Circle / Polygon Manager と同パターンで実装する。
+ */
+
+import type { Observer } from "@babylonjs/core/Misc/observable";
+import type { Scene } from "@babylonjs/core/scene";
+import { SceneLoader } from "@babylonjs/core/Loading/sceneLoader";
+import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import type { AbstractMesh } from "@babylonjs/core/Meshes/abstractMesh";
+import type { AnimationGroup } from "@babylonjs/core/Animations/animationGroup";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import "@babylonjs/loaders/glTF";
+
+import {
+    assertLatLonInBounds,
+    latLonToWorld,
+    type OverlayContext,
+} from "./overlayCoords";
+import {
+    MODEL_DEFAULTS,
+    type AltitudeMode,
+    type ModelHandle,
+    type ModelOptions,
+    type ModelUpdate,
+    type ModelVector3,
+} from "../lib/types";
+
+export interface ModelManager {
+    add(id: string, options: ModelOptions): ModelHandle;
+    get(id: string): ModelHandle | null;
+    update(id: string, partial: ModelUpdate): ModelHandle;
+    remove(id: string): void;
+    setEnabled(id: string, enabled: boolean): void;
+    list(): readonly string[];
+    playAnimation(id: string, name?: string): void;
+    stopAnimation(id: string, name?: string): void;
+    dispose(): void;
+}
+
+const ERROR_PREFIX = "JpmapTerrain.addModel";
+const UPDATE_ERROR_PREFIX = "JpmapTerrain.updateModel";
+
+interface ModelEntry {
+    id: string;
+    url: string;
+    lat: number;
+    lon: number;
+    altitude: number;
+    altitudeMode: AltitudeMode;
+    rotation: Required<ModelVector3>;
+    scaling: Required<ModelVector3>;
+    enabled: boolean;
+    gravity: boolean;
+    loaded: boolean;
+    elevationResolved: boolean;
+    root: TransformNode;
+    meshes: AbstractMesh[];
+    animationGroups: AnimationGroup[];
+    /** ロード中止用。dispose / remove 時に true にする */
+    cancelled: boolean;
+}
+
+const resolveVec3 = (
+    v: ModelVector3 | undefined,
+    defaults: Readonly<Required<ModelVector3>>,
+): Required<ModelVector3> => ({
+    x: v?.x ?? defaults.x,
+    y: v?.y ?? defaults.y,
+    z: v?.z ?? defaults.z,
+});
+
+const toHandle = (entry: ModelEntry): ModelHandle => ({
+    id: entry.id,
+    url: entry.url,
+    lat: entry.lat,
+    lon: entry.lon,
+    altitude: entry.altitude,
+    altitudeMode: entry.altitudeMode,
+    rotation: { ...entry.rotation },
+    scaling: { ...entry.scaling },
+    enabled: entry.enabled,
+    gravity: entry.gravity,
+    loaded: entry.loaded,
+    elevationResolved: entry.elevationResolved,
+    animationNames: entry.animationGroups.map((ag) => ag.name),
+});
+
+const applyRotation = (root: TransformNode, rotation: Required<ModelVector3>): void => {
+    root.rotation = new Vector3(
+        (rotation.x * Math.PI) / 180,
+        (rotation.y * Math.PI) / 180,
+        (rotation.z * Math.PI) / 180,
+    );
+};
+
+const applyScaling = (root: TransformNode, scaling: Required<ModelVector3>): void => {
+    root.scaling = new Vector3(scaling.x, scaling.y, scaling.z);
+};
+
+/**
+ * URL を rootUrl（ディレクトリ部分）と sceneFilename（ファイル名部分）に分割する。
+ * SceneLoader.ImportMeshAsync は rootUrl + sceneFilename の形で指定する。
+ */
+const splitUrl = (url: string): { rootUrl: string; sceneFilename: string } => {
+    const lastSlash = url.lastIndexOf("/");
+    if (lastSlash === -1) {
+        return { rootUrl: "", sceneFilename: url };
+    }
+    return {
+        rootUrl: url.substring(0, lastSlash + 1),
+        sceneFilename: url.substring(lastSlash + 1),
+    };
+};
+
+export const createModelManager = (ctx: OverlayContext): ModelManager => {
+    const entries = new Map<string, ModelEntry>();
+    let disposed = false;
+
+    const applyTransform = (entry: ModelEntry): void => {
+        const { wx, wz } = latLonToWorld(ctx, entry.lat, entry.lon);
+
+        if (entry.altitudeMode === "absolute") {
+            entry.root.position = new Vector3(wx, entry.altitude, wz);
+            entry.elevationResolved = true;
+            return;
+        }
+
+        // terrain モード
+        if (entry.gravity) {
+            const elev = ctx.tileManager.queryElevationAtWorld(wx, wz);
+            if (elev === null) {
+                entry.elevationResolved = false;
+                setMeshVisibility(entry, false);
+                return;
+            }
+            entry.elevationResolved = true;
+            entry.root.position = new Vector3(wx, elev + entry.altitude, wz);
+        } else {
+            entry.root.position = new Vector3(wx, entry.altitude, wz);
+            entry.elevationResolved = true;
+        }
+        setMeshVisibility(entry, entry.enabled);
+    };
+
+    const setMeshVisibility = (entry: ModelEntry, visible: boolean): void => {
+        for (const mesh of entry.meshes) {
+            mesh.setEnabled(visible);
+        }
+    };
+
+    const tickFrame = (): void => {
+        if (entries.size === 0) return;
+        for (const entry of entries.values()) {
+            if (!entry.loaded) continue;
+            applyTransform(entry);
+        }
+    };
+
+    const observer: Observer<Scene> | null =
+        ctx.scene.onBeforeRenderObservable.add(tickFrame);
+
+    const unsubscribeTerrain = ctx.tileManager.subscribeTerrainUpdated(() => {
+        // 標高更新時は次フレームの tickFrame で自動的に再評価される
+    });
+
+    const requireEntry = (id: string, prefix: string): ModelEntry => {
+        const entry = entries.get(id);
+        if (!entry) {
+            throw new Error(`${prefix}: id "${id}" not found`);
+        }
+        return entry;
+    };
+
+    const loadModel = async (entry: ModelEntry): Promise<void> => {
+        const { rootUrl, sceneFilename } = splitUrl(entry.url);
+        try {
+            const result = await SceneLoader.ImportMeshAsync(
+                "",
+                rootUrl,
+                sceneFilename,
+                ctx.scene,
+            );
+            if (entry.cancelled) {
+                // dispose / remove が先に呼ばれた場合はロード結果を破棄
+                for (const mesh of result.meshes) {
+                    mesh.dispose();
+                }
+                for (const ag of result.animationGroups) {
+                    ag.dispose();
+                }
+                return;
+            }
+            entry.meshes = result.meshes;
+            entry.animationGroups = result.animationGroups;
+            entry.loaded = true;
+
+            // 全メッシュを root TransformNode の子にする
+            for (const mesh of result.meshes) {
+                if (!mesh.parent) {
+                    mesh.parent = entry.root;
+                }
+            }
+
+            applyRotation(entry.root, entry.rotation);
+            applyScaling(entry.root, entry.scaling);
+            setMeshVisibility(entry, entry.enabled);
+            applyTransform(entry);
+
+            // アニメーションは最初は停止状態
+            for (const ag of result.animationGroups) {
+                ag.stop();
+            }
+        } catch (err) {
+            if (!entry.cancelled) {
+                console.error(
+                    `[jpmap-terrain] Failed to load model "${entry.id}" from "${entry.url}":`,
+                    err,
+                );
+            }
+        }
+    };
+
+    return {
+        add(id: string, options: ModelOptions): ModelHandle {
+            if (disposed) {
+                throw new Error("ModelManager has been disposed");
+            }
+            if (entries.has(id)) {
+                throw new Error(
+                    `${ERROR_PREFIX}: id "${id}" already exists`,
+                );
+            }
+            if (!options.url) {
+                throw new Error(`${ERROR_PREFIX}: url is required`);
+            }
+            assertLatLonInBounds(options.lat, options.lon, ERROR_PREFIX);
+
+            const altitudeMode =
+                options.altitudeMode ?? MODEL_DEFAULTS.altitudeMode;
+            if (
+                altitudeMode === "absolute" &&
+                options.altitude === undefined
+            ) {
+                throw new Error(
+                    `${ERROR_PREFIX}: altitudeMode="absolute" requires altitude`,
+                );
+            }
+
+            const root = new TransformNode(`model-${id}`, ctx.scene);
+
+            const entry: ModelEntry = {
+                id,
+                url: options.url,
+                lat: options.lat,
+                lon: options.lon,
+                altitude: options.altitude ?? MODEL_DEFAULTS.altitude,
+                altitudeMode,
+                rotation: resolveVec3(options.rotation, MODEL_DEFAULTS.rotation),
+                scaling: resolveVec3(options.scaling, MODEL_DEFAULTS.scaling),
+                enabled: options.enabled ?? MODEL_DEFAULTS.enabled,
+                gravity: options.gravity ?? MODEL_DEFAULTS.gravity,
+                loaded: false,
+                elevationResolved: altitudeMode === "absolute",
+                root,
+                meshes: [],
+                animationGroups: [],
+                cancelled: false,
+            };
+
+            entries.set(id, entry);
+
+            // 非同期でモデルをロード
+            void loadModel(entry);
+
+            return toHandle(entry);
+        },
+
+        get(id: string): ModelHandle | null {
+            const entry = entries.get(id);
+            return entry ? toHandle(entry) : null;
+        },
+
+        update(id: string, partial: ModelUpdate): ModelHandle {
+            if (disposed) {
+                throw new Error("ModelManager has been disposed");
+            }
+            const entry = requireEntry(id, UPDATE_ERROR_PREFIX);
+
+            if (partial.lat !== undefined || partial.lon !== undefined) {
+                const newLat = partial.lat ?? entry.lat;
+                const newLon = partial.lon ?? entry.lon;
+                assertLatLonInBounds(newLat, newLon, UPDATE_ERROR_PREFIX);
+                entry.lat = newLat;
+                entry.lon = newLon;
+            }
+
+            if (partial.altitude !== undefined) {
+                entry.altitude = partial.altitude;
+            }
+
+            if (partial.altitudeMode !== undefined) {
+                if (
+                    partial.altitudeMode === "absolute" &&
+                    (partial.altitude ?? entry.altitude) === undefined
+                ) {
+                    throw new Error(
+                        `${UPDATE_ERROR_PREFIX}: altitudeMode="absolute" requires altitude`,
+                    );
+                }
+                entry.altitudeMode = partial.altitudeMode;
+            }
+
+            if (partial.rotation !== undefined) {
+                entry.rotation = resolveVec3(partial.rotation, entry.rotation);
+                if (entry.loaded) {
+                    applyRotation(entry.root, entry.rotation);
+                }
+            }
+
+            if (partial.scaling !== undefined) {
+                entry.scaling = resolveVec3(partial.scaling, entry.scaling);
+                if (entry.loaded) {
+                    applyScaling(entry.root, entry.scaling);
+                }
+            }
+
+            if (partial.enabled !== undefined) {
+                entry.enabled = partial.enabled;
+                if (entry.loaded) {
+                    setMeshVisibility(entry, partial.enabled);
+                }
+            }
+
+            if (partial.gravity !== undefined) {
+                entry.gravity = partial.gravity;
+            }
+
+            if (entry.loaded) {
+                applyTransform(entry);
+            }
+
+            return toHandle(entry);
+        },
+
+        remove(id: string): void {
+            const entry = entries.get(id);
+            if (!entry) {
+                console.warn(
+                    `[jpmap-terrain] removeModel: id "${id}" not found`,
+                );
+                return;
+            }
+            entry.cancelled = true;
+            for (const ag of entry.animationGroups) {
+                ag.stop();
+                ag.dispose();
+            }
+            for (const mesh of entry.meshes) {
+                mesh.dispose();
+            }
+            entry.root.dispose();
+            entries.delete(id);
+        },
+
+        setEnabled(id: string, enabled: boolean): void {
+            if (disposed) {
+                throw new Error("ModelManager has been disposed");
+            }
+            const entry = requireEntry(id, "JpmapTerrain.setModelEnabled");
+            entry.enabled = enabled;
+            if (entry.loaded) {
+                setMeshVisibility(entry, enabled);
+            }
+        },
+
+        list(): readonly string[] {
+            return Array.from(entries.keys());
+        },
+
+        playAnimation(id: string, name?: string): void {
+            if (disposed) {
+                throw new Error("ModelManager has been disposed");
+            }
+            const entry = requireEntry(id, "JpmapTerrain.playModelAnimation");
+            if (!entry.loaded) {
+                console.warn(
+                    `[jpmap-terrain] playModelAnimation: model "${id}" is not loaded yet`,
+                );
+                return;
+            }
+            if (name !== undefined) {
+                const ag = entry.animationGroups.find((g) => g.name === name);
+                if (!ag) {
+                    console.warn(
+                        `[jpmap-terrain] playModelAnimation: animation "${name}" not found in model "${id}"`,
+                    );
+                    return;
+                }
+                ag.start(true);
+            } else {
+                for (const ag of entry.animationGroups) {
+                    ag.start(true);
+                }
+            }
+        },
+
+        stopAnimation(id: string, name?: string): void {
+            if (disposed) {
+                throw new Error("ModelManager has been disposed");
+            }
+            const entry = requireEntry(id, "JpmapTerrain.stopModelAnimation");
+            if (!entry.loaded) return;
+            if (name !== undefined) {
+                const ag = entry.animationGroups.find((g) => g.name === name);
+                if (ag) {
+                    ag.stop();
+                }
+            } else {
+                for (const ag of entry.animationGroups) {
+                    ag.stop();
+                }
+            }
+        },
+
+        dispose(): void {
+            if (disposed) return;
+            disposed = true;
+            if (observer) {
+                ctx.scene.onBeforeRenderObservable.remove(observer);
+            }
+            unsubscribeTerrain();
+            for (const entry of entries.values()) {
+                entry.cancelled = true;
+                for (const ag of entry.animationGroups) {
+                    ag.stop();
+                    ag.dispose();
+                }
+                for (const mesh of entry.meshes) {
+                    mesh.dispose();
+                }
+                entry.root.dispose();
+            }
+            entries.clear();
+        },
+    };
+};

--- a/src/terrain/modelManager.ts
+++ b/src/terrain/modelManager.ts
@@ -66,6 +66,8 @@ interface ModelEntry {
     animationGroups: AnimationGroup[];
     /** ロード中止用。dispose / remove 時に true にする */
     cancelled: boolean;
+    /** 前フレームの可視状態キャッシュ（冗長な setEnabled 呼び出しを削減） */
+    lastVisible: boolean | null;
 }
 
 const resolveVec3 = (
@@ -152,6 +154,8 @@ export const createModelManager = (ctx: OverlayContext): ModelManager => {
     };
 
     const setMeshVisibility = (entry: ModelEntry, visible: boolean): void => {
+        if (entry.lastVisible === visible) return;
+        entry.lastVisible = visible;
         for (const mesh of entry.meshes) {
             mesh.setEnabled(visible);
         }
@@ -276,6 +280,7 @@ export const createModelManager = (ctx: OverlayContext): ModelManager => {
                 meshes: [],
                 animationGroups: [],
                 cancelled: false,
+                lastVisible: null,
             };
 
             entries.set(id, entry);

--- a/src/terrain/modelManager.ts
+++ b/src/terrain/modelManager.ts
@@ -352,6 +352,17 @@ export const createModelManager = (ctx: OverlayContext): ModelManager => {
 
             if (entry.loaded) {
                 applyTransform(entry);
+            } else {
+                // ロード完了前でも altitudeMode 切替で elevationResolved を正しく反映する
+                if (entry.altitudeMode === "absolute") {
+                    entry.elevationResolved = true;
+                } else if (entry.gravity) {
+                    const { wx, wz } = latLonToWorld(ctx, entry.lat, entry.lon);
+                    entry.elevationResolved =
+                        ctx.tileManager.queryElevationAtWorld(wx, wz) !== null;
+                } else {
+                    entry.elevationResolved = true;
+                }
             }
 
             return toHandle(entry);

--- a/src/terrain/modelManager.ts
+++ b/src/terrain/modelManager.ts
@@ -305,12 +305,16 @@ export const createModelManager = (ctx: OverlayContext): ModelManager => {
             }
 
             if (partial.altitudeMode !== undefined) {
+                // absolute モードへの切替時は、同じ update 呼び出しで altitude も明示指定を要求する。
+                // entry.altitude は常に数値（MODEL_DEFAULTS.altitude = 0）なので、
+                // 暗黙の 0 が absolute の海抜高度として使われることを防ぐ。
                 if (
                     partial.altitudeMode === "absolute" &&
-                    (partial.altitude ?? entry.altitude) === undefined
+                    entry.altitudeMode !== "absolute" &&
+                    partial.altitude === undefined
                 ) {
                     throw new Error(
-                        `${UPDATE_ERROR_PREFIX}: altitudeMode="absolute" requires altitude`,
+                        `${UPDATE_ERROR_PREFIX}: switching to altitudeMode="absolute" requires explicit altitude`,
                     );
                 }
                 entry.altitudeMode = partial.altitudeMode;

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -214,6 +214,85 @@ jest.unstable_mockModule("../src/terrain/circle", () => ({
     },
 }));
 
+// `modelManager.ts` は Babylon.js の TransformNode / SceneLoader に依存するため、
+// Model API テストでは `createModelManager` を軽量スタブに差し替える。
+jest.unstable_mockModule("../src/terrain/modelManager", () => ({
+    createModelManager: () => {
+        const models = new Map<
+            string,
+            {
+                id: string;
+                url: string;
+                lat: number;
+                lon: number;
+                altitude: number;
+                altitudeMode: string;
+                rotation: { x: number; y: number; z: number };
+                scaling: { x: number; y: number; z: number };
+                enabled: boolean;
+                gravity: boolean;
+                loaded: boolean;
+                elevationResolved: boolean;
+                animationNames: readonly string[];
+            }
+        >();
+        let disposed = false;
+        const toHandle = (m: (typeof models extends Map<string, infer V> ? V : never)) => ({ ...m });
+        return {
+            add(id: string, options: Record<string, unknown>) {
+                if (disposed) throw new Error("ModelManager has been disposed");
+                if (models.has(id)) throw new Error(`id "${id}" already exists`);
+                const entry = {
+                    id,
+                    url: options.url as string,
+                    lat: options.lat as number,
+                    lon: options.lon as number,
+                    altitude: (options.altitude as number) ?? 0,
+                    altitudeMode: (options.altitudeMode as string) ?? "terrain",
+                    rotation: { x: 0, y: 0, z: 0 },
+                    scaling: { x: 1, y: 1, z: 1 },
+                    enabled: (options.enabled as boolean) ?? true,
+                    gravity: (options.gravity as boolean) ?? true,
+                    loaded: false,
+                    elevationResolved: false,
+                    animationNames: [] as readonly string[],
+                };
+                models.set(id, entry);
+                return toHandle(entry);
+            },
+            get(id: string) {
+                const m = models.get(id);
+                return m ? toHandle(m) : null;
+            },
+            update(id: string, partial: Record<string, unknown>) {
+                if (disposed) throw new Error("ModelManager has been disposed");
+                const m = models.get(id);
+                if (!m) throw new Error(`id "${id}" not found`);
+                if (partial.lat !== undefined) m.lat = partial.lat as number;
+                if (partial.lon !== undefined) m.lon = partial.lon as number;
+                if (partial.altitude !== undefined) m.altitude = partial.altitude as number;
+                return toHandle(m);
+            },
+            remove(id: string) {
+                models.delete(id);
+            },
+            setEnabled(id: string, enabled: boolean) {
+                const m = models.get(id);
+                if (m) m.enabled = enabled;
+            },
+            list() {
+                return [...models.keys()];
+            },
+            playAnimation() { /* no-op */ },
+            stopAnimation() { /* no-op */ },
+            dispose() {
+                disposed = true;
+                models.clear();
+            },
+        };
+    },
+}));
+
 jest.unstable_mockModule("../src/scenes/default", () => {
     // モック内で refreshTerrain 相当の呼び出し回数を記録し、
     // テストから検証できるよう getter を export する（T5 のバッチ refresh 検証用）。
@@ -2370,6 +2449,60 @@ describe("JpmapTerrain (skeleton)", () => {
             const updated = viewer.updateCircle("c1", { radius: 300 });
             expect(updated.radius).toBe(300);
             viewer.dispose();
+        });
+    });
+
+    describe("Model API (Issue #243)", () => {
+        const validPos = { lat: 35.681, lon: 139.767 };
+        const validOpts = { url: "test.glb", ...validPos };
+
+        it("addModel → getModel / listModels で参照できる", async () => {
+            const viewer = await create(createMountElement());
+            const handle = viewer.addModel("m1", validOpts);
+            expect(handle.id).toBe("m1");
+            expect(viewer.getModel("m1")?.id).toBe("m1");
+            expect(viewer.listModels()).toEqual(["m1"]);
+        });
+
+        it("removeModel で消える", async () => {
+            const viewer = await create(createMountElement());
+            viewer.addModel("m1", validOpts);
+            viewer.removeModel("m1");
+            expect(viewer.getModel("m1")).toBeNull();
+            expect(viewer.listModels()).toEqual([]);
+        });
+
+        it("updateModel で位置を変更できる", async () => {
+            const viewer = await create(createMountElement());
+            viewer.addModel("m1", validOpts);
+            const updated = viewer.updateModel("m1", { lat: 35.0 });
+            expect(updated.lat).toBe(35.0);
+        });
+
+        it("setModelEnabled は登録済み id に対して throw しない", async () => {
+            const viewer = await create(createMountElement());
+            viewer.addModel("m1", validOpts);
+            expect(() => viewer.setModelEnabled("m1", false)).not.toThrow();
+        });
+
+        it("playModelAnimation / stopModelAnimation は throw しない", async () => {
+            const viewer = await create(createMountElement());
+            viewer.addModel("m1", validOpts);
+            expect(() => viewer.playModelAnimation("m1")).not.toThrow();
+            expect(() => viewer.stopModelAnimation("m1")).not.toThrow();
+        });
+
+        it("dispose 後の addModel / updateModel は throw、その他は no-op / null / []", async () => {
+            const viewer = await create(createMountElement());
+            viewer.dispose();
+            expect(() => viewer.addModel("m1", validOpts)).toThrow();
+            expect(() => viewer.updateModel("m1", { lat: 35.0 })).toThrow();
+            expect(viewer.getModel("m1")).toBeNull();
+            expect(viewer.listModels()).toEqual([]);
+            expect(() => viewer.removeModel("m1")).not.toThrow();
+            expect(() => viewer.setModelEnabled("m1", false)).not.toThrow();
+            expect(() => viewer.playModelAnimation("m1")).not.toThrow();
+            expect(() => viewer.stopModelAnimation("m1")).not.toThrow();
         });
     });
 });

--- a/tests/libExports.unit.spec.ts
+++ b/tests/libExports.unit.spec.ts
@@ -37,6 +37,10 @@ import type {
     PolygonPointHoverListener,
     PolygonPointClickListener,
     PolygonPointDragListener,
+    ModelVector3,
+    ModelOptions,
+    ModelUpdate,
+    ModelHandle,
 } from "../src/lib";
 
 describe("package entry exports (T8)", () => {
@@ -147,5 +151,29 @@ describe("package entry exports (T8)", () => {
         expect(click.lat).toBe(0);
         expect(point.polygonId).toBe("p1");
         expect(drag.lat).toBeNull();
+    });
+
+    // #243: 3Dモデル公開型がエントリから import 可能。
+    it("3Dモデル公開型 (#243) がパッケージエントリから import できる（typecheck）", () => {
+        const vec: ModelVector3 = { x: 1, y: 2, z: 3 };
+        const opts: ModelOptions = {
+            url: "model.glb",
+            lat: 35.68,
+            lon: 139.77,
+            rotation: vec,
+            scaling: { x: 2 },
+        };
+        const update: ModelUpdate = { lat: 35.69, rotation: { y: 90 } };
+        const handleShape: Pick<ModelHandle, "id" | "url" | "loaded"> = {
+            id: "m1",
+            url: "model.glb",
+            loaded: false,
+        };
+
+        expect(opts.url).toBe("model.glb");
+        expect(update.lat).toBe(35.69);
+        expect(handleShape.id).toBe("m1");
+        expect(pkg.MODEL_DEFAULTS).toBeDefined();
+        expect(pkg.MODEL_DEFAULTS.gravity).toBe(true);
     });
 });

--- a/tests/modelManager.unit.spec.ts
+++ b/tests/modelManager.unit.spec.ts
@@ -246,4 +246,12 @@ describe("ModelManager altitudeMode", () => {
         const handle = mgr.add("a", { ...VALID, gravity: true });
         expect(handle.elevationResolved).toBe(false);
     });
+
+    test("ロード前に altitudeMode を absolute に切り替えると elevationResolved が true になる", () => {
+        const { ctx } = buildCtx(null);
+        const mgr = createModelManager(ctx);
+        mgr.add("a", { ...VALID, gravity: true });
+        const updated = mgr.update("a", { altitudeMode: "absolute", altitude: 50 });
+        expect(updated.elevationResolved).toBe(true);
+    });
 });

--- a/tests/modelManager.unit.spec.ts
+++ b/tests/modelManager.unit.spec.ts
@@ -1,0 +1,249 @@
+/**
+ * ModelManager の単体テスト (Issue #243)。
+ *
+ * - `@babylonjs/core/Meshes/transformNode` をスタブ化し Babylon 実体の生成を回避
+ * - `./overlayCoords` をスタブ化し `scenes/default` の大きな依存チェーンを断ち切る
+ * - `@babylonjs/core/Loading/sceneLoader` と `@babylonjs/loaders/glTF` もスタブ化
+ *
+ * 検証対象: CRUD / バリデーション / dispose の冪等性 / altitudeMode
+ */
+import { jest } from "@jest/globals";
+
+// ---- TransformNode スタブ ----
+interface FakeTransformNode {
+    name: string;
+    position: { x: number; y: number; z: number; set: (x: number, y: number, z: number) => void };
+    rotation: { x: number; y: number; z: number };
+    scaling: { x: number; y: number; z: number };
+    disposed: boolean;
+    dispose: () => void;
+}
+const createdNodes: FakeTransformNode[] = [];
+
+jest.unstable_mockModule("@babylonjs/core/Meshes/transformNode", () => {
+    class TransformNode {
+        name: string;
+        position: FakeTransformNode["position"];
+        rotation: { x: number; y: number; z: number } = { x: 0, y: 0, z: 0 };
+        scaling: { x: number; y: number; z: number } = { x: 1, y: 1, z: 1 };
+        disposed = false;
+        constructor(name: string) {
+            this.name = name;
+            const pos = { x: 0, y: 0, z: 0, set(x: number, y: number, z: number) { this.x = x; this.y = y; this.z = z; } };
+            this.position = pos;
+            createdNodes.push(this as unknown as FakeTransformNode);
+        }
+        dispose() { this.disposed = true; }
+    }
+    return { TransformNode };
+});
+
+// ---- overlayCoords スタブ（scenes/default 依存を断ち切る）----
+jest.unstable_mockModule("../src/terrain/overlayCoords", () => ({
+    latLonToWorld: () => ({ wx: 0, wz: 0 }),
+    assertLatLonInBounds: (lat: number, lon: number, prefix: string) => {
+        if (lat < 20 || lat > 50 || lon < 120 || lon > 155) {
+            throw new Error(`${prefix}: JAPAN_BOUNDS`);
+        }
+    },
+}));
+
+// ---- SceneLoader スタブ ----
+jest.unstable_mockModule("@babylonjs/core/Loading/sceneLoader", () => ({
+    SceneLoader: {
+        ImportMeshAsync: jest.fn<() => Promise<{ meshes: unknown[]; animationGroups: unknown[] }>>(() =>
+            Promise.resolve({ meshes: [], animationGroups: [] }),
+        ),
+    },
+}));
+
+// ---- glTF 動的 import スタブ ----
+jest.unstable_mockModule("@babylonjs/loaders/glTF", () => ({}));
+
+// ---- buildCtx ヘルパー ----
+const buildCtx = (elevation: number | null = 0) => {
+    const observers: Array<() => void> = [];
+    const fakeScene = {
+        onBeforeRenderObservable: {
+            add: (cb: () => void) => { observers.push(cb); return cb; },
+            remove: () => {},
+        },
+    };
+    let elev = elevation;
+    const ctx = {
+        scene: fakeScene,
+        tileManager: {
+            queryElevationAtWorld: (): number | null => elev,
+            subscribeTerrainUpdated: (): (() => void) => () => {},
+        },
+        getOrigin: () => ({ lat: 35.681, lon: 139.767, gridResidualX: 0, gridResidualZ: 0 }),
+        getCameraPosition: () => ({ x: 0, y: 1000, z: 0, radius: 1000, beta: Math.PI / 4 }),
+    };
+    return {
+        ctx: ctx as unknown as Parameters<
+            (typeof import("../src/terrain/modelManager"))["createModelManager"]
+        >[0],
+        tick: () => { for (const o of observers.slice()) o(); },
+        setElevation: (v: number | null) => { elev = v; },
+    };
+};
+
+const VALID = {
+    url: "assets/human.glb",
+    lat: 35.681236,
+    lon: 139.767125,
+    altitudeMode: "terrain" as const,
+    altitude: 0,
+};
+
+const { createModelManager } = await import("../src/terrain/modelManager");
+
+beforeEach(() => { createdNodes.length = 0; });
+
+// ---- CRUD ----
+
+describe("ModelManager CRUD", () => {
+    test("add → get / list で同 id を取得できる", () => {
+        const { ctx } = buildCtx();
+        const mgr = createModelManager(ctx);
+        const handle = mgr.add("a", VALID);
+        expect(handle.id).toBe("a");
+        expect(mgr.get("a")?.id).toBe("a");
+        expect(mgr.list()).toEqual(["a"]);
+    });
+
+    test("重複 id の add は throw", () => {
+        const { ctx } = buildCtx();
+        const mgr = createModelManager(ctx);
+        mgr.add("a", VALID);
+        expect(() => mgr.add("a", VALID)).toThrow(/already exists/);
+    });
+
+    test("url 未指定の add は throw", () => {
+        const { ctx } = buildCtx();
+        const mgr = createModelManager(ctx);
+        expect(() => mgr.add("a", { ...VALID, url: "" })).toThrow(/url is required/);
+    });
+
+    test("未存在 id の get は null", () => {
+        const { ctx } = buildCtx();
+        const mgr = createModelManager(ctx);
+        expect(mgr.get("missing")).toBeNull();
+    });
+
+    test("未存在 id の update は throw", () => {
+        const { ctx } = buildCtx();
+        const mgr = createModelManager(ctx);
+        expect(() => mgr.update("missing", { altitude: 10 })).toThrow(/not found/);
+    });
+
+    test("remove で list / get から消える", () => {
+        const { ctx } = buildCtx();
+        const mgr = createModelManager(ctx);
+        mgr.add("a", VALID);
+        mgr.remove("a");
+        expect(mgr.get("a")).toBeNull();
+        expect(mgr.list()).toEqual([]);
+    });
+
+    test("未存在 id の remove は warn + no-op", () => {
+        const { ctx } = buildCtx();
+        const mgr = createModelManager(ctx);
+        const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+        mgr.remove("missing");
+        expect(warn).toHaveBeenCalled();
+        warn.mockRestore();
+    });
+
+    test("list は追加順を保持する", () => {
+        const { ctx } = buildCtx();
+        const mgr = createModelManager(ctx);
+        mgr.add("c", VALID);
+        mgr.add("a", VALID);
+        mgr.add("b", VALID);
+        expect(mgr.list()).toEqual(["c", "a", "b"]);
+    });
+});
+
+// ---- バリデーション ----
+
+describe("ModelManager バリデーション", () => {
+    test("JAPAN_BOUNDS 外 (lat=0, lon=0) は throw", () => {
+        const { ctx } = buildCtx();
+        const mgr = createModelManager(ctx);
+        expect(() => mgr.add("a", { ...VALID, lat: 0, lon: 0 })).toThrow(/JAPAN_BOUNDS/);
+    });
+
+    test("absolute モードで altitude 未指定は throw", () => {
+        const { ctx } = buildCtx();
+        const mgr = createModelManager(ctx);
+        expect(() =>
+            mgr.add("a", { ...VALID, altitudeMode: "absolute", altitude: undefined }),
+        ).toThrow(/altitude/);
+    });
+
+    test("update で absolute モードへの切替時に altitude 未指定は throw", () => {
+        const { ctx } = buildCtx();
+        const mgr = createModelManager(ctx);
+        mgr.add("a", VALID);
+        expect(() => mgr.update("a", { altitudeMode: "absolute" })).toThrow(/altitude/);
+    });
+
+    test("update で lat/lon が範囲外なら throw", () => {
+        const { ctx } = buildCtx();
+        const mgr = createModelManager(ctx);
+        mgr.add("a", VALID);
+        expect(() => mgr.update("a", { lat: 0, lon: 0 })).toThrow(/JAPAN_BOUNDS/);
+    });
+});
+
+// ---- dispose / 冪等性 ----
+
+describe("ModelManager dispose", () => {
+    test("dispose 後の add は throw", () => {
+        const { ctx } = buildCtx();
+        const mgr = createModelManager(ctx);
+        mgr.dispose();
+        expect(() => mgr.add("a", VALID)).toThrow(/disposed/);
+    });
+
+    test("dispose 後の update は throw", () => {
+        const { ctx } = buildCtx();
+        const mgr = createModelManager(ctx);
+        mgr.dispose();
+        expect(() => mgr.update("a", { altitude: 10 })).toThrow(/disposed/);
+    });
+
+    test("dispose 後の setEnabled は throw", () => {
+        const { ctx } = buildCtx();
+        const mgr = createModelManager(ctx);
+        mgr.dispose();
+        expect(() => mgr.setEnabled("a", true)).toThrow(/disposed/);
+    });
+
+    test("dispose を 2 回呼んでも throw しない", () => {
+        const { ctx } = buildCtx();
+        const mgr = createModelManager(ctx);
+        mgr.dispose();
+        expect(() => mgr.dispose()).not.toThrow();
+    });
+});
+
+// ---- altitudeMode ----
+
+describe("ModelManager altitudeMode", () => {
+    test("absolute モードの handle は elevationResolved=true", () => {
+        const { ctx } = buildCtx();
+        const mgr = createModelManager(ctx);
+        const handle = mgr.add("a", { ...VALID, altitudeMode: "absolute", altitude: 100 });
+        expect(handle.altitudeMode).toBe("absolute");
+        expect(handle.elevationResolved).toBe(true);
+    });
+
+    test("terrain+gravity で elevation=null なら elevationResolved=false", () => {
+        const { ctx } = buildCtx(null);
+        const mgr = createModelManager(ctx);
+        const handle = mgr.add("a", { ...VALID, gravity: true });
+        expect(handle.elevationResolved).toBe(false);
+    });
+});

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -63,6 +63,13 @@ const ENTRY_DEFINITIONS = [
         filename: "plan.html",
         title: "jpmap_terrain – Plan Viewer",
     },
+    {
+        name: "model",
+        entry: "src/demos/model/index.ts",
+        template: "public/model.html",
+        filename: "model.html",
+        title: "jpmap_terrain – 3Dモデルデモ",
+    },
 ];
 
 const entry = Object.fromEntries(

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -11,7 +11,10 @@ module.exports = merge(common, {
     mode: 'development',
     devtool: 'inline-source-map',
     devServer: {
-        static: path.resolve(appDirectory, "public"),
+        static: [
+            path.resolve(appDirectory, "public"),
+            { directory: path.resolve(appDirectory, "assets"), publicPath: "/assets" },
+        ],
         compress: true,
         hot: true,
         historyApiFallback: {

--- a/webpack.rewrites.js
+++ b/webpack.rewrites.js
@@ -20,5 +20,7 @@ module.exports = {
         { from: /^\/circle\.html(?:\/?@.*)?\/?$/, to: '/circle.html' },
         { from: /^\/plan(?:\/@.*)?\/?$/, to: '/plan.html' },
         { from: /^\/plan\.html(?:\/?@.*)?\/?$/, to: '/plan.html' },
+        { from: /^\/model(?:\/@.*)?\/?$/, to: '/model.html' },
+        { from: /^\/model\.html(?:\/?@.*)?\/?$/, to: '/model.html' },
     ],
 };

--- a/webpack.tests.js
+++ b/webpack.tests.js
@@ -11,7 +11,10 @@ module.exports = merge(common, {
     mode: 'development',
     devtool: 'inline-source-map',
     devServer: {
-        static: path.resolve(appDirectory, "public"),
+        static: [
+            path.resolve(appDirectory, "public"),
+            { directory: path.resolve(appDirectory, "assets"), publicPath: "/assets" },
+        ],
         compress: true,
         historyApiFallback: {
             disableDotRule: true,


### PR DESCRIPTION
## 概要

Babylon.js がサポートする 3D モデルファイル (glb/gltf/obj) を地形上にロード・管理する公開 API を `JpmapTerrain` に追加し、そのAPIを使った地面クリックでモデルを配置するデモアプリを実装。

## 変更内容

### #243 glbファイル表示API
- `ModelOptions` / `ModelHandle` / `ModelUpdate` / `ModelVector3` 型を `src/lib/types.ts` に追加
- `ModelManager` を `src/terrain/modelManager.ts` に新規実装（SceneLoader による非同期ロード・位置/回転/スケール/表示切替・アニメーション制御・地表追従）
- `JpmapTerrain` に `addModel` / `removeModel` / `updateModel` / `getModel` / `setModelEnabled` / `listModels` / `playModelAnimation` / `stopModelAnimation` を追加
- `src/lib.ts` に Model 関連型を re-export
- `spec/package.md` §3.3.13 に API 仕様を追記

### #244 デモアプリ
- `src/demos/model/index.ts` — 東京駅に human.glb を初期配置、地面クリック移動、方位スライダー、座標表示、flyTo ボタン
- `public/model.html` — デモ HTML テンプレート
- `webpack.common.js` に model エントリ追加
- ポータルに「3Dモデル」項目追加
- `spec/demos.md` にデモ仕様追記

## 影響範囲
- API・型の追加（既存 API への変更なし）
- 新規デモ追加（既存デモへの影響なし）

## 検証結果
- TypeScript typecheck ✅
- ESLint ✅
- Unit Test 696件 全パス ✅

Closes #243, Closes #244