### PR TITLE
fix(2d-zoom): correct zoom behavior in 2D mode for elevated terrain (#254)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,42 @@ npm start
 
 3D ビューアデモ（`src/demos/viewer/index.ts`）は、Google Maps 互換のパス形式 `/@緯度,経度` と `engine` / `mapType` クエリパラメータをサポートします。ここで説明するのは開発デモ用 URL の仕様であり、npm パッケージの公開 API（`EngineType` は `"webgpu" | "webgl2"`、`MapType` は `"standard" | "photo"`）とは別です。
 
-- 形式: `http://localhost:8080/viewer.html/@<lat>,<lon>?engine=<webgpu|webgl|webgl2>&mapType=<standard|photo>`（`webgl` は URL クエリでのみ後方互換として受け付け、内部的に `webgl2` に正規化）
-- 例:
-  - `http://localhost:8080/viewer.html/@35.681236,139.767125?engine=webgpu`（東京駅・WebGPU）
-  - `http://localhost:8080/viewer.html/@35.3606,138.7274?engine=webgl2`（富士山・WebGL2）
-  - `http://localhost:8080/viewer.html/@35.681236,139.767125?engine=webgpu&mapType=photo`（東京駅・航空写真）
+### パス形式（カメラ位置）
+
+**3D モード**
+
+- 形式: `/@<lat>,<lon>,<altitude>,<azimuth>,<tilt>`
+- `altitude`: カメラのワールド高度（m）。範囲 [50, 80000]
+- `azimuth`: 方位角（度）。0 = 北、時計回り正
+- `tilt`: 仰角（度）。範囲 [約5.7, 75]
+- 省略した場合は既定値（altitude=2000, azimuth=0, tilt=45）で補完されます
+
+```
+/@35.3606,138.7274,7411,0.00,45.00   ← 富士山山頂、海抜 7411m、真北向き
+```
+
+**2D モード（平行投影・Issue #254）**
+
+- 2D モードでは海抜高度の代わりに **Google Maps 互換のズームレベル**（`z` サフィックス付き）を使用します
+- 形式: `/@<lat>,<lon>,<zoom>z`
+- `zoom`: Web Mercator ズームレベル（小数 2 桁）。範囲 [5, 23]
+- azimuth / tilt は 2D では固定のため URL に含みません
+- ズームレベルは `canvasHeight × 156543 × cos(緯度) / (2^z × 2 × tan(fov/2))` で `camera.radius` に変換されます
+
+```
+/@35.3606,138.7274,14.50z            ← 富士山山頂、ズームレベル 14.5
+```
+
+- URL をコピーして貼り付けることで、ほぼ同等の表示を再現できます
+- 2D モードでは平行投影のためカメラの海抜高度は表示範囲に影響しないため、URL には含めません
+- 3D モードの `/@lat,lon,altitude,...` 形式の URL を 2D モードで開いた場合、altitude はズームレベルに変換されて扱われます
+
+**例:**
+
+- `http://localhost:8080/viewer.html/@35.681236,139.767125?engine=webgpu`（東京駅・3D・WebGPU）
+- `http://localhost:8080/viewer.html/@35.3606,138.7274?engine=webgl2`（富士山・3D・WebGL2）
+- `http://localhost:8080/viewer.html/@35.681236,139.767125?engine=webgpu&mapType=photo`（東京駅・3D・航空写真）
+- `http://localhost:8080/viewer.html/@35.3606,138.7274,14.50z?viewMode=2d`（富士山・2D・ズームレベル 14.5）
 
 ### `engine` パラメータ
 
@@ -115,10 +146,16 @@ npm start
 - 省略・不正値・URL 解析失敗時は `standard` にフォールバックします
 - 地図切替ボタン操作 / `viewer.mapType = ...` のいずれでも、URL のクエリ `?mapType=` が `history.replaceState` で更新されます（パス・他クエリ・ハッシュは保持）
 
+### `viewMode` パラメータ
+
+- `3d` / `2d` を指定できます（大小文字無視）
+- 省略・不正値時は `3d` にフォールバックします
+- 2D/3D 切替ボタン操作でも `?viewMode=` が更新されます
+
 ### 緯度経度の扱い
 
 - 緯度経度は `JAPAN_BOUNDS`（緯度 20〜46、経度 122〜154）でクランプされます
-- カメラ移動に追従して、URL のパスは `/@lat,lon` 形式に書き戻されます（既存のクエリパラメータは保持）
+- カメラ移動に追従して URL のパスが自動更新されます（既存のクエリパラメータは保持）
 
 実装の詳細は `src/demos/viewer/index.ts` および `src/terrain/urlState.ts` を参照してください。
 

--- a/spec/package.md
+++ b/spec/package.md
@@ -396,6 +396,21 @@ interface MarkerOptions {
 - 不正値・欠落・URL 解析失敗時は `JPMAP_TERRAIN_DEFAULTS.viewMode`（= `"3d"`）にフォールバックする。
 - `viewer.viewMode` の変化は `onViewModeChange` 経由でデモ層が `history.replaceState` により URL の `?viewMode=` を更新する。パス・他クエリ・ハッシュは保持される。
 
+**2D モードにおけるパス形式（Issue #254）:**
+
+- 3D モードのパス形式: `/@<lat>,<lon>,<altitude>,<azimuth>,<tilt>`
+  - `altitude` はカメラのワールド高度（m）。範囲 [50, 80000]
+- 2D モードのパス形式: `/@<lat>,<lon>,<zoom>z`（Google Maps 互換）
+  - `zoom` は Web Mercator ズームレベル（小数 2 桁）。範囲 [5, 23]
+  - 2D では平行投影のためカメラの海抜高度は表示範囲に影響しないため、altitude の代わりにズームレベルを使用する
+  - azimuth / tilt は 2D モードでは固定のため URL に含めない
+  - ズームレベルと `camera.radius` の変換式:
+    - `z = log₂(canvasHeight × 156543 × cos(φ) / (2 × radius × tan(fov/2)))`
+    - `radius = canvasHeight × 156543 × cos(φ) / (2^z × 2 × tan(fov/2))`
+  - URL コピー＆ペーストで同等の表示を再現できる
+  - 例: `/@35.3606,138.7274,14.50z?viewMode=2d`（富士山をズームレベル 14.5 で表示）
+- パーサーは `z` サフィックスの有無でズームレベルか海抜高度かを自動判別する（`CameraUrlState.zoomLevel` フィールドに格納）
+
 #### 3.3.8 ポリゴン (Issue #169)
 
 任意の点列を受け取り、地表または絶対標高に沿って **ポイント球体** と **ポリライン** を表示する API（基盤）。

--- a/src/demos/timelapse/index.ts
+++ b/src/demos/timelapse/index.ts
@@ -134,7 +134,8 @@ const start = async (): Promise<void> => {
 
     const viewer = await JpmapTerrain.create(mount, opts);
 
-    // URL 同期: カメラ変化のたびに `/<demo>@lat,lon,altitude,azimuth,tilt` 形式へ反映する (Issue #155)。
+    // URL 同期: カメラ変化のたびに URL を更新する (Issue #155)。
+    // 2D モードでは `@lat,lon,Xz`、3D では `@lat,lon,altitude,azimuth,tilt` (#254)。
     // 既存クエリ（?engine=, ?start=, ?speed= など）は `createUrlUpdater` 内で保持される。
     const urlUpdater = createUrlUpdater(200);
     viewer.onCameraChange((event) =>
@@ -144,6 +145,7 @@ const start = async (): Promise<void> => {
             altitude: event.altitude,
             azimuth: event.azimuth,
             tilt: event.tilt,
+            zoomLevel: event.zoomLevel,
         }),
     );
 

--- a/src/demos/viewer/index.ts
+++ b/src/demos/viewer/index.ts
@@ -2,7 +2,9 @@
  * 開発用デモエントリ (T9 / Issue #123, #136)
  *
  * パッケージ公開 API である `JpmapTerrain` を直接利用してデモを起動する。
- * - URL 形式: `/@lat,lon[,altitude,azimuth,tilt]?engine=webgpu|webgl|webgl2`
+ * - URL 形式:
+ *   - 3D: `/@lat,lon[,altitude,azimuth,tilt]?engine=webgpu|webgl|webgl2`
+ *   - 2D: `/@lat,lon,Xz?viewMode=2d` （X はズームレベル, Issue #254）
  *   （`webgl`/`webgl2` は `webgl2` に正規化、既定: 自動。altitude/azimuth/tilt は省略可、Issue #64）
  * - `#root` 要素にビューアをマウントする。
  * - URL ↔ カメラ同期はパッケージ層から切り離し、デモ層 (本ファイル) で
@@ -148,11 +150,17 @@ const start = async (): Promise<void> => {
         ...(autoSunPosition !== undefined ? { autoSunPosition } : {}),
         ...(showSunShadows !== undefined ? { showSunShadows } : {}),
         ...(mapType !== null ? { mapType } : {}),
-        ...(viewMode !== null ? { viewMode } : {}),
+        // zoomLevel が URL に含まれていれば 2D モードを暗黙に指定する (#254)。
+        ...(viewMode !== null
+            ? { viewMode }
+            : cameraState?.zoomLevel !== undefined
+              ? { viewMode: "2d" as const }
+              : {}),
     };
     const viewer = await JpmapTerrain.create(mount, opts);
 
-    // URL 同期: カメラ変化のたびに `/@lat,lon,altitude,azimuth,tilt` 形式へ反映する（既存クエリは保持）。
+    // URL 同期: カメラ変化のたびに URL を更新する。
+    // 2D モードでは `@lat,lon,Xz`（ズームレベル）、3D では `@lat,lon,altitude,azimuth,tilt` (#254)。
     const urlUpdater = createUrlUpdater(1000);
     viewer.onCameraChange((event) =>
         urlUpdater({
@@ -161,6 +169,7 @@ const start = async (): Promise<void> => {
             altitude: event.altitude,
             azimuth: event.azimuth,
             tilt: event.tilt,
+            zoomLevel: event.zoomLevel,
         }),
     );
 

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -65,6 +65,8 @@ export class JpmapTerrain {
     private _tilt: number;
     private _mapType: MapType;
     private _viewMode: ViewMode;
+    /** 2D モード初期化用ズームレベル (#254)。URL 復元時にのみ設定される。 */
+    private _zoomLevel?: number;
 
     private _showCompass = true;
     private _showZoomButtons = true;
@@ -126,6 +128,7 @@ export class JpmapTerrain {
         this._tilt = options.tilt ?? JPMAP_TERRAIN_DEFAULTS.tilt;
         this._mapType = options.mapType ?? JPMAP_TERRAIN_DEFAULTS.mapType;
         this._viewMode = options.viewMode ?? JPMAP_TERRAIN_DEFAULTS.viewMode;
+        this._zoomLevel = options.zoomLevel;
         this._showViewModeButton =
             options.showViewModeButton ??
             JPMAP_TERRAIN_DEFAULTS.showViewModeButton;
@@ -209,6 +212,7 @@ export class JpmapTerrain {
                 altitude: this._altitude,
                 azimuth: this._azimuth,
                 tilt: this._tilt,
+                zoomLevel: this._zoomLevel,
                 mapType: this._mapType,
                 onMapTypeChange: (next) => this._handleMapTypeChange(next),
                 viewMode: this._viewMode,
@@ -577,6 +581,14 @@ export class JpmapTerrain {
     }
 
     /**
+     * 2D モード時の Google Maps 互換ズームレベル (#254)。
+     * 3D モードでは `undefined` を返す。
+     */
+    public get zoomLevel(): number | undefined {
+        return this._controller?.getZoomLevel();
+    }
+
+    /**
      * `viewMode` が変化した際に呼ばれるリスナーを登録する (Issue #193)。
      *
      * `onMapTypeChange` と対称な API。UI ボタン操作・`viewMode` setter のいずれの
@@ -908,6 +920,7 @@ export class JpmapTerrain {
             azimuth: this.azimuth,
             tilt: this.tilt,
             viewMode: this.viewMode,
+            zoomLevel: this.zoomLevel,
         };
         const prev = this._lastCameraSnapshot;
         if (prev === null) {
@@ -915,13 +928,18 @@ export class JpmapTerrain {
             return;
         }
         const eps = 1e-9;
+        const zoomChanged =
+            snapshot.zoomLevel !== undefined && prev.zoomLevel !== undefined
+                ? Math.abs(snapshot.zoomLevel - prev.zoomLevel) > eps
+                : snapshot.zoomLevel !== prev.zoomLevel;
         const changed =
             Math.abs(snapshot.lat - prev.lat) > eps ||
             Math.abs(snapshot.lon - prev.lon) > eps ||
             Math.abs(snapshot.altitude - prev.altitude) > eps ||
             Math.abs(snapshot.azimuth - prev.azimuth) > eps ||
             Math.abs(snapshot.tilt - prev.tilt) > eps ||
-            snapshot.viewMode !== prev.viewMode;
+            snapshot.viewMode !== prev.viewMode ||
+            zoomChanged;
         if (!changed) return;
         this._lastCameraSnapshot = snapshot;
         // iterate 中の add/remove 安全のためスナップショットを取って iterate

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -36,6 +36,11 @@ export interface JpmapTerrainOptions {
     azimuth?: number;
     /** カメラチルト角（度） */
     tilt?: number;
+    /**
+     * 2D モード時の Google Maps 互換ズームレベル (#254)。
+     * `viewMode: "2d"` と組み合わせて指定する。指定時は `altitude` より優先。
+     */
+    zoomLevel?: number;
     /** 地図種類 */
     mapType?: MapType;
     /**
@@ -136,6 +141,12 @@ export interface CameraChangeEvent {
      * `"2d"` のとき `tilt` は常に `0` を返す。
      */
     readonly viewMode: ViewMode;
+    /**
+     * 2D モード時の Google Maps 互換ズームレベル (#254)。
+     * `viewMode === "2d"` のとき `camera.radius` から算出した値。
+     * 3D モードでは `undefined`。
+     */
+    readonly zoomLevel?: number;
 }
 
 /** `JpmapTerrain.onCameraChange` リスナー */

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -668,12 +668,10 @@ export class DefaultScene implements CreateSceneClass {
                 const anchorX = camera.target.x;
                 const anchorZ = camera.target.z;
                 const prevAlpha = camera.alpha;
-                const lower = camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
-                // radius は常に保持する (#254)。
-                // ズーム操作は retarget 呼出し前に camera.radius を更新済みのため、
-                // ここでは savedRadius をそのまま使えば正しいズームが維持される。
-                // ドラッグ中もドロップ後も radius を再計算しないことで、
-                // 地形 pick の微小な誤差による見かけ上のズームジッタを防ぐ。
+                // 2D は平行投影のため camera.position.y は表示範囲に影響しない。
+                // ズームは camera.radius → applyOrthoFrustum のみで決まる。
+                // したがって radius は一切変更しない (#254)。
+                // ズーム操作は retarget 呼出し前に camera.radius を更新済み。
                 const savedRadius = camera.radius;
                 const rayOriginY = Math.max(camY, 10000);
                 const rayDown = new Ray(
@@ -689,14 +687,14 @@ export class DefaultScene implements CreateSceneClass {
                     pick2d?.hit && pick2d.pickedPoint
                         ? pick2d.pickedPoint.y
                         : camera.target.y;
-                // camY を維持する。山岳衝突の場合のみ camY を引き上げる。
-                const minCamY = terrainY + lower;
-                const newCamY = Math.max(camY, minCamY);
-                const newRadius = newCamY > camY ? lower : savedRadius;
-                const newTargetY = newCamY - newRadius;
+                // position.y は camY を基本維持。地形が高い場合のみ引き上げる
+                // （near/far clip で地形が消えるのを防ぐため）。
+                const lower = camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
+                const newCamY = Math.max(camY, terrainY + lower);
+                const newTargetY = newCamY - savedRadius;
                 camera.setPosition(new Vector3(anchorX, newCamY, anchorZ));
                 camera.setTarget(new Vector3(anchorX, newTargetY, anchorZ));
-                camera.radius = newRadius;
+                camera.radius = savedRadius;
                 camera.alpha = prevAlpha;
                 camera.beta = BETA_2D;
                 return;

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -1912,8 +1912,13 @@ export class DefaultScene implements CreateSceneClass {
             } else {
                 // 2D → 3D: 2D 中は position.y を ORTHO_MIN_CAM_Y に引き上げており
                 // target.y もそれに連動して高い。3D ではカメラが地形の上空を
-                // 周回するため、target.y を地形高度に戻す (#254)。
+                // 周回するため、target.y を地形高度に戻し、radius / position.y を
+                // 再計算する (#254)。
                 if (currentViewMode === "2d") {
+                    // ズームレベルを保持するため、先に radius を退避する。
+                    const savedRadius2d = camera.radius;
+                    const savedAlpha2d = camera.alpha;
+
                     const rayDown = new Ray(
                         new Vector3(
                             camera.target.x,
@@ -1931,7 +1936,34 @@ export class DefaultScene implements CreateSceneClass {
                         pick?.hit && pick.pickedPoint
                             ? pick.pickedPoint.y
                             : 0;
-                    camera.target.y = tY;
+
+                    // 3D 復帰時の beta を先に確定する。
+                    const beta3d = clamp(
+                        (savedTiltDeg * Math.PI) / 180,
+                        lowerBetaLimit3d,
+                        camera.upperBetaLimit ?? Math.PI,
+                    );
+                    const cosB = Math.cos(beta3d);
+                    const sinB = Math.sin(beta3d);
+
+                    // radius はそのまま引き継ぎ、target.y + radius*cosB で正しい高度に配置する。
+                    const newCamY = tY + savedRadius2d * cosB;
+                    const newCamX =
+                        camera.target.x +
+                        savedRadius2d * sinB * Math.cos(savedAlpha2d);
+                    const newCamZ =
+                        camera.target.z +
+                        savedRadius2d * sinB * Math.sin(savedAlpha2d);
+
+                    camera.setPosition(
+                        new Vector3(newCamX, newCamY, newCamZ),
+                    );
+                    camera.setTarget(
+                        new Vector3(camera.target.x, tY, camera.target.z),
+                    );
+                    camera.radius = savedRadius2d;
+                    camera.alpha = savedAlpha2d;
+                    camera.beta = beta3d;
                 }
                 camera.mode = Camera.PERSPECTIVE_CAMERA;
 
@@ -2395,13 +2427,22 @@ export class DefaultScene implements CreateSceneClass {
                     gridResidualX,
                     gridResidualZ,
                 }),
-                getCameraPosition: () => ({
-                    x: camera.globalPosition.x,
-                    y: camera.globalPosition.y,
-                    z: camera.globalPosition.z,
-                    radius: camera.radius,
-                    beta: camera.beta,
-                }),
+                getCameraPosition: () => {
+                    // 2D ortho: position.y は ORTHO_MIN_CAM_Y に引き上げているが、
+                    // マーカー等の distScale はズームレベル（radius）に基づくべき。
+                    // 論理的な高度 target.y + radius を返す (#254)。
+                    const logicalY =
+                        currentViewMode === "2d"
+                            ? camera.target.y + camera.radius
+                            : camera.globalPosition.y;
+                    return {
+                        x: camera.globalPosition.x,
+                        y: logicalY,
+                        z: camera.globalPosition.z,
+                        radius: camera.radius,
+                        beta: camera.beta,
+                    };
+                },
             }),
             subscribeTerrainClick: (listener) => {
                 terrainClickListeners.push(listener);

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -668,11 +668,8 @@ export class DefaultScene implements CreateSceneClass {
                 const anchorX = camera.target.x;
                 const anchorZ = camera.target.z;
                 const prevAlpha = camera.alpha;
-                // 3D モードと同様、camY（海抜絶対高度）を維持する。
-                // radius = camY - terrainY とすることでズームが絶対高度に連動し、
-                // 平地では radius が大きく（ズームアウト）、山岳では小さく（ズームイン）なる。
-                // これにより position.y = terrainY + radius = camY が保たれ、
-                // URL 高度が安定したまま表示スケールも正しくなる (#254)。
+                const lower = camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
+                const upper = camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS;
                 const rayOriginY = Math.max(camY, 10000);
                 const rayDown = new Ray(
                     new Vector3(anchorX, rayOriginY, anchorZ),
@@ -687,14 +684,33 @@ export class DefaultScene implements CreateSceneClass {
                     pick2d?.hit && pick2d.pickedPoint
                         ? pick2d.pickedPoint.y
                         : camera.target.y;
-                // camY を基準に radius を算出する。地形衝突（terrainY >= camY）の場合は
-                // lowerRadiusLimit 分だけ position.y を引き上げて衝突を回避する。
-                const lower = camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
-                const upper = camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS;
-                const newRadius = clamp(camY - terrainY, lower, upper);
-                const newCamY = terrainY + newRadius;
+
+                let newRadius: number;
+                let newCamY: number;
+                if (pointerDown) {
+                    // ドラッグ中: radius を固定してスムーズなパンを実現する (#254)。
+                    // camY（海抜絶対高度）を維持し、radius は変更しない。
+                    // 山岳衝突（terrainY >= camY - lower）の場合のみ camY を引き上げる。
+                    const savedRadius = camera.radius;
+                    const minCamY = terrainY + lower;
+                    newCamY = Math.max(camY, minCamY);
+                    // 衝突で newCamY > camY となった場合は radius = lower に縮小。
+                    newRadius = newCamY > camY ? lower : savedRadius;
+                } else {
+                    // ドラッグ外（ズーム・ポインタアップ・URL 適用）:
+                    // radius = camY - terrainY で絶対高度ベースに再調整する (#254)。
+                    // position.y = terrainY + radius = camY が成立し、
+                    // 表示スケールが海抜高度に正しく対応する。
+                    newRadius = clamp(camY - terrainY, lower, upper);
+                    newCamY = terrainY + newRadius;
+                }
+
+                // ドラッグ中は target.y を (newCamY - newRadius) に固定して
+                // position.y = target.y + radius = newCamY が成立するようにする。
+                // ドラッグ外は target.y を実際の地形高さに合わせる。
+                const newTargetY = pointerDown ? newCamY - newRadius : terrainY;
                 camera.setPosition(new Vector3(anchorX, newCamY, anchorZ));
-                camera.setTarget(new Vector3(anchorX, terrainY, anchorZ));
+                camera.setTarget(new Vector3(anchorX, newTargetY, anchorZ));
                 camera.radius = newRadius;
                 camera.alpha = prevAlpha;
                 camera.beta = BETA_2D;

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -584,6 +584,13 @@ export class DefaultScene implements CreateSceneClass {
         let prevTargetZ = NaN;
 
         const terrainMinRadius = (): number => {
+            // 2D モード: カメラは常にターゲット直上 (beta ≈ 0) にあり、
+            // retargetAtCameraPosition が position.y = terrainY + radius を保証するため、
+            // 角度補正やキャッシュ標高の参照は不要。固定値で十分 (#254)。
+            if (currentViewMode === "2d") {
+                return camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
+            }
+
             const { alpha, beta, radius } = camera;
             const { x: tx, y: ty, z: tz } = camera.target;
             if (

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -346,10 +346,6 @@ export class DefaultScene implements CreateSceneClass {
         // tileManager / mapToggle 構築後に行う。
         let currentViewMode: ViewMode = options?.viewMode ?? "3d";
         let savedTiltDeg: number = tiltDeg;
-        // 2D モードの URL 高度は camera.position.y（Y=0 からの絶対高度）だが、
-        // ドラッグ中に position.y が terrainY に追随して変動するため、
-        // URL 向けに安定した値を保持する。ズーム/ポインタアップ/setAltitude 時のみ更新 (#254)。
-        let stableAltitude2d: number = altitude;
         // 2D モード中は lowerBetaLimit を 0 に変更するため、3D 復帰用に元の値を保持する。
         const lowerBetaLimit3d = 0.1;
 
@@ -672,14 +668,12 @@ export class DefaultScene implements CreateSceneClass {
                 const anchorX = camera.target.x;
                 const anchorZ = camera.target.z;
                 const prevAlpha = camera.alpha;
-                // radius（地形からの高度 = ズームレベル）を保存する。
-                // setPosition → setTarget の間に Babylon の rebuildAnglesAndRadius() が
-                // 呼ばれ、stale な target.y を参照して radius が一時的に変化しうる。
-                // _checkLimits() が同期で走ると inertialRadiusOffset がリセットされる
-                // 副作用もあるため、明示的に復元して確実に値を保持する (#254)。
                 const savedRadius = camera.radius;
-                // 山など地形高さが変化してもレイが確実に地形を検出できるよう、
-                // 十分高い位置からキャストする (#254)。
+                // 3D モードと同様、呼び出し元が渡した camY を基本的に維持する。
+                // これによりドラッグ中に地形高さが変化しても camera.position.y が
+                // 変動せず URL 高度が安定する (#254)。
+                // ただし山などで地形が camY - savedRadius より高い場合は
+                // 衝突回避のため position.y を引き上げる。
                 const rayOriginY = Math.max(camY, 10000);
                 const rayDown = new Ray(
                     new Vector3(anchorX, rayOriginY, anchorZ),
@@ -694,13 +688,12 @@ export class DefaultScene implements CreateSceneClass {
                     pick2d?.hit && pick2d.pickedPoint
                         ? pick2d.pickedPoint.y
                         : camera.target.y;
-                // radius（地形からの高度 = ズームレベル）を保持しながら
-                // position.y を terrain に追随させる (#254)。
-                // ドラッグ中に radius が変化せず一定の俯瞰高度を維持する。
-                // 山など地形が高い場合は camera.position.y が上昇（衝突回避）。
-                const newCamY = terrainY + savedRadius;
+                // 地形衝突時のみ引き上げ。それ以外は呼び出し元の camY を尊重する。
+                const minCamY = terrainY + savedRadius;
+                const newCamY = Math.max(camY, minCamY);
+                const newTargetY = newCamY - savedRadius;
                 camera.setPosition(new Vector3(anchorX, newCamY, anchorZ));
-                camera.setTarget(new Vector3(anchorX, terrainY, anchorZ));
+                camera.setTarget(new Vector3(anchorX, newTargetY, anchorZ));
                 camera.radius = savedRadius;
                 camera.alpha = prevAlpha;
                 camera.beta = BETA_2D;
@@ -1340,7 +1333,6 @@ export class DefaultScene implements CreateSceneClass {
             commitPanOffset();
             if (currentViewMode === "2d") {
                 retargetAtCameraPosition(camera.position.x, camera.position.y, camera.position.z);
-                stableAltitude2d = camera.position.y;
             } else {
                 // 3D: commitPanOffset が target.x/z = gridResidual にリセット済み。
                 // setTarget() を呼ぶと rebuildAnglesAndRadius() が走り beta/tilt が変わるため、
@@ -1624,7 +1616,6 @@ export class DefaultScene implements CreateSceneClass {
                     const factor = computeWheelFactor(e.deltaY < 0);
                     zoomTowardPoint(hit.worldX, hit.worldZ, factor);
                     retargetAtCameraPosition(camera.position.x, camera.position.y, camera.position.z);
-                    if (currentViewMode === "2d") stableAltitude2d = camera.position.y;
                 } else {
                     // 空のホイール操作: カメラ高度ベースの2段階ズーム
                     const upper = camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS;
@@ -1656,7 +1647,6 @@ export class DefaultScene implements CreateSceneClass {
                         retargetAtCameraPosition(camX, newCamY, camZ);
                         commitPanOffset();
                         retargetAtCameraPosition(camera.position.x, camera.position.y, camera.position.z);
-                        if (currentViewMode === "2d") stableAltitude2d = camera.position.y;
                     } else {
                         // Phase 1: ターゲットに向かってズーム
                         const effectiveLower1 = Math.max(lower, terrainMinRadius());
@@ -1664,7 +1654,6 @@ export class DefaultScene implements CreateSceneClass {
                         if (!zoomIn && camera.radius >= upper) return;
                         camera.radius = clamp(camera.radius * factor, effectiveLower1, upper);
                         retargetAtCameraPosition(camera.position.x, camera.position.y, camera.position.z);
-                        if (currentViewMode === "2d") stableAltitude2d = camera.position.y;
                     }
                 }
             },
@@ -1685,9 +1674,6 @@ export class DefaultScene implements CreateSceneClass {
                     lower,
                     camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS
                 );
-            }
-            if (currentViewMode === "2d") {
-                stableAltitude2d = camera.target.y + camera.radius;
             }
         });
 
@@ -1904,7 +1890,6 @@ export class DefaultScene implements CreateSceneClass {
                 camera.beta = BETA_2D;
                 camera.mode = Camera.ORTHOGRAPHIC_CAMERA;
                 applyOrthoFrustum();
-                stableAltitude2d = camera.position.y;
             } else {
                 camera.mode = Camera.PERSPECTIVE_CAMERA;
 
@@ -2018,7 +2003,6 @@ export class DefaultScene implements CreateSceneClass {
                     // radius = altitude - terrainY (= camera.target.y) として設定する。
                     const desiredRadius = values.altitude - camera.target.y;
                     camera.radius = clamp(desiredRadius, lower, upper);
-                    stableAltitude2d = camera.target.y + camera.radius;
                 } else {
                     // URL/API の altitude はカメラ世界高度 (海抜 = camera.position.y) として扱う。
                     // ArcRotateCamera は radius を保持するため、
@@ -2217,11 +2201,10 @@ export class DefaultScene implements CreateSceneClass {
             getLat: derivedLat,
             getLon: derivedLon,
             getAltitude: () => {
-                // 3D モード: camera.position.y（Y=0 からの絶対高度）。
-                // パン中も position.y が一定に保たれるため URL は変動しない (#225)。
-                // 2D モード: stableAltitude2d（ズーム/ポインタアップ時に更新）。
-                // ドラッグ中に position.y が地形追随で変化しても URL は変動しない (#254)。
-                if (currentViewMode === "2d") return stableAltitude2d;
+                // 両モード共通: camera.position.y（Y=0 からの絶対高度）。
+                // 3D: パン中に position.y が一定に保たれる (#225)。
+                // 2D: retargetAtCameraPosition が呼び出し元の camY を尊重するため
+                //     ドラッグ中も position.y が安定する (#254)。
                 return camera.position.y;
             },
             getAzimuth: () => azimuthDegFromAlpha(camera.alpha),
@@ -2399,9 +2382,6 @@ export class DefaultScene implements CreateSceneClass {
             const lower = camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
             const upper = camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS;
             camera.radius = clamp(r, lower, upper);
-            if (currentViewMode === "2d") {
-                stableAltitude2d = targetY + camera.radius;
-            }
         };
         const initElev = tileManager.queryElevationAtWorld(
             gridResidualX,

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -1973,17 +1973,22 @@ export class DefaultScene implements CreateSceneClass {
             if (values.altitude !== undefined) {
                 const lower = camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
                 const upper = camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS;
-                // URL/API の altitude はカメラ世界高度 (海抜 = camera.position.y) として扱う。
-                // ArcRotateCamera は radius を保持するため、
-                //   camY = target.y + radius * cos(beta)
-                // を解いて radius に変換する (#225)。
-                const cosB = Math.cos(camera.beta);
-                if (Math.abs(cosB) >= 1e-6) {
-                    const desiredRadius =
-                        (values.altitude - camera.target.y) / cosB;
-                    camera.radius = clamp(desiredRadius, lower, upper);
-                } else {
+                if (currentViewMode === "2d") {
+                    // 2D モードでは altitude = camera.radius（地形からの高度）として扱う (#254)。
                     camera.radius = clamp(values.altitude, lower, upper);
+                } else {
+                    // URL/API の altitude はカメラ世界高度 (海抜 = camera.position.y) として扱う。
+                    // ArcRotateCamera は radius を保持するため、
+                    //   camY = target.y + radius * cos(beta)
+                    // を解いて radius に変換する (#225)。
+                    const cosB = Math.cos(camera.beta);
+                    if (Math.abs(cosB) >= 1e-6) {
+                        const desiredRadius =
+                            (values.altitude - camera.target.y) / cosB;
+                        camera.radius = clamp(desiredRadius, lower, upper);
+                    } else {
+                        camera.radius = clamp(values.altitude, lower, upper);
+                    }
                 }
             }
             if (values.azimuth !== undefined) {
@@ -2169,10 +2174,12 @@ export class DefaultScene implements CreateSceneClass {
             getLat: derivedLat,
             getLon: derivedLon,
             getAltitude: () => {
-                // altitude は Y=0 からの絶対高度 (= camera.position.y) (#225)。
-                // ドラッグ移動でカメラ Y が変わらない限り URL の altitude も変動しない。
-                // リロード時の水平位置一致は retargetAtCameraPosition で target.y を
-                // queryElevationAtWorld 由来に揃えることで保証する。
+                // 3D モード: altitude = camera.position.y（海抜高度）。パン中は position.y が
+                // 一定に保たれるため URL は変動しない (#225)。
+                // 2D モード: altitude = camera.radius（地形からの高度 = ズームレベル）。
+                // 新しい radius ベース frustum では radius がパン中も一定のため URL は変動しない。
+                // position.y = terrainY + radius はパン中に地形高さに追随して変化するため不適 (#254)。
+                if (currentViewMode === "2d") return camera.radius;
                 return camera.position.y;
             },
             getAzimuth: () => azimuthDegFromAlpha(camera.alpha),
@@ -2344,6 +2351,9 @@ export class DefaultScene implements CreateSceneClass {
         // ことで、リロード時のフラッシュを防ぐ (#225)。
         const desiredCamY = altitude;
         const adjustRadiusForCamY = (targetY: number): void => {
+            // 2D モードでは altitude = radius（地形からの高度）のため、
+            // target.y が変化しても radius は維持する (#254)。
+            if (currentViewMode === "2d") return;
             const cosB = Math.cos(camera.beta);
             if (Math.abs(cosB) < 1e-6) return;
             const r = (desiredCamY - targetY) / cosB;

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -59,6 +59,15 @@ const CAMERA_UPPER_RADIUS = 75000;
 const CAMERA_FAR_CLIP = 400000;
 
 /**
+ * 2D (orthographic) モードでのカメラ最低高度（メートル）。
+ * 平行投影では position.y は表示範囲に影響しないが、near clip (minZ=1) より
+ * 高い地形頂点が「カメラの背後」に来ると描画されない。
+ * 日本最高点（富士山 3776m）を十分に下回る位置に near plane が来るよう、
+ * カメラを常にこの高度以上に保つ。
+ */
+const ORTHO_MIN_CAM_Y = 10000;
+
+/**
  * 2D モード時の camera.beta 固定値（ラジアン）。
  * beta=0 だとジンバルロックで alpha（方位）変化がカメラ位置に反映されず、
  * かつ camera.lowerBetaLimit によるクランプで意図通りにならないため、
@@ -684,7 +693,7 @@ export class DefaultScene implements CreateSceneClass {
                 // したがって radius は一切変更しない (#254)。
                 // ズーム操作は retarget 呼出し前に camera.radius を更新済み。
                 const savedRadius = camera.radius;
-                const rayOriginY = Math.max(camY, 10000);
+                const rayOriginY = Math.max(camY, ORTHO_MIN_CAM_Y);
                 const rayDown = new Ray(
                     new Vector3(anchorX, rayOriginY, anchorZ),
                     new Vector3(0, -1, 0),
@@ -698,10 +707,9 @@ export class DefaultScene implements CreateSceneClass {
                     pick2d?.hit && pick2d.pickedPoint
                         ? pick2d.pickedPoint.y
                         : camera.target.y;
-                // position.y は camY を基本維持。地形が高い場合のみ引き上げる
-                // （near/far clip で地形が消えるのを防ぐため）。
-                const lower = camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
-                const newCamY = Math.max(camY, terrainY + lower);
+                // 2D ortho: position.y は表示範囲に影響しない。
+                // 全地形が near clip 内に収まるよう ORTHO_MIN_CAM_Y 以上を保つ (#254)。
+                const newCamY = Math.max(ORTHO_MIN_CAM_Y, terrainY + ORTHO_MIN_CAM_Y);
                 const newTargetY = newCamY - savedRadius;
                 camera.setPosition(new Vector3(anchorX, newCamY, anchorZ));
                 camera.setTarget(new Vector3(anchorX, newTargetY, anchorZ));
@@ -1902,6 +1910,29 @@ export class DefaultScene implements CreateSceneClass {
                 camera.mode = Camera.ORTHOGRAPHIC_CAMERA;
                 applyOrthoFrustum();
             } else {
+                // 2D → 3D: 2D 中は position.y を ORTHO_MIN_CAM_Y に引き上げており
+                // target.y もそれに連動して高い。3D ではカメラが地形の上空を
+                // 周回するため、target.y を地形高度に戻す (#254)。
+                if (currentViewMode === "2d") {
+                    const rayDown = new Ray(
+                        new Vector3(
+                            camera.target.x,
+                            camera.position.y,
+                            camera.target.z,
+                        ),
+                        Vector3.Down(),
+                        CAMERA_FAR_CLIP,
+                    );
+                    const pick = scene.pickWithRay(
+                        rayDown,
+                        (m) => m.name.startsWith("tile-ground-"),
+                    );
+                    const tY =
+                        pick?.hit && pick.pickedPoint
+                            ? pick.pickedPoint.y
+                            : 0;
+                    camera.target.y = tY;
+                }
                 camera.mode = Camera.PERSPECTIVE_CAMERA;
 
                 // 3D 復帰時に元の lowerBetaLimit を戻してから beta を復元する。
@@ -1948,6 +1979,22 @@ export class DefaultScene implements CreateSceneClass {
         const orthoFrustumObserver = scene.onBeforeRenderObservable.add(() => {
             if (currentViewMode === "2d") {
                 applyOrthoFrustum();
+                // 初回レンダやリロード直後など retargetAtCameraPosition が未発火の状態で
+                // position.y が低いままだと近くの高地形が near clip される。
+                // 安全弁として ORTHO_MIN_CAM_Y 未満なら引き上げる (#254)。
+                if (camera.position.y < ORTHO_MIN_CAM_Y) {
+                    const savedRadius = camera.radius;
+                    const savedAlpha = camera.alpha;
+                    const tx = camera.target.x;
+                    const tz = camera.target.z;
+                    camera.setPosition(new Vector3(tx, ORTHO_MIN_CAM_Y, tz));
+                    camera.setTarget(
+                        new Vector3(tx, ORTHO_MIN_CAM_Y - savedRadius, tz),
+                    );
+                    camera.radius = savedRadius;
+                    camera.alpha = savedAlpha;
+                    camera.beta = BETA_2D;
+                }
             }
         });
 

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -1556,8 +1556,13 @@ export class DefaultScene implements CreateSceneClass {
         /** レイキャスト距離の一定割合を1ステップとするホイールfactorを返す */
         const WHEEL_STEP = 0.05;
         const computeWheelFactor = (zoomIn: boolean): number => {
-            const rayDist = queryViewRayDistance();
-            const dist = rayDist ?? camera.radius;
+            // 2D ortho: queryViewRayDistance はカメラ→地形の 3D 距離を返すが、
+            // position.y が ORTHO_MIN_CAM_Y で固定のため radius と無関係な定数になる。
+            // radius を直接使うことで一定割合 (5%) のステップを保つ (#254)。
+            const dist =
+                currentViewMode === "2d"
+                    ? camera.radius
+                    : (queryViewRayDistance() ?? camera.radius);
             const delta = dist * WHEEL_STEP;
             return zoomIn
                 ? (camera.radius - delta) / camera.radius
@@ -2427,22 +2432,13 @@ export class DefaultScene implements CreateSceneClass {
                     gridResidualX,
                     gridResidualZ,
                 }),
-                getCameraPosition: () => {
-                    // 2D ortho: position.y は ORTHO_MIN_CAM_Y に引き上げているが、
-                    // マーカー等の distScale はズームレベル（radius）に基づくべき。
-                    // 論理的な高度 target.y + radius を返す (#254)。
-                    const logicalY =
-                        currentViewMode === "2d"
-                            ? camera.target.y + camera.radius
-                            : camera.globalPosition.y;
-                    return {
-                        x: camera.globalPosition.x,
-                        y: logicalY,
-                        z: camera.globalPosition.z,
-                        radius: camera.radius,
-                        beta: camera.beta,
-                    };
-                },
+                getCameraPosition: () => ({
+                    x: camera.globalPosition.x,
+                    y: camera.globalPosition.y,
+                    z: camera.globalPosition.z,
+                    radius: camera.radius,
+                    beta: camera.beta,
+                }),
             }),
             subscribeTerrainClick: (listener) => {
                 terrainClickListeners.push(listener);

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -668,6 +668,12 @@ export class DefaultScene implements CreateSceneClass {
                 const anchorX = camera.target.x;
                 const anchorZ = camera.target.z;
                 const prevAlpha = camera.alpha;
+                // radius（地形からの高度 = ズームレベル）を保存する。
+                // setPosition → setTarget の間に Babylon の rebuildAnglesAndRadius() が
+                // 呼ばれ、stale な target.y を参照して radius が一時的に変化しうる。
+                // _checkLimits() が同期で走ると inertialRadiusOffset がリセットされる
+                // 副作用もあるため、明示的に復元して確実に値を保持する (#254)。
+                const savedRadius = camera.radius;
                 // 山など地形高さが変化してもレイが確実に地形を検出できるよう、
                 // 十分高い位置からキャストする (#254)。
                 const rayOriginY = Math.max(camY, 10000);
@@ -688,9 +694,10 @@ export class DefaultScene implements CreateSceneClass {
                 // position.y を terrain に追随させる (#254)。
                 // ドラッグ中に radius が変化せず一定の俯瞰高度を維持する。
                 // 山など地形が高い場合は camera.position.y が上昇（衝突回避）。
-                const newCamY = terrainY + camera.radius;
+                const newCamY = terrainY + savedRadius;
                 camera.setPosition(new Vector3(anchorX, newCamY, anchorZ));
                 camera.setTarget(new Vector3(anchorX, terrainY, anchorZ));
+                camera.radius = savedRadius;
                 camera.alpha = prevAlpha;
                 camera.beta = BETA_2D;
                 return;

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -1814,12 +1814,11 @@ export class DefaultScene implements CreateSceneClass {
             const h = engine.getRenderHeight();
             if (w <= 0 || h <= 0) return;
             const aspect = w / h;
-            // perspective でターゲット平面に映る範囲と一致させるため、
-            // 半画角 fov/2 と絶対高度（target.y + radius = camera.position.y）から halfH を導出する。
-            // radius だけを使うと地形高さが変わると radius が変動してズームが不安定になるため、
-            // 絶対高度を使うことでドラッグ中も安定したズームを保つ (#225)。
+            // 2D の可視範囲は radius（地形上面からの高度）に比例させる (#254)。
+            // perspective でターゲット平面に映る範囲 = radius * tan(fov/2) と一致する。
+            // 絶対高度 (target.y + radius) を使うと標高の高い地形で最大ズームが効かなくなる。
             // 前提: camera.fovMode は既定の FOVMODE_VERTICAL_FIXED（fov は鉛直方向）。
-            const halfH = (camera.target.y + camera.radius) * Math.tan(camera.fov / 2);
+            const halfH = camera.radius * Math.tan(camera.fov / 2);
             const halfW = halfH * aspect;
             camera.orthoTop = halfH;
             camera.orthoBottom = -halfH;
@@ -1843,20 +1842,9 @@ export class DefaultScene implements CreateSceneClass {
             opts?: { silent?: boolean; force?: boolean },
         ): void => {
             if (next === currentViewMode && !opts?.force) return;
-            const lower = camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
-            const upper = camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS;
             if (next === "2d") {
                 // 現在の tilt を保存（3D 復帰時に復元するため）
                 savedTiltDeg = (camera.beta * 180) / Math.PI;
-
-                // --- 高度補正 (Issue #255) ---
-                // Perspective ではターゲット平面での可視半高 = radius * tan(fov/2)。
-                // Ortho の frustum は camera.position.y（≈ target.y + radius）を使うため、
-                // target.y > 0 の地形上では 2D 切替時にズームアウトして見える。
-                // radius を target.y ぶん縮めて camera.position.y ≈ old_radius にし、
-                // perspective と同じズームレベルを保つ。
-                const perspRadius = camera.radius;
-                camera.radius = clamp(perspRadius - camera.target.y, lower, upper);
 
                 // ArcRotateCamera は beta=0 でジンバルロックが生じ alpha（方位）変化がカメラ位置に
                 // 反映されなくなる。また lowerBetaLimit=0.1 のままでは 0 付近にクランプされてしまう。
@@ -1868,12 +1856,6 @@ export class DefaultScene implements CreateSceneClass {
                 applyOrthoFrustum();
             } else {
                 camera.mode = Camera.PERSPECTIVE_CAMERA;
-
-                // --- 高度補正 (Issue #255) ---
-                // 2D での ortho frustum は camera.position.y（= target.y + radius）基準。
-                // 3D 復帰時に perspective で同じ可視範囲を得るには
-                // radius_3d = camera.position.y（= target.y + current_2d_radius）にする。
-                camera.radius = clamp(camera.target.y + camera.radius, lower, upper);
 
                 // 3D 復帰時に元の lowerBetaLimit を戻してから beta を復元する。
                 camera.lowerBetaLimit = lowerBetaLimit3d;

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -2002,8 +2002,10 @@ export class DefaultScene implements CreateSceneClass {
                 const lower = camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
                 const upper = camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS;
                 if (currentViewMode === "2d") {
-                    // 2D モードでは altitude = camera.radius（地形からの高度）として扱う (#254)。
-                    camera.radius = clamp(values.altitude, lower, upper);
+                    // 2D モードでは altitude = camera.position.y（Y=0 からの絶対高度）。
+                    // radius = altitude - terrainY (= camera.target.y) として設定する。
+                    const desiredRadius = values.altitude - camera.target.y;
+                    camera.radius = clamp(desiredRadius, lower, upper);
                 } else {
                     // URL/API の altitude はカメラ世界高度 (海抜 = camera.position.y) として扱う。
                     // ArcRotateCamera は radius を保持するため、
@@ -2202,12 +2204,10 @@ export class DefaultScene implements CreateSceneClass {
             getLat: derivedLat,
             getLon: derivedLon,
             getAltitude: () => {
-                // 3D モード: altitude = camera.position.y（海抜高度）。パン中は position.y が
-                // 一定に保たれるため URL は変動しない (#225)。
-                // 2D モード: altitude = camera.radius（地形からの高度 = ズームレベル）。
-                // 新しい radius ベース frustum では radius がパン中も一定のため URL は変動しない。
-                // position.y = terrainY + radius はパン中に地形高さに追随して変化するため不適 (#254)。
-                if (currentViewMode === "2d") return camera.radius;
+                // 両モード共通: altitude = camera.position.y（Y=0 からの絶対高度）。
+                // 3D モードではパン中に position.y が一定に保たれる (#225)。
+                // 2D モードでは position.y = terrainY + radius であり、パン中に地形高さに
+                // 追随して変化するが、radius（ズームレベル）は一定のため表示スケールは不変。
                 return camera.position.y;
             },
             getAzimuth: () => azimuthDegFromAlpha(camera.alpha),
@@ -2379,9 +2379,6 @@ export class DefaultScene implements CreateSceneClass {
         // ことで、リロード時のフラッシュを防ぐ (#225)。
         const desiredCamY = altitude;
         const adjustRadiusForCamY = (targetY: number): void => {
-            // 2D モードでは altitude = radius（地形からの高度）のため、
-            // target.y が変化しても radius は維持する (#254)。
-            if (currentViewMode === "2d") return;
             const cosB = Math.cos(camera.beta);
             if (Math.abs(cosB) < 1e-6) return;
             const r = (desiredCamY - targetY) / cosB;

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -2298,8 +2298,8 @@ export class DefaultScene implements CreateSceneClass {
             getAltitude: () => {
                 // 両モード共通: camera.position.y（Y=0 からの絶対高度）。
                 // 3D: パン中に position.y が一定に保たれる (#225)。
-                // 2D: retargetAtCameraPosition が呼び出し元の camY を尊重するため
-                //     ドラッグ中も position.y が安定する (#254)。
+                // 2D: position.y は ORTHO_MIN_CAM_Y 固定（平行投影のため表示には無影響）。
+                //     ズームは camera.radius / zoomLevel で制御する (#254)。
                 return camera.position.y;
             },
             getAzimuth: () => azimuthDegFromAlpha(camera.alpha),

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -661,8 +661,11 @@ export class DefaultScene implements CreateSceneClass {
                 const anchorX = camera.target.x;
                 const anchorZ = camera.target.z;
                 const prevAlpha = camera.alpha;
+                // 山など地形高さが変化してもレイが確実に地形を検出できるよう、
+                // 十分高い位置からキャストする (#254)。
+                const rayOriginY = Math.max(camY, 10000);
                 const rayDown = new Ray(
-                    new Vector3(anchorX, camY, anchorZ),
+                    new Vector3(anchorX, rayOriginY, anchorZ),
                     new Vector3(0, -1, 0),
                     CAMERA_FAR_CLIP,
                 );
@@ -670,12 +673,17 @@ export class DefaultScene implements CreateSceneClass {
                     rayDown,
                     (m) => m.name.startsWith("tile-ground-"),
                 );
-                const anchorY =
+                const terrainY =
                     pick2d?.hit && pick2d.pickedPoint
                         ? pick2d.pickedPoint.y
                         : camera.target.y;
-                camera.setPosition(new Vector3(anchorX, camY, anchorZ));
-                camera.setTarget(new Vector3(anchorX, anchorY, anchorZ));
+                // radius（地形からの高度 = ズームレベル）を保持しながら
+                // position.y を terrain に追随させる (#254)。
+                // ドラッグ中に radius が変化せず一定の俯瞰高度を維持する。
+                // 山など地形が高い場合は camera.position.y が上昇（衝突回避）。
+                const newCamY = terrainY + camera.radius;
+                camera.setPosition(new Vector3(anchorX, newCamY, anchorZ));
+                camera.setTarget(new Vector3(anchorX, terrainY, anchorZ));
                 camera.alpha = prevAlpha;
                 camera.beta = BETA_2D;
                 return;
@@ -1607,6 +1615,9 @@ export class DefaultScene implements CreateSceneClass {
                         // radius factor 分だけカメラ高度のみ変化
                         const newRadius = clamp(camera.radius * factor, effectiveLower2, upper);
                         const newCamY = camera.target.y + newRadius * cosB;
+                        // 2D モードでは retargetAtCameraPosition が camera.radius を使って高度を決めるため、
+                        // 先に radius を更新してから旧 camX/Z・新 camY で再ターゲットする (#254)。
+                        camera.radius = newRadius;
                         // 新しいカメラ位置から Ray を飛ばし、camera.targetを設定
                         retargetAtCameraPosition(camX, newCamY, camZ);
                         commitPanOffset();

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -346,6 +346,10 @@ export class DefaultScene implements CreateSceneClass {
         // tileManager / mapToggle 構築後に行う。
         let currentViewMode: ViewMode = options?.viewMode ?? "3d";
         let savedTiltDeg: number = tiltDeg;
+        // 2D モードの URL 高度は camera.position.y（Y=0 からの絶対高度）だが、
+        // ドラッグ中に position.y が terrainY に追随して変動するため、
+        // URL 向けに安定した値を保持する。ズーム/ポインタアップ/setAltitude 時のみ更新 (#254)。
+        let stableAltitude2d: number = altitude;
         // 2D モード中は lowerBetaLimit を 0 に変更するため、3D 復帰用に元の値を保持する。
         const lowerBetaLimit3d = 0.1;
 
@@ -1336,6 +1340,7 @@ export class DefaultScene implements CreateSceneClass {
             commitPanOffset();
             if (currentViewMode === "2d") {
                 retargetAtCameraPosition(camera.position.x, camera.position.y, camera.position.z);
+                stableAltitude2d = camera.position.y;
             } else {
                 // 3D: commitPanOffset が target.x/z = gridResidual にリセット済み。
                 // setTarget() を呼ぶと rebuildAnglesAndRadius() が走り beta/tilt が変わるため、
@@ -1619,6 +1624,7 @@ export class DefaultScene implements CreateSceneClass {
                     const factor = computeWheelFactor(e.deltaY < 0);
                     zoomTowardPoint(hit.worldX, hit.worldZ, factor);
                     retargetAtCameraPosition(camera.position.x, camera.position.y, camera.position.z);
+                    if (currentViewMode === "2d") stableAltitude2d = camera.position.y;
                 } else {
                     // 空のホイール操作: カメラ高度ベースの2段階ズーム
                     const upper = camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS;
@@ -1650,6 +1656,7 @@ export class DefaultScene implements CreateSceneClass {
                         retargetAtCameraPosition(camX, newCamY, camZ);
                         commitPanOffset();
                         retargetAtCameraPosition(camera.position.x, camera.position.y, camera.position.z);
+                        if (currentViewMode === "2d") stableAltitude2d = camera.position.y;
                     } else {
                         // Phase 1: ターゲットに向かってズーム
                         const effectiveLower1 = Math.max(lower, terrainMinRadius());
@@ -1657,6 +1664,7 @@ export class DefaultScene implements CreateSceneClass {
                         if (!zoomIn && camera.radius >= upper) return;
                         camera.radius = clamp(camera.radius * factor, effectiveLower1, upper);
                         retargetAtCameraPosition(camera.position.x, camera.position.y, camera.position.z);
+                        if (currentViewMode === "2d") stableAltitude2d = camera.position.y;
                     }
                 }
             },
@@ -1677,6 +1685,9 @@ export class DefaultScene implements CreateSceneClass {
                     lower,
                     camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS
                 );
+            }
+            if (currentViewMode === "2d") {
+                stableAltitude2d = camera.target.y + camera.radius;
             }
         });
 
@@ -1893,6 +1904,7 @@ export class DefaultScene implements CreateSceneClass {
                 camera.beta = BETA_2D;
                 camera.mode = Camera.ORTHOGRAPHIC_CAMERA;
                 applyOrthoFrustum();
+                stableAltitude2d = camera.position.y;
             } else {
                 camera.mode = Camera.PERSPECTIVE_CAMERA;
 
@@ -2006,6 +2018,7 @@ export class DefaultScene implements CreateSceneClass {
                     // radius = altitude - terrainY (= camera.target.y) として設定する。
                     const desiredRadius = values.altitude - camera.target.y;
                     camera.radius = clamp(desiredRadius, lower, upper);
+                    stableAltitude2d = camera.target.y + camera.radius;
                 } else {
                     // URL/API の altitude はカメラ世界高度 (海抜 = camera.position.y) として扱う。
                     // ArcRotateCamera は radius を保持するため、
@@ -2204,10 +2217,11 @@ export class DefaultScene implements CreateSceneClass {
             getLat: derivedLat,
             getLon: derivedLon,
             getAltitude: () => {
-                // 両モード共通: altitude = camera.position.y（Y=0 からの絶対高度）。
-                // 3D モードではパン中に position.y が一定に保たれる (#225)。
-                // 2D モードでは position.y = terrainY + radius であり、パン中に地形高さに
-                // 追随して変化するが、radius（ズームレベル）は一定のため表示スケールは不変。
+                // 3D モード: camera.position.y（Y=0 からの絶対高度）。
+                // パン中も position.y が一定に保たれるため URL は変動しない (#225)。
+                // 2D モード: stableAltitude2d（ズーム/ポインタアップ時に更新）。
+                // ドラッグ中に position.y が地形追随で変化しても URL は変動しない (#254)。
+                if (currentViewMode === "2d") return stableAltitude2d;
                 return camera.position.y;
             },
             getAzimuth: () => azimuthDegFromAlpha(camera.alpha),
@@ -2385,6 +2399,9 @@ export class DefaultScene implements CreateSceneClass {
             const lower = camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
             const upper = camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS;
             camera.radius = clamp(r, lower, upper);
+            if (currentViewMode === "2d") {
+                stableAltitude2d = targetY + camera.radius;
+            }
         };
         const initElev = tileManager.queryElevationAtWorld(
             gridResidualX,

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -2096,10 +2096,8 @@ export class DefaultScene implements CreateSceneClass {
                 const lower = camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
                 const upper = camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS;
                 if (currentViewMode === "2d") {
-                    // 2D モードでは altitude = camera.position.y（Y=0 からの絶対高度）。
-                    // radius = altitude - terrainY (= camera.target.y) として設定する。
-                    const desiredRadius = values.altitude - camera.target.y;
-                    camera.radius = clamp(desiredRadius, lower, upper);
+                    // 2D モードでは平行投影のため altitude（海抜高度）は表示範囲に影響しない。
+                    // ズーム制御は zoomLevel (= radius) で行う。altitude 指定は無視する (#254)。
                 } else {
                     // URL/API の altitude はカメラ世界高度 (海抜 = camera.position.y) として扱う。
                     // ArcRotateCamera は radius を保持するため、

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -14,6 +14,7 @@ import { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Ray } from "@babylonjs/core/Culling/ray";
 import { CreateSceneClass } from "../createScene";
 import { clamp, toTileXY, tileEdgeMeters, tileCenterLatLon, JAPAN_BOUNDS } from "../terrain/gsiTile";
+import { radiusToZoomLevel, zoomLevelToRadius } from "../terrain/urlState";
 import { createControlPanel, snapScale, formatScale, showToast } from "../terrain/controlPanel";
 import { attachResizeRefresh } from "../terrain/resizeRefresh";
 import { createTileManager } from "../terrain/tileManager";
@@ -122,6 +123,11 @@ export interface DefaultSceneController {
     getAzimuth(): number;
     /** チルト角（度）= camera.beta を度に変換した値 */
     getTilt(): number;
+    /**
+     * 2D モード時の Google Maps 互換ズームレベル (#254)。
+     * 3D モードでは `undefined` を返す。
+     */
+    getZoomLevel(): number | undefined;
 
     /** 緯度を即時反映する。Japan bounds でクランプされる */
     setLat(value: number): void;
@@ -278,6 +284,11 @@ export interface DefaultSceneInitOptions {
     azimuth?: number;
     /** カメラチルト角（度）。0 で真下、90 で水平 */
     tilt?: number;
+    /**
+     * 2D モード時の初期ズームレベル (Google Maps 互換, #254)。
+     * 定義時は `altitude` より優先して `camera.radius` を設定する。
+     */
+    zoomLevel?: number;
     /** 地図種類（T6 で配線） */
     mapType?: "standard" | "photo";
     /**
@@ -1914,6 +1925,22 @@ export class DefaultScene implements CreateSceneClass {
         if (currentViewMode === "2d") {
             // 同値だが初期化のため force で適用する（camera.mode / ortho frustum を確定させる）。
             applyViewModeInternal("2d", { silent: true, force: true });
+
+            // URL から zoomLevel が指定された場合、radius へ変換する (#254)。
+            if (options?.zoomLevel !== undefined) {
+                const h = engine.getRenderHeight();
+                if (h > 0) {
+                    const r = zoomLevelToRadius(
+                        options.zoomLevel,
+                        h,
+                        currentLat,
+                        camera.fov,
+                    );
+                    const lower = camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
+                    const upper = camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS;
+                    camera.radius = clamp(r, lower, upper);
+                }
+            }
         }
 
         // 2D の間は radius / リサイズで ortho frustum を追従させる必要がある。
@@ -2212,6 +2239,12 @@ export class DefaultScene implements CreateSceneClass {
                 currentViewMode === "2d"
                     ? 0
                     : (camera.beta * 180) / Math.PI,
+            getZoomLevel: () => {
+                if (currentViewMode !== "2d") return undefined;
+                const h = engine.getRenderHeight();
+                if (h <= 0) return undefined;
+                return radiusToZoomLevel(camera.radius, h, currentLat, camera.fov);
+            },
             setLat: (value) => applyView({ lat: value }, true),
             setLon: (value) => applyView({ lon: value }, true),
             setAltitude: (value) => applyView({ altitude: value }, true),
@@ -2375,7 +2408,11 @@ export class DefaultScene implements CreateSceneClass {
         // canvas の表示はカメラ高度が確定した後の初回レンダリングまで遅延させる
         // ことで、リロード時のフラッシュを防ぐ (#225)。
         const desiredCamY = altitude;
+        // 2D + zoomLevel 指定時は radius を変更しない（zoomLevel が radius を決定済み）。
+        const initUsesZoomLevel =
+            currentViewMode === "2d" && options?.zoomLevel !== undefined;
         const adjustRadiusForCamY = (targetY: number): void => {
+            if (initUsesZoomLevel) return;
             const cosB = Math.cos(camera.beta);
             if (Math.abs(cosB) < 1e-6) return;
             const r = (desiredCamY - targetY) / cosB;

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -668,12 +668,11 @@ export class DefaultScene implements CreateSceneClass {
                 const anchorX = camera.target.x;
                 const anchorZ = camera.target.z;
                 const prevAlpha = camera.alpha;
-                const savedRadius = camera.radius;
-                // 3D モードと同様、呼び出し元が渡した camY を基本的に維持する。
-                // これによりドラッグ中に地形高さが変化しても camera.position.y が
-                // 変動せず URL 高度が安定する (#254)。
-                // ただし山などで地形が camY - savedRadius より高い場合は
-                // 衝突回避のため position.y を引き上げる。
+                // 3D モードと同様、camY（海抜絶対高度）を維持する。
+                // radius = camY - terrainY とすることでズームが絶対高度に連動し、
+                // 平地では radius が大きく（ズームアウト）、山岳では小さく（ズームイン）なる。
+                // これにより position.y = terrainY + radius = camY が保たれ、
+                // URL 高度が安定したまま表示スケールも正しくなる (#254)。
                 const rayOriginY = Math.max(camY, 10000);
                 const rayDown = new Ray(
                     new Vector3(anchorX, rayOriginY, anchorZ),
@@ -688,13 +687,15 @@ export class DefaultScene implements CreateSceneClass {
                     pick2d?.hit && pick2d.pickedPoint
                         ? pick2d.pickedPoint.y
                         : camera.target.y;
-                // 地形衝突時のみ引き上げ。それ以外は呼び出し元の camY を尊重する。
-                const minCamY = terrainY + savedRadius;
-                const newCamY = Math.max(camY, minCamY);
-                const newTargetY = newCamY - savedRadius;
+                // camY を基準に radius を算出する。地形衝突（terrainY >= camY）の場合は
+                // lowerRadiusLimit 分だけ position.y を引き上げて衝突を回避する。
+                const lower = camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
+                const upper = camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS;
+                const newRadius = clamp(camY - terrainY, lower, upper);
+                const newCamY = terrainY + newRadius;
                 camera.setPosition(new Vector3(anchorX, newCamY, anchorZ));
-                camera.setTarget(new Vector3(anchorX, newTargetY, anchorZ));
-                camera.radius = savedRadius;
+                camera.setTarget(new Vector3(anchorX, terrainY, anchorZ));
+                camera.radius = newRadius;
                 camera.alpha = prevAlpha;
                 camera.beta = BETA_2D;
                 return;

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -605,7 +605,7 @@ export class DefaultScene implements CreateSceneClass {
 
         const terrainMinRadius = (): number => {
             // 2D モード: カメラは常にターゲット直上 (beta ≈ 0) にあり、
-            // retargetAtCameraPosition が position.y = terrainY + radius を保証するため、
+            // position.y は ORTHO_MIN_CAM_Y 固定、target.y = ORTHO_MIN_CAM_Y - radius。
             // 角度補正やキャッシュ標高の参照は不要。固定値で十分 (#254)。
             if (currentViewMode === "2d") {
                 return camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -747,6 +747,9 @@ export class DefaultScene implements CreateSceneClass {
         let dragMeshMode = false;
         let dragAnchorLat = 0;
         let dragAnchorLon = 0;
+        // pointerup 直後に releasePointerCapture が発火させる lostpointercapture
+        // による resetPointerState の二重実行を一度だけ抑止する (#254)。
+        let suppressNextResetPointerState = false;
 
         // ---- ポリゴン頂点インタラクション (Issue #184) ----
         const polygonPointHoverListeners: PolygonPointHoverListener[] = [];
@@ -1322,6 +1325,13 @@ export class DefaultScene implements CreateSceneClass {
             }
             if (e.pointerId !== activePointerId) return;
             pointerDown = false;
+            // releasePointerCapture が lostpointercapture を発火させ
+            // resetPointerState 経由で commitPanOffset / retargetAtCameraPosition が
+            // 二重に呼ばれる。2D モードでは大ドラッグ時に refreshTerrain の
+            // 同期前半で gridResidual が再計算され、僅かに target が動くため
+            // 二度目の retarget で pickWithRay の結果が変動し見かけのズーム
+            // ジッタが発生する。明示的に抑止する (#254)。
+            suppressNextResetPointerState = true;
             canvas.releasePointerCapture(e.pointerId);
             commitPanOffset();
             if (currentViewMode === "2d") {
@@ -1412,9 +1422,13 @@ export class DefaultScene implements CreateSceneClass {
         canvas.addEventListener("pointercancel", (e: PointerEvent) =>
             resetPointerState(e),
         );
-        canvas.addEventListener("lostpointercapture", (e: PointerEvent) =>
-            resetPointerState(e),
-        );
+        canvas.addEventListener("lostpointercapture", (e: PointerEvent) => {
+            if (suppressNextResetPointerState) {
+                suppressNextResetPointerState = false;
+                return;
+            }
+            resetPointerState(e);
+        });
 
         // ---- 地形クリック通知 (Issue #183) ----
         //

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -14,7 +14,7 @@ import { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Ray } from "@babylonjs/core/Culling/ray";
 import { CreateSceneClass } from "../createScene";
 import { clamp, toTileXY, tileEdgeMeters, tileCenterLatLon, JAPAN_BOUNDS } from "../terrain/gsiTile";
-import { radiusToZoomLevel, zoomLevelToRadius } from "../terrain/urlState";
+import { clampZoomLevel, radiusToZoomLevel, zoomLevelToRadius } from "../terrain/urlState";
 import { createControlPanel, snapScale, formatScale, showToast } from "../terrain/controlPanel";
 import { attachResizeRefresh } from "../terrain/resizeRefresh";
 import { createTileManager } from "../terrain/tileManager";
@@ -2311,7 +2311,9 @@ export class DefaultScene implements CreateSceneClass {
                 if (currentViewMode !== "2d") return undefined;
                 const h = engine.getRenderHeight();
                 if (h <= 0) return undefined;
-                return radiusToZoomLevel(camera.radius, h, currentLat, camera.fov);
+                return clampZoomLevel(
+                    radiusToZoomLevel(camera.radius, h, currentLat, camera.fov),
+                );
             },
             setLat: (value) => applyView({ lat: value }, true),
             setLon: (value) => applyView({ lon: value }, true),

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -669,7 +669,12 @@ export class DefaultScene implements CreateSceneClass {
                 const anchorZ = camera.target.z;
                 const prevAlpha = camera.alpha;
                 const lower = camera.lowerRadiusLimit ?? CAMERA_LOWER_RADIUS;
-                const upper = camera.upperRadiusLimit ?? CAMERA_UPPER_RADIUS;
+                // radius は常に保持する (#254)。
+                // ズーム操作は retarget 呼出し前に camera.radius を更新済みのため、
+                // ここでは savedRadius をそのまま使えば正しいズームが維持される。
+                // ドラッグ中もドロップ後も radius を再計算しないことで、
+                // 地形 pick の微小な誤差による見かけ上のズームジッタを防ぐ。
+                const savedRadius = camera.radius;
                 const rayOriginY = Math.max(camY, 10000);
                 const rayDown = new Ray(
                     new Vector3(anchorX, rayOriginY, anchorZ),
@@ -684,31 +689,11 @@ export class DefaultScene implements CreateSceneClass {
                     pick2d?.hit && pick2d.pickedPoint
                         ? pick2d.pickedPoint.y
                         : camera.target.y;
-
-                let newRadius: number;
-                let newCamY: number;
-                if (pointerDown) {
-                    // ドラッグ中: radius を固定してスムーズなパンを実現する (#254)。
-                    // camY（海抜絶対高度）を維持し、radius は変更しない。
-                    // 山岳衝突（terrainY >= camY - lower）の場合のみ camY を引き上げる。
-                    const savedRadius = camera.radius;
-                    const minCamY = terrainY + lower;
-                    newCamY = Math.max(camY, minCamY);
-                    // 衝突で newCamY > camY となった場合は radius = lower に縮小。
-                    newRadius = newCamY > camY ? lower : savedRadius;
-                } else {
-                    // ドラッグ外（ズーム・ポインタアップ・URL 適用）:
-                    // radius = camY - terrainY で絶対高度ベースに再調整する (#254)。
-                    // position.y = terrainY + radius = camY が成立し、
-                    // 表示スケールが海抜高度に正しく対応する。
-                    newRadius = clamp(camY - terrainY, lower, upper);
-                    newCamY = terrainY + newRadius;
-                }
-
-                // ドラッグ中は target.y を (newCamY - newRadius) に固定して
-                // position.y = target.y + radius = newCamY が成立するようにする。
-                // ドラッグ外は target.y を実際の地形高さに合わせる。
-                const newTargetY = pointerDown ? newCamY - newRadius : terrainY;
+                // camY を維持する。山岳衝突の場合のみ camY を引き上げる。
+                const minCamY = terrainY + lower;
+                const newCamY = Math.max(camY, minCamY);
+                const newRadius = newCamY > camY ? lower : savedRadius;
+                const newTargetY = newCamY - newRadius;
                 camera.setPosition(new Vector3(anchorX, newCamY, anchorZ));
                 camera.setTarget(new Vector3(anchorX, newTargetY, anchorZ));
                 camera.radius = newRadius;

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -693,23 +693,9 @@ export class DefaultScene implements CreateSceneClass {
                 // したがって radius は一切変更しない (#254)。
                 // ズーム操作は retarget 呼出し前に camera.radius を更新済み。
                 const savedRadius = camera.radius;
-                const rayOriginY = Math.max(camY, ORTHO_MIN_CAM_Y);
-                const rayDown = new Ray(
-                    new Vector3(anchorX, rayOriginY, anchorZ),
-                    new Vector3(0, -1, 0),
-                    CAMERA_FAR_CLIP,
-                );
-                const pick2d = scene.pickWithRay(
-                    rayDown,
-                    (m) => m.name.startsWith("tile-ground-"),
-                );
-                const terrainY =
-                    pick2d?.hit && pick2d.pickedPoint
-                        ? pick2d.pickedPoint.y
-                        : camera.target.y;
                 // 2D ortho: position.y は表示範囲に影響しない。
-                // 全地形が near clip 内に収まるよう ORTHO_MIN_CAM_Y 以上を保つ (#254)。
-                const newCamY = Math.max(ORTHO_MIN_CAM_Y, terrainY + ORTHO_MIN_CAM_Y);
+                // 全地形が near clip 内に収まるよう ORTHO_MIN_CAM_Y 固定とする (#254)。
+                const newCamY = ORTHO_MIN_CAM_Y;
                 const newTargetY = newCamY - savedRadius;
                 camera.setPosition(new Vector3(anchorX, newCamY, anchorZ));
                 camera.setTarget(new Vector3(anchorX, newTargetY, anchorZ));

--- a/src/terrain/overlayCoords.ts
+++ b/src/terrain/overlayCoords.ts
@@ -70,6 +70,9 @@ export const assertLatLonInBounds = (
 /**
  * カメラ位置とワールド座標 (wx, wy, wz) からスクリーン定スケール係数を計算する。
  * 近距離での過大スケールを抑えるため下限 0.1 を持つ。
+ *
+ * 2D (orthographic) モード（beta ≈ 0）では、表示範囲が camera.radius に比例するため
+ * 3D 距離ではなく radius を基準にスケールする (#254)。
  */
 export const computeDistanceScale = (
     ctx: OverlayContext,
@@ -78,6 +81,11 @@ export const computeDistanceScale = (
     wz: number,
 ): number => {
     const cam = ctx.getCameraPosition();
+    // 2D ortho: frustum halfH = radius * tan(fov/2)。radius ベースでスケールすることで
+    // ズームに関係なく一定のスクリーンサイズを保つ。
+    if (cam.beta < 0.001) {
+        return Math.max(cam.radius / REF_DISTANCE_M, 0.1);
+    }
     const dx = cam.x - wx;
     const dy = cam.y - wy;
     const dz = cam.z - wz;

--- a/src/terrain/urlState.ts
+++ b/src/terrain/urlState.ts
@@ -14,6 +14,12 @@ export interface CameraUrlState extends LatLon {
     altitude: number;
     azimuth: number;
     tilt: number;
+    /**
+     * 2D モード時の Google Maps 互換ズームレベル (#254)。
+     * 定義されている場合、`toAtPath` は `@lat,lon,Xz` 形式で出力し
+     * altitude / azimuth / tilt は URL に含めない。
+     */
+    zoomLevel?: number;
 }
 
 const PRECISION = 6;
@@ -32,7 +38,53 @@ const TILT_MIN_DEG = (TILT_MIN_RAD * 180) / Math.PI;
 export const CAMERA_URL_LIMITS = {
     altitude: { min: 50, max: 80000 },
     tilt: { min: TILT_MIN_DEG, max: 75 },
+    zoomLevel: { min: 5, max: 23 },
 } as const;
+
+/** ズームレベルの表示精度（小数桁数） */
+const ZOOM_LEVEL_PRECISION = 2;
+
+/**
+ * Web Mercator の赤道上 zoom 0 における 1 ピクセルあたりメートル。
+ * `2π × 6378137 / 256 ≈ 156543.03392804097`
+ */
+const EQUATOR_MPP = 156543.03392804097;
+
+/**
+ * `camera.radius` → Google Maps 互換ズームレベルへ変換する (#254)。
+ *
+ * Web Mercator の定義に基づく:
+ *   mpp = EQUATOR_MPP × cos(φ) / 2^z
+ *   visibleHeight = 2 × radius × tan(fov / 2)
+ *   z = log₂(canvasHeight × EQUATOR_MPP × cos(φ) / (2 × radius × tan(fov / 2)))
+ */
+export const radiusToZoomLevel = (
+    radius: number,
+    canvasHeight: number,
+    latDeg: number,
+    fovRad: number,
+): number => {
+    const cosLat = Math.cos((latDeg * Math.PI) / 180);
+    const tanHalfFov = Math.tan(fovRad / 2);
+    return Math.log2(
+        (canvasHeight * EQUATOR_MPP * cosLat) / (2 * radius * tanHalfFov),
+    );
+};
+
+/**
+ * Google Maps 互換ズームレベル → `camera.radius` へ変換する (#254)。
+ * {@link radiusToZoomLevel} の逆関数。
+ */
+export const zoomLevelToRadius = (
+    z: number,
+    canvasHeight: number,
+    latDeg: number,
+    fovRad: number,
+): number => {
+    const cosLat = Math.cos((latDeg * Math.PI) / 180);
+    const tanHalfFov = Math.tan(fovRad / 2);
+    return (canvasHeight * EQUATOR_MPP * cosLat) / (2 ** z * 2 * tanHalfFov);
+};
 
 /**
  * URL に欠損トークンがあった場合の補完値。
@@ -45,17 +97,22 @@ export const CAMERA_URL_DEFAULTS = {
 } as const;
 
 /**
- * @lat,lon[,altitude,azimuth,tilt] パターン。
+ * @lat,lon[,altitude_or_zoomz,azimuth,tilt] パターン。
  * 2〜5 トークンに対応し、欠損トークンはパース後にデフォルト補完する。
+ * 3 番目のトークンが `z` で終わる場合（例: `14.50z`）はズームレベルとして解釈する (#254)。
  */
 const AT_PATTERN =
-    /@(-?\d+\.?\d*),(-?\d+\.?\d*)(?:,(-?\d+\.?\d*))?(?:,(-?\d+\.?\d*))?(?:,(-?\d+\.?\d*))?/;
+    /@(-?\d+\.?\d*),(-?\d+\.?\d*)(?:,(-?\d+\.?\d*z?))?(?:,(-?\d+\.?\d*))?(?:,(-?\d+\.?\d*))?/;
 
 /** altitude を [50, 80000] にクランプし整数化する */
 export const clampAltitude = (v: number): number => {
     const c = clamp(v, CAMERA_URL_LIMITS.altitude.min, CAMERA_URL_LIMITS.altitude.max);
     return Math.round(c);
 };
+
+/** ズームレベルを [5, 23] にクランプする */
+export const clampZoomLevel = (v: number): number =>
+    clamp(v, CAMERA_URL_LIMITS.zoomLevel.min, CAMERA_URL_LIMITS.zoomLevel.max);
 
 /** tilt を [TILT_MIN_DEG, 75]（deg）にクランプする */
 export const clampTilt = (v: number): number =>
@@ -75,9 +132,12 @@ const pickFinite = (raw: string | undefined, fallback: number): number => {
 
 /**
  * URL からカメラ姿勢を含む状態を読み取る。優先順位:
- * 1. パス / ハッシュ内の `@lat,lon[,altitude,azimuth,tilt]`
+ * 1. パス / ハッシュ内の `@lat,lon[,altitude_or_zoomz,azimuth,tilt]`
  * 2. クエリパラメータ `?lat=&lon=`（altitude/azimuth/tilt はデフォルト補完）
  * いずれも無い場合は null を返す。
+ *
+ * 3 番目のトークンが `z` で終わる場合（例: `14.50z`）は Google Maps 互換の
+ * ズームレベルとして解釈し、`zoomLevel` フィールドに格納する (#254)。
  */
 export const parseCameraStateFromUrl = (url: string): CameraUrlState | null => {
     try {
@@ -90,12 +150,31 @@ export const parseCameraStateFromUrl = (url: string): CameraUrlState | null => {
             const lat = Number(atMatch[1]);
             const lon = Number(atMatch[2]);
             if (isFinite(lat) && isFinite(lon)) {
-                const altitude = pickFinite(atMatch[3], CAMERA_URL_DEFAULTS.altitude);
+                const clampedLat = clamp(lat, JAPAN_BOUNDS.minLat, JAPAN_BOUNDS.maxLat);
+                const clampedLon = clamp(lon, JAPAN_BOUNDS.minLon, JAPAN_BOUNDS.maxLon);
+
+                const rawThird = atMatch[3];
+                if (rawThird !== undefined && rawThird.endsWith("z")) {
+                    // ズームレベル形式: @lat,lon,14.50z (#254)
+                    const z = Number(rawThird.slice(0, -1));
+                    if (isFinite(z)) {
+                        return {
+                            lat: clampedLat,
+                            lon: clampedLon,
+                            altitude: clampAltitude(CAMERA_URL_DEFAULTS.altitude),
+                            azimuth: normalizeAzimuth(CAMERA_URL_DEFAULTS.azimuth),
+                            tilt: clampTilt(CAMERA_URL_DEFAULTS.tilt),
+                            zoomLevel: clampZoomLevel(z),
+                        };
+                    }
+                }
+
+                const altitude = pickFinite(rawThird, CAMERA_URL_DEFAULTS.altitude);
                 const azimuth = pickFinite(atMatch[4], CAMERA_URL_DEFAULTS.azimuth);
                 const tilt = pickFinite(atMatch[5], CAMERA_URL_DEFAULTS.tilt);
                 return {
-                    lat: clamp(lat, JAPAN_BOUNDS.minLat, JAPAN_BOUNDS.maxLat),
-                    lon: clamp(lon, JAPAN_BOUNDS.minLon, JAPAN_BOUNDS.maxLon),
+                    lat: clampedLat,
+                    lon: clampedLon,
                     altitude: clampAltitude(altitude),
                     azimuth: normalizeAzimuth(azimuth),
                     tilt: clampTilt(tilt),
@@ -189,6 +268,7 @@ export function toAtPath(
     const prefix = (typeof b === "string" ? b : undefined) ?? "";
     const head = buildHead(prefix);
     const hasExtra =
+        state.zoomLevel !== undefined ||
         state.altitude !== undefined ||
         state.azimuth !== undefined ||
         state.tilt !== undefined;
@@ -196,6 +276,11 @@ export function toAtPath(
     const lonStr = state.lon.toFixed(PRECISION);
     if (!hasExtra) {
         return `${head}${latStr},${lonStr}`;
+    }
+    // zoomLevel が定義されている場合は Google Maps 互換 `@lat,lon,Xz` 形式 (#254)。
+    if (state.zoomLevel !== undefined) {
+        const z = clampZoomLevel(state.zoomLevel);
+        return `${head}${latStr},${lonStr},${z.toFixed(ZOOM_LEVEL_PRECISION)}z`;
     }
     const altitude = clampAltitude(state.altitude ?? CAMERA_URL_DEFAULTS.altitude);
     const azimuth = normalizeAzimuth(state.azimuth ?? CAMERA_URL_DEFAULTS.azimuth);

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -496,6 +496,7 @@ jest.unstable_mockModule("../src/scenes/default", () => {
                     getAltitude: () => altitude,
                     getAzimuth: () => azimuth,
                     getTilt: () => (lastViewMode === "2d" ? 0 : tilt),
+                    getZoomLevel: () => lastViewMode === "2d" ? 14.0 : undefined,
                     setLat: (v: number) => applyView({ lat: v }, true),
                     setLon: (v: number) => applyView({ lon: v }, true),
                     setAltitude: (v: number) => applyView({ altitude: v }, true),

--- a/tests/urlState.unit.spec.ts
+++ b/tests/urlState.unit.spec.ts
@@ -6,8 +6,11 @@ import {
     createUrlUpdater,
     clampAltitude,
     clampTilt,
+    clampZoomLevel,
     normalizeAzimuth,
     extractDemoPathPrefix,
+    radiusToZoomLevel,
+    zoomLevelToRadius,
     CAMERA_URL_DEFAULTS,
     CAMERA_URL_LIMITS,
     MAP_TYPE_QUERY_KEY,
@@ -694,6 +697,133 @@ describe("urlState", () => {
                     (globalThis as { window?: unknown }).window = originalWindow;
                 }
             }
+        });
+    });
+
+    // ---- ズームレベル (Issue #254) ----
+
+    describe("clampZoomLevel", () => {
+        it("範囲内はそのまま返す", () => {
+            expect(clampZoomLevel(14.5)).toBe(14.5);
+        });
+        it("下限クランプ", () => {
+            expect(clampZoomLevel(3)).toBe(CAMERA_URL_LIMITS.zoomLevel.min);
+        });
+        it("上限クランプ", () => {
+            expect(clampZoomLevel(30)).toBe(CAMERA_URL_LIMITS.zoomLevel.max);
+        });
+    });
+
+    describe("radiusToZoomLevel / zoomLevelToRadius", () => {
+        const H = 800;
+        const LAT = 35.681;
+        const FOV = 0.8;
+
+        it("往復変換で元の radius に戻る", () => {
+            const radius = 5000;
+            const z = radiusToZoomLevel(radius, H, LAT, FOV);
+            const recovered = zoomLevelToRadius(z, H, LAT, FOV);
+            expect(recovered).toBeCloseTo(radius, 4);
+        });
+
+        it("radius が小さいほどズームレベルが大きい", () => {
+            const z1 = radiusToZoomLevel(50, H, LAT, FOV);
+            const z2 = radiusToZoomLevel(75000, H, LAT, FOV);
+            expect(z1).toBeGreaterThan(z2);
+        });
+
+        it("canvas が高いほど同じ radius で大きなズームレベル", () => {
+            const z1 = radiusToZoomLevel(1000, 600, LAT, FOV);
+            const z2 = radiusToZoomLevel(1000, 1200, LAT, FOV);
+            expect(z2).toBeGreaterThan(z1);
+        });
+    });
+
+    describe("parseCameraStateFromUrl – ズームレベル形式", () => {
+        it("@lat,lon,14.50z をパースできる", () => {
+            const result = parseCameraStateFromUrl(
+                "http://localhost/@35.681236,139.767125,14.50z",
+            );
+            expect(result).not.toBeNull();
+            expect(result!.zoomLevel).toBeCloseTo(14.5, 2);
+            expect(result!.azimuth).toBe(CAMERA_URL_DEFAULTS.azimuth);
+            expect(result!.tilt).toBe(CAMERA_URL_DEFAULTS.tilt);
+        });
+
+        it("整数ズームレベル @lat,lon,12z をパースできる", () => {
+            const result = parseCameraStateFromUrl(
+                "http://localhost/@35.0,139.0,12z",
+            );
+            expect(result).not.toBeNull();
+            expect(result!.zoomLevel).toBe(12);
+        });
+
+        it("ズームレベルが上限を超える場合はクランプされる", () => {
+            const result = parseCameraStateFromUrl(
+                "http://localhost/@35.0,139.0,99z",
+            );
+            expect(result).not.toBeNull();
+            expect(result!.zoomLevel).toBe(CAMERA_URL_LIMITS.zoomLevel.max);
+        });
+
+        it("ズームレベルが下限未満の場合はクランプされる", () => {
+            const result = parseCameraStateFromUrl(
+                "http://localhost/@35.0,139.0,1z",
+            );
+            expect(result).not.toBeNull();
+            expect(result!.zoomLevel).toBe(CAMERA_URL_LIMITS.zoomLevel.min);
+        });
+
+        it("通常の altitude 形式では zoomLevel が undefined", () => {
+            const result = parseCameraStateFromUrl(
+                "http://localhost/@35.0,139.0,2000,0,45",
+            );
+            expect(result).not.toBeNull();
+            expect(result!.zoomLevel).toBeUndefined();
+            expect(result!.altitude).toBe(2000);
+        });
+    });
+
+    describe("toAtPath – ズームレベル形式", () => {
+        it("zoomLevel が指定されている場合、@lat,lon,Xz を出力する", () => {
+            const path = toAtPath({
+                lat: 35.681236,
+                lon: 139.767125,
+                zoomLevel: 14.5,
+            });
+            expect(path).toBe("/@35.681236,139.767125,14.50z");
+        });
+
+        it("zoomLevel がクランプされる", () => {
+            const path = toAtPath({
+                lat: 35.0,
+                lon: 139.0,
+                zoomLevel: 99,
+            });
+            expect(path).toContain(`${CAMERA_URL_LIMITS.zoomLevel.max}.00z`);
+        });
+
+        it("zoomLevel 未指定で altitude がある場合は従来形式", () => {
+            const path = toAtPath({
+                lat: 35.0,
+                lon: 139.0,
+                altitude: 2000,
+                azimuth: 0,
+                tilt: 45,
+            });
+            expect(path).toBe("/@35.000000,139.000000,2000,0.00,45.00");
+        });
+
+        it("prefix 付きズームレベル形式", () => {
+            const path = toAtPath(
+                {
+                    lat: 35.681236,
+                    lon: 139.767125,
+                    zoomLevel: 12.0,
+                },
+                "/viewer",
+            );
+            expect(path).toBe("/viewer/@35.681236,139.767125,12.00z");
         });
     });
 });


### PR DESCRIPTION
## 修正内容

Issue #254: 2Dモードで標高の高い地形（富士山等）でズームが正しく動作しない問題を修正。多数のサブバグも併せて修正。

---

### 1. フラスタム計算の修正（根本原因）

**問題:** `applyOrthoFrustum` が `halfH = (target.y + radius) * tan(fov/2)` で計算していたため、標高の高い地点では最小 radius でもフラスタムが巨大になりズームインが不可能だった。

**修正:** `halfH = radius * tan(fov/2)` に変更。radius だけでズームを制御する一貫した動作を実現。

---

### 2. ニアクリッピング対策（高標高地形でのメッシュ欠け）

**問題:** 2D モード時、`camera.position.y` が地形高度 +50m 程度に設定されていたため、富士山山頂など高標高地形でニアクリッピングが発生し、メッシュが欠けてズームが止まった。

**修正:** 2D モードでは `ORTHO_MIN_CAM_Y = 10000m` の固定高度にカメラを配置。平行投影ではカメラ高度は表示範囲に影響しないため視覚的な変化なし。

---

### 3. ドラッグ中の radius 保護

**問題:** ドラッグ中に `retargetAtCameraPosition` が毎フレーム地形高度から radius を再計算し、カメラ高度が変動・ドロップ時にジャンプが発生した。

**修正:** ドラッグ開始時に `savedRadius` を保存し、ドラッグ中は radius を一切変更しない。2D モードの `retarget` は radius を変更しないパスに統一。

---

### 4. Google Maps 互換 URL ズームレベル（2D モード）

**問題:** 2D モードで altitude（海抜高度）を URL に入れていたが、ドラッグで地形の標高が変わると altitude の値が変動し混乱を招く。平行投影ではカメラ高度が表示範囲に影響しないため altitude に意味がない。

**修正:** 2D モードの URL は `/@lat,lon,<zoom>z` 形式（Google Maps 互換）に変更。

- ズームレベル = Web Mercator ズームレベル（小数 2 桁、範囲 [5, 23]）
- URL のコピー＆ペーストで同等の表示を再現可能
- `z` サフィックスの有無でパーサーが自動判別
- 変換式: `z = log₂(canvasHeight × 156543 × cos(φ) / (2 × radius × tan(fov/2)))`

---

### 5. lostpointercapture 二重発火の抑制

**問題:** ポインターリリース時に `pointerup` と `lostpointercapture` の両方が発火し、`retarget` が二重実行されていた。

**修正:** フラグで二重発火を抑制。

---

### 6. 2D→3D モード切替時のカメラ状態復元

**問題:** 2D から 3D に切り替えると `camera.target.y` の直接書き込みで radius が再計算され、ドラッグリリース時のマップずれ・ズーム異常が発生した。

**修正:** 切替前に radius/alpha を退避し、`setPosition`/`setTarget` 後に明示的に復元。3D での savedTiltDeg から球座標でカメラ位置を計算。

---

### 7. マーカーサイズの固定化（2D モード）

**問題:** `computeDistanceScale` が 3D 距離ベースで計算していたため、ortho frustum が radius に連動して変化すると、マーカーが地図タイルと一緒に拡大縮小していた。

**修正:** 2D モード（`beta < 0.001`）では `radius / REF_DISTANCE_M` を使用。frustum サイズへの比例スケールにより、画面上のマーカーサイズが常に一定。

---

### 8. ズームアウト速度の修正

**問題:** `computeWheelFactor` が `queryViewRayDistance()` を使用していたが、2D では `camera.position.y` が `ORTHO_MIN_CAM_Y` 固定のため常に ~10000m を返し、radius が大きくなると 1% 以下の極小ステップになっていた。

**修正:** 2D モードでは `camera.radius` を直接使用し、常に一定割合（5%）のステップを維持。

---

### ドキュメント更新

- `README.md`: URL フォーマット節を 3D/2D 別に整理。2D の `@lat,lon,Xz` 形式・変換式・例を追記。`viewMode` クエリ節を新設。
- `spec/package.md`: `viewMode` URL 仕様の下に 2D パス形式・変換式・クランプ範囲を追記。

---

### 3D モードへの影響

なし。修正はすべて 2D（orthographic）パスにスコープされており、3D の frustum・pan・zoom・URL は変更なし。

---

Closes #254