### PR TITLE
feat(flight): reverse ribbon color animation direction

### DIFF
--- a/src/demos/flight/routeLine.ts
+++ b/src/demos/flight/routeLine.ts
@@ -77,7 +77,7 @@ const smoothstep = (edge0: number, edge1: number, x: number): number => {
  * 両端を smoothstep でフェードアウトする。
  */
 const computeGradientColor = (t: number, timeSec: number): Color4 => {
-    const phase = ((t * 2.0 - timeSec * 0.4) % 1.0 + 1.0) % 1.0;
+    const phase = ((t * 2.0 + timeSec * 0.4) % 1.0 + 1.0) % 1.0;
     const c1 = { r: 0.0, g: 0.8, b: 1.0 };
     const c2 = { r: 1.0, g: 0.2, b: 0.6 };
     const c3 = { r: 1.0, g: 0.9, b: 0.1 };


### PR DESCRIPTION
## 概要
Close #272

フライトルート表示のリボンカラーアニメーション方向を反転（手前→奥 から 奥→手前）。

## 変更内容
- `computeGradientColor` の phase 計算式で時間成分の符号を反転（`- timeSec * 0.4` → `+ timeSec * 0.4`）

## 検証
- lint ✅
- typecheck ✅
- unit test (804件) ✅