### PR TITLE
fix(tileManager): zoom > maxElevationZoom で標高クエリが null を返す問題を修正 (#260)

### DIFF
--- a/spec/demos.md
+++ b/spec/demos.md
@@ -15,6 +15,7 @@
 | 距離計測 | `/distance.html` | `src/demos/distance/index.ts` | 地形クリックで頂点を追加し、辺ごとに水平距離・高低差を表示する。`onTerrainClick` (#183) / `onPolygonPoint*` (#184) / `edgeLabels` (#185) の統合動作確認デモ (#186) |
 | Plan Viewer | `/plan.html` | `src/demos/plan/index.ts` | QGroundControl の `.plan` ファイルをドラッグ&ドロップで表示するビューア。ウェイポイント・ジオフェンス・ラリーポイントを描画 |
 | 3Dモデル | `/model.html` | `src/demos/model/index.ts` | 地面クリックで 3D モデル（human.glb/obj/stl）を配置・移動するデモ。方位変更・座標表示・カメラ移動・フォーマット切替。Model API (#243 / #247) の動作確認 |
+| アバターアニメーション #01 | `/avatar.html` | `src/demos/avatar/index.ts` | 3D アバター（`human_walk.glb`）が地形に沿って円軌道を移動するアニメーションデモ。地面クリックで軌道中心を変更、半径・速度スライダー、アニメーション開始/停止トグル。Model API + `playModelAnimation` (#250) の動作確認 |
 
 ## 設計方針
 
@@ -158,3 +159,27 @@ QGroundControl の `.plan` ファイルをドラッグ&ドロップでマップ�
 
 - 既存の VR スナップショット（`tests/validation.spec.ts-snapshots/`）は viewer の URL 変更（`/?scene=default` → `/viewer.html?scene=default`）後も同一の描画結果のため流用可能。
 - `splitChunks.cacheGroups` は変更していないため、バンドル分割の方針は従来どおり。
+
+### avatar (`/avatar.html`)
+
+3D アバター（`assets/human_walk.glb`）が地形に沿って円軌道を移動するアニメーションデモ（#250）。`JpmapTerrain` の Model 公開 API と `playModelAnimation` を使用する。
+
+**仕様:**
+
+- 東京駅（35.681236, 139.767125）に初期配置
+- 地面クリックでクリック地点を中心とする円軌道の中心を移動（カメラから 5000m 以内）
+- 歩行アニメーション（`rig-action`）を再生しながら毎フレーム円周上を移動
+- 進行方向に向きを自動回転（接線方向 = `angleDeg + 90°`）
+- 地形追従（`altitudeMode: "terrain"`, `gravity: true`）
+- モデルスケール: 50 倍
+
+**コントロール（右上パネル）:**
+
+| UI | 操作 |
+|---|---|
+| 半径スライダー | 円軌道の半径 (m) を変更（既定 200m） |
+| 速度スライダー | 角速度 (°/秒) を変更（既定 20°/秒） |
+| 開始/停止ボタン | アニメーション再生のトグル |
+| 中心へ移動ボタン | カメラを軌道中心に移動 |
+
+**URL:** `engine` に加えてカメラ初期位置（`/@lat,lon[,...]` のパス形式）と `?mapType=standard|photo` を受け付ける（`parseCameraStateFromUrl` / `parseMapTypeFromUrl` を共用）。

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -878,7 +878,8 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
      */
     const queryLocalElevation = (wx: number, wz: number): number | null => {
         if (!currentCenter) return null;
-        // activeTiles は表示ズーム（zoom）で登録されるため、
+        // activeTiles には可視タイル（minZoom〜zoom）が登録される。
+        // zoom > maxElevationZoom のタイルも activeTiles に含まれるため、
         // maxElevationZoom ではなく zoom から探索を開始する（#260）。
         for (let z = zoom; z >= minElevationZoom; z--) {
             const ts = tileSizeForZoom(z);

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -878,7 +878,9 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
      */
     const queryLocalElevation = (wx: number, wz: number): number | null => {
         if (!currentCenter) return null;
-        for (let z = maxElevationZoom; z >= minElevationZoom; z--) {
+        // activeTiles は表示ズーム（zoom）で登録されるため、
+        // maxElevationZoom ではなく zoom から探索を開始する（#260）。
+        for (let z = zoom; z >= minElevationZoom; z--) {
             const ts = tileSizeForZoom(z);
             const center = convertTileZoom(currentCenter, z);
             const { fracX, fracY } = computeSubTileOffset(currentCenter, z);

--- a/tests/tileManager.unit.spec.ts
+++ b/tests/tileManager.unit.spec.ts
@@ -1166,6 +1166,46 @@ describe("queryElevationAtWorld", () => {
         expect(tm.queryElevationAtWorld(0, 0)).toBe(88);
         tm.dispose();
     });
+
+    it("zoom > maxElevationZoom でも activeTiles のデータから標高を返す (#260)", async () => {
+        // zoom=18（表示最大）, maxElevationZoom=17（標高タイル最大）
+        // zoom18 の標高データは zoom17 から extractSubTileElevation で抽出される。
+        // 修正前: ループが maxElevationZoom(17) から始まるため activeTiles(zoom18) にヒットせず null。
+        // 修正後: ループが zoom(18) から始まるため activeTiles(zoom18) にヒットして値を返す。
+        (gsiTileMock.tileEdgeMeters as jest.Mock<(lat: number, zoom: number) => number>).mockImplementation(
+            (_lat, zoom) => 1000 * Math.pow(2, 14 - zoom)
+        );
+        const elevData = new Float32Array(256 * 256).fill(55);
+        (gsiTileMock.loadElevationTile as jest.Mock<(zoom: number, x: number, y: number) => Promise<Float32Array>>).mockImplementation(
+            (zoom) => {
+                if (zoom >= 18) return Promise.reject(new Error("not available"));
+                return Promise.resolve(elevData);
+            }
+        );
+
+        const camera = createNearCamera();
+        // radius を小さくして zoom18 のタイルがロードされるようにする
+        (camera as any).radius = 50;
+        (camera as any).position = { x: 0, y: 50, z: 0 };
+        const tm = createTileManager({
+            scene: createMockScene() as never,
+            camera,
+            zoom: 18,
+            subdivisions: 128,
+            heightScale: 1.0,
+            maxTiles: 5,
+            minZoom: 18,
+            maxElevationZoom: 17,
+            minElevationZoom: 17,
+        });
+
+        await tm.setCenter(35.68, 139.77);
+        const result = tm.queryElevationAtWorld(0, 0);
+        // activeTiles には zoom18 のエントリがあり、その標高データは
+        // zoom17 から抽出された値（55）。修正により正しくヒットする。
+        expect(result).toBe(55);
+        tm.dispose();
+    });
 });
 
 /* ================================================================


### PR DESCRIPTION
## 概要

タイルレベル18（`zoom > maxElevationZoom`）の地形上で、`queryLocalElevation` が常に `null` を返し、terrain 追従モデル（アバター等）が非表示になるバグを修正。

## 変更内容

| ファイル | 変更 |
|---|---|
| `src/terrain/tileManager.ts` | `queryLocalElevation` のループ開始を `maxElevationZoom` → `zoom` に修正 |
| `tests/tileManager.unit.spec.ts` | `zoom > maxElevationZoom` での標高クエリテスト追加 |
| `spec/demos.md` | アバターアニメーション #01 のデモ情報を追記 |

## 原因

`activeTiles` は表示ズーム（`zoom=18`）で登録されるが、`queryLocalElevation` のループが `maxElevationZoom`（=17）から開始するため、ズーム18のキーにヒットせず全ズームで失敗していた。

## テスト

- 全762ユニットテスト通過（新規1件含む）
- lint / typecheck エラーなし
- ビジュアルテスト確認済み

Closes #260