### PR TITLE
feat(flight): ウェイポイント通過エフェクト機能 (#274)

### DIFF
--- a/public/flight.html
+++ b/public/flight.html
@@ -42,28 +42,30 @@
       z-index: 9;
       opacity: 0;
       border-radius: 50%;
-      mix-blend-mode: screen;
       background: radial-gradient(
         circle at center,
-        rgba(255, 255, 255, 0) 0%,
-        rgba(120, 200, 255, 0) 60%,
-        rgba(180, 240, 255, 0.6) 75%,
-        rgba(255, 255, 255, 0.9) 86%,
-        rgba(180, 240, 255, 0.6) 94%,
-        rgba(80, 160, 255, 0) 100%
+        rgba(255, 255, 255, 0)    0%,
+        rgba(180, 240, 255, 0)   52%,
+        rgba(180, 240, 255, 0.7) 62%,
+        rgba(255, 255, 255, 1.0) 72%,
+        rgba(140, 220, 255, 1.0) 80%,
+        rgba(80,  180, 255, 0.5) 90%,
+        rgba(40,  140, 255, 0)  100%
       );
       box-shadow:
-        0 0 60px 10px rgba(180, 230, 255, 0.4),
-        0 0 120px 30px rgba(120, 200, 255, 0.2);
+        0 0 30px 12px rgba(255, 255, 255, 0.6),
+        0 0 80px 30px rgba(140, 210, 255, 0.5),
+        0 0 140px 60px rgba(80, 160, 255, 0.3);
       transform: scale(0.1);
     }
     #wp-shockwave.firing {
-      animation: wpShockwave 0.8s cubic-bezier(0.15, 0.7, 0.3, 1) forwards;
+      animation: wpShockwave 0.9s cubic-bezier(0.1, 0.6, 0.3, 1) forwards;
     }
     @keyframes wpShockwave {
-      0%   { opacity: 0;    transform: scale(0.1); }
-      10%  { opacity: 1;    transform: scale(0.3); }
-      100% { opacity: 0;    transform: scale(18); }
+      0%   { opacity: 0;   transform: scale(0.1); }
+      8%   { opacity: 1;   transform: scale(0.4); }
+      40%  { opacity: 1;   transform: scale(2.8); }
+      100% { opacity: 0;   transform: scale(8); }
     }
 
     #flight-overlay .back-link {

--- a/public/flight.html
+++ b/public/flight.html
@@ -268,7 +268,7 @@
         <strong style="font-size: 11px;">表示切替</strong>
         <label style="display: flex; align-items: center; gap: 6px; font-size: 12px; cursor: pointer;">
           <input type="checkbox" id="waypoint-toggle" checked style="cursor: pointer;">
-          ウェイポイント (Followのみ)
+          ウェイポイント
         </label>
         <label style="display: flex; align-items: center; gap: 6px; font-size: 12px; cursor: pointer;">
           <input type="checkbox" id="ribbon-toggle" checked style="cursor: pointer;">

--- a/public/flight.html
+++ b/public/flight.html
@@ -264,6 +264,17 @@
       <div style="font-size: 10px; color: #c8cdd6; margin-top: 2px;">
         地面クリックで円軌道の中心を移動
       </div>
+      <div style="border-top: 1px solid rgba(255,255,255,0.15); padding-top: 6px; margin-top: 2px; display: flex; flex-direction: column; gap: 4px;">
+        <strong style="font-size: 11px;">表示切替</strong>
+        <label style="display: flex; align-items: center; gap: 6px; font-size: 12px; cursor: pointer;">
+          <input type="checkbox" id="waypoint-toggle" checked style="cursor: pointer;">
+          ウェイポイント (Followのみ)
+        </label>
+        <label style="display: flex; align-items: center; gap: 6px; font-size: 12px; cursor: pointer;">
+          <input type="checkbox" id="ribbon-toggle" checked style="cursor: pointer;">
+          リボン (飛行経路)
+        </label>
+      </div>
     </div>
     <div id="pip-frame">
       <div id="pip-mount"></div>

--- a/public/flight.html
+++ b/public/flight.html
@@ -30,6 +30,42 @@
         "Hiragino Sans", "Noto Sans JP", Meiryo, sans-serif;
     }
 
+    #wp-shockwave {
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      width: 200px;
+      height: 200px;
+      margin-left: -100px;
+      margin-top: -100px;
+      pointer-events: none;
+      z-index: 9;
+      opacity: 0;
+      border-radius: 50%;
+      mix-blend-mode: screen;
+      background: radial-gradient(
+        circle at center,
+        rgba(255, 255, 255, 0) 0%,
+        rgba(120, 200, 255, 0) 60%,
+        rgba(180, 240, 255, 0.6) 75%,
+        rgba(255, 255, 255, 0.9) 86%,
+        rgba(180, 240, 255, 0.6) 94%,
+        rgba(80, 160, 255, 0) 100%
+      );
+      box-shadow:
+        0 0 60px 10px rgba(180, 230, 255, 0.4),
+        0 0 120px 30px rgba(120, 200, 255, 0.2);
+      transform: scale(0.1);
+    }
+    #wp-shockwave.firing {
+      animation: wpShockwave 0.8s cubic-bezier(0.15, 0.7, 0.3, 1) forwards;
+    }
+    @keyframes wpShockwave {
+      0%   { opacity: 0;    transform: scale(0.1); }
+      10%  { opacity: 1;    transform: scale(0.3); }
+      100% { opacity: 0;    transform: scale(18); }
+    }
+
     #flight-overlay .back-link {
       position: absolute;
       top: 12px;
@@ -210,6 +246,7 @@
 </head>
 <body>
   <div id="root"></div>
+  <div id="wp-shockwave"></div>
   <div id="flight-overlay">
     <a class="back-link" href="/">← デモ一覧へ</a>
     <div id="flight-controls">

--- a/src/demos/flight/index.ts
+++ b/src/demos/flight/index.ts
@@ -851,6 +851,7 @@ const start = async (): Promise<void> => {
             const scene = viewer.__debugScene;
             if (scene) {
                 routeLine = createRouteLine(scene);
+                routeLine.setVisible(showRibbon);
             }
         }
         if (routeLine) {

--- a/src/demos/flight/index.ts
+++ b/src/demos/flight/index.ts
@@ -27,6 +27,7 @@ import {
 } from "../../terrain/urlState";
 import { circularOrbitPosition, circularOrbitHeading } from "../avatar/orbit";
 import { createRouteLine, type RouteLine } from "./routeLine";
+import { createWaypointManager, type WaypointManager } from "./waypoints";
 import planeGlbUrl from "../../../assets/plane.glb";
 
 /** PIP 用セカンダリ Viewer 設定 (Issue #264 Option C: 別 Canvas + 別 Engine) */
@@ -161,6 +162,13 @@ const start = async (): Promise<void> => {
 
     // --- ルートライン (Issue #265) ---
     let routeLine: RouteLine | null = null;
+
+    // --- ウェイポイント (Issue #274) ---
+    let waypointManager: WaypointManager | null = null;
+    /** ウェイポイント表示フラグ */
+    let showWaypoints = true;
+    /** リボン表示フラグ */
+    let showRibbon = true;
 
     // --- PIP (Picture-in-Picture) セカンダリ Viewer セットアップ ---
     // Issue #264 Option C: 別 Canvas + 別 Engine + 別 Scene による完全独立構成。
@@ -490,6 +498,21 @@ const start = async (): Promise<void> => {
         radiusSlider.addEventListener("input", () => {
             radiusM = Number(radiusSlider.value);
             updateDisplay();
+            // ウェイポイント再計算 (Issue #274)
+            if (waypointManager) {
+                const scene = viewer.__debugScene;
+                if (scene) {
+                    waypointManager.reset({
+                        scene,
+                        centerLat,
+                        centerLon,
+                        radiusM,
+                        altitudeM,
+                        angleDeg,
+                        modelNodeName: `model-${MODEL_ID}`,
+                    });
+                }
+            }
         });
     }
 
@@ -508,6 +531,21 @@ const start = async (): Promise<void> => {
         altitudeSlider.addEventListener("input", () => {
             altitudeM = Number(altitudeSlider.value);
             updateDisplay();
+            // ウェイポイント再計算 (Issue #274)
+            if (waypointManager) {
+                const scene = viewer.__debugScene;
+                if (scene) {
+                    waypointManager.reset({
+                        scene,
+                        centerLat,
+                        centerLon,
+                        radiusM,
+                        altitudeM,
+                        angleDeg,
+                        modelNodeName: `model-${MODEL_ID}`,
+                    });
+                }
+            }
         });
     }
 
@@ -526,6 +564,29 @@ const start = async (): Promise<void> => {
                 lastTimestamp = null;
             }
             updateToggleLabel();
+        });
+    }
+
+    // ウェイポイント / リボン 表示切替チェックボックス (Issue #274)
+    const waypointToggle = document.getElementById("waypoint-toggle") as HTMLInputElement | null;
+    const ribbonToggle = document.getElementById("ribbon-toggle") as HTMLInputElement | null;
+    if (waypointToggle) {
+        waypointToggle.checked = showWaypoints;
+        waypointToggle.addEventListener("change", () => {
+            showWaypoints = waypointToggle.checked;
+            if (!showWaypoints && waypointManager) {
+                waypointManager.dispose();
+                waypointManager = null;
+            }
+        });
+    }
+    if (ribbonToggle) {
+        ribbonToggle.checked = showRibbon;
+        ribbonToggle.addEventListener("change", () => {
+            showRibbon = ribbonToggle.checked;
+            if (routeLine) {
+                routeLine.setVisible(showRibbon);
+            }
         });
     }
 
@@ -609,6 +670,21 @@ const start = async (): Promise<void> => {
         angleDeg = 0;
         lastTimestamp = null;
         updateDisplay();
+        // ウェイポイント再計算 (Issue #274)
+        if (waypointManager) {
+            const scene = viewer.__debugScene;
+            if (scene) {
+                waypointManager.reset({
+                    scene,
+                    centerLat,
+                    centerLon,
+                    radiusM,
+                    altitudeM,
+                    angleDeg,
+                    modelNodeName: `model-${MODEL_ID}`,
+                });
+            }
+        }
     });
 
     // 毎フレーム更新: 円軌道上の位置を計算してモデルを移動
@@ -781,18 +857,58 @@ const start = async (): Promise<void> => {
             }
         }
         if (routeLine) {
-            routeLine.update(
-                {
-                    scene: viewer.__debugScene!,
-                    angleDeg,
-                    centerLat,
-                    centerLon,
-                    radiusM,
-                    modelNodeName: `model-${MODEL_ID}`,
-                },
-                timestamp,
-            );
+            if (showRibbon) {
+                routeLine.update(
+                    {
+                        scene: viewer.__debugScene!,
+                        angleDeg,
+                        centerLat,
+                        centerLon,
+                        radiusM,
+                        modelNodeName: `model-${MODEL_ID}`,
+                    },
+                    timestamp,
+                );
+            }
         }
