### PR TITLE
feat(flight): アフターバーナーエフェクトを追加 (#276)

### DIFF
--- a/public/flight.html
+++ b/public/flight.html
@@ -313,6 +313,10 @@
           <input type="checkbox" id="ribbon-toggle" checked style="cursor: pointer;">
           リボン (飛行経路)
         </label>
+        <label style="display: flex; align-items: center; gap: 6px; font-size: 12px; cursor: pointer;">
+          <input type="checkbox" id="contrail-toggle" checked style="cursor: pointer;">
+          飛行機雲
+        </label>
       </div>
     </div>
     <div id="pip-frame">

--- a/public/flight.html
+++ b/public/flight.html
@@ -315,7 +315,7 @@
         </label>
         <label style="display: flex; align-items: center; gap: 6px; font-size: 12px; cursor: pointer;">
           <input type="checkbox" id="contrail-toggle" checked style="cursor: pointer;">
-          飛行機雲
+          アフターバーナー
         </label>
       </div>
     </div>

--- a/public/flight.html
+++ b/public/flight.html
@@ -314,7 +314,7 @@
           リボン (飛行経路)
         </label>
         <label style="display: flex; align-items: center; gap: 6px; font-size: 12px; cursor: pointer;">
-          <input type="checkbox" id="contrail-toggle" checked style="cursor: pointer;">
+          <input type="checkbox" id="afterburner-toggle" checked style="cursor: pointer;">
           アフターバーナー
         </label>
       </div>

--- a/src/demos/flight/afterburner.ts
+++ b/src/demos/flight/afterburner.ts
@@ -211,9 +211,9 @@ export const createAfterburner = (scene: Scene): Afterburner => {
         visible = v;
         leftTrail?.setEnabled(v);
         rightTrail?.setEnabled(v);
-        // GlowLayer も非表示時は intensity=0 にして描画コストを抑える
+        // GlowLayer も非表示時は isEnabled=false にしてポストプロセスを完全停止する
         if (glow) {
-            glow.intensity = v ? 1.5 : 0;
+            glow.isEnabled = v;
         }
         if (!v && running) {
             leftTrail?.stop();

--- a/src/demos/flight/afterburner.ts
+++ b/src/demos/flight/afterburner.ts
@@ -29,7 +29,7 @@ const ENGINE_VERTICAL_OFFSET_M = 1.5;
 
 /** TrailMesh のリボン直径 (m)。アフターバーナーの炎幅 */
 const TRAIL_DIAMETER_M = 0.5;
-/** TrailMesh の長さ（セグメント数）。約30m相当（60fps / 100m/s で≈18フレーム） */
+/** TrailMesh の長さ（セグメント数）。60fps / 100m/s 前提で約17m相当 */
 const TRAIL_LENGTH = 10;
 /** 断面の多角形頂点数。8+で円柱状に滑らか */
 const TRAIL_SECTIONS = 8;

--- a/src/demos/flight/afterburner.ts
+++ b/src/demos/flight/afterburner.ts
@@ -211,6 +211,10 @@ export const createAfterburner = (scene: Scene): Afterburner => {
         visible = v;
         leftTrail?.setEnabled(v);
         rightTrail?.setEnabled(v);
+        // GlowLayer も非表示時は intensity=0 にして描画コストを抑える
+        if (glow) {
+            glow.intensity = v ? 1.5 : 0;
+        }
         if (!v && running) {
             leftTrail?.stop();
             rightTrail?.stop();

--- a/src/demos/flight/afterburner.ts
+++ b/src/demos/flight/afterburner.ts
@@ -174,6 +174,10 @@ export const createAfterburner = (scene: Scene): Afterburner => {
         if (disposed || running) return;
         // 毎回作り直すことで、前回 Follow セッションの残骸軌跡を完全に排除する
         if (!buildTrails(ctx)) return;
+        // 生成直後に reset() で全頂点を現在の generator 位置に揃える。
+        // root がまだ正しい座標に位置していないケースで「原点→機体」の折れ線を防ぐ。
+        leftTrail?.reset();
+        rightTrail?.reset();
         if (visible) {
             leftTrail?.start();
             rightTrail?.start();

--- a/src/demos/flight/afterburner.ts
+++ b/src/demos/flight/afterburner.ts
@@ -56,8 +56,7 @@ export interface Afterburner {
 
 /**
  * アフターバーナー用 StandardMaterial を作成する。
- * emissive オレンジ〜青のグラデーション感を出すため、明るいオレンジの emissive に
- * ALPHA_ADD ブレンドで重なりが強く光る炎っぽい表現にする。
+ * 明るいオレンジの emissive + ALPHA_ADD ブレンドで重なりが強く光る炎っぽい表現にする。
  */
 const createAfterburnerMaterial = (scene: Scene): StandardMaterial => {
     const mat = new StandardMaterial("afterburner-mat", scene);

--- a/src/demos/flight/afterburner.ts
+++ b/src/demos/flight/afterburner.ts
@@ -86,6 +86,7 @@ export const createAfterburner = (scene: Scene): Afterburner => {
     let rightTrail: TrailMesh | null = null;
     let running = false;
     let visible = true;
+    let disposed = false;
 
     const buildTrails = (ctx: AfterburnerContext): boolean => {
         const root = ctx.scene.getTransformNodeByName(ctx.modelNodeName);
@@ -170,7 +171,7 @@ export const createAfterburner = (scene: Scene): Afterburner => {
     };
 
     const start = (ctx: AfterburnerContext): void => {
-        if (running) return;
+        if (disposed || running) return;
         // 毎回作り直すことで、前回 Follow セッションの残骸軌跡を完全に排除する
         if (!buildTrails(ctx)) return;
         if (visible) {
@@ -220,17 +221,12 @@ export const createAfterburner = (scene: Scene): Afterburner => {
     };
 
     const dispose = (): void => {
-        leftTrail?.dispose();
-        rightTrail?.dispose();
-        leftGen?.dispose();
-        rightGen?.dispose();
-        glow?.dispose();
+        if (disposed) return;
+        disposed = true;
+        // stop() 相当の処理で running=false にしてから material を解放する。
+        // これにより dispose 後に start() が呼ばれても no-op になる。
+        stop();
         material.dispose();
-        leftTrail = null;
-        rightTrail = null;
-        leftGen = null;
-        rightGen = null;
-        glow = null;
     };
 
     return { start, stop, reset, setVisible, dispose };

--- a/src/demos/flight/afterburner.ts
+++ b/src/demos/flight/afterburner.ts
@@ -35,15 +35,15 @@ const TRAIL_LENGTH = 10;
 const TRAIL_SECTIONS = 8;
 
 // ─── 型 ─────────────────────────────────────────────────
-export interface ContrailContext {
+export interface AfterburnerContext {
     scene: Scene;
     /** model の TransformNode 名（generator の親に使う） */
     modelNodeName: string;
 }
 
-export interface Contrail {
+export interface Afterburner {
     /** トレイル生成を開始（Follow モード ON 時に呼ぶ） */
-    start(ctx: ContrailContext): void;
+    start(ctx: AfterburnerContext): void;
     /** トレイル生成を停止（Follow モード OFF 時に呼ぶ） */
     stop(): void;
     /** トレイルの頂点をリセット（グリッド原点ジャンプ後の折れ線防止） */
@@ -59,7 +59,7 @@ export interface Contrail {
  * emissive オレンジ〜青のグラデーション感を出すため、明るいオレンジの emissive に
  * ALPHA_ADD ブレンドで重なりが強く光る炎っぽい表現にする。
  */
-const createContrailMaterial = (scene: Scene): StandardMaterial => {
+const createAfterburnerMaterial = (scene: Scene): StandardMaterial => {
     const mat = new StandardMaterial("afterburner-mat", scene);
     mat.disableLighting = true;
     // アフターバーナーの炎色: 明るいオレンジ〜黄（高輝度で GlowLayer に反応）
@@ -73,12 +73,12 @@ const createContrailMaterial = (scene: Scene): StandardMaterial => {
 };
 
 /**
- * コントレイルエフェクトを作成する。
+ * アフターバーナーエフェクトを作成する。
  * 初期化時には TrailMesh は作らず、start() で実際の generator を取得して構築する
  * （飛行機モデルの非同期ロード完了後に呼ばれるため）。
  */
-export const createContrail = (scene: Scene): Contrail => {
-    const material = createContrailMaterial(scene);
+export const createAfterburner = (scene: Scene): Afterburner => {
+    const material = createAfterburnerMaterial(scene);
 
     // GlowLayer: TrailMesh のみに発光を適用（他メッシュに影響なし）
     const glow = new GlowLayer("afterburner-glow", scene, {
@@ -93,7 +93,7 @@ export const createContrail = (scene: Scene): Contrail => {
     let running = false;
     let visible = true;
 
-    const buildTrails = (ctx: ContrailContext): boolean => {
+    const buildTrails = (ctx: AfterburnerContext): boolean => {
         const root = ctx.scene.getTransformNodeByName(ctx.modelNodeName);
         if (!root) return false;
 
@@ -111,7 +111,7 @@ export const createContrail = (scene: Scene): Contrail => {
         // root は updateModel() で明示的に lat/lon に従って位置・回転が更新されるため、
         // 子メッシュ (childMesh) よりも安定して飛行機の動きに追従する。
         // Babylon.js 左手座標系: X=右, Y=上, Z=前方。後方は -Z。
-        leftGen = new TransformNode("contrail-left-gen", ctx.scene);
+        leftGen = new TransformNode("afterburner-left-gen", ctx.scene);
         leftGen.parent = root;
         leftGen.position.set(
             -ENGINE_LATERAL_OFFSET_M,
@@ -119,7 +119,7 @@ export const createContrail = (scene: Scene): Contrail => {
             -ENGINE_REAR_OFFSET_M,
         );
 
-        rightGen = new TransformNode("contrail-right-gen", ctx.scene);
+        rightGen = new TransformNode("afterburner-right-gen", ctx.scene);
         rightGen.parent = root;
         rightGen.position.set(
             ENGINE_LATERAL_OFFSET_M,
@@ -132,7 +132,7 @@ export const createContrail = (scene: Scene): Contrail => {
         leftGen.computeWorldMatrix(true);
         rightGen.computeWorldMatrix(true);
 
-        leftTrail = new TrailMesh("contrail-left", leftGen, ctx.scene, {
+        leftTrail = new TrailMesh("afterburner-left", leftGen, ctx.scene, {
             diameter: TRAIL_DIAMETER_M,
             length: TRAIL_LENGTH,
             sections: TRAIL_SECTIONS,
@@ -144,7 +144,7 @@ export const createContrail = (scene: Scene): Contrail => {
         leftTrail.alwaysSelectAsActiveMesh = true;
         leftTrail.renderingGroupId = 1;
 
-        rightTrail = new TrailMesh("contrail-right", rightGen, ctx.scene, {
+        rightTrail = new TrailMesh("afterburner-right", rightGen, ctx.scene, {
             diameter: TRAIL_DIAMETER_M,
             length: TRAIL_LENGTH,
             sections: TRAIL_SECTIONS,
@@ -166,7 +166,7 @@ export const createContrail = (scene: Scene): Contrail => {
         return true;
     };
 
-    const start = (ctx: ContrailContext): void => {
+    const start = (ctx: AfterburnerContext): void => {
         if (running) return;
         // 毎回作り直すことで、前回 Follow セッションの残骸軌跡を完全に排除する
         if (!buildTrails(ctx)) return;

--- a/src/demos/flight/afterburner.ts
+++ b/src/demos/flight/afterburner.ts
@@ -36,7 +36,6 @@ const TRAIL_SECTIONS = 8;
 
 // ─── 型 ─────────────────────────────────────────────────
 export interface AfterburnerContext {
-    scene: Scene;
     /** model の TransformNode 名（generator の親に使う） */
     modelNodeName: string;
 }
@@ -89,7 +88,7 @@ export const createAfterburner = (scene: Scene): Afterburner => {
     let disposed = false;
 
     const buildTrails = (ctx: AfterburnerContext): boolean => {
-        const root = ctx.scene.getTransformNodeByName(ctx.modelNodeName);
+        const root = scene.getTransformNodeByName(ctx.modelNodeName);
         if (!root) return false;
 
         // 既存があれば一度破棄してから作り直す（連続 start でのリーク防止）
@@ -106,7 +105,7 @@ export const createAfterburner = (scene: Scene): Afterburner => {
 
         // GlowLayer: TrailMesh のみに発光を適用（他メッシュに影響なし）
         // Trail と同じライフサイクルで生成し、stop 時に破棄する。
-        glow = new GlowLayer("afterburner-glow", ctx.scene, {
+        glow = new GlowLayer("afterburner-glow", scene, {
             blurKernelSize: 64,
         });
         glow.intensity = 1.5;
@@ -115,7 +114,7 @@ export const createAfterburner = (scene: Scene): Afterburner => {
         // root は updateModel() で明示的に lat/lon に従って位置・回転が更新されるため、
         // 子メッシュ (childMesh) よりも安定して飛行機の動きに追従する。
         // Babylon.js 左手座標系: X=右, Y=上, Z=前方。後方は -Z。
-        leftGen = new TransformNode("afterburner-left-gen", ctx.scene);
+        leftGen = new TransformNode("afterburner-left-gen", scene);
         leftGen.parent = root;
         leftGen.position.set(
             -ENGINE_LATERAL_OFFSET_M,
@@ -123,7 +122,7 @@ export const createAfterburner = (scene: Scene): Afterburner => {
             -ENGINE_REAR_OFFSET_M,
         );
 
-        rightGen = new TransformNode("afterburner-right-gen", ctx.scene);
+        rightGen = new TransformNode("afterburner-right-gen", scene);
         rightGen.parent = root;
         rightGen.position.set(
             ENGINE_LATERAL_OFFSET_M,
@@ -136,7 +135,7 @@ export const createAfterburner = (scene: Scene): Afterburner => {
         leftGen.computeWorldMatrix(true);
         rightGen.computeWorldMatrix(true);
 
-        leftTrail = new TrailMesh("afterburner-left", leftGen, ctx.scene, {
+        leftTrail = new TrailMesh("afterburner-left", leftGen, scene, {
             diameter: TRAIL_DIAMETER_M,
             length: TRAIL_LENGTH,
             sections: TRAIL_SECTIONS,
@@ -148,7 +147,7 @@ export const createAfterburner = (scene: Scene): Afterburner => {
         leftTrail.alwaysSelectAsActiveMesh = true;
         leftTrail.renderingGroupId = 1;
 
-        rightTrail = new TrailMesh("afterburner-right", rightGen, ctx.scene, {
+        rightTrail = new TrailMesh("afterburner-right", rightGen, scene, {
             diameter: TRAIL_DIAMETER_M,
             length: TRAIL_LENGTH,
             sections: TRAIL_SECTIONS,

--- a/src/demos/flight/afterburner.ts
+++ b/src/demos/flight/afterburner.ts
@@ -79,12 +79,7 @@ const createAfterburnerMaterial = (scene: Scene): StandardMaterial => {
 export const createAfterburner = (scene: Scene): Afterburner => {
     const material = createAfterburnerMaterial(scene);
 
-    // GlowLayer: TrailMesh のみに発光を適用（他メッシュに影響なし）
-    const glow = new GlowLayer("afterburner-glow", scene, {
-        blurKernelSize: 64,
-    });
-    glow.intensity = 1.5;
-
+    let glow: GlowLayer | null = null;
     let leftGen: TransformNode | null = null;
     let rightGen: TransformNode | null = null;
     let leftTrail: TrailMesh | null = null;
@@ -101,10 +96,19 @@ export const createAfterburner = (scene: Scene): Afterburner => {
         rightTrail?.dispose();
         leftGen?.dispose();
         rightGen?.dispose();
+        glow?.dispose();
         leftTrail = null;
         rightTrail = null;
         leftGen = null;
         rightGen = null;
+        glow = null;
+
+        // GlowLayer: TrailMesh のみに発光を適用（他メッシュに影響なし）
+        // Trail と同じライフサイクルで生成し、stop 時に破棄する。
+        glow = new GlowLayer("afterburner-glow", ctx.scene, {
+            blurKernelSize: 64,
+        });
+        glow.intensity = 1.5;
 
         // generator となる TransformNode を **root** TransformNode に親付け。
         // root は updateModel() で明示的に lat/lon に従って位置・回転が更新されるため、
@@ -180,15 +184,18 @@ export const createAfterburner = (scene: Scene): Afterburner => {
         if (!running) return;
         leftTrail?.stop();
         rightTrail?.stop();
-        // 停止時に TrailMesh と generator を破棄して、次回 start で完全に新規構築する
+        // 停止時に TrailMesh, generator, GlowLayer を破棄して、
+        // 次回 start で完全に新規構築する。Follow モード外ではポストプロセス不要。
         leftTrail?.dispose();
         rightTrail?.dispose();
         leftGen?.dispose();
         rightGen?.dispose();
+        glow?.dispose();
         leftTrail = null;
         rightTrail = null;
         leftGen = null;
         rightGen = null;
+        glow = null;
         running = false;
     };
 
@@ -217,12 +224,13 @@ export const createAfterburner = (scene: Scene): Afterburner => {
         rightTrail?.dispose();
         leftGen?.dispose();
         rightGen?.dispose();
-        glow.dispose();
+        glow?.dispose();
         material.dispose();
         leftTrail = null;
         rightTrail = null;
         leftGen = null;
         rightGen = null;
+        glow = null;
     };
 
     return { start, stop, reset, setVisible, dispose };

--- a/src/demos/flight/contrail.ts
+++ b/src/demos/flight/contrail.ts
@@ -1,0 +1,230 @@
+/**
+ * アフターバーナーエフェクト (Issue #276)。
+ *
+ * Babylon.js `TrailMesh` を使用し、飛行機の左右エンジン位置から
+ * 後方に短く伸びるアフターバーナーの炎を表現する。
+ *
+ * 実装方針:
+ * - 飛行機の TransformNode 配下に左右エンジン位置の TransformNode を作成
+ * - 各 TransformNode を generator として TrailMesh を生成
+ * - TrailMesh は内部の `beforeRender` で自動更新
+ * - Follow モード開始時に start()、終了時に stop() を呼ぶ
+ */
+
+import { Color3 } from "@babylonjs/core/Maths/math.color";
+import { Constants } from "@babylonjs/core/Engines/constants";
+import { GlowLayer } from "@babylonjs/core/Layers/glowLayer";
+import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
+import { TrailMesh } from "@babylonjs/core/Meshes/trailMesh";
+import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import type { Scene } from "@babylonjs/core/scene";
+
+// ─── 調整可能な定数 ─────────────────────────────────────
+/** 左右エンジンの横方向オフセット (m)。中央寄せで2本が近い位置に */
+const ENGINE_LATERAL_OFFSET_M = 1.4;
+/** エンジン位置の後方オフセット (m)。機体中心から後方 */
+const ENGINE_REAR_OFFSET_M = 4.5;
+/** エンジン位置の垂直オフセット (m)。機体中心から上方向 */
+const ENGINE_VERTICAL_OFFSET_M = 1.5;
+
+/** TrailMesh のリボン直径 (m)。アフターバーナーの炎幅 */
+const TRAIL_DIAMETER_M = 0.5;
+/** TrailMesh の長さ（セグメント数）。約30m相当（60fps / 100m/s で≈18フレーム） */
+const TRAIL_LENGTH = 10;
+/** 断面の多角形頂点数。8+で円柱状に滑らか */
+const TRAIL_SECTIONS = 8;
+
+// ─── 型 ─────────────────────────────────────────────────
+export interface ContrailContext {
+    scene: Scene;
+    /** model の TransformNode 名（generator の親に使う） */
+    modelNodeName: string;
+}
+
+export interface Contrail {
+    /** トレイル生成を開始（Follow モード ON 時に呼ぶ） */
+    start(ctx: ContrailContext): void;
+    /** トレイル生成を停止（Follow モード OFF 時に呼ぶ） */
+    stop(): void;
+    /** トレイルの頂点をリセット（グリッド原点ジャンプ後の折れ線防止） */
+    reset(): void;
+    /** 表示/非表示切替 */
+    setVisible(visible: boolean): void;
+    /** リソース解放 */
+    dispose(): void;
+}
+
+/**
+ * アフターバーナー用 StandardMaterial を作成する。
+ * emissive オレンジ〜青のグラデーション感を出すため、明るいオレンジの emissive に
+ * ALPHA_ADD ブレンドで重なりが強く光る炎っぽい表現にする。
+ */
+const createContrailMaterial = (scene: Scene): StandardMaterial => {
+    const mat = new StandardMaterial("afterburner-mat", scene);
+    mat.disableLighting = true;
+    // アフターバーナーの炎色: 明るいオレンジ〜黄（高輝度で GlowLayer に反応）
+    mat.emissiveColor = new Color3(1.0, 0.7, 0.2);
+    mat.diffuseColor = new Color3(0, 0, 0);
+    mat.specularColor = new Color3(0, 0, 0);
+    mat.alpha = 0.7;
+    mat.alphaMode = Constants.ALPHA_ADD;
+    mat.backFaceCulling = false;
+    return mat;
+};
+
+/**
+ * コントレイルエフェクトを作成する。
+ * 初期化時には TrailMesh は作らず、start() で実際の generator を取得して構築する
+ * （飛行機モデルの非同期ロード完了後に呼ばれるため）。
+ */
+export const createContrail = (scene: Scene): Contrail => {
+    const material = createContrailMaterial(scene);
+
+    // GlowLayer: TrailMesh のみに発光を適用（他メッシュに影響なし）
+    const glow = new GlowLayer("afterburner-glow", scene, {
+        blurKernelSize: 64,
+    });
+    glow.intensity = 1.5;
+
+    let leftGen: TransformNode | null = null;
+    let rightGen: TransformNode | null = null;
+    let leftTrail: TrailMesh | null = null;
+    let rightTrail: TrailMesh | null = null;
+    let running = false;
+    let visible = true;
+
+    const buildTrails = (ctx: ContrailContext): boolean => {
+        const root = ctx.scene.getTransformNodeByName(ctx.modelNodeName);
+        if (!root) return false;
+
+        // 既存があれば一度破棄してから作り直す（連続 start でのリーク防止）
+        leftTrail?.dispose();
+        rightTrail?.dispose();
+        leftGen?.dispose();
+        rightGen?.dispose();
+        leftTrail = null;
+        rightTrail = null;
+        leftGen = null;
+        rightGen = null;
+
+        // generator となる TransformNode を **root** TransformNode に親付け。
+        // root は updateModel() で明示的に lat/lon に従って位置・回転が更新されるため、
+        // 子メッシュ (childMesh) よりも安定して飛行機の動きに追従する。
+        // Babylon.js 左手座標系: X=右, Y=上, Z=前方。後方は -Z。
+        leftGen = new TransformNode("contrail-left-gen", ctx.scene);
+        leftGen.parent = root;
+        leftGen.position.set(
+            -ENGINE_LATERAL_OFFSET_M,
+            ENGINE_VERTICAL_OFFSET_M,
+            -ENGINE_REAR_OFFSET_M,
+        );
+
+        rightGen = new TransformNode("contrail-right-gen", ctx.scene);
+        rightGen.parent = root;
+        rightGen.position.set(
+            ENGINE_LATERAL_OFFSET_M,
+            ENGINE_VERTICAL_OFFSET_M,
+            -ENGINE_REAR_OFFSET_M,
+        );
+
+        // generator のワールド行列を即時確定させてから TrailMesh を作る
+        // (_createMesh が generator.absolutePosition を読むため)
+        leftGen.computeWorldMatrix(true);
+        rightGen.computeWorldMatrix(true);
+
+        leftTrail = new TrailMesh("contrail-left", leftGen, ctx.scene, {
+            diameter: TRAIL_DIAMETER_M,
+            length: TRAIL_LENGTH,
+            sections: TRAIL_SECTIONS,
+            doNotTaper: false,
+            autoStart: false,
+        });
+        leftTrail.material = material;
+        leftTrail.isPickable = false;
+        leftTrail.alwaysSelectAsActiveMesh = true;
+        leftTrail.renderingGroupId = 1;
+
+        rightTrail = new TrailMesh("contrail-right", rightGen, ctx.scene, {
+            diameter: TRAIL_DIAMETER_M,
+            length: TRAIL_LENGTH,
+            sections: TRAIL_SECTIONS,
+            doNotTaper: false,
+            autoStart: false,
+        });
+        rightTrail.material = material;
+        rightTrail.isPickable = false;
+        rightTrail.alwaysSelectAsActiveMesh = true;
+        rightTrail.renderingGroupId = 1;
+
+        leftTrail.setEnabled(visible);
+        rightTrail.setEnabled(visible);
+
+        // GlowLayer にトレイルメッシュを登録（これらのみ発光する）
+        glow.addIncludedOnlyMesh(leftTrail);
+        glow.addIncludedOnlyMesh(rightTrail);
+
+        return true;
+    };
+
+    const start = (ctx: ContrailContext): void => {
+        if (running) return;
+        // 毎回作り直すことで、前回 Follow セッションの残骸軌跡を完全に排除する
+        if (!buildTrails(ctx)) return;
+        if (visible) {
+            leftTrail?.start();
+            rightTrail?.start();
+        }
+        running = true;
+    };
+
+    const stop = (): void => {
+        if (!running) return;
+        leftTrail?.stop();
+        rightTrail?.stop();
+        // 停止時に TrailMesh と generator を破棄して、次回 start で完全に新規構築する
+        leftTrail?.dispose();
+        rightTrail?.dispose();
+        leftGen?.dispose();
+        rightGen?.dispose();
+        leftTrail = null;
+        rightTrail = null;
+        leftGen = null;
+        rightGen = null;
+        running = false;
+    };
+
+    /** グリッド原点がジャンプした後に呼ぶ。全頂点を現在位置にリセットして折れ線を防ぐ */
+    const reset = (): void => {
+        if (!running) return;
+        leftTrail?.reset();
+        rightTrail?.reset();
+    };
+
+    const setVisible = (v: boolean): void => {
+        visible = v;
+        leftTrail?.setEnabled(v);
+        rightTrail?.setEnabled(v);
+        if (!v && running) {
+            leftTrail?.stop();
+            rightTrail?.stop();
+        } else if (v && running) {
+            leftTrail?.start();
+            rightTrail?.start();
+        }
+    };
+
+    const dispose = (): void => {
+        leftTrail?.dispose();
+        rightTrail?.dispose();
+        leftGen?.dispose();
+        rightGen?.dispose();
+        glow.dispose();
+        material.dispose();
+        leftTrail = null;
+        rightTrail = null;
+        leftGen = null;
+        rightGen = null;
+    };
+
+    return { start, stop, reset, setVisible, dispose };
+};

--- a/src/demos/flight/index.ts
+++ b/src/demos/flight/index.ts
@@ -839,11 +839,11 @@ const start = async (): Promise<void> => {
                 lastRefreshRadius = followCamRadius;
                 lastTileUpdateTime = timestamp;
                 tileRefreshInFlight = true;
-                // 位置移動によるリフレッシュのみ gridResidual がジャンプするため、
-                // 回転/高さ/半径変化だけの場合は reset 不要。
-                if (moved >= TILE_UPDATE_DISTANCE_M) {
-                    afterburnerResetNeeded = true;
-                }
+                // タイルジャンプ検出のため refresh 前の terrain camera target を記録。
+                // refreshTerrainWithExternalFrustum の同期部分で centerTile が変化した
+                // 場合のみ target がタイルサイズ単位（〜1000m以上）で不連続にジャンプする。
+                const targetXBefore = target.x;
+                const targetZBefore = target.z;
                 // この呼び出しの同期部分で gridResidualX/Z が更新される。
                 void viewer
                     .refreshTerrainWithExternalFrustum(
@@ -856,6 +856,15 @@ const start = async (): Promise<void> => {
                     .finally(() => {
                         tileRefreshInFlight = false;
                     });
+                // centerTile が変化したフレームのみ target が大きく変化する。
+                // 通常の微小移動（最大 TILE_UPDATE_DISTANCE_M = 80m）は誤検知しない。
+                const TILE_JUMP_THRESHOLD_M = 200;
+                if (
+                    Math.abs(target.x - targetXBefore) > TILE_JUMP_THRESHOLD_M ||
+                    Math.abs(target.z - targetZBefore) > TILE_JUMP_THRESHOLD_M
+                ) {
+                    afterburnerResetNeeded = true;
+                }
             } else {
                 // 意味のある変化なし: 次回の判定を遅延させすぎないよう最終チェック時刻だけ進める
                 lastTileUpdateTime = timestamp;

--- a/src/demos/flight/index.ts
+++ b/src/demos/flight/index.ts
@@ -480,7 +480,6 @@ const start = async (): Promise<void> => {
             }
             if (afterburner) {
                 afterburner.start({
-                    scene,
                     modelNodeName: `model-${MODEL_ID}`,
                 });
                 afterburner.setVisible(showAfterburner);

--- a/src/demos/flight/index.ts
+++ b/src/demos/flight/index.ts
@@ -468,14 +468,17 @@ const start = async (): Promise<void> => {
             }
 
             // コントレイル開始 (Issue #276)
+            // 常に start() して TrailMesh を構築し、表示は setVisible で制御する。
+            // これにより Follow 中にチェックボックスを ON にしても正しく表示される。
             if (!contrail && scene) {
                 contrail = createContrail(scene);
             }
-            if (contrail && showContrail) {
+            if (contrail) {
                 contrail.start({
                     scene,
                     modelNodeName: `model-${MODEL_ID}`,
                 });
+                contrail.setVisible(showContrail);
             }
         }
     };

--- a/src/demos/flight/index.ts
+++ b/src/demos/flight/index.ts
@@ -30,7 +30,7 @@ import { createRouteLine, type RouteLine } from "./routeLine";
 import { createWaypointManager, type WaypointManager } from "./waypoints";
 import { createFlightAudio, type FlightAudio } from "./flightAudio";
 import { createAfterburner, type Afterburner } from "./afterburner";
-import { toTileXY } from "../../terrain/gsiTile";
+import { toTileXY, TILE_MAX_ZOOM } from "../../terrain/gsiTile";
 import planeGlbUrl from "../../../assets/plane.glb";
 
 /** PIP 用セカンダリ Viewer 設定 (Issue #264 Option C: 別 Canvas + 別 Engine) */
@@ -138,10 +138,8 @@ const start = async (): Promise<void> => {
     let lastRefreshRotationOffset = FOLLOW_CAMERA_ROTATION_OFFSET;
     let lastRefreshHeightOffset = FOLLOW_CAMERA_HEIGHT_OFFSET;
     let lastRefreshRadius = FOLLOW_CAMERA_RADIUS;
-    /** refreshTerrainWithExternalFrustum で使用されるズームレベル */
-    const TERRAIN_MAX_ZOOM = 18;
     /** 前回 refresh 時の centerTile (タイルジャンプ検出用) */
-    let lastCenterTile = toTileXY(TOKYO_STATION.lat, TOKYO_STATION.lon, TERRAIN_MAX_ZOOM);
+    let lastCenterTile = toTileXY(TOKYO_STATION.lat, TOKYO_STATION.lon, TILE_MAX_ZOOM);
     /** Follow モードでタイル中心を飛行機位置に追従させる最小間隔 (ms) */
     const TILE_UPDATE_INTERVAL_MS = 300;
     /** 緯度/経度差がこの距離 (m) を超えたら更新を発火 */
@@ -854,7 +852,7 @@ const start = async (): Promise<void> => {
                 tileRefreshInFlight = true;
                 // centerTile が変わるとき gridResidual がタイルサイズ単位でジャンプする。
                 // 事前に centerTile を比較して検出し、reset フラグを立てる。
-                const currentTile = toTileXY(pos.lat, pos.lon, TERRAIN_MAX_ZOOM);
+                const currentTile = toTileXY(pos.lat, pos.lon, TILE_MAX_ZOOM);
                 if (currentTile.x !== lastCenterTile.x || currentTile.y !== lastCenterTile.y) {
                     afterburnerResetNeeded = true;
                 }

--- a/src/demos/flight/index.ts
+++ b/src/demos/flight/index.ts
@@ -29,6 +29,7 @@ import { circularOrbitPosition, circularOrbitHeading } from "../avatar/orbit";
 import { createRouteLine, type RouteLine } from "./routeLine";
 import { createWaypointManager, type WaypointManager } from "./waypoints";
 import { createFlightAudio, type FlightAudio } from "./flightAudio";
+import { createContrail, type Contrail } from "./contrail";
 import planeGlbUrl from "../../../assets/plane.glb";
 
 /** PIP 用セカンダリ Viewer 設定 (Issue #264 Option C: 別 Canvas + 別 Engine) */
@@ -129,6 +130,8 @@ const start = async (): Promise<void> => {
     // Follow モードでのタイル中心更新スロットル
     let lastTileUpdateTime = 0;
     let tileRefreshInFlight = false;
+    /** グリッド原点ジャンプが発生したフレームで1回だけ contrail.reset() を呼ぶためのフラグ */
+    let contrailResetNeeded = false;
     let lastRefreshLat = TOKYO_STATION.lat;
     let lastRefreshLon = TOKYO_STATION.lon;
     let lastRefreshRotationOffset = FOLLOW_CAMERA_ROTATION_OFFSET;
@@ -174,6 +177,10 @@ const start = async (): Promise<void> => {
     // --- SE (Issue #269) ---
     let flightAudio: FlightAudio | null = null;
     let audioInitializing = false;
+
+    // --- コントレイル (Issue #276) ---
+    let contrail: Contrail | null = null;
+    let showContrail = true;
 
     /** ウェイポイント再計算ヘルパー — パラメータ変更時に共通で呼ぶ */
     const resetWaypointsIfNeeded = (): void => {
@@ -459,6 +466,17 @@ const start = async (): Promise<void> => {
             } else if (flightAudio) {
                 flightAudio.startEngineSound();
             }
+
+            // コントレイル開始 (Issue #276)
+            if (!contrail && scene) {
+                contrail = createContrail(scene);
+            }
+            if (contrail && showContrail) {
+                contrail.start({
+                    scene,
+                    modelNodeName: `model-${MODEL_ID}`,
+                });
+            }
         }
     };
 
@@ -483,6 +501,9 @@ const start = async (): Promise<void> => {
 
         // SE 停止 (Issue #269)
         flightAudio?.stopEngineSound();
+
+        // コントレイル停止 (Issue #276)
+        contrail?.stop();
     };
 
     // --- UI 要素の取得 ---
@@ -599,6 +620,18 @@ const start = async (): Promise<void> => {
             showRibbon = ribbonToggle.checked;
             if (routeLine) {
                 routeLine.setVisible(showRibbon);
+            }
+        });
+    }
+
+    // コントレイル表示切替チェックボックス (Issue #276)
+    const contrailToggle = document.getElementById("contrail-toggle") as HTMLInputElement | null;
+    if (contrailToggle) {
+        contrailToggle.checked = showContrail;
+        contrailToggle.addEventListener("change", () => {
+            showContrail = contrailToggle.checked;
+            if (contrail) {
+                contrail.setVisible(showContrail);
             }
         });
     }
@@ -803,6 +836,7 @@ const start = async (): Promise<void> => {
                 lastRefreshRadius = followCamRadius;
                 lastTileUpdateTime = timestamp;
                 tileRefreshInFlight = true;
+                contrailResetNeeded = true;
                 // この呼び出しの同期部分で gridResidualX/Z が更新される。
                 void viewer
                     .refreshTerrainWithExternalFrustum(
@@ -832,6 +866,17 @@ const start = async (): Promise<void> => {
             rotation: { y: heading },
             gravity: false,
         });
+
+        // updateModel で root.position が確定した後にトレイルをリセットする。
+        // refreshTerrainWithExternalFrustum が走ったフレームでのみ1回だけ実行。
+        // gridResidual ジャンプで旧座標の頂点が残り折れ線になるのを防止する。
+        if (contrailResetNeeded && contrail) {
+            contrailResetNeeded = false;
+            const scene = viewer.__debugScene;
+            const root = scene?.getTransformNodeByName(`model-${MODEL_ID}`);
+            root?.computeWorldMatrix(true);
+            contrail.reset();
+        }
 
         // Follow モード: 毎フレームカメラ位置を飛行機の後方に直接設定 + コンパス同期
         // plane.root.position 更新後に呼ぶことで、followCamera の注視点が
@@ -939,6 +984,9 @@ const start = async (): Promise<void> => {
         }
         if (flightAudio) {
             flightAudio.dispose();
+        }
+        if (contrail) {
+            contrail.dispose();
         }
         pipCleanups.forEach((fn) => fn());
         if (pipViewer) {

--- a/src/demos/flight/index.ts
+++ b/src/demos/flight/index.ts
@@ -186,6 +186,8 @@ const start = async (): Promise<void> => {
     // --- アフターバーナー (Issue #276) ---
     let afterburner: Afterburner | null = null;
     let showAfterburner = true;
+    /** Follow モードに入ったがモデル未ロードのため start() を保留中のフラグ */
+    let afterburnerStartPending = false;
 
     /** ウェイポイント再計算ヘルパー — パラメータ変更時に共通で呼ぶ */
     const resetWaypointsIfNeeded = (): void => {
@@ -473,16 +475,22 @@ const start = async (): Promise<void> => {
             }
 
             // アフターバーナー開始 (Issue #276)
-            // 常に start() して TrailMesh を構築し、表示は setVisible で制御する。
-            // これにより Follow 中にチェックボックスを ON にしても正しく表示される。
+            // モデルロード完了後に start() する。未ロードなら pending フラグを立て
+            // tick() 内でリトライすることで「原点→機体位置」の折れ線トレイルを防ぐ。
             if (!afterburner && scene) {
                 afterburner = createAfterburner(scene);
             }
             if (afterburner) {
-                afterburner.start({
-                    modelNodeName: `model-${MODEL_ID}`,
-                });
-                afterburner.setVisible(showAfterburner);
+                const handle = viewer.getModel(MODEL_ID);
+                if (handle?.loaded) {
+                    afterburner.start({
+                        modelNodeName: `model-${MODEL_ID}`,
+                    });
+                    afterburner.setVisible(showAfterburner);
+                } else {
+                    // 未ロード: tick() 内でモデルロード完了を検知してから start する
+                    afterburnerStartPending = true;
+                }
             }
         }
     };
@@ -510,6 +518,7 @@ const start = async (): Promise<void> => {
         flightAudio?.stopEngineSound();
 
         // アフターバーナー停止 (Issue #276)
+        afterburnerStartPending = false;
         afterburner?.stop();
     };
 
@@ -889,6 +898,17 @@ const start = async (): Promise<void> => {
             const root = scene?.getTransformNodeByName(`model-${MODEL_ID}`);
             root?.computeWorldMatrix(true);
             afterburner.reset();
+        }
+
+        // モデルロード完了後に afterburner を start するリトライ処理。
+        // activateFollowCamera() 時点で handle.loaded=false だった場合、ここで開始する。
+        // updateModel() 後に実行することで root.position が正しい座標に確定している。
+        if (afterburnerStartPending && afterburner && handle.loaded && currentCameraMode === "follow") {
+            afterburnerStartPending = false;
+            afterburner.start({
+                modelNodeName: `model-${MODEL_ID}`,
+            });
+            afterburner.setVisible(showAfterburner);
         }
 
         // Follow モード: 毎フレームカメラ位置を飛行機の後方に直接設定 + コンパス同期

--- a/src/demos/flight/index.ts
+++ b/src/demos/flight/index.ts
@@ -628,11 +628,11 @@ const start = async (): Promise<void> => {
     }
 
     // アフターバーナー表示切替チェックボックス (Issue #276)
-    const contrailToggle = document.getElementById("contrail-toggle") as HTMLInputElement | null;
-    if (contrailToggle) {
-        contrailToggle.checked = showAfterburner;
-        contrailToggle.addEventListener("change", () => {
-            showAfterburner = contrailToggle.checked;
+    const afterburnerToggle = document.getElementById("afterburner-toggle") as HTMLInputElement | null;
+    if (afterburnerToggle) {
+        afterburnerToggle.checked = showAfterburner;
+        afterburnerToggle.addEventListener("change", () => {
+            showAfterburner = afterburnerToggle.checked;
             if (afterburner) {
                 afterburner.setVisible(showAfterburner);
             }

--- a/src/demos/flight/index.ts
+++ b/src/demos/flight/index.ts
@@ -30,6 +30,7 @@ import { createRouteLine, type RouteLine } from "./routeLine";
 import { createWaypointManager, type WaypointManager } from "./waypoints";
 import { createFlightAudio, type FlightAudio } from "./flightAudio";
 import { createAfterburner, type Afterburner } from "./afterburner";
+import { toTileXY } from "../../terrain/gsiTile";
 import planeGlbUrl from "../../../assets/plane.glb";
 
 /** PIP 用セカンダリ Viewer 設定 (Issue #264 Option C: 別 Canvas + 別 Engine) */
@@ -137,6 +138,10 @@ const start = async (): Promise<void> => {
     let lastRefreshRotationOffset = FOLLOW_CAMERA_ROTATION_OFFSET;
     let lastRefreshHeightOffset = FOLLOW_CAMERA_HEIGHT_OFFSET;
     let lastRefreshRadius = FOLLOW_CAMERA_RADIUS;
+    /** refreshTerrainWithExternalFrustum で使用されるズームレベル */
+    const TERRAIN_MAX_ZOOM = 18;
+    /** 前回 refresh 時の centerTile (タイルジャンプ検出用) */
+    let lastCenterTile = toTileXY(TOKYO_STATION.lat, TOKYO_STATION.lon, TERRAIN_MAX_ZOOM);
     /** Follow モードでタイル中心を飛行機位置に追従させる最小間隔 (ms) */
     const TILE_UPDATE_INTERVAL_MS = 300;
     /** 緯度/経度差がこの距離 (m) を超えたら更新を発火 */
@@ -839,11 +844,13 @@ const start = async (): Promise<void> => {
                 lastRefreshRadius = followCamRadius;
                 lastTileUpdateTime = timestamp;
                 tileRefreshInFlight = true;
-                // タイルジャンプ検出のため refresh 前の terrain camera target を記録。
-                // refreshTerrainWithExternalFrustum の同期部分で centerTile が変化した
-                // 場合のみ target がタイルサイズ単位（〜1000m以上）で不連続にジャンプする。
-                const targetXBefore = target.x;
-                const targetZBefore = target.z;
+                // centerTile が変わるとき gridResidual がタイルサイズ単位でジャンプする。
+                // 事前に centerTile を比較して検出し、reset フラグを立てる。
+                const currentTile = toTileXY(pos.lat, pos.lon, TERRAIN_MAX_ZOOM);
+                if (currentTile.x !== lastCenterTile.x || currentTile.y !== lastCenterTile.y) {
+                    afterburnerResetNeeded = true;
+                }
+                lastCenterTile = currentTile;
                 // この呼び出しの同期部分で gridResidualX/Z が更新される。
                 void viewer
                     .refreshTerrainWithExternalFrustum(
@@ -856,15 +863,6 @@ const start = async (): Promise<void> => {
                     .finally(() => {
                         tileRefreshInFlight = false;
                     });
-                // centerTile が変化したフレームのみ target が大きく変化する。
-                // 通常の微小移動（最大 TILE_UPDATE_DISTANCE_M = 80m）は誤検知しない。
-                const TILE_JUMP_THRESHOLD_M = 200;
-                if (
-                    Math.abs(target.x - targetXBefore) > TILE_JUMP_THRESHOLD_M ||
-                    Math.abs(target.z - targetZBefore) > TILE_JUMP_THRESHOLD_M
-                ) {
-                    afterburnerResetNeeded = true;
-                }
             } else {
                 // 意味のある変化なし: 次回の判定を遅延させすぎないよう最終チェック時刻だけ進める
                 lastTileUpdateTime = timestamp;

--- a/src/demos/flight/index.ts
+++ b/src/demos/flight/index.ts
@@ -839,7 +839,11 @@ const start = async (): Promise<void> => {
                 lastRefreshRadius = followCamRadius;
                 lastTileUpdateTime = timestamp;
                 tileRefreshInFlight = true;
-                afterburnerResetNeeded = true;
+                // 位置移動によるリフレッシュのみ gridResidual がジャンプするため、
+                // 回転/高さ/半径変化だけの場合は reset 不要。
+                if (moved >= TILE_UPDATE_DISTANCE_M) {
+                    afterburnerResetNeeded = true;
+                }
                 // この呼び出しの同期部分で gridResidualX/Z が更新される。
                 void viewer
                     .refreshTerrainWithExternalFrustum(

--- a/src/demos/flight/index.ts
+++ b/src/demos/flight/index.ts
@@ -29,7 +29,7 @@ import { circularOrbitPosition, circularOrbitHeading } from "../avatar/orbit";
 import { createRouteLine, type RouteLine } from "./routeLine";
 import { createWaypointManager, type WaypointManager } from "./waypoints";
 import { createFlightAudio, type FlightAudio } from "./flightAudio";
-import { createContrail, type Contrail } from "./contrail";
+import { createAfterburner, type Afterburner } from "./afterburner";
 import planeGlbUrl from "../../../assets/plane.glb";
 
 /** PIP 用セカンダリ Viewer 設定 (Issue #264 Option C: 別 Canvas + 別 Engine) */
@@ -130,8 +130,8 @@ const start = async (): Promise<void> => {
     // Follow モードでのタイル中心更新スロットル
     let lastTileUpdateTime = 0;
     let tileRefreshInFlight = false;
-    /** グリッド原点ジャンプが発生したフレームで1回だけ contrail.reset() を呼ぶためのフラグ */
-    let contrailResetNeeded = false;
+    /** グリッド原点ジャンプが発生したフレームで1回だけ afterburner.reset() を呼ぶためのフラグ */
+    let afterburnerResetNeeded = false;
     let lastRefreshLat = TOKYO_STATION.lat;
     let lastRefreshLon = TOKYO_STATION.lon;
     let lastRefreshRotationOffset = FOLLOW_CAMERA_ROTATION_OFFSET;
@@ -178,9 +178,9 @@ const start = async (): Promise<void> => {
     let flightAudio: FlightAudio | null = null;
     let audioInitializing = false;
 
-    // --- コントレイル (Issue #276) ---
-    let contrail: Contrail | null = null;
-    let showContrail = true;
+    // --- アフターバーナー (Issue #276) ---
+    let afterburner: Afterburner | null = null;
+    let showAfterburner = true;
 
     /** ウェイポイント再計算ヘルパー — パラメータ変更時に共通で呼ぶ */
     const resetWaypointsIfNeeded = (): void => {
@@ -467,18 +467,18 @@ const start = async (): Promise<void> => {
                 flightAudio.startEngineSound();
             }
 
-            // コントレイル開始 (Issue #276)
+            // アフターバーナー開始 (Issue #276)
             // 常に start() して TrailMesh を構築し、表示は setVisible で制御する。
             // これにより Follow 中にチェックボックスを ON にしても正しく表示される。
-            if (!contrail && scene) {
-                contrail = createContrail(scene);
+            if (!afterburner && scene) {
+                afterburner = createAfterburner(scene);
             }
-            if (contrail) {
-                contrail.start({
+            if (afterburner) {
+                afterburner.start({
                     scene,
                     modelNodeName: `model-${MODEL_ID}`,
                 });
-                contrail.setVisible(showContrail);
+                afterburner.setVisible(showAfterburner);
             }
         }
     };
@@ -505,8 +505,8 @@ const start = async (): Promise<void> => {
         // SE 停止 (Issue #269)
         flightAudio?.stopEngineSound();
 
-        // コントレイル停止 (Issue #276)
-        contrail?.stop();
+        // アフターバーナー停止 (Issue #276)
+        afterburner?.stop();
     };
 
     // --- UI 要素の取得 ---
@@ -627,14 +627,14 @@ const start = async (): Promise<void> => {
         });
     }
 
-    // コントレイル表示切替チェックボックス (Issue #276)
+    // アフターバーナー表示切替チェックボックス (Issue #276)
     const contrailToggle = document.getElementById("contrail-toggle") as HTMLInputElement | null;
     if (contrailToggle) {
-        contrailToggle.checked = showContrail;
+        contrailToggle.checked = showAfterburner;
         contrailToggle.addEventListener("change", () => {
-            showContrail = contrailToggle.checked;
-            if (contrail) {
-                contrail.setVisible(showContrail);
+            showAfterburner = contrailToggle.checked;
+            if (afterburner) {
+                afterburner.setVisible(showAfterburner);
             }
         });
     }
@@ -839,7 +839,7 @@ const start = async (): Promise<void> => {
                 lastRefreshRadius = followCamRadius;
                 lastTileUpdateTime = timestamp;
                 tileRefreshInFlight = true;
-                contrailResetNeeded = true;
+                afterburnerResetNeeded = true;
                 // この呼び出しの同期部分で gridResidualX/Z が更新される。
                 void viewer
                     .refreshTerrainWithExternalFrustum(
@@ -873,12 +873,12 @@ const start = async (): Promise<void> => {
         // updateModel で root.position が確定した後にトレイルをリセットする。
         // refreshTerrainWithExternalFrustum が走ったフレームでのみ1回だけ実行。
         // gridResidual ジャンプで旧座標の頂点が残り折れ線になるのを防止する。
-        if (contrailResetNeeded && contrail) {
-            contrailResetNeeded = false;
+        if (afterburnerResetNeeded && afterburner) {
+            afterburnerResetNeeded = false;
             const scene = viewer.__debugScene;
             const root = scene?.getTransformNodeByName(`model-${MODEL_ID}`);
             root?.computeWorldMatrix(true);
-            contrail.reset();
+            afterburner.reset();
         }
 
         // Follow モード: 毎フレームカメラ位置を飛行機の後方に直接設定 + コンパス同期
@@ -988,8 +988,8 @@ const start = async (): Promise<void> => {
         if (flightAudio) {
             flightAudio.dispose();
         }
-        if (contrail) {
-            contrail.dispose();
+        if (afterburner) {
+            afterburner.dispose();
         }
         pipCleanups.forEach((fn) => fn());
         if (pipViewer) {

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -13,7 +13,7 @@ import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
 import { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import { Ray } from "@babylonjs/core/Culling/ray";
 import { CreateSceneClass } from "../createScene";
-import { clamp, toTileXY, tileEdgeMeters, tileCenterLatLon, JAPAN_BOUNDS } from "../terrain/gsiTile";
+import { clamp, toTileXY, tileEdgeMeters, tileCenterLatLon, JAPAN_BOUNDS, TILE_MAX_ZOOM } from "../terrain/gsiTile";
 import { clampZoomLevel, radiusToZoomLevel, zoomLevelToRadius } from "../terrain/urlState";
 import { createControlPanel, snapScale, formatScale, showToast } from "../terrain/controlPanel";
 import { attachResizeRefresh } from "../terrain/resizeRefresh";
@@ -39,7 +39,7 @@ import {
 } from "../lib/types";
 
 const TERRAIN_SUBDIVISIONS = 128;
-const MAX_ZOOM = 18;
+const MAX_ZOOM = TILE_MAX_ZOOM;
 const MAX_ELEVATION_ZOOM = 17;
 const MIN_ELEVATION_ZOOM = 10;
 const HEIGHT_SCALE = 1.0;

--- a/src/terrain/gsiTile.ts
+++ b/src/terrain/gsiTile.ts
@@ -2,6 +2,9 @@
 
 export const TILE_SIZE = 256;
 
+/** 地理院タイルの最大ズームレベル */
+export const TILE_MAX_ZOOM = 18;
+
 export const JAPAN_BOUNDS = { minLat: 20, maxLat: 46, minLon: 122, maxLon: 154 } as const;
 
 const DEM_LAYERS = ["dem5a_png", "dem5b_png", "dem_png"] as const;

--- a/tests/afterburner.unit.spec.ts
+++ b/tests/afterburner.unit.spec.ts
@@ -1,0 +1,171 @@
+/**
+ * `src/demos/flight/afterburner.ts` の unit test (Issue #276)。
+ *
+ * TrailMesh + GlowLayer によるアフターバーナーの状態遷移をテストする。
+ * Babylon.js 依存はモック化。
+ */
+import { describe, it, expect, jest, beforeAll } from "@jest/globals";
+import type { Scene } from "@babylonjs/core/scene";
+
+// --- Babylon.js モック ---
+
+const mockTrailMeshInstance = () => ({
+    material: null,
+    isPickable: false,
+    alwaysSelectAsActiveMesh: false,
+    renderingGroupId: 0,
+    start: jest.fn(),
+    stop: jest.fn(),
+    reset: jest.fn(),
+    dispose: jest.fn(),
+    setEnabled: jest.fn(),
+});
+
+const mockTransformNodeInstance = () => ({
+    parent: null,
+    position: { x: 0, y: 0, z: 0, set: jest.fn() },
+    computeWorldMatrix: jest.fn(),
+    dispose: jest.fn(),
+});
+
+jest.unstable_mockModule("@babylonjs/core/Maths/math.color", () => ({
+    Color3: jest.fn(() => ({ r: 0, g: 0, b: 0 })),
+}));
+
+jest.unstable_mockModule("@babylonjs/core/Engines/constants", () => ({
+    Constants: { ALPHA_ADD: 6 },
+}));
+
+jest.unstable_mockModule("@babylonjs/core/Layers/glowLayer", () => ({
+    GlowLayer: jest.fn(() => ({
+        intensity: 0,
+        addIncludedOnlyMesh: jest.fn(),
+        dispose: jest.fn(),
+    })),
+}));
+
+jest.unstable_mockModule("@babylonjs/core/Materials/standardMaterial", () => ({
+    StandardMaterial: jest.fn(() => ({
+        disableLighting: false,
+        emissiveColor: null,
+        diffuseColor: null,
+        specularColor: null,
+        alpha: 1,
+        alphaMode: 0,
+        backFaceCulling: true,
+        dispose: jest.fn(),
+    })),
+}));
+
+const TrailMeshMock = jest.fn(mockTrailMeshInstance);
+jest.unstable_mockModule("@babylonjs/core/Meshes/trailMesh", () => ({
+    TrailMesh: TrailMeshMock,
+}));
+
+const TransformNodeMock = jest.fn(mockTransformNodeInstance);
+jest.unstable_mockModule("@babylonjs/core/Meshes/transformNode", () => ({
+    TransformNode: TransformNodeMock,
+}));
+
+// --- テスト ---
+
+const MODEL_NODE_NAME = "model-test";
+
+const createMockScene = (): Scene =>
+    ({
+        getTransformNodeByName: jest.fn(() => ({
+            computeWorldMatrix: jest.fn(),
+        })),
+    }) as unknown as Scene;
+
+describe("createAfterburner", () => {
+    let createAfterburner: typeof import("../src/demos/flight/afterburner").createAfterburner;
+
+    beforeAll(async () => {
+        const mod = await import("../src/demos/flight/afterburner");
+        createAfterburner = mod.createAfterburner;
+    });
+
+    it("start が TrailMesh と TransformNode を生成する", () => {
+        const scene = createMockScene();
+        const ab = createAfterburner(scene);
+
+        TrailMeshMock.mockClear();
+        TransformNodeMock.mockClear();
+
+        ab.start({ scene, modelNodeName: MODEL_NODE_NAME });
+
+        // 左右2つの generator TransformNode が作成される
+        expect(TransformNodeMock).toHaveBeenCalledTimes(2);
+        // 左右2つの TrailMesh が作成される
+        expect(TrailMeshMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("setVisible(false) で TrailMesh が stop/setEnabled(false) される", () => {
+        TrailMeshMock.mockClear();
+
+        const scene = createMockScene();
+        const ab = createAfterburner(scene);
+        ab.start({ scene, modelNodeName: MODEL_NODE_NAME });
+
+        const trailInstances = TrailMeshMock.mock.results.map((r) => r.value);
+
+        ab.setVisible(false);
+
+        for (const trail of trailInstances) {
+            expect(trail.stop).toHaveBeenCalled();
+            expect(trail.setEnabled).toHaveBeenCalledWith(false);
+        }
+    });
+
+    it("setVisible(true) で TrailMesh が start/setEnabled(true) される", () => {
+        TrailMeshMock.mockClear();
+
+        const scene = createMockScene();
+        const ab = createAfterburner(scene);
+        ab.start({ scene, modelNodeName: MODEL_NODE_NAME });
+
+        ab.setVisible(false);
+        // clear mocks to check next call
+        const trailInstances = TrailMeshMock.mock.results.map((r) => r.value);
+        for (const t of trailInstances) {
+            (t.start as jest.Mock).mockClear();
+            (t.setEnabled as jest.Mock).mockClear();
+        }
+
+        ab.setVisible(true);
+
+        for (const trail of trailInstances) {
+            expect(trail.start).toHaveBeenCalled();
+            expect(trail.setEnabled).toHaveBeenCalledWith(true);
+        }
+    });
+
+    it("stop/dispose を二重呼び出ししてもエラーにならない", () => {
+        const scene = createMockScene();
+        const ab = createAfterburner(scene);
+        ab.start({ scene, modelNodeName: MODEL_NODE_NAME });
+
+        expect(() => {
+            ab.stop();
+            ab.stop();
+        }).not.toThrow();
+
+        expect(() => {
+            ab.dispose();
+            ab.dispose();
+        }).not.toThrow();
+    });
+
+    it("start 前に stop/reset/setVisible を呼んでもエラーにならない", () => {
+        const scene = createMockScene();
+        const ab = createAfterburner(scene);
+
+        expect(() => {
+            ab.stop();
+            ab.reset();
+            ab.setVisible(false);
+            ab.setVisible(true);
+        }).not.toThrow();
+    });
+});

--- a/tests/afterburner.unit.spec.ts
+++ b/tests/afterburner.unit.spec.ts
@@ -105,7 +105,7 @@ describe("createAfterburner", () => {
         TrailMeshMock.mockClear();
         TransformNodeMock.mockClear();
 
-        ab.start({ scene, modelNodeName: MODEL_NODE_NAME });
+        ab.start({ modelNodeName: MODEL_NODE_NAME });
 
         // 左右2つの generator TransformNode が作成される
         expect(TransformNodeMock).toHaveBeenCalledTimes(2);
@@ -118,7 +118,7 @@ describe("createAfterburner", () => {
 
         const scene = createMockScene();
         const ab = createAfterburner(scene);
-        ab.start({ scene, modelNodeName: MODEL_NODE_NAME });
+        ab.start({ modelNodeName: MODEL_NODE_NAME });
 
         const trailInstances = TrailMeshMock.mock.results.map((r) => r.value as MockTrailInstance);
 
@@ -135,7 +135,7 @@ describe("createAfterburner", () => {
 
         const scene = createMockScene();
         const ab = createAfterburner(scene);
-        ab.start({ scene, modelNodeName: MODEL_NODE_NAME });
+        ab.start({ modelNodeName: MODEL_NODE_NAME });
 
         ab.setVisible(false);
         // clear mocks to check next call
@@ -156,7 +156,7 @@ describe("createAfterburner", () => {
     it("stop/dispose を二重呼び出ししてもエラーにならない", () => {
         const scene = createMockScene();
         const ab = createAfterburner(scene);
-        ab.start({ scene, modelNodeName: MODEL_NODE_NAME });
+        ab.start({ modelNodeName: MODEL_NODE_NAME });
 
         expect(() => {
             ab.stop();

--- a/tests/afterburner.unit.spec.ts
+++ b/tests/afterburner.unit.spec.ts
@@ -9,7 +9,19 @@ import type { Scene } from "@babylonjs/core/scene";
 
 // --- Babylon.js モック ---
 
-const mockTrailMeshInstance = () => ({
+interface MockTrailInstance {
+    material: null;
+    isPickable: boolean;
+    alwaysSelectAsActiveMesh: boolean;
+    renderingGroupId: number;
+    start: jest.Mock;
+    stop: jest.Mock;
+    reset: jest.Mock;
+    dispose: jest.Mock;
+    setEnabled: jest.Mock;
+}
+
+const mockTrailMeshInstance = (): MockTrailInstance => ({
     material: null,
     isPickable: false,
     alwaysSelectAsActiveMesh: false,
@@ -108,7 +120,7 @@ describe("createAfterburner", () => {
         const ab = createAfterburner(scene);
         ab.start({ scene, modelNodeName: MODEL_NODE_NAME });
 
-        const trailInstances = TrailMeshMock.mock.results.map((r) => r.value);
+        const trailInstances = TrailMeshMock.mock.results.map((r) => r.value as MockTrailInstance);
 
         ab.setVisible(false);
 
@@ -127,10 +139,10 @@ describe("createAfterburner", () => {
 
         ab.setVisible(false);
         // clear mocks to check next call
-        const trailInstances = TrailMeshMock.mock.results.map((r) => r.value);
+        const trailInstances = TrailMeshMock.mock.results.map((r) => r.value as MockTrailInstance);
         for (const t of trailInstances) {
-            (t.start as jest.Mock).mockClear();
-            (t.setEnabled as jest.Mock).mockClear();
+            t.start.mockClear();
+            t.setEnabled.mockClear();
         }
 
         ab.setVisible(true);


### PR DESCRIPTION
## 概要

Closes #276

Follow モードで飛行機の左右エンジン位置からアフターバーナーの炎を TrailMesh で描画する。

## 変更内容

- `src/demos/flight/afterburner.ts` — 新規作成
  - Babylon.js TrailMesh を使った左右2本のアフターバーナートレイル
  - GlowLayer で発光エフェクト（トレイルのみに適用、Follow モード中のみ生成）
  - ALPHA_ADD ブレンド + emissive オレンジ色で炎っぽい表現
- `src/demos/flight/index.ts` — 統合
  - Follow モード ON で start / OFF で stop
  - グリッド原点ジャンプ時に1回だけ reset（折れ線防止）
  - dispose をページ離脱時に実行
- `public/flight.html` — 「アフターバーナー」チェックボックス追加
- `tests/afterburner.unit.spec.ts` — ユニットテスト追加

## 検証

- `npm run lint` ✅
- `npm run typecheck` ✅  
- `npm run build` ✅
- `npm run start` でブラウザ目視確認済み（Follow モードでアフターバーナー表示）
