### PR TITLE
fix(terrain): 2D回転/ズーム後のタイル表示乱れを解消 (#286)

### DIFF
--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -1047,11 +1047,15 @@ export class DefaultScene implements CreateSceneClass {
                 );
                 if (centerPick?.hit && centerPick.pickedPoint) {
                     if (currentViewMode === "2d") {
-                        // 2D 中の setTarget も alpha 再計算で不安定化するため alpha/beta を保護する。
+                        // 2D 中の setTarget は alpha/radius も再計算され、
+                        // ズーム後の radius が回転開始時に巻き戻る (#286)。
+                        // alpha/beta/radius を保護する。
                         const prevAlpha = camera.alpha;
+                        const prevRadius = camera.radius;
                         camera.setTarget(centerPick.pickedPoint);
                         camera.alpha = prevAlpha;
                         camera.beta = BETA_2D;
+                        camera.radius = prevRadius;
                     } else {
                         camera.setTarget(centerPick.pickedPoint);
                     }

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -9,6 +9,7 @@ import { VertexBuffer } from "@babylonjs/core/Buffers/buffer";
 import { Frustum } from "@babylonjs/core/Maths/math.frustum";
 import { Matrix } from "@babylonjs/core/Maths/math.vector";
 import { Plane } from "@babylonjs/core/Maths/math.plane";
+import { Camera } from "@babylonjs/core/Cameras/camera";
 
 import { TileCoord, TileKey, toTileKey, tileOffsetToWorld, convertTileZoom, computeSubTileOffset } from "./tileTypes";
 import { computeQuadtreeTiles, FrustumPlane, LodTileEntry } from "./visibleTiles";
@@ -197,6 +198,14 @@ export const extractSubTileElevation = (
 
 /** Babylon.js Frustum planes を FrustumPlane[] に変換 */
 const extractFrustumPlanes = (camera: ArcRotateCamera): FrustumPlane[] => {
+    // 2D (ortho) では camera.alpha 変更（画面回転）に伴って AABB-frustum 交差が
+    // 拡大し、`computeQuadtreeTiles` の maxTiles / maxVisited に達して粗LODへの
+    // 強制フォールバックや遠方タイル切捨てが起き、回転中にタイルレベルが乱れる
+    // (#286)。タイル選択は地理的中心と orthoサイズだけで決めれば十分なので、
+    // ortho 時は回転に依存しない axis-aligned な frustum 平面を構築する。
+    if (camera.mode === Camera.ORTHOGRAPHIC_CAMERA) {
+        return extractOrthoStableFrustumPlanes(camera);
+    }
     const transform = Matrix.Identity();
     camera
         .getViewMatrix()
@@ -208,6 +217,45 @@ const extractFrustumPlanes = (camera: ArcRotateCamera): FrustumPlane[] => {
         normal: { x: p.normal.x, y: p.normal.y, z: p.normal.z },
         d: p.d,
     }));
+};
+
+/**
+ * 2D (ortho) 用の回転安定な frustum 平面を返す (#286)。
+ *
+ * orthoLeft/Right/Top/Bottom が定義する可視矩形を、`camera.alpha` がどの値でも
+ * 完全に内包する正方形（中心 `camera.target`、半辺 `hypot(halfW, halfH)`）
+ * に展開して X/Z 軸方向の4平面を構築する。Y 方向は地形の標高範囲を十分に
+ * カバーする大きな上下平面を返す。
+ * これにより、画面回転だけでタイル選択集合が変動するのを防ぐ。
+ */
+export const extractOrthoStableFrustumPlanes = (camera: {
+    orthoLeft?: number | null;
+    orthoRight?: number | null;
+    orthoTop?: number | null;
+    orthoBottom?: number | null;
+    target: { x: number; z: number };
+}): FrustumPlane[] => {
+    const left = camera.orthoLeft ?? 0;
+    const right = camera.orthoRight ?? 0;
+    const top = camera.orthoTop ?? 0;
+    const bottom = camera.orthoBottom ?? 0;
+    const halfW = (right - left) / 2;
+    const halfH = (top - bottom) / 2;
+    // 任意の回転角で可視矩形を内包する半辺（外接円半径）
+    const radius = Math.hypot(halfW, halfH);
+    const cx = camera.target.x;
+    const cz = camera.target.z;
+    // Y 方向は地形標高 ±数千m を大きく上回る値で常に内側判定にする。
+    // isAABBInFrustum は `n·p + d < 0` で外側判定するため、上下とも d を大きく取る。
+    const Y_HALF = 1e9;
+    return [
+        { normal: { x: 1, y: 0, z: 0 }, d: -(cx - radius) },
+        { normal: { x: -1, y: 0, z: 0 }, d: cx + radius },
+        { normal: { x: 0, y: 0, z: 1 }, d: -(cz - radius) },
+        { normal: { x: 0, y: 0, z: -1 }, d: cz + radius },
+        { normal: { x: 0, y: 1, z: 0 }, d: Y_HALF },
+        { normal: { x: 0, y: -1, z: 0 }, d: Y_HALF },
+    ];
 };
 
 export const createTileManager = (opts: TileManagerOptions): TileManager => {

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -1801,7 +1801,53 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
 
         attachCamera(): void {
             if (cameraObserver) return;
+            // ArcRotateCamera の onViewMatrixChangedObservable は毎フレーム発火する
+            // 仕様のため、単純に debounce すると永遠に reset され refresh が走らない。
+            // 直近 refresh トリガ時のカメラ状態と比較し、実質的な変化があった場合のみ
+            // debounce タイマを再設定する (#286)。
+            const snapshot = (): {
+                alpha: number;
+                beta: number;
+                radius: number;
+                tx: number;
+                ty: number;
+                tz: number;
+                oL: number | null;
+                oR: number | null;
+                oT: number | null;
+                oB: number | null;
+            } => ({
+                alpha: camera.alpha,
+                beta: camera.beta,
+                radius: camera.radius,
+                tx: camera.target.x,
+                ty: camera.target.y,
+                tz: camera.target.z,
+                oL: camera.orthoLeft,
+                oR: camera.orthoRight,
+                oT: camera.orthoTop,
+                oB: camera.orthoBottom,
+            });
+            type Snap = ReturnType<typeof snapshot>;
+            const EPS_ANG = 1e-4; // ~0.006°
+            const EPS_LEN = 0.05; // 5cm
+            const EPS_ORTHO = 0.5; // 0.5m
+            const changed = (a: Snap, b: Snap): boolean =>
+                Math.abs(a.alpha - b.alpha) > EPS_ANG ||
+                Math.abs(a.beta - b.beta) > EPS_ANG ||
+                Math.abs(a.radius - b.radius) > EPS_LEN ||
+                Math.abs(a.tx - b.tx) > EPS_LEN ||
+                Math.abs(a.ty - b.ty) > EPS_LEN ||
+                Math.abs(a.tz - b.tz) > EPS_LEN ||
+                Math.abs((a.oL ?? 0) - (b.oL ?? 0)) > EPS_ORTHO ||
+                Math.abs((a.oR ?? 0) - (b.oR ?? 0)) > EPS_ORTHO ||
+                Math.abs((a.oT ?? 0) - (b.oT ?? 0)) > EPS_ORTHO ||
+                Math.abs((a.oB ?? 0) - (b.oB ?? 0)) > EPS_ORTHO;
+            let lastSnap: Snap = snapshot();
             cameraObserver = camera.onViewMatrixChangedObservable.add(() => {
+                const cur = snapshot();
+                if (!changed(lastSnap, cur)) return;
+                lastSnap = cur;
                 if (debounceTimer !== null) {
                     clearTimeout(debounceTimer);
                 }

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -1682,6 +1682,14 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
             await loadTilesInQueue(toLoad, rid);
         }
 
+        // 2D 回転や同一可視集合での再 refresh など、新規ロードが発生しないケースでは
+        // loadTile 経路の checkAndReleaseCoveredTiles が呼ばれないため、既に祖先タイルが
+        // ロード済みの pendingRelease タイルがタイムアウト (5s) まで滞留してしまう (#286)。
+        // ここで全 pending を対象に再判定し、カバー済みのものを即時解放する。
+        if (pendingRelease.size > 0) {
+            checkAndReleaseCoveredTiles();
+        }
+
         if (rid === requestId) {
             // all-NaN だったタイルを反復補間で埋める（湖中央等）
             await refineAllNaNTiles();

--- a/tests/tileManager.unit.spec.ts
+++ b/tests/tileManager.unit.spec.ts
@@ -91,6 +91,10 @@ jest.unstable_mockModule("@babylonjs/core/Maths/math.frustum", () => ({
     },
 }));
 
+jest.unstable_mockModule("@babylonjs/core/Cameras/camera", () => ({
+    Camera: { ORTHOGRAPHIC_CAMERA: 1, PERSPECTIVE_CAMERA: 0 },
+}));
+
 jest.unstable_mockModule("@babylonjs/core/Maths/math.vector", () => {
     class Vector3Mock {
         x: number;
@@ -165,7 +169,7 @@ jest.unstable_mockModule("../src/terrain/gsiTile", () => ({
     fillInvalidPixels: jest.fn(),
 }));
 
-const { createTileManager, extractSubTileElevation, computeTextureUvParams } = await import("../src/terrain/tileManager");
+const { createTileManager, extractSubTileElevation, computeTextureUvParams, extractOrthoStableFrustumPlanes } = await import("../src/terrain/tileManager");
 const gsiTileMock = await import("../src/terrain/gsiTile");
 
 const createMockCamera = () => {
@@ -1829,3 +1833,63 @@ describe("LOD遷移時の遅延解放 (Issue #268)", () => {
     });
 });
 
+
+describe("extractOrthoStableFrustumPlanes (#286)", () => {
+    const makeCamera = (
+        orthoHalfW: number,
+        orthoHalfH: number,
+        targetX = 100,
+        targetZ = -50,
+    ) => ({
+        orthoLeft: -orthoHalfW,
+        orthoRight: orthoHalfW,
+        orthoTop: orthoHalfH,
+        orthoBottom: -orthoHalfH,
+        target: { x: targetX, z: targetZ },
+    });
+
+    it("正方形 ortho 矩形のとき、半辺は対角距離(=hypot(halfW,halfH))に拡張される", () => {
+        const cam = makeCamera(1000, 1000);
+        const planes = extractOrthoStableFrustumPlanes(cam);
+        // X+ 方向の平面: normal=(1,0,0), d = -(cx - radius)
+        // radius = hypot(1000, 1000) = 1000 * sqrt(2)
+        const expectedRadius = Math.hypot(1000, 1000);
+        const cx = 100;
+        const cz = -50;
+        expect(planes[0].normal).toEqual({ x: 1, y: 0, z: 0 });
+        expect(planes[0].d).toBeCloseTo(-(cx - expectedRadius), 6);
+        expect(planes[1].normal).toEqual({ x: -1, y: 0, z: 0 });
+        expect(planes[1].d).toBeCloseTo(cx + expectedRadius, 6);
+        expect(planes[2].normal).toEqual({ x: 0, y: 0, z: 1 });
+        expect(planes[2].d).toBeCloseTo(-(cz - expectedRadius), 6);
+        expect(planes[3].normal).toEqual({ x: 0, y: 0, z: -1 });
+        expect(planes[3].d).toBeCloseTo(cz + expectedRadius, 6);
+    });
+
+    it("camera.target を中心とする回転不変な平面である（alphaに依存しない）", () => {
+        // 関数引数に alpha は含まれないため、引数が同じなら結果は同一
+        const cam1 = makeCamera(800, 600, 0, 0);
+        const cam2 = makeCamera(800, 600, 0, 0);
+        expect(extractOrthoStableFrustumPlanes(cam1)).toEqual(
+            extractOrthoStableFrustumPlanes(cam2),
+        );
+    });
+
+    it("Y 方向は十分大きな上下平面（地形 ±数千m を完全カバー）", () => {
+        const cam = makeCamera(500, 500);
+        const planes = extractOrthoStableFrustumPlanes(cam);
+        expect(planes[4].normal).toEqual({ x: 0, y: 1, z: 0 });
+        expect(planes[5].normal).toEqual({ x: 0, y: -1, z: 0 });
+        expect(planes[4].d).toBeGreaterThan(1e6);
+        expect(planes[5].d).toBeGreaterThan(1e6);
+    });
+
+    it("ortho* が未設定（null/undefined）でも 0 として安全にフォールバックする", () => {
+        const planes = extractOrthoStableFrustumPlanes({
+            target: { x: 0, z: 0 },
+        });
+        expect(planes).toHaveLength(6);
+        // radius = hypot(0,0) = 0 → X+ 平面の d = ±0（Object.is で -0/+0 区別を避ける）
+        expect(planes[0].d).toBeCloseTo(0);
+    });
+});


### PR DESCRIPTION
## 概要
Issue #286 の修正。2Dモードで以下の症状を解消。

- 回転すると勝手にズームが変動する
- ズームダウン後、以前の高ズームタイルが残る
- ズームアップ後、タイル位置がズレる

## 真因
1. **debounce が永遠 reset**: `ArcRotateCamera.onViewMatrixChangedObservable` は毎フレーム発火する仕様。`attachCamera` の `setTimeout` ベース debounce が永遠に reset され、回転だけの操作で `refreshFromCamera` が一度も呼ばれていなかった。
2. **Ctrl+drag 開始時の radius 巻き戻し**: 2D の Ctrl+drag pointerdown で画面中央地形点を新 target に設定する際 `camera.setTarget()` が radius も再計算するため、ズーム後の radius が巻き戻っていた。alpha/beta は保護していたが radius が抜けていた。

## 修正
- `src/terrain/tileManager.ts`: viewMatrixChanged ハンドラ内でカメラ状態（alpha/beta/radius/target/ortho*）の snapshot を比較し、実質的な変化があった場合のみ debounce タイマを再設定。
- `src/scenes/default.ts`: 2D の Ctrl+drag 開始時、`camera.setTarget()` 前後で radius も保護。
- `src/terrain/tileManager.ts`: `applyVisibleTiles` 末尾で pendingRelease の即時カバレッジ判定（旧コミット 6e7ffaf）。
- `src/terrain/tileManager.ts`: 2D ortho 専用の軸沿い frustum 平面抽出（旧コミット 48d30b3）。

## 影響範囲
- 2D モード: 回転・ズーム操作のタイル表示安定化
- 3D モード: snapshot 比較ロジックの恩恵あり、副作用なし（既存テスト 867件 PASS）

## 検証
- `npm run typecheck` ✔
- `npm run lint` ✔
- `npm run test:unit` ✔ (867 passed)
- 実機: 回転中のズーム変動・タイル残留・ズレ全て解消（ユーザ確認済み）

Closes #286