+
+        // ウェイポイント更新 (Issue #274) — Followモードのみ
+        if (currentCameraMode === "follow" && showWaypoints) {
+            if (!waypointManager) {
+                const scene = viewer.__debugScene;
+                if (scene) {
+                    waypointManager = createWaypointManager(scene);
+                    waypointManager.reset({
+                        scene,
+                        centerLat,
+                        centerLon,
+                        radiusM,
+                        altitudeM,
+                        angleDeg,
+                        modelNodeName: `model-${MODEL_ID}`,
+                    });
+                }
+            }
+            if (waypointManager) {
+                waypointManager.update(
+                    {
+                        scene: viewer.__debugScene!,
+                        centerLat,
+                        centerLon,
+                        radiusM,
+                        altitudeM,
+                        angleDeg,
+                        modelNodeName: `model-${MODEL_ID}`,
+                    },
+                    timestamp,
+                );
+            }
+        } else if (waypointManager && currentCameraMode !== "follow") {
+            // Followモードを離れたらウェイポイントを破棄
+            waypointManager.dispose();
+            waypointManager = null;
+        }
+
 
         // PIP セカンダリ Viewer 更新: 飛行機の腹部カメラを再現。
         // lib の lat/lon = ArcRotateCamera のターゲット (地面の注視点)。
@@ -824,6 +940,9 @@ const start = async (): Promise<void> => {
         cancelAnimationFrame(rafId);
         if (routeLine) {
             routeLine.dispose();
+        }
+        if (waypointManager) {
+            waypointManager.dispose();
         }
         pipCleanups.forEach((fn) => fn());
         if (pipViewer) {

--- a/src/demos/flight/index.ts
+++ b/src/demos/flight/index.ts
@@ -170,6 +170,20 @@ const start = async (): Promise<void> => {
     /** リボン表示フラグ */
     let showRibbon = true;
 
+    /** ウェイポイント再計算ヘルパー — パラメータ変更時に共通で呼ぶ */
+    const resetWaypointsIfNeeded = (): void => {
+        if (waypointManager && viewer.__debugScene) {
+            waypointManager.reset({
+                centerLat,
+                centerLon,
+                radiusM,
+                altitudeM,
+                angleDeg,
+                modelNodeName: `model-${MODEL_ID}`,
+            });
+        }
+    };
+
     // --- PIP (Picture-in-Picture) セカンダリ Viewer セットアップ ---
     // Issue #264 Option C: 別 Canvas + 別 Engine + 別 Scene による完全独立構成。
     // - メイン Viewer の入力系・タイル管理・カメラに一切手を入れない（バグ非導入）
@@ -498,20 +512,7 @@ const start = async (): Promise<void> => {
         radiusSlider.addEventListener("input", () => {
             radiusM = Number(radiusSlider.value);
             updateDisplay();
-            // ウェイポイント再計算 (Issue #274)
-            if (waypointManager) {
-                const scene = viewer.__debugScene;
-                if (scene) {
-                    waypointManager.reset({
-                        centerLat,
-                        centerLon,
-                        radiusM,
-                        altitudeM,
-                        angleDeg,
-                        modelNodeName: `model-${MODEL_ID}`,
-                    });
-                }
-            }
+            resetWaypointsIfNeeded();
         });
     }
 
@@ -530,20 +531,7 @@ const start = async (): Promise<void> => {
         altitudeSlider.addEventListener("input", () => {
             altitudeM = Number(altitudeSlider.value);
             updateDisplay();
-            // ウェイポイント再計算 (Issue #274)
-            if (waypointManager) {
-                const scene = viewer.__debugScene;
-                if (scene) {
-                    waypointManager.reset({
-                        centerLat,
-                        centerLon,
-                        radiusM,
-                        altitudeM,
-                        angleDeg,
-                        modelNodeName: `model-${MODEL_ID}`,
-                    });
-                }
-            }
+            resetWaypointsIfNeeded();
         });
     }
 
@@ -668,20 +656,7 @@ const start = async (): Promise<void> => {
         angleDeg = 0;
         lastTimestamp = null;
         updateDisplay();
-        // ウェイポイント再計算 (Issue #274)
-        if (waypointManager) {
-            const scene = viewer.__debugScene;
-            if (scene) {
-                waypointManager.reset({
-                    centerLat,
-                    centerLon,
-                    radiusM,
-                    altitudeM,
-                    angleDeg,
-                    modelNodeName: `model-${MODEL_ID}`,
-                });
-            }
-        }
+        resetWaypointsIfNeeded();
     });
 
     // 毎フレーム更新: 円軌道上の位置を計算してモデルを移動
@@ -876,14 +851,7 @@ const start = async (): Promise<void> => {
                 const scene = viewer.__debugScene;
                 if (scene) {
                     waypointManager = createWaypointManager(scene);
-                    waypointManager.reset({
-                        centerLat,
-                        centerLon,
-                        radiusM,
-                        altitudeM,
-                        angleDeg,
-                        modelNodeName: `model-${MODEL_ID}`,
-                    });
+                    resetWaypointsIfNeeded();
                 }
             }
             if (waypointManager) {

--- a/src/demos/flight/index.ts
+++ b/src/demos/flight/index.ts
@@ -503,7 +503,6 @@ const start = async (): Promise<void> => {
                 const scene = viewer.__debugScene;
                 if (scene) {
                     waypointManager.reset({
-                        scene,
                         centerLat,
                         centerLon,
                         radiusM,
@@ -536,7 +535,6 @@ const start = async (): Promise<void> => {
                 const scene = viewer.__debugScene;
                 if (scene) {
                     waypointManager.reset({
-                        scene,
                         centerLat,
                         centerLon,
                         radiusM,
@@ -675,7 +673,6 @@ const start = async (): Promise<void> => {
             const scene = viewer.__debugScene;
             if (scene) {
                 waypointManager.reset({
-                    scene,
                     centerLat,
                     centerLon,
                     radiusM,
@@ -879,7 +876,6 @@ const start = async (): Promise<void> => {
                 if (scene) {
                     waypointManager = createWaypointManager(scene);
                     waypointManager.reset({
-                        scene,
                         centerLat,
                         centerLon,
                         radiusM,
@@ -892,7 +888,6 @@ const start = async (): Promise<void> => {
             if (waypointManager) {
                 waypointManager.update(
                     {
-                        scene: viewer.__debugScene!,
                         centerLat,
                         centerLon,
                         radiusM,

--- a/src/demos/flight/routeLine.ts
+++ b/src/demos/flight/routeLine.ts
@@ -61,6 +61,8 @@ export interface RouteLineContext {
 export interface RouteLine {
     /** 毎フレーム呼び出してリボンを更新する */
     update(ctx: RouteLineContext, time: number): void;
+    /** リボンの表示/非表示を切り替える */
+    setVisible(visible: boolean): void;
     /** リソース解放 */
     dispose(): void;
 }
@@ -233,10 +235,14 @@ export const createRouteLine = (scene: Scene): RouteLine => {
         }
     };
 
+    const setVisible = (visible: boolean): void => {
+        ribbon.setEnabled(visible);
+    };
+
     const dispose = (): void => {
         ribbon.dispose();
         material.dispose();
     };
 
-    return { update, dispose };
+    return { update, setVisible, dispose };
 };

--- a/src/demos/flight/waypointEffect.ts
+++ b/src/demos/flight/waypointEffect.ts
@@ -1,7 +1,11 @@
 /**
- * ウェイポイント通過エフェクト — パーティクル爆発 (Issue #274)。
+ * ウェイポイント通過エフェクト — 多層パーティクル爆発 (Issue #274)。
  *
- * 飛行機がリングを通過したとき、短時間のバースト（ゴールド→白）を放射する。
+ * 4 種類の ParticleSystem を同時に発火させて派手な爆発を演出する。
+ * - core    : 中心爆発（ゴールド/白）
+ * - shock   : 衝撃波リング（円盤状に広がる青白い輝き）
+ * - sparks  : スパーク（細く高速で飛び散る輝点）
+ * - sparkle : キラキラ漂う星屑（虹色）
  */
 
 import { ParticleSystem } from "@babylonjs/core/Particles/particleSystem";
@@ -21,58 +25,139 @@ const PARTICLE_TEXTURE_BASE64 =
     "LIZkMJgNEmBgYGBkAAlAaJACSAAkAGIzMEJNAQkAAHHJDQkd" +
     "hBG8AAAAAElFTkSuQmCC";
 
+let sharedTexture: Texture | null = null;
+const getTexture = (scene: Scene): Texture => {
+    if (!sharedTexture) {
+        sharedTexture = new Texture(PARTICLE_TEXTURE_BASE64, scene);
+    }
+    return sharedTexture;
+};
+
+interface ParticleConfig {
+    name: string;
+    capacity: number;
+    color1: Color4;
+    color2: Color4;
+    colorDead: Color4;
+    minSize: number;
+    maxSize: number;
+    minLifeTime: number;
+    maxLifeTime: number;
+    minEmitPower: number;
+    maxEmitPower: number;
+    emitRate: number;
+    duration: number;
+    emitBoxMin: Vector3;
+    emitBoxMax: Vector3;
+    gravity?: Vector3;
+}
+
+const createPS = (scene: Scene, position: Vector3, cfg: ParticleConfig): ParticleSystem => {
+    const ps = new ParticleSystem(cfg.name, cfg.capacity, scene);
+    ps.particleTexture = getTexture(scene);
+    ps.emitter = position;
+    ps.minEmitBox = cfg.emitBoxMin;
+    ps.maxEmitBox = cfg.emitBoxMax;
+    ps.color1 = cfg.color1;
+    ps.color2 = cfg.color2;
+    ps.colorDead = cfg.colorDead;
+    ps.minSize = cfg.minSize;
+    ps.maxSize = cfg.maxSize;
+    ps.minLifeTime = cfg.minLifeTime;
+    ps.maxLifeTime = cfg.maxLifeTime;
+    ps.minEmitPower = cfg.minEmitPower;
+    ps.maxEmitPower = cfg.maxEmitPower;
+    ps.emitRate = cfg.emitRate;
+    ps.gravity = cfg.gravity ?? new Vector3(0, 0, 0);
+    ps.blendMode = ParticleSystem.BLENDMODE_ADD;
+    ps.targetStopDuration = cfg.duration;
+    ps.disposeOnStop = true;
+    ps.start();
+    return ps;
+};
+
 /**
- * ウェイポイント通過時のパーティクルバーストエフェクトを作成・開始する。
- *
- * エフェクトは `targetStopDuration` 後に自動停止し、
- * `disposeOnStop = true` で自動破棄される。
- *
- * @param scene Babylon.js シーン
- * @param position エフェクト発生のワールド座標
- * @returns 作成された ParticleSystem（自動停止・自動破棄）
+ * ウェイポイント通過時の派手な爆発エフェクトを発火する。
+ * 複数の ParticleSystem を同時起動し、全て自動停止・破棄される。
  */
 export const createPassEffect = (scene: Scene, position: Vector3): ParticleSystem => {
-    const ps = new ParticleSystem("wpPassEffect", 200, scene);
+    // ① 中心爆発 — ゴールド/白の大きな閃光
+    const core = createPS(scene, position, {
+        name: "wpPass_core",
+        capacity: 400,
+        emitBoxMin: new Vector3(-1, -1, -1),
+        emitBoxMax: new Vector3(1, 1, 1),
+        color1: new Color4(1.0, 0.9, 0.3, 1.0),
+        color2: new Color4(1.0, 1.0, 0.8, 1.0),
+        colorDead: new Color4(1.0, 0.6, 0.2, 0.0),
+        minSize: 4,
+        maxSize: 12,
+        minLifeTime: 0.3,
+        maxLifeTime: 0.7,
+        minEmitPower: 40,
+        maxEmitPower: 110,
+        emitRate: 1200,
+        duration: 0.25,
+    });
 
-    // テクスチャ
-    ps.particleTexture = new Texture(PARTICLE_TEXTURE_BASE64, scene);
+    // ② 衝撃波 — 横方向（XZ平面）に広がる青白いリング
+    createPS(scene, position, {
+        name: "wpPass_shock",
+        capacity: 300,
+        emitBoxMin: new Vector3(-1, -0.05, -1),
+        emitBoxMax: new Vector3(1, 0.05, 1),
+        color1: new Color4(0.3, 0.8, 1.0, 1.0),
+        color2: new Color4(0.8, 0.9, 1.0, 1.0),
+        colorDead: new Color4(0.2, 0.4, 1.0, 0.0),
+        minSize: 6,
+        maxSize: 16,
+        minLifeTime: 0.4,
+        maxLifeTime: 0.8,
+        minEmitPower: 80,
+        maxEmitPower: 150,
+        emitRate: 800,
+        duration: 0.2,
+    });
 
-    // 発生位置
-    ps.emitter = position;
+    // ③ スパーク — 高速で遠くまで飛ぶ細い輝点
+    createPS(scene, position, {
+        name: "wpPass_sparks",
+        capacity: 500,
+        emitBoxMin: new Vector3(-0.5, -0.5, -0.5),
+        emitBoxMax: new Vector3(0.5, 0.5, 0.5),
+        color1: new Color4(1.0, 1.0, 1.0, 1.0),
+        color2: new Color4(1.0, 0.9, 0.6, 1.0),
+        colorDead: new Color4(1.0, 0.5, 0.2, 0.0),
+        minSize: 1,
+        maxSize: 3,
+        minLifeTime: 0.5,
+        maxLifeTime: 1.2,
+        minEmitPower: 100,
+        maxEmitPower: 200,
+        emitRate: 1500,
+        duration: 0.3,
+        gravity: new Vector3(0, -20, 0),
+    });
 
-    // 放射方向: 全方位球状
-    ps.minEmitBox = new Vector3(-1, -1, -1);
-    ps.maxEmitBox = new Vector3(1, 1, 1);
+    // ④ キラキラ — ゆっくり漂う星屑（虹色・長寿命）
+    createPS(scene, position, {
+        name: "wpPass_sparkle",
+        capacity: 200,
+        emitBoxMin: new Vector3(-1, -1, -1),
+        emitBoxMax: new Vector3(1, 1, 1),
+        color1: new Color4(1.0, 0.4, 0.9, 1.0),
+        color2: new Color4(0.4, 0.9, 1.0, 1.0),
+        colorDead: new Color4(0.8, 0.4, 1.0, 0.0),
+        minSize: 2,
+        maxSize: 5,
+        minLifeTime: 1.0,
+        maxLifeTime: 2.0,
+        minEmitPower: 15,
+        maxEmitPower: 50,
+        emitRate: 400,
+        duration: 0.4,
+        gravity: new Vector3(0, -5, 0),
+    });
 
-    // カラーグラデーション: ゴールド → 白
-    ps.color1 = new Color4(1.0, 0.85, 0.2, 1.0);
-    ps.color2 = new Color4(1.0, 0.95, 0.6, 1.0);
-    ps.colorDead = new Color4(1.0, 1.0, 1.0, 0.0);
-
-    // サイズ（大きめで派手に）
-    ps.minSize = 3;
-    ps.maxSize = 8;
-
-    // ライフタイム
-    ps.minLifeTime = 0.2;
-    ps.maxLifeTime = 0.5;
-
-    // 放射速度
-    ps.minEmitPower = 30;
-    ps.maxEmitPower = 80;
-
-    // 放出レート (バースト風: 短時間に大量)
-    ps.emitRate = 600;
-
-    // 重力なし
-    ps.gravity = new Vector3(0, 0, 0);
-
-    // 自動停止 & 破棄
-    ps.targetStopDuration = 0.3;
-    ps.disposeOnStop = true;
-
-    // 開始
-    ps.start();
-
-    return ps;
+    return core;
 };

--- a/src/demos/flight/waypointEffect.ts
+++ b/src/demos/flight/waypointEffect.ts
@@ -1,0 +1,78 @@
+/**
+ * ウェイポイント通過エフェクト — パーティクル爆発 (Issue #274)。
+ *
+ * 飛行機がリングを通過したとき、短時間のバースト（ゴールド→白）を放射する。
+ */
+
+import { ParticleSystem } from "@babylonjs/core/Particles/particleSystem";
+import { Color4 } from "@babylonjs/core/Maths/math.color";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { Texture } from "@babylonjs/core/Materials/Textures/texture";
+import type { Scene } from "@babylonjs/core/scene";
+
+/**
+ * 8×8 の白い円 PNG を base64 でインライン化。
+ * パーティクルテクスチャとして使用する。
+ */
+const PARTICLE_TEXTURE_BASE64 =
+    "data:image/png;base64," +
+    "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAA" +
+    "RElEQVQYV2P8////fwYGBgZGRkYGBgYGBkYQDWJgYMDCgHKA" +
+    "LIZkMJgNEmBgYGBkAAlAaJACSAAkAGIzMEJNAQkAAHHJDQkd" +
+    "hBG8AAAAAElFTkSuQmCC";
+
+/**
+ * ウェイポイント通過時のパーティクルバーストエフェクトを作成・開始する。
+ *
+ * エフェクトは `targetStopDuration` 後に自動停止し、
+ * `disposeOnStop = true` で自動破棄される。
+ *
+ * @param scene Babylon.js シーン
+ * @param position エフェクト発生のワールド座標
+ * @returns 作成された ParticleSystem（自動停止・自動破棄）
+ */
+export const createPassEffect = (scene: Scene, position: Vector3): ParticleSystem => {
+    const ps = new ParticleSystem("wpPassEffect", 200, scene);
+
+    // テクスチャ
+    ps.particleTexture = new Texture(PARTICLE_TEXTURE_BASE64, scene);
+
+    // 発生位置
+    ps.emitter = position;
+
+    // 放射方向: 全方位球状
+    ps.minEmitBox = new Vector3(-1, -1, -1);
+    ps.maxEmitBox = new Vector3(1, 1, 1);
+
+    // カラーグラデーション: ゴールド → 白
+    ps.color1 = new Color4(1.0, 0.85, 0.2, 1.0);
+    ps.color2 = new Color4(1.0, 0.95, 0.6, 1.0);
+    ps.colorDead = new Color4(1.0, 1.0, 1.0, 0.0);
+
+    // サイズ（大きめで派手に）
+    ps.minSize = 3;
+    ps.maxSize = 8;
+
+    // ライフタイム
+    ps.minLifeTime = 0.2;
+    ps.maxLifeTime = 0.5;
+
+    // 放射速度
+    ps.minEmitPower = 30;
+    ps.maxEmitPower = 80;
+
+    // 放出レート (バースト風: 短時間に大量)
+    ps.emitRate = 600;
+
+    // 重力なし
+    ps.gravity = new Vector3(0, 0, 0);
+
+    // 自動停止 & 破棄
+    ps.targetStopDuration = 0.3;
+    ps.disposeOnStop = true;
+
+    // 開始
+    ps.start();
+
+    return ps;
+};

--- a/src/demos/flight/waypointEffect.ts
+++ b/src/demos/flight/waypointEffect.ts
@@ -1,62 +1,47 @@
 /**
- * ウェイポイント通過エフェクト — 小粒パーティクルの軽快な弾け (Issue #274)。
+ * ウェイポイント通過エフェクト — 画面全体の衝撃波リップル (Issue #274)。
  *
- * 全方位に小さな輝点を短時間放射し、すぐに消える「シャラッ」とした演出。
+ * DOM オーバーレイ (#wp-shockwave) に `firing` クラスを付与して
+ * CSS keyframes で画面いっぱいに広がる円形リップルを再生する。
+ * 3D シーンに依存しないため、カメラ位置・モードに関わらず画面中央から発火。
+ *
+ * 連射対応: アニメーション中に再発火された場合は再生をリセットする。
  */
 
-import { ParticleSystem } from "@babylonjs/core/Particles/particleSystem";
-import { Color4 } from "@babylonjs/core/Maths/math.color";
-import { Vector3 } from "@babylonjs/core/Maths/math.vector";
-import { Texture } from "@babylonjs/core/Materials/Textures/texture";
+import type { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import type { Scene } from "@babylonjs/core/scene";
 
-/** 8×8 の白い円 PNG (パーティクルテクスチャ) */
-const PARTICLE_TEXTURE_BASE64 =
-    "data:image/png;base64," +
-    "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAA" +
-    "RElEQVQYV2P8////fwYGBgZGRkYGBgYGBkYQDWJgYMDCgHKA" +
-    "LIZkMJgNEmBgYGBkAAlAaJACSAAkAGIzMEJNAQkAAHHJDQkd" +
-    "hBG8AAAAAElFTkSuQmCC";
+const OVERLAY_ID = "wp-shockwave";
+const FIRING_CLASS = "firing";
+
+let pendingTimer: number | null = null;
+
+const getOverlay = (): HTMLElement | null => {
+    if (typeof document === "undefined") return null;
+    return document.getElementById(OVERLAY_ID);
+};
 
 /**
- * ウェイポイント通過時の小粒パーティクル弾けエフェクト。
- * 自動停止・自動破棄。
+ * ウェイポイント通過時の画面衝撃波エフェクトを発火する。
+ * 引数 scene/position は API 互換のため受け取るが内部では使用しない
+ * (3D 空間ではなく DOM オーバーレイで再生)。
  */
-export const createPassEffect = (scene: Scene, position: Vector3): ParticleSystem => {
-    const ps = new ParticleSystem("wpPassEffect", 120, scene);
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const createPassEffect = (_scene: Scene, _position: Vector3): void => {
+    const el = getOverlay();
+    if (!el) return;
 
-    ps.particleTexture = new Texture(PARTICLE_TEXTURE_BASE64, scene);
-    ps.emitter = position;
+    // 連射時はクラスを一旦外して reflow → 再付与してアニメーション再生
+    el.classList.remove(FIRING_CLASS);
+    // 強制 reflow
+    void el.offsetWidth;
+    el.classList.add(FIRING_CLASS);
 
-    // 全方位に小さく放射
-    ps.minEmitBox = new Vector3(-0.5, -0.5, -0.5);
-    ps.maxEmitBox = new Vector3(0.5, 0.5, 0.5);
-
-    // カラー: 白〜薄いシアン (魔法陣のカラーに合わせる)
-    ps.color1 = new Color4(1.0, 1.0, 1.0, 1.0);
-    ps.color2 = new Color4(0.6, 0.9, 1.0, 1.0);
-    ps.colorDead = new Color4(0.4, 0.7, 1.0, 0.0);
-
-    // 小さなパーティクル
-    ps.minSize = 0.8;
-    ps.maxSize = 2.0;
-
-    // 短いライフタイム
-    ps.minLifeTime = 0.2;
-    ps.maxLifeTime = 0.5;
-
-    // 中速で弾ける
-    ps.minEmitPower = 20;
-    ps.maxEmitPower = 50;
-
-    ps.emitRate = 600;
-    ps.gravity = new Vector3(0, 0, 0);
-    ps.blendMode = ParticleSystem.BLENDMODE_ADD;
-
-    // 短い発火時間で「シャラッ」と消える
-    ps.targetStopDuration = 0.1;
-    ps.disposeOnStop = true;
-
-    ps.start();
-    return ps;
+    if (pendingTimer !== null) {
+        clearTimeout(pendingTimer);
+    }
+    pendingTimer = window.setTimeout(() => {
+        el.classList.remove(FIRING_CLASS);
+        pendingTimer = null;
+    }, 900);
 };

--- a/src/demos/flight/waypointEffect.ts
+++ b/src/demos/flight/waypointEffect.ts
@@ -1,11 +1,7 @@
 /**
- * ウェイポイント通過エフェクト — 多層パーティクル爆発 (Issue #274)。
+ * ウェイポイント通過エフェクト — 小粒パーティクルの軽快な弾け (Issue #274)。
  *
- * 4 種類の ParticleSystem を同時に発火させて派手な爆発を演出する。
- * - core    : 中心爆発（ゴールド/白）
- * - shock   : 衝撃波リング（円盤状に広がる青白い輝き）
- * - sparks  : スパーク（細く高速で飛び散る輝点）
- * - sparkle : キラキラ漂う星屑（虹色）
+ * 全方位に小さな輝点を短時間放射し、すぐに消える「シャラッ」とした演出。
  */
 
 import { ParticleSystem } from "@babylonjs/core/Particles/particleSystem";
@@ -14,10 +10,7 @@ import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { Texture } from "@babylonjs/core/Materials/Textures/texture";
 import type { Scene } from "@babylonjs/core/scene";
 
-/**
- * 8×8 の白い円 PNG を base64 でインライン化。
- * パーティクルテクスチャとして使用する。
- */
+/** 8×8 の白い円 PNG (パーティクルテクスチャ) */
 const PARTICLE_TEXTURE_BASE64 =
     "data:image/png;base64," +
     "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAA" +
@@ -26,137 +19,44 @@ const PARTICLE_TEXTURE_BASE64 =
     "hBG8AAAAAElFTkSuQmCC";
 
 /**
- * パーティクルテクスチャを生成する。
- * ParticleSystem の dispose で Texture も破棄されるため共有しない。
- */
-const createParticleTexture = (scene: Scene): Texture =>
-    new Texture(PARTICLE_TEXTURE_BASE64, scene);
-
-interface ParticleConfig {
-    name: string;
-    capacity: number;
-    color1: Color4;
-    color2: Color4;
-    colorDead: Color4;
-    minSize: number;
-    maxSize: number;
-    minLifeTime: number;
-    maxLifeTime: number;
-    minEmitPower: number;
-    maxEmitPower: number;
-    emitRate: number;
-    duration: number;
-    emitBoxMin: Vector3;
-    emitBoxMax: Vector3;
-    gravity?: Vector3;
-}
-
-const createPS = (scene: Scene, position: Vector3, cfg: ParticleConfig): ParticleSystem => {
-    const ps = new ParticleSystem(cfg.name, cfg.capacity, scene);
-    ps.particleTexture = createParticleTexture(scene);
-    ps.emitter = position;
-    ps.minEmitBox = cfg.emitBoxMin;
-    ps.maxEmitBox = cfg.emitBoxMax;
-    ps.color1 = cfg.color1;
-    ps.color2 = cfg.color2;
-    ps.colorDead = cfg.colorDead;
-    ps.minSize = cfg.minSize;
-    ps.maxSize = cfg.maxSize;
-    ps.minLifeTime = cfg.minLifeTime;
-    ps.maxLifeTime = cfg.maxLifeTime;
-    ps.minEmitPower = cfg.minEmitPower;
-    ps.maxEmitPower = cfg.maxEmitPower;
-    ps.emitRate = cfg.emitRate;
-    ps.gravity = cfg.gravity ?? new Vector3(0, 0, 0);
-    ps.blendMode = ParticleSystem.BLENDMODE_ADD;
-    ps.targetStopDuration = cfg.duration;
-    ps.disposeOnStop = true;
-    ps.start();
-    return ps;
-};
-
-/**
- * ウェイポイント通過時の派手な爆発エフェクトを発火する。
- * 複数の ParticleSystem を同時起動し、全て自動停止・破棄される。
+ * ウェイポイント通過時の小粒パーティクル弾けエフェクト。
+ * 自動停止・自動破棄。
  */
 export const createPassEffect = (scene: Scene, position: Vector3): ParticleSystem => {
-    // ① 中心爆発 — ゴールド/白の大きな閃光
-    const core = createPS(scene, position, {
-        name: "wpPass_core",
-        capacity: 400,
-        emitBoxMin: new Vector3(-1, -1, -1),
-        emitBoxMax: new Vector3(1, 1, 1),
-        color1: new Color4(1.0, 0.9, 0.3, 1.0),
-        color2: new Color4(1.0, 1.0, 0.8, 1.0),
-        colorDead: new Color4(1.0, 0.6, 0.2, 0.0),
-        minSize: 4,
-        maxSize: 12,
-        minLifeTime: 0.3,
-        maxLifeTime: 0.7,
-        minEmitPower: 40,
-        maxEmitPower: 110,
-        emitRate: 1200,
-        duration: 0.25,
-    });
+    const ps = new ParticleSystem("wpPassEffect", 120, scene);
 
-    // ② 衝撃波 — 横方向（XZ平面）に広がる青白いリング
-    createPS(scene, position, {
-        name: "wpPass_shock",
-        capacity: 300,
-        emitBoxMin: new Vector3(-1, -0.05, -1),
-        emitBoxMax: new Vector3(1, 0.05, 1),
-        color1: new Color4(0.3, 0.8, 1.0, 1.0),
-        color2: new Color4(0.8, 0.9, 1.0, 1.0),
-        colorDead: new Color4(0.2, 0.4, 1.0, 0.0),
-        minSize: 6,
-        maxSize: 16,
-        minLifeTime: 0.4,
-        maxLifeTime: 0.8,
-        minEmitPower: 80,
-        maxEmitPower: 150,
-        emitRate: 800,
-        duration: 0.2,
-    });
+    ps.particleTexture = new Texture(PARTICLE_TEXTURE_BASE64, scene);
+    ps.emitter = position;
 
-    // ③ スパーク — 高速で遠くまで飛ぶ細い輝点
-    createPS(scene, position, {
-        name: "wpPass_sparks",
-        capacity: 500,
-        emitBoxMin: new Vector3(-0.5, -0.5, -0.5),
-        emitBoxMax: new Vector3(0.5, 0.5, 0.5),
-        color1: new Color4(1.0, 1.0, 1.0, 1.0),
-        color2: new Color4(1.0, 0.9, 0.6, 1.0),
-        colorDead: new Color4(1.0, 0.5, 0.2, 0.0),
-        minSize: 1,
-        maxSize: 3,
-        minLifeTime: 0.5,
-        maxLifeTime: 1.2,
-        minEmitPower: 100,
-        maxEmitPower: 200,
-        emitRate: 1500,
-        duration: 0.3,
-        gravity: new Vector3(0, -20, 0),
-    });
+    // 全方位に小さく放射
+    ps.minEmitBox = new Vector3(-0.5, -0.5, -0.5);
+    ps.maxEmitBox = new Vector3(0.5, 0.5, 0.5);
 
-    // ④ キラキラ — ゆっくり漂う星屑（虹色・長寿命）
-    createPS(scene, position, {
-        name: "wpPass_sparkle",
-        capacity: 200,
-        emitBoxMin: new Vector3(-1, -1, -1),
-        emitBoxMax: new Vector3(1, 1, 1),
-        color1: new Color4(1.0, 0.4, 0.9, 1.0),
-        color2: new Color4(0.4, 0.9, 1.0, 1.0),
-        colorDead: new Color4(0.8, 0.4, 1.0, 0.0),
-        minSize: 2,
-        maxSize: 5,
-        minLifeTime: 1.0,
-        maxLifeTime: 2.0,
-        minEmitPower: 15,
-        maxEmitPower: 50,
-        emitRate: 400,
-        duration: 0.4,
-        gravity: new Vector3(0, -5, 0),
-    });
+    // カラー: 白〜薄いシアン (魔法陣のカラーに合わせる)
+    ps.color1 = new Color4(1.0, 1.0, 1.0, 1.0);
+    ps.color2 = new Color4(0.6, 0.9, 1.0, 1.0);
+    ps.colorDead = new Color4(0.4, 0.7, 1.0, 0.0);
 
-    return core;
+    // 小さなパーティクル
+    ps.minSize = 0.8;
+    ps.maxSize = 2.0;
+
+    // 短いライフタイム
+    ps.minLifeTime = 0.2;
+    ps.maxLifeTime = 0.5;
+
+    // 中速で弾ける
+    ps.minEmitPower = 20;
+    ps.maxEmitPower = 50;
+
+    ps.emitRate = 600;
+    ps.gravity = new Vector3(0, 0, 0);
+    ps.blendMode = ParticleSystem.BLENDMODE_ADD;
+
+    // 短い発火時間で「シャラッ」と消える
+    ps.targetStopDuration = 0.1;
+    ps.disposeOnStop = true;
+
+    ps.start();
+    return ps;
 };

--- a/src/demos/flight/waypointEffect.ts
+++ b/src/demos/flight/waypointEffect.ts
@@ -25,13 +25,12 @@ const PARTICLE_TEXTURE_BASE64 =
     "LIZkMJgNEmBgYGBkAAlAaJACSAAkAGIzMEJNAQkAAHHJDQkd" +
     "hBG8AAAAAElFTkSuQmCC";
 
-let sharedTexture: Texture | null = null;
-const getTexture = (scene: Scene): Texture => {
-    if (!sharedTexture) {
-        sharedTexture = new Texture(PARTICLE_TEXTURE_BASE64, scene);
-    }
-    return sharedTexture;
-};
+/**
+ * パーティクルテクスチャを生成する。
+ * ParticleSystem の dispose で Texture も破棄されるため共有しない。
+ */
+const createParticleTexture = (scene: Scene): Texture =>
+    new Texture(PARTICLE_TEXTURE_BASE64, scene);
 
 interface ParticleConfig {
     name: string;
@@ -54,7 +53,7 @@ interface ParticleConfig {
 
 const createPS = (scene: Scene, position: Vector3, cfg: ParticleConfig): ParticleSystem => {
     const ps = new ParticleSystem(cfg.name, cfg.capacity, scene);
-    ps.particleTexture = getTexture(scene);
+    ps.particleTexture = createParticleTexture(scene);
     ps.emitter = position;
     ps.minEmitBox = cfg.emitBoxMin;
     ps.maxEmitBox = cfg.emitBoxMax;

--- a/src/demos/flight/waypointShader.ts
+++ b/src/demos/flight/waypointShader.ts
@@ -54,6 +54,7 @@ float ring(float r, float center, float width) {
 }
 
 // N角形の距離関数
+// atan(p.x, p.y) は意図的: +Y軸を0°基準にして頂点を12時方向に配置する
 float polygon(vec2 p, int n, float size) {
     float a = atan(p.x, p.y) + PI;
     float r = TAU / float(n);

--- a/src/demos/flight/waypointShader.ts
+++ b/src/demos/flight/waypointShader.ts
@@ -1,0 +1,191 @@
+/**
+ * ウェイポイント魔法陣シェーダー (Issue #274)。
+ *
+ * ディスクメッシュに適用する ShaderMaterial。
+ * - 同心円リング（内・外で逆回転）
+ * - 六芒星・幾何学模様
+ * - ルーン風セグメント
+ * - パルス発光 + シアン/紫のグラデーション
+ */
+
+import { ShaderMaterial } from "@babylonjs/core/Materials/shaderMaterial";
+import { Effect } from "@babylonjs/core/Materials/effect";
+import type { Scene } from "@babylonjs/core/scene";
+
+// ─── シェーダーソース ────────────────────────────────────
+
+const VERTEX_SHADER = `
+precision highp float;
+
+attribute vec3 position;
+attribute vec2 uv;
+
+uniform mat4 worldViewProjection;
+
+varying vec2 vUV;
+
+void main() {
+    vUV = uv;
+    gl_Position = worldViewProjection * vec4(position, 1.0);
+}
+`;
+
+const FRAGMENT_SHADER = `
+precision highp float;
+
+varying vec2 vUV;
+uniform float uTime;
+
+#define PI 3.14159265
+#define TAU 6.28318530
+
+// --- ユーティリティ ---
+
+// 回転
+vec2 rotate2D(vec2 p, float a) {
+    float c = cos(a);
+    float s = sin(a);
+    return vec2(p.x*c - p.y*s, p.x*s + p.y*c);
+}
+
+// アンチエイリアスされたリング
+float ring(float r, float center, float width) {
+    return smoothstep(center - width, center, r) - smoothstep(center, center + width, r);
+}
+
+// N角形の距離関数
+float polygon(vec2 p, int n, float size) {
+    float a = atan(p.x, p.y) + PI;
+    float r = TAU / float(n);
+    float d = cos(floor(0.5 + a/r) * r - a) * length(p);
+    return smoothstep(size + 0.005, size, d);
+}
+
+// セグメント（ルーン風の破線マーク）
+float segments(float angle, int count, float width) {
+    float seg = fract(angle / TAU * float(count));
+    return step(width, seg) * step(seg, 1.0 - width);
+}
+
+void main() {
+    vec2 uv = vUV * 2.0 - 1.0;
+    float r = length(uv);
+    float angle = atan(uv.y, uv.x);
+
+    // 円盤外を完全透明に
+    if (r > 0.98) discard;
+
+    float alpha = 0.0;
+    vec3 color = vec3(0.0);
+
+    // --- 基本カラー: シアン〜紫のグラデーション ---
+    float hueShift = uTime * 0.4;
+    vec3 col1 = vec3(0.1, 0.8, 1.0); // シアン
+    vec3 col2 = vec3(0.6, 0.2, 1.0); // 紫
+    vec3 baseColor = mix(col1, col2, 0.5 + 0.5 * sin(angle * 2.0 + hueShift));
+
+    // --- 外側リング (逆回転) ---
+    float outerRing = ring(r, 0.92, 0.015);
+    float outerRing2 = ring(r, 0.85, 0.008);
+    // ルーン風セグメント（外周に沿った破線）
+    float outerAngle = angle + uTime * 1.2;
+    float runeOuter = segments(outerAngle, 24, 0.15) * ring(r, 0.88, 0.02);
+    alpha += outerRing + outerRing2 + runeOuter * 0.7;
+    color += baseColor * (outerRing + outerRing2 + runeOuter * 0.7);
+
+    // --- 中間リング (正回転) ---
+    float midRing = ring(r, 0.68, 0.01);
+    float midRing2 = ring(r, 0.62, 0.006);
+    float midAngle = angle - uTime * 0.8;
+    float runeMid = segments(midAngle, 16, 0.2) * ring(r, 0.65, 0.025);
+    alpha += midRing + midRing2 + runeMid * 0.6;
+    color += baseColor * (midRing + midRing2 + runeMid * 0.6);
+
+    // --- 内側リング ---
+    float innerRing = ring(r, 0.42, 0.008);
+    float innerAngle = angle + uTime * 1.5;
+    float runeInner = segments(innerAngle, 12, 0.25) * ring(r, 0.44, 0.02);
+    alpha += innerRing + runeInner * 0.5;
+    color += baseColor * (innerRing + runeInner * 0.5);
+
+    // --- 六芒星 (外側, 逆回転) ---
+    vec2 hexUV = rotate2D(uv, -uTime * 0.5);
+    float hex1 = polygon(hexUV, 3, 0.72) - polygon(hexUV, 3, 0.70);
+    vec2 hexUV2 = rotate2D(uv, -uTime * 0.5 + PI / 3.0);
+    float hex2 = polygon(hexUV2, 3, 0.72) - polygon(hexUV2, 3, 0.70);
+    float hexagram = clamp(hex1 + hex2, 0.0, 1.0);
+    alpha += hexagram * 0.8;
+    color += vec3(0.3, 0.9, 1.0) * hexagram * 0.8;
+
+    // --- 内側六角形 (正回転) ---
+    vec2 innerHexUV = rotate2D(uv, uTime * 0.7);
+    float innerHex = polygon(innerHexUV, 6, 0.35) - polygon(innerHexUV, 6, 0.33);
+    alpha += innerHex * 0.6;
+    color += vec3(0.8, 0.4, 1.0) * innerHex * 0.6;
+
+    // --- 中心の円 (パルス) ---
+    float centerGlow = smoothstep(0.15, 0.0, r);
+    float pulse = 0.5 + 0.5 * sin(uTime * 3.0);
+    alpha += centerGlow * pulse * 0.4;
+    color += vec3(1.0, 1.0, 1.0) * centerGlow * pulse * 0.4;
+
+    // --- 放射線 (十字, 回転) ---
+    vec2 crossUV = rotate2D(uv, uTime * 0.3);
+    float crossLine = (step(abs(crossUV.x), 0.003) + step(abs(crossUV.y), 0.003))
+                      * step(0.2, r) * step(r, 0.6);
+    alpha += crossLine * 0.4;
+    color += baseColor * crossLine * 0.4;
+
+    // --- 全体パルス + エミッシブ ---
+    float emit = 2.0 + 1.0 * sin(uTime * 2.0);
+    color *= emit;
+    alpha = clamp(alpha, 0.0, 1.0);
+
+    // 外縁フェード
+    alpha *= smoothstep(0.98, 0.93, r);
+
+    gl_FragColor = vec4(color, alpha * 0.9);
+}
+`;
+
+let shaderRegistered = false;
+
+/** シェーダーソースを Effect.ShadersStore に登録する（初回のみ） */
+const ensureShaderRegistered = (): void => {
+    if (shaderRegistered) return;
+    Effect.ShadersStore["waypointRingVertexShader"] = VERTEX_SHADER;
+    Effect.ShadersStore["waypointRingFragmentShader"] = FRAGMENT_SHADER;
+    shaderRegistered = true;
+};
+
+/**
+ * ウェイポイントリング用の ShaderMaterial を作成する。
+ * @param scene Babylon.js シーン
+ * @param id マテリアルに付与するユニーク名
+ */
+export const createWaypointMaterial = (scene: Scene, id: string): ShaderMaterial => {
+    ensureShaderRegistered();
+
+    const mat = new ShaderMaterial(
+        `waypointMat_${id}`,
+        scene,
+        { vertex: "waypointRing", fragment: "waypointRing" },
+        {
+            attributes: ["position", "uv"],
+            uniforms: ["worldViewProjection", "uTime"],
+        },
+    );
+    mat.backFaceCulling = false;
+    mat.alpha = 0.9;
+    mat.setFloat("uTime", 0);
+    return mat;
+};
+
+/**
+ * 毎フレーム呼び出してシェーダーの時間 uniform を更新する。
+ * @param material createWaypointMaterial で作成したマテリアル
+ * @param time 経過時間 (秒)
+ */
+export const updateWaypointMaterialTime = (material: ShaderMaterial, time: number): void => {
+    material.setFloat("uTime", time);
+};

--- a/src/demos/flight/waypoints.ts
+++ b/src/demos/flight/waypoints.ts
@@ -196,6 +196,7 @@ export const createWaypointManager = (scene: Scene): WaypointManager => {
                     nextSpawnAngleDeg += angleStepDeg;
                     wp.passed = false;
                     wp.fadeAlpha = 1;
+                    wp.mesh.visibility = 1;
                     wp.mesh.scaling.set(1, 1, 1);
                     applyRingOrientation(wp.mesh, wp.angleDeg);
                     // setEnabled(true) は位置更新後（下部）に実行

--- a/src/demos/flight/waypoints.ts
+++ b/src/demos/flight/waypoints.ts
@@ -15,7 +15,11 @@ import { createWaypointMaterial, updateWaypointMaterialTime } from "./waypointSh
 import { createPassEffect } from "./waypointEffect";
 
 // ─── 定数 ────────────────────────────────────────────────
-/** ウェイポイント間の弧長距離 (m) */
+/**
+ * ウェイポイント間の弧長距離 (m)。
+ * Issue #274 初版は約350m（音速340m/s相当）だったが、視認性と密度のバランスを
+ * 確認した結果ユーザー判断で 600m に変更（PR #277 レビュースレッド参照）。
+ */
 const WAYPOINT_SPACING_M = 600;
 /** ウィンドウの最大ウェイポイント数 */
 const MAX_WAYPOINT_COUNT = 10;

--- a/src/demos/flight/waypoints.ts
+++ b/src/demos/flight/waypoints.ts
@@ -36,7 +36,6 @@ const INITIAL_OFFSET_M = WAYPOINT_SPACING_M * 0.5;
 
 // ─── 型 ──────────────────────────────────────────────────
 export interface WaypointManagerContext {
-    scene: Scene;
     centerLat: number;
     centerLon: number;
     radiusM: number;
@@ -164,7 +163,7 @@ export const createWaypointManager = (scene: Scene): WaypointManager => {
         const timeSec = time * 0.001;
 
         // 飛行機のワールド座標
-        const root = ctx.scene.getTransformNodeByName(ctx.modelNodeName);
+        const root = scene.getTransformNodeByName(ctx.modelNodeName);
         if (!root) return;
         const childMesh = root.getChildMeshes(false)[0];
         if (!childMesh) return;
@@ -185,7 +184,7 @@ export const createWaypointManager = (scene: Scene): WaypointManager => {
             // ─── 通過判定: 前方かつ近い ───
             if (!wp.passed && ahead && dist < PASS_THRESHOLD_M) {
                 wp.passed = true;
-                createPassEffect(ctx.scene, wp.mesh.position.clone());
+                createPassEffect(scene, wp.mesh.position.clone());
             }
 
             // ─── フェードアウト + 拡大アニメーション ───

--- a/src/demos/flight/waypoints.ts
+++ b/src/demos/flight/waypoints.ts
@@ -25,6 +25,8 @@ const DISC_DIAMETER_M = 60;
 const PASS_THRESHOLD_M = 40;
 /** フェードアウト速度 (alpha/秒) */
 const FADE_SPEED = 3.0;
+/** フェード完了時の拡大倍率 */
+const FADE_MAX_SCALE = 2.5;
 /** 初期配置時に飛行機の前方へずらすオフセット (m) — 即通過を防ぐ */
 const INITIAL_OFFSET_M = WAYPOINT_SPACING_M * 0.5;
 
@@ -182,7 +184,7 @@ export const createWaypointManager = (scene: Scene): WaypointManager => {
                 createPassEffect(ctx.scene, wp.mesh.position.clone());
             }
 
-            // ─── フェードアウト ───
+            // ─── フェードアウト + 拡大アニメーション ───
             if (wp.passed && wp.fadeAlpha > 0) {
                 wp.fadeAlpha -= FADE_SPEED * dt;
                 if (wp.fadeAlpha <= 0) {
@@ -194,10 +196,15 @@ export const createWaypointManager = (scene: Scene): WaypointManager => {
                     nextSpawnAngleDeg += angleStepDeg;
                     wp.passed = false;
                     wp.fadeAlpha = 1;
+                    wp.mesh.scaling.set(1, 1, 1);
                     applyRingOrientation(wp.mesh, wp.angleDeg);
                     // setEnabled(true) は位置更新後（下部）に実行
                 } else {
                     wp.mesh.visibility = wp.fadeAlpha;
+                    // fadeAlpha 1→0 にあわせて 1→FADE_MAX_SCALE に拡大
+                    const t = 1 - wp.fadeAlpha;
+                    const scale = 1 + t * (FADE_MAX_SCALE - 1);
+                    wp.mesh.scaling.set(scale, scale, scale);
                 }
             }
 

--- a/src/demos/flight/waypoints.ts
+++ b/src/demos/flight/waypoints.ts
@@ -137,7 +137,6 @@ export const createWaypointManager = (scene: Scene): WaypointManager => {
             mesh.material = mat;
             mesh.isPickable = false;
             mesh.alwaysSelectAsActiveMesh = true;
-            mesh.rotation.x = Math.PI / 2;
             applyRingOrientation(mesh, wpAngle);
 
             waypoints.push({

--- a/src/demos/flight/waypoints.ts
+++ b/src/demos/flight/waypoints.ts
@@ -1,0 +1,235 @@
+/**
+ * ウェイポイント管理モジュール (Issue #274)。
+ *
+ * 円軌道上にスライディングウィンドウ方式でリング（トーラス）を配置。
+ * 飛行機が通過するとフェードアウトし、完全消滅後に最後尾の次の位置へ移動して復活。
+ * メッシュをプールとして再利用するため create/dispose のオーバーヘッドがない。
+ */
+
+import { CreateTorus } from "@babylonjs/core/Meshes/Builders/torusBuilder";
+import { Mesh } from "@babylonjs/core/Meshes/mesh";
+import type { Scene } from "@babylonjs/core/scene";
+
+import { circularOrbitPosition, circularOrbitHeading } from "../avatar/orbit";
+import { createWaypointMaterial, updateWaypointMaterialTime } from "./waypointShader";
+import { createPassEffect } from "./waypointEffect";
+
+// ─── 定数 ────────────────────────────────────────────────
+/** ウェイポイント間の弧長距離 (m) */
+const WAYPOINT_SPACING_M = 600;
+/** ウィンドウの最大ウェイポイント数 */
+const MAX_WAYPOINT_COUNT = 10;
+/** リングの直径 (m) — 飛行機がくぐれるサイズ */
+const RING_DIAMETER_M = 60;
+/** リングのチューブ太さ (m) */
+const RING_TUBE_DIAMETER_M = 3;
+/** 通過判定の弧長距離 (m) */
+const PASS_THRESHOLD_M = 40;
+/** フェードアウト速度 (alpha/秒) */
+const FADE_SPEED = 3.0;
+/** 初期配置時に飛行機の前方へずらすオフセット (m) — 即通過を防ぐ */
+const INITIAL_OFFSET_M = WAYPOINT_SPACING_M * 0.5;
+
+// ─── 型 ──────────────────────────────────────────────────
+export interface WaypointManagerContext {
+    scene: Scene;
+    centerLat: number;
+    centerLon: number;
+    radiusM: number;
+    altitudeM: number;
+    angleDeg: number;
+    modelNodeName: string;
+}
+
+export interface WaypointManager {
+    update(ctx: WaypointManagerContext, time: number): void;
+    reset(ctx: WaypointManagerContext): void;
+    dispose(): void;
+}
+
+interface WaypointState {
+    /** 円周上の角度 (度, 単調増加・ラップなし) */
+    angleDeg: number;
+    mesh: Mesh | null;
+    passed: boolean;
+    fadeAlpha: number;
+}
+
+// ─── ユーティリティ ──────────────────────────────────────
+
+/** 弧長距離→角度差 (度) に変換 */
+const metersToDeg = (meters: number, radiusM: number): number =>
+    (meters / (2 * Math.PI * radiusM)) * 360;
+
+/**
+ * angle2 が angle1 より前方 (進行方向) にあるかを判定。
+ * fwdDeg = (angle2 - angle1 + 360) % 360 が 180° 未満なら前方。
+ */
+const isAhead = (angle1Deg: number, angle2Deg: number): boolean => {
+    const fwd = ((angle2Deg - angle1Deg) % 360 + 360) % 360;
+    return fwd < 180;
+};
+
+/**
+ * 2角度間の弧長距離 (m) を返す。最短弧。
+ */
+const arcDistance = (angle1Deg: number, angle2Deg: number, radiusM: number): number => {
+    let diff = ((angle2Deg - angle1Deg) % 360 + 360) % 360;
+    if (diff > 180) diff = 360 - diff;
+    return (diff * Math.PI / 180) * radiusM;
+};
+
+// ─── メイン ──────────────────────────────────────────────
+
+export const createWaypointManager = (scene: Scene): WaypointManager => {
+    let waypoints: WaypointState[] = [];
+    let materials: ReturnType<typeof createWaypointMaterial>[] = [];
+    let lastTime = 0;
+    /** 次に復活するウェイポイントを配置する角度 (度, 単調増加) */
+    let nextSpawnAngleDeg = 0;
+    /** 1ウェイポイント分の角度ステップ (度) */
+    let angleStepDeg = 0;
+
+    const disposeAll = (): void => {
+        for (const wp of waypoints) {
+            if (wp.mesh) {
+                wp.mesh.dispose();
+                wp.mesh = null;
+            }
+        }
+        for (const mat of materials) {
+            mat.dispose();
+        }
+        waypoints = [];
+        materials = [];
+    };
+
+    /** 半径から使用するウェイポイント数を算出 */
+    const computeCount = (radiusM: number): number => {
+        const circumference = 2 * Math.PI * radiusM;
+        return Math.max(1, Math.min(MAX_WAYPOINT_COUNT, Math.floor(circumference / WAYPOINT_SPACING_M)));
+    };
+
+    /** メッシュの Y 回転をウェイポイント角度に合わせて更新 */
+    const applyRingOrientation = (mesh: Mesh, wpAngleDeg: number): void => {
+        const heading = circularOrbitHeading(wpAngleDeg);
+        mesh.rotation.y = (heading * Math.PI) / 180;
+    };
+
+    const reset = (ctx: WaypointManagerContext): void => {
+        disposeAll();
+
+        const count = computeCount(ctx.radiusM);
+        angleStepDeg = metersToDeg(WAYPOINT_SPACING_M, ctx.radiusM);
+        const offsetDeg = metersToDeg(INITIAL_OFFSET_M, ctx.radiusM);
+
+        for (let i = 0; i < count; i++) {
+            const wpAngle = ctx.angleDeg + offsetDeg + i * angleStepDeg;
+            const mat = createWaypointMaterial(scene, `wp${i}`);
+            materials.push(mat);
+
+            const mesh = CreateTorus(
+                `waypointRing_${i}`,
+                {
+                    diameter: RING_DIAMETER_M,
+                    thickness: RING_TUBE_DIAMETER_M,
+                    tessellation: 24,
+                },
+                scene,
+            );
+            mesh.material = mat;
+            mesh.isPickable = false;
+            mesh.alwaysSelectAsActiveMesh = true;
+            mesh.rotation.x = Math.PI / 2;
+            applyRingOrientation(mesh, wpAngle);
+
+            waypoints.push({
+                angleDeg: wpAngle,
+                mesh,
+                passed: false,
+                fadeAlpha: 1,
+            });
+        }
+
+        // 最後のウェイポイントの次の位置が次の復活先
+        nextSpawnAngleDeg = ctx.angleDeg + offsetDeg + count * angleStepDeg;
+    };
+
+    const update = (ctx: WaypointManagerContext, time: number): void => {
+        const dt = lastTime > 0 ? (time - lastTime) * 0.001 : 0.016;
+        lastTime = time;
+
+        const timeSec = time * 0.001;
+
+        // 飛行機のワールド座標
+        const root = ctx.scene.getTransformNodeByName(ctx.modelNodeName);
+        if (!root) return;
+        const childMesh = root.getChildMeshes(false)[0];
+        if (!childMesh) return;
+        childMesh.computeWorldMatrix(true);
+        const planeWorldPos = childMesh.absolutePosition;
+
+        const planeGeo = circularOrbitPosition(
+            ctx.centerLat, ctx.centerLon, ctx.radiusM, ctx.angleDeg,
+        );
+
+        for (let i = 0; i < waypoints.length; i++) {
+            const wp = waypoints[i];
+            if (!wp.mesh) continue;
+
+            const dist = arcDistance(ctx.angleDeg, wp.angleDeg, ctx.radiusM);
+            const ahead = isAhead(ctx.angleDeg, wp.angleDeg);
+
+            // ─── 通過判定: 前方かつ近い ───
+            if (!wp.passed && ahead && dist < PASS_THRESHOLD_M) {
+                wp.passed = true;
+                createPassEffect(ctx.scene, wp.mesh.position.clone());
+            }
+
+            // ─── フェードアウト ───
+            if (wp.passed && wp.fadeAlpha > 0) {
+                wp.fadeAlpha -= FADE_SPEED * dt;
+                if (wp.fadeAlpha <= 0) {
+                    wp.fadeAlpha = 0;
+                    wp.mesh.setEnabled(false);
+
+                    // ─── 再利用: 最後尾の次の位置へ移動して復活 ───
+                    wp.angleDeg = nextSpawnAngleDeg;
+                    nextSpawnAngleDeg += angleStepDeg;
+                    wp.passed = false;
+                    wp.fadeAlpha = 1;
+                    applyRingOrientation(wp.mesh, wp.angleDeg);
+                    // setEnabled(true) は位置更新後（下部）に実行
+                } else {
+                    wp.mesh.visibility = wp.fadeAlpha;
+                }
+            }
+
+            // ─── メッシュ位置更新 ───
+            const active = !wp.passed || wp.fadeAlpha > 0;
+            if (active) {
+                const wpGeo = circularOrbitPosition(
+                    ctx.centerLat, ctx.centerLon, ctx.radiusM, wp.angleDeg,
+                );
+                const dLat = wpGeo.lat - planeGeo.lat;
+                const dLon = wpGeo.lon - planeGeo.lon;
+                const cosLat = Math.cos((planeGeo.lat * Math.PI) / 180);
+                const offsetX = dLon * 111320 * cosLat;
+                const offsetZ = dLat * 111320;
+
+                wp.mesh.position.set(
+                    planeWorldPos.x + offsetX,
+                    planeWorldPos.y,
+                    planeWorldPos.z + offsetZ,
+                );
+                wp.mesh.setEnabled(true);
+
+                if (materials[i]) {
+                    updateWaypointMaterialTime(materials[i], timeSec);
+                }
+            }
+        }
+    };
+
+    return { update, reset, dispose: disposeAll };
+};

--- a/src/demos/flight/waypoints.ts
+++ b/src/demos/flight/waypoints.ts
@@ -1,12 +1,12 @@
 /**
  * ウェイポイント管理モジュール (Issue #274)。
  *
- * 円軌道上にスライディングウィンドウ方式でリング（トーラス）を配置。
+ * 円軌道上にスライディングウィンドウ方式で魔法陣ディスクを配置。
  * 飛行機が通過するとフェードアウトし、完全消滅後に最後尾の次の位置へ移動して復活。
  * メッシュをプールとして再利用するため create/dispose のオーバーヘッドがない。
  */
 
-import { CreateTorus } from "@babylonjs/core/Meshes/Builders/torusBuilder";
+import { CreateDisc } from "@babylonjs/core/Meshes/Builders/discBuilder";
 import { Mesh } from "@babylonjs/core/Meshes/mesh";
 import type { Scene } from "@babylonjs/core/scene";
 
@@ -19,10 +19,8 @@ import { createPassEffect } from "./waypointEffect";
 const WAYPOINT_SPACING_M = 600;
 /** ウィンドウの最大ウェイポイント数 */
 const MAX_WAYPOINT_COUNT = 10;
-/** リングの直径 (m) — 飛行機がくぐれるサイズ */
-const RING_DIAMETER_M = 60;
-/** リングのチューブ太さ (m) */
-const RING_TUBE_DIAMETER_M = 3;
+/** 魔法陣ディスクの直径 (m) — 飛行機がくぐれるサイズ */
+const DISC_DIAMETER_M = 60;
 /** 通過判定の弧長距離 (m) */
 const PASS_THRESHOLD_M = 40;
 /** フェードアウト速度 (alpha/秒) */
@@ -128,12 +126,11 @@ export const createWaypointManager = (scene: Scene): WaypointManager => {
             const mat = createWaypointMaterial(scene, `wp${i}`);
             materials.push(mat);
 
-            const mesh = CreateTorus(
-                `waypointRing_${i}`,
+            const mesh = CreateDisc(
+                `waypointDisc_${i}`,
                 {
-                    diameter: RING_DIAMETER_M,
-                    thickness: RING_TUBE_DIAMETER_M,
-                    tessellation: 24,
+                    radius: DISC_DIAMETER_M / 2,
+                    tessellation: 48,
                 },
                 scene,
             );

--- a/tests/waypoints.unit.spec.ts
+++ b/tests/waypoints.unit.spec.ts
@@ -1,0 +1,189 @@
+/**
+ * `src/demos/flight/waypoints.ts` の unit test (Issue #274)。
+ *
+ * ウェイポイント管理ロジック（arcDistance 等）をテストする。
+ * Babylon.js の Scene/Mesh 依存部分はモック化。
+ *
+ * ESM + jest.unstable_mockModule で完全にモジュールを分離して
+ * 他テストとのキャッシュ衝突を回避する。
+ */
+import { describe, it, expect, jest, beforeAll } from "@jest/globals";
+
+// ESM環境のモック: jest.unstable_mockModule を使い、動的 import でテスト対象を取得
+
+jest.unstable_mockModule("@babylonjs/core/Meshes/Builders/torusBuilder", () => ({
+    CreateTorus: jest.fn(() => ({
+        material: null,
+        isPickable: false,
+        alwaysSelectAsActiveMesh: false,
+        rotation: { x: 0, y: 0, z: 0 },
+        position: { x: 0, y: 0, z: 0, set: jest.fn(), clone: jest.fn(() => ({ x: 0, y: 0, z: 0 })) },
+        visibility: 1,
+        dispose: jest.fn(),
+        setEnabled: jest.fn(),
+    })),
+}));
+
+jest.unstable_mockModule("@babylonjs/core/Meshes/mesh", () => ({
+    Mesh: class {},
+}));
+
+jest.unstable_mockModule("@babylonjs/core/Materials/shaderMaterial", () => ({
+    ShaderMaterial: jest.fn(() => ({
+        setFloat: jest.fn(), dispose: jest.fn(), backFaceCulling: false, alpha: 1,
+    })),
+}));
+
+jest.unstable_mockModule("@babylonjs/core/Materials/effect", () => ({
+    Effect: { ShadersStore: {} },
+}));
+
+jest.unstable_mockModule("@babylonjs/core/Particles/particleSystem", () => ({
+    ParticleSystem: jest.fn(() => ({
+        particleTexture: null, emitter: null,
+        minEmitBox: null, maxEmitBox: null,
+        color1: null, color2: null, colorDead: null,
+        minSize: 0, maxSize: 0, minLifeTime: 0, maxLifeTime: 0,
+        minEmitPower: 0, maxEmitPower: 0, emitRate: 0,
+        gravity: null, targetStopDuration: 0, disposeOnStop: false,
+        start: jest.fn(),
+    })),
+}));
+
+jest.unstable_mockModule("@babylonjs/core/Maths/math.color", () => ({
+    Color4: jest.fn(),
+}));
+
+jest.unstable_mockModule("@babylonjs/core/Maths/math.vector", () => ({
+    Vector3: jest.fn((x = 0, y = 0, z = 0) => ({ x, y, z })),
+}));
+
+jest.unstable_mockModule("@babylonjs/core/Materials/Textures/texture", () => ({
+    Texture: jest.fn(),
+}));
+
+jest.unstable_mockModule("../src/demos/flight/waypointShader", () => ({
+    createWaypointMaterial: jest.fn(() => ({
+        setFloat: jest.fn(), dispose: jest.fn(), backFaceCulling: false, alpha: 1,
+    })),
+    updateWaypointMaterialTime: jest.fn(),
+}));
+
+jest.unstable_mockModule("../src/demos/flight/waypointEffect", () => ({
+    createPassEffect: jest.fn(),
+}));
+
+const createMockScene = () => ({
+    getTransformNodeByName: jest.fn((): unknown => ({
+        getChildMeshes: jest.fn(() => [
+            {
+                computeWorldMatrix: jest.fn(),
+                absolutePosition: { x: 0, y: 100, z: 0 },
+            },
+        ]),
+    })),
+});
+
+describe("createWaypointManager", () => {
+    let createWaypointManager: any;
+    let CreateTorusMock: jest.Mock;
+
+    beforeAll(async () => {
+        const waypoints = await import("../src/demos/flight/waypoints");
+        createWaypointManager = waypoints.createWaypointManager;
+
+        const torusModule = await import("@babylonjs/core/Meshes/Builders/torusBuilder");
+        CreateTorusMock = torusModule.CreateTorus as unknown as jest.Mock;
+    });
+
+    it("creates a WaypointManager with update/reset/dispose", () => {
+        const scene = createMockScene();
+        const mgr = createWaypointManager(scene);
+        expect(mgr).toBeDefined();
+        expect(typeof mgr.update).toBe("function");
+        expect(typeof mgr.reset).toBe("function");
+        expect(typeof mgr.dispose).toBe("function");
+    });
+
+    it("reset creates waypoints based on radius", () => {
+        CreateTorusMock.mockClear();
+        const scene = createMockScene();
+        const mgr = createWaypointManager(scene);
+        mgr.reset({
+            scene,
+            centerLat: 35.68,
+            centerLon: 139.77,
+            radiusM: 2000,
+            altitudeM: 2000,
+            angleDeg: 0,
+            modelNodeName: "model-plane",
+        });
+
+        // 2000m 半径 → 周長 ≈ 12566m → 12566/600 ≈ 20 → cap at MAX_WAYPOINT_COUNT=10
+        const expectedCount = Math.min(
+            Math.floor((2 * Math.PI * 2000) / 600),
+            10,
+        );
+        expect(CreateTorusMock).toHaveBeenCalledTimes(expectedCount);
+    });
+
+    it("reset caps waypoints at MAX_WAYPOINTS", () => {
+        CreateTorusMock.mockClear();
+        const scene = createMockScene();
+        const mgr = createWaypointManager(scene);
+        mgr.reset({
+            scene,
+            centerLat: 35.68,
+            centerLon: 139.77,
+            radiusM: 50000,
+            altitudeM: 2000,
+            angleDeg: 0,
+            modelNodeName: "model-plane",
+        });
+        expect(CreateTorusMock).toHaveBeenCalledTimes(10);
+    });
+
+    it("dispose cleans up without error", () => {
+        const scene = createMockScene();
+        const mgr = createWaypointManager(scene);
+        mgr.reset({
+            scene,
+            centerLat: 35.68,
+            centerLon: 139.77,
+            radiusM: 2000,
+            altitudeM: 2000,
+            angleDeg: 0,
+            modelNodeName: "model-plane",
+        });
+        expect(() => mgr.dispose()).not.toThrow();
+    });
+
+    it("update does not throw when no model node found", () => {
+        const scene = createMockScene();
+        scene.getTransformNodeByName = jest.fn(() => null);
+        const mgr = createWaypointManager(scene);
+        mgr.reset({
+            scene,
+            centerLat: 35.68,
+            centerLon: 139.77,
+            radiusM: 2000,
+            altitudeM: 2000,
+            angleDeg: 0,
+            modelNodeName: "model-plane",
+        });
+        expect(() =>
+            mgr.update(
+                {
+                    scene,
+                    centerLat: 35.68,
+                    centerLon: 139.77,
+                    radiusM: 2000,
+                    altitudeM: 2000,
+                    angleDeg: 10,
+                    modelNodeName: "model-plane",
+                },
+                1000,
+            ),
+        ).not.toThrow();
+    });
+});

--- a/tests/waypoints.unit.spec.ts
+++ b/tests/waypoints.unit.spec.ts
@@ -13,16 +13,21 @@ import type { Scene } from "@babylonjs/core/scene";
 // ESM環境のモック: jest.unstable_mockModule を使い、動的 import でテスト対象を取得
 
 jest.unstable_mockModule("@babylonjs/core/Meshes/Builders/discBuilder", () => ({
-    CreateDisc: jest.fn(() => ({
-        material: null,
-        isPickable: false,
-        alwaysSelectAsActiveMesh: false,
-        rotation: { x: 0, y: 0, z: 0 },
-        position: { x: 0, y: 0, z: 0, set: jest.fn(), clone: jest.fn(() => ({ x: 0, y: 0, z: 0 })) },
-        visibility: 1,
-        dispose: jest.fn(),
-        setEnabled: jest.fn(),
-    })),
+    CreateDisc: jest.fn(() => {
+        const scaling = { x: 1, y: 1, z: 1, set(x: number, y: number, z: number) { this.x = x; this.y = y; this.z = z; } };
+        return {
+            material: null,
+            isPickable: false,
+            alwaysSelectAsActiveMesh: false,
+            rotation: { x: 0, y: 0, z: 0 },
+            position: { x: 0, y: 0, z: 0, set: jest.fn(), clone: jest.fn(() => ({ x: 0, y: 0, z: 0 })) },
+            visibility: 1,
+            scaling,
+            enabled: true,
+            dispose: jest.fn(),
+            setEnabled(v: boolean) { this.enabled = v; },
+        };
+    }),
 }));
 
 jest.unstable_mockModule("@babylonjs/core/Meshes/mesh", () => ({
@@ -181,5 +186,68 @@ describe("createWaypointManager", () => {
                 1000,
             ),
         ).not.toThrow();
+    });
+
+    // Issue #274 PR #277 レビュー指摘: 通過 → フェード → 復活で state がリセットされることを検証
+    it("regenerates waypoint after pass: passed/fadeAlpha/visibility/scaling reset", () => {
+        CreateDiscMock.mockClear();
+        const scene = createMockScene();
+        const mgr = createWaypointManager(scene);
+        const radiusM = 2000;
+        mgr.reset({
+            centerLat: 35.68,
+            centerLon: 139.77,
+            radiusM,
+            altitudeM: 2000,
+            angleDeg: 0,
+            modelNodeName: "model-plane",
+        });
+
+        // CreateDisc が返した最初のメッシュインスタンス（先頭ウェイポイント）
+        const firstMesh = CreateDiscMock.mock.results[0].value as {
+            visibility: number;
+            scaling: { x: number; y: number; z: number };
+            enabled: boolean;
+        };
+
+        // 先頭ウェイポイントは ctx.angleDeg + offsetDeg ≈ 8.594° (radius=2000, offset=300m)
+        // 通過判定: |dist| < PASS_THRESHOLD_M(40m) かつ ahead=true
+        // 飛行機角度を 8.594° の少し手前 (8.5°) に置き、約 3.3m 手前 → ahead+dist<40m で通過
+        const passingAngle = 8.5;
+
+        // 第1フレーム: lastTime=0 のため dt=0.016 既定。通過判定発火。
+        mgr.update(
+            {
+                centerLat: 35.68,
+                centerLon: 139.77,
+                radiusM,
+                altitudeM: 2000,
+                angleDeg: passingAngle,
+                modelNodeName: "model-plane",
+            },
+            1000,
+        );
+
+        // フェードが完了するまで update を回す (FADE_SPEED=3/sec → ~340ms で完了)
+        for (let i = 1; i <= 30; i++) {
+            mgr.update(
+                {
+                    centerLat: 35.68,
+                    centerLon: 139.77,
+                    radiusM,
+                    altitudeM: 2000,
+                    angleDeg: passingAngle,
+                    modelNodeName: "model-plane",
+                },
+                1000 + i * 20, // 20ms 刻み × 30 = 600ms
+            );
+        }
+
+        // 復活後の検証: visibility=1, scaling=1, mesh 再有効化されている (フレーム末 setEnabled(true))
+        expect(firstMesh.visibility).toBe(1);
+        expect(firstMesh.scaling.x).toBe(1);
+        expect(firstMesh.scaling.y).toBe(1);
+        expect(firstMesh.scaling.z).toBe(1);
+        expect(firstMesh.enabled).toBe(true);
     });
 });

--- a/tests/waypoints.unit.spec.ts
+++ b/tests/waypoints.unit.spec.ts
@@ -110,7 +110,6 @@ describe("createWaypointManager", () => {
         const scene = createMockScene();
         const mgr = createWaypointManager(scene);
         mgr.reset({
-            scene,
             centerLat: 35.68,
             centerLon: 139.77,
             radiusM: 2000,
@@ -132,7 +131,6 @@ describe("createWaypointManager", () => {
         const scene = createMockScene();
         const mgr = createWaypointManager(scene);
         mgr.reset({
-            scene,
             centerLat: 35.68,
             centerLon: 139.77,
             radiusM: 50000,
@@ -147,7 +145,6 @@ describe("createWaypointManager", () => {
         const scene = createMockScene();
         const mgr = createWaypointManager(scene);
         mgr.reset({
-            scene,
             centerLat: 35.68,
             centerLon: 139.77,
             radiusM: 2000,
@@ -163,7 +160,6 @@ describe("createWaypointManager", () => {
         scene.getTransformNodeByName = jest.fn(() => null);
         const mgr = createWaypointManager(scene);
         mgr.reset({
-            scene,
             centerLat: 35.68,
             centerLon: 139.77,
             radiusM: 2000,
@@ -174,7 +170,6 @@ describe("createWaypointManager", () => {
         expect(() =>
             mgr.update(
                 {
-                    scene,
                     centerLat: 35.68,
                     centerLon: 139.77,
                     radiusM: 2000,

--- a/tests/waypoints.unit.spec.ts
+++ b/tests/waypoints.unit.spec.ts
@@ -8,6 +8,7 @@
  * 他テストとのキャッシュ衝突を回避する。
  */
 import { describe, it, expect, jest, beforeAll } from "@jest/globals";
+import type { Scene } from "@babylonjs/core/scene";
 
 // ESM環境のモック: jest.unstable_mockModule を使い、動的 import でテスト対象を取得
 
@@ -73,7 +74,7 @@ jest.unstable_mockModule("../src/demos/flight/waypointEffect", () => ({
     createPassEffect: jest.fn(),
 }));
 
-const createMockScene = () => ({
+const createMockScene = (): Scene => ({
     getTransformNodeByName: jest.fn((): unknown => ({
         getChildMeshes: jest.fn(() => [
             {
@@ -82,10 +83,10 @@ const createMockScene = () => ({
             },
         ]),
     })),
-});
+}) as unknown as Scene;
 
 describe("createWaypointManager", () => {
-    let createWaypointManager: any;
+    let createWaypointManager: typeof import("../src/demos/flight/waypoints").createWaypointManager;
     let CreateDiscMock: jest.Mock;
 
     beforeAll(async () => {

--- a/tests/waypoints.unit.spec.ts
+++ b/tests/waypoints.unit.spec.ts
@@ -11,8 +11,8 @@ import { describe, it, expect, jest, beforeAll } from "@jest/globals";
 
 // ESM環境のモック: jest.unstable_mockModule を使い、動的 import でテスト対象を取得
 
-jest.unstable_mockModule("@babylonjs/core/Meshes/Builders/torusBuilder", () => ({
-    CreateTorus: jest.fn(() => ({
+jest.unstable_mockModule("@babylonjs/core/Meshes/Builders/discBuilder", () => ({
+    CreateDisc: jest.fn(() => ({
         material: null,
         isPickable: false,
         alwaysSelectAsActiveMesh: false,
@@ -86,14 +86,14 @@ const createMockScene = () => ({
 
 describe("createWaypointManager", () => {
     let createWaypointManager: any;
-    let CreateTorusMock: jest.Mock;
+    let CreateDiscMock: jest.Mock;
 
     beforeAll(async () => {
         const waypoints = await import("../src/demos/flight/waypoints");
         createWaypointManager = waypoints.createWaypointManager;
 
-        const torusModule = await import("@babylonjs/core/Meshes/Builders/torusBuilder");
-        CreateTorusMock = torusModule.CreateTorus as unknown as jest.Mock;
+        const discModule = await import("@babylonjs/core/Meshes/Builders/discBuilder");
+        CreateDiscMock = discModule.CreateDisc as unknown as jest.Mock;
     });
 
     it("creates a WaypointManager with update/reset/dispose", () => {
@@ -106,7 +106,7 @@ describe("createWaypointManager", () => {
     });
 
     it("reset creates waypoints based on radius", () => {
-        CreateTorusMock.mockClear();
+        CreateDiscMock.mockClear();
         const scene = createMockScene();
         const mgr = createWaypointManager(scene);
         mgr.reset({
@@ -124,11 +124,11 @@ describe("createWaypointManager", () => {
             Math.floor((2 * Math.PI * 2000) / 600),
             10,
         );
-        expect(CreateTorusMock).toHaveBeenCalledTimes(expectedCount);
+        expect(CreateDiscMock).toHaveBeenCalledTimes(expectedCount);
     });
 
     it("reset caps waypoints at MAX_WAYPOINTS", () => {
-        CreateTorusMock.mockClear();
+        CreateDiscMock.mockClear();
         const scene = createMockScene();
         const mgr = createWaypointManager(scene);
         mgr.reset({
@@ -140,7 +140,7 @@ describe("createWaypointManager", () => {
             angleDeg: 0,
             modelNodeName: "model-plane",
         });
-        expect(CreateTorusMock).toHaveBeenCalledTimes(10);
+        expect(CreateDiscMock).toHaveBeenCalledTimes(10);
     });
 
     it("dispose cleans up without error", () => {


### PR DESCRIPTION
## 概要
Issue #274 — フライトデモにウェイポイント通過エフェクト機能を追加。

## 変更内容
- **魔法陣ウェイポイント**: 円軌道上に600m間隔でディスクメッシュを配置。シェーダーで同心円リング・六芒星・ルーンセグメント・パルス発光を描画
- **スライディングウィンドウ方式**: 最大10個のメッシュプールを再利用。通過→フェードアウト→最後尾に復活
- **拡大フェードアウト**: 通過後にscale 1→2.5に拡大しながら透明化
- **画面衝撃波エフェクト**: DOM オーバーレイで画面全体に広がるリップルアニメーション (CSS keyframes)
- **UIトグル**: ウェイポイント/リボンの表示切替チェックボックス
- **routeLine.setVisible**: リボンの表示/非表示メソッド追加

## テスト結果
- typecheck ✅
- lint ✅
- Unit Tests: 809 passed ✅
- Visual Regression: 19 passed ✅

## レビュー結果
- コードレビュー: 条件付き承認（ブロッカーなし）
- セキュリティレビュー: ✅ OK（重大リスクなし）

Closes #274