### PR TITLE
feat(avatar-controller): ジャンプ機能を追加 (#288)

### DIFF
--- a/public/avatar-controller.html
+++ b/public/avatar-controller.html
@@ -130,20 +130,56 @@
       <div>
         <div class="info-row">
           <label for="speed-slider" style="font-size: 11px; color: #e0e4ea;">速度 (m/s)</label>
-          <span class="value" id="speed-value">10</span>
+          <span class="value" id="speed-value">30</span>
         </div>
-        <input type="range" id="speed-slider" min="1" max="50" value="10" step="1">
+        <input type="range" id="speed-slider" min="1" max="50" value="30" step="1">
       </div>
       <button id="fly-to-avatar">アバターへカメラ移動</button>
       <div class="info-row" style="align-items: center;">
         <label for="auto-scroll-toggle" style="font-size: 11px; color: #e0e4ea;">自動スクロール</label>
         <input type="checkbox" id="auto-scroll-toggle" checked>
       </div>
+      <hr style="border: none; border-top: 1px solid rgba(255,255,255,0.15); margin: 4px 0;">
+      <strong>ジャンプ</strong>
+      <div>
+        <div class="info-row">
+          <label for="jump-height-slider" style="font-size: 11px; color: #e0e4ea;">高さ</label>
+          <span class="value" id="jump-height-value">100</span>
+        </div>
+        <input type="range" id="jump-height-slider" min="20" max="200" value="100" step="10">
+      </div>
+      <div>
+        <div class="info-row">
+          <label for="jump-gravity-slider" style="font-size: 11px; color: #e0e4ea;">重力 (m/s²)</label>
+          <span class="value" id="jump-gravity-value">490.5</span>
+        </div>
+        <input type="range" id="jump-gravity-slider" min="1" max="2000" value="490.5" step="0.1">
+      </div>
       <div class="hint">
         操作: 矢印キー / WASD / Gamepad 左スティック / Virtual Joystick<br>
+        ジャンプ: Space / Gamepad A / 画面右下ボタン<br>
         地面クリックでアバターの位置を変更します
       </div>
     </div>
+    <button id="jump-btn" style="
+      position: absolute;
+      right: 70px;
+      bottom: 40px;
+      width: 60px;
+      height: 60px;
+      border-radius: 50%;
+      background: rgba(255, 100, 50, 0.7);
+      border: 2px solid rgba(255, 255, 255, 0.5);
+      color: #fff;
+      font-size: 12px;
+      font-weight: bold;
+      cursor: pointer;
+      pointer-events: auto;
+      z-index: 20;
+      touch-action: none;
+      user-select: none;
+      -webkit-user-select: none;
+    ">JUMP</button>
   </div>
 </body>
 </html>

--- a/public/avatar-controller.html
+++ b/public/avatar-controller.html
@@ -150,7 +150,7 @@
       </div>
       <div>
         <div class="info-row">
-          <label for="jump-gravity-slider" style="font-size: 11px; color: #e0e4ea;">重力 (m/s²)</label>
+          <label for="jump-gravity-slider" style="font-size: 11px; color: #e0e4ea;">重力 (ワールドスケール)</label>
           <span class="value" id="jump-gravity-value">490.5</span>
         </div>
         <input type="range" id="jump-gravity-slider" min="1" max="2000" value="490.5" step="0.1">

--- a/src/demos/avatar-controller/index.ts
+++ b/src/demos/avatar-controller/index.ts
@@ -23,6 +23,7 @@ import {
     parseMapTypeFromUrl,
 } from "../../terrain/urlState";
 import { GamepadManager } from "@babylonjs/core/Gamepads/gamepadManager";
+import type { GenericPad } from "@babylonjs/core/Gamepads/gamepad";
 import { createDomJoystick } from "./domJoystick";
 import {
     combineInputs,
@@ -38,6 +39,15 @@ import {
     DEFAULT_DEADZONE_RATIO,
     DEFAULT_SCROLL_LERP,
 } from "./autoScroll";
+import {
+    DEFAULT_GRAVITY,
+    DEFAULT_JUMP_HEIGHT,
+    isJumping,
+    JUMP_IDLE,
+    startJump,
+    tickJump,
+    type JumpState,
+} from "./jump";
 import { Frustum } from "@babylonjs/core/Maths/math.frustum";
 import { Matrix } from "@babylonjs/core/Maths/math.vector";
 import { Plane } from "@babylonjs/core/Maths/math.plane";
@@ -57,7 +67,7 @@ const TOKYO_STATION = { lat: 35.681236, lon: 139.767125 };
 /** モデルの表示スケール */
 const MODEL_SCALE = 50;
 /** デフォルト歩行速度 (m/s) */
-const DEFAULT_SPEED_MPS = 10;
+const DEFAULT_SPEED_MPS = 30;
 /** クリック可能距離 (m) */
 const MAX_CLICK_DISTANCE_M = 5000;
 /** 移動を「歩行中」とみなす入力強度の閾値 */
@@ -103,6 +113,11 @@ const start = async (): Promise<void> => {
     let lastTimestamp: number | null = null;
     let animationStarted = false;
     let autoScrollEnabled = true;
+    let jumpState: JumpState = JUMP_IDLE;
+    let jumpHeight = DEFAULT_JUMP_HEIGHT;
+    let jumpGravity = DEFAULT_GRAVITY;
+    /** ジャンプボタンが押された（次フレームで発動） */
+    let jumpRequested = false;
 
     /**
      * 自動スクロール — Flight demo Follow モードと同じ手法 (Issue #287):
@@ -192,7 +207,7 @@ const start = async (): Promise<void> => {
                     lat: avatarLat,
                     lon: avatarLon,
                     altitudeMode: "terrain",
-                    altitude: 0,
+                    altitude: jumpState.altitude,
                     gravity: true,
                 });
             });
@@ -228,10 +243,15 @@ const start = async (): Promise<void> => {
     // --- 入力: Gamepad ---
     const gamepadManager = new GamepadManager();
     const gamepadStick = { x: 0, y: 0 };
+    let gamepadJumpPressed = false;
     gamepadManager.onGamepadConnectedObservable.add((gp) => {
         gp.onleftstickchanged((values) => {
             gamepadStick.x = values.x;
             gamepadStick.y = values.y;
+        });
+        (gp as GenericPad).onbuttondown((index: number) => {
+            // A ボタン (Xbox: index 0) でジャンプ
+            if (index === 0) gamepadJumpPressed = true;
         });
     });
     gamepadManager.onGamepadDisconnectedObservable.add(() => {
@@ -272,6 +292,21 @@ const start = async (): Promise<void> => {
     const autoScrollCheckbox = document.getElementById(
         "auto-scroll-toggle",
     ) as HTMLInputElement | null;
+    const jumpBtn = document.getElementById(
+        "jump-btn",
+    ) as HTMLButtonElement | null;
+    const jumpHeightSlider = document.getElementById(
+        "jump-height-slider",
+    ) as HTMLInputElement | null;
+    const jumpHeightDisplay = document.getElementById(
+        "jump-height-value",
+    ) as HTMLSpanElement | null;
+    const jumpGravitySlider = document.getElementById(
+        "jump-gravity-slider",
+    ) as HTMLInputElement | null;
+    const jumpGravityDisplay = document.getElementById(
+        "jump-gravity-value",
+    ) as HTMLSpanElement | null;
 
     const updateDisplay = (): void => {
         if (latDisplay) latDisplay.textContent = avatarLat.toFixed(6);
@@ -305,6 +340,40 @@ const start = async (): Promise<void> => {
                 tileCameraDetached = false;
             }
         });
+    }
+
+    if (jumpBtn) {
+        jumpBtn.addEventListener("pointerdown", () => {
+            jumpRequested = true;
+        });
+    }
+
+    if (jumpHeightSlider) {
+        jumpHeightSlider.value = String(jumpHeight);
+        if (jumpHeightDisplay) jumpHeightDisplay.textContent = `${jumpHeight}`;
+        jumpHeightSlider.addEventListener("input", () => {
+            jumpHeight = Number(jumpHeightSlider.value);
+            if (jumpHeightDisplay) jumpHeightDisplay.textContent = `${jumpHeight}`;
+        });
+    }
+
+    if (jumpGravitySlider) {
+        jumpGravitySlider.value = String(jumpGravity);
+        if (jumpGravityDisplay) jumpGravityDisplay.textContent = `${jumpGravity.toFixed(1)}`;
+        jumpGravitySlider.addEventListener("input", () => {
+            jumpGravity = Number(jumpGravitySlider.value);
+            if (jumpGravityDisplay) jumpGravityDisplay.textContent = `${jumpGravity.toFixed(1)}`;
+        });
+    }
+
+    // パネル操作後にキーボードフォーカスを canvas に戻す
+    const controlsPanel = document.getElementById("avatar-controls");
+    const canvas = mount.querySelector("canvas");
+    if (controlsPanel && canvas) {
+        canvas.tabIndex = 0;
+        const refocus = (): void => { canvas.focus(); };
+        controlsPanel.addEventListener("pointerup", refocus);
+        controlsPanel.addEventListener("change", refocus);
     }
 
     viewer.onTerrainClick((event: TerrainClickEvent) => {
@@ -364,78 +433,130 @@ const start = async (): Promise<void> => {
 
         const input = readInputs();
         const mag = moveVectorMagnitude(input);
-        const isMoving = mag > MOVING_THRESHOLD;
 
-        if (isMoving) {
-            const next = stepPosition(avatarLat, avatarLon, input, speedMps, dtSec);
-            avatarLat = next.lat;
-            avatarLon = next.lon;
-            const heading = movementHeading(input);
-            if (heading !== null) lastHeadingDeg = heading;
+        // --- ジャンプ開始判定 ---
+        const jumpTrigger = jumpRequested || gamepadJumpPressed || pressedKeys.has("Space");
+        jumpRequested = false;
+        gamepadJumpPressed = false;
+        if (jumpTrigger && !isJumping(jumpState)) {
+            jumpState = startJump(jumpHeight, jumpGravity, input);
+            // ジャンプ中は歩行アニメを停止
+            if (walking) {
+                viewer.stopModelAnimation(MODEL_ID, WALK_ANIM);
+                walking = false;
+            }
+        }
+
+        // --- ジャンプ中のフレーム更新 ---
+        if (isJumping(jumpState)) {
+            jumpState = tickJump(jumpState, jumpGravity, dtSec);
+            // ジャンプ中はロックされた方向で水平移動
+            const jumpDir = jumpState.active ? jumpState.lockedDirection : JUMP_IDLE.lockedDirection;
+            const jumpMag = moveVectorMagnitude(jumpDir);
+            if (jumpMag > MOVING_THRESHOLD) {
+                const next = stepPosition(avatarLat, avatarLon, jumpDir, speedMps, dtSec);
+                avatarLat = next.lat;
+                avatarLon = next.lon;
+                const heading = movementHeading(jumpDir);
+                if (heading !== null) lastHeadingDeg = heading;
+            }
             viewer.updateModel(MODEL_ID, {
                 lat: avatarLat,
                 lon: avatarLon,
                 altitudeMode: "terrain",
-                altitude: 0,
+                altitude: jumpState.altitude,
                 rotation: { y: lastHeadingDeg },
                 gravity: true,
             });
             updateDisplay();
+        } else {
+            // --- 通常移動 ---
+            const isMoving = mag > MOVING_THRESHOLD;
 
-            // 自動スクロール: アバターが画面端に近づいたらカメラを追従
-            // (Flight Follow モードと同じ二段構成: 滑らかな target 移動 + 距離スロットルされたタイル refresh)
-            if (autoScrollEnabled && arcCamera) {
-                const cameraLatNow = viewer.lat;
-                const cameraLonNow = viewer.lon;
-                // 2D (ortho) モードでは altitude/tilt から可視範囲を推定できないため、
-                // ortho サイズを extent として渡す。
-                // 短辺側を使うことでアスペクト比に関わらず画面外に出ないことを保証する。
-                const is2D = viewer.viewMode === "2d";
-                const viewExtentOverride = is2D
-                    ? Math.min(
-                          arcCamera.orthoTop ?? 0,
-                          arcCamera.orthoRight ?? 0,
-                      ) || undefined
-                    : undefined;
-                const scroll = computeAutoScroll({
-                    avatarLat,
-                    avatarLon,
-                    cameraLat: cameraLatNow,
-                    cameraLon: cameraLonNow,
-                    cameraAltitude: viewer.altitude,
-                    cameraTilt: viewer.tilt,
-                    deadzoneRatio: DEFAULT_DEADZONE_RATIO,
-                    scrollLerp: DEFAULT_SCROLL_LERP,
-                    viewExtentOverride,
+            if (isMoving) {
+                const next = stepPosition(avatarLat, avatarLon, input, speedMps, dtSec);
+                avatarLat = next.lat;
+                avatarLon = next.lon;
+                const heading = movementHeading(input);
+                if (heading !== null) lastHeadingDeg = heading;
+                viewer.updateModel(MODEL_ID, {
+                    lat: avatarLat,
+                    lon: avatarLon,
+                    altitudeMode: "terrain",
+                    altitude: 0,
+                    rotation: { y: lastHeadingDeg },
+                    gravity: true,
                 });
-                if (scroll.scrolled) {
-                    // 初回スクロール時に detach する（初期表示の境界タイル欠けを防ぐ）
-                    if (!tileCameraDetached) {
-                        viewer.detachTileCamera();
-                        tileCameraDetached = true;
-                    }
-                    // (1) camera.target を直接動かして滑らかに追従 (setter は呼ばない)
-                    const dLat = scroll.lat - cameraLatNow;
-                    const dLon = scroll.lon - cameraLonNow;
-                    const metersPerDegLon =
-                        METERS_PER_DEGREE_LAT *
-                        Math.cos((cameraLatNow * Math.PI) / 180);
-                    arcCamera.target.x += dLon * metersPerDegLon;
-                    arcCamera.target.z += dLat * METERS_PER_DEGREE_LAT;
+                updateDisplay();
+            }
 
-                    // (2) 距離スロットル + in-flight ガード付きでタイル refresh
-                    const refLatNow = viewer.lat;
-                    const refLonNow = viewer.lon;
-                    const movedLat =
-                        (refLatNow - lastRefreshLat) * METERS_PER_DEGREE_LAT;
-                    const movedLon =
-                        (refLonNow - lastRefreshLon) *
-                        METERS_PER_DEGREE_LAT *
-                        Math.cos((refLatNow * Math.PI) / 180);
-                    const movedM = Math.hypot(movedLat, movedLon);
-                    if (movedM >= SCROLL_REFRESH_DISTANCE_M) {
-                        triggerTileRefresh(timestamp);
-                    }
+            if (animationStarted) {
+                if (isMoving && !walking) {
+                    viewer.playModelAnimation(MODEL_ID, WALK_ANIM);
+                    walking = true;
+                } else if (!isMoving && walking) {
+                    viewer.stopModelAnimation(MODEL_ID, WALK_ANIM);
+                    walking = false;
+                }
+            }
+        }
+
+        // --- 自動スクロール ---
+        // ジャンプ中・通常移動どちらでも水平位置が変わるのでスクロール判定する
+        const isMovingForScroll = isJumping(jumpState)
+            ? moveVectorMagnitude(jumpState.lockedDirection) > MOVING_THRESHOLD
+            : mag > MOVING_THRESHOLD;
+        if (isMovingForScroll && autoScrollEnabled && arcCamera) {
+            const cameraLatNow = viewer.lat;
+            const cameraLonNow = viewer.lon;
+            // 2D (ortho) モードでは altitude/tilt から可視範囲を推定できないため、
+            // ortho サイズを extent として渡す。
+            // 短辺側を使うことでアスペクト比に関わらず画面外に出ないことを保証する。
+            const is2D = viewer.viewMode === "2d";
+            const viewExtentOverride = is2D
+                ? Math.min(
+                      arcCamera.orthoTop ?? 0,
+                      arcCamera.orthoRight ?? 0,
+                  ) || undefined
+                : undefined;
+            const scroll = computeAutoScroll({
+                avatarLat,
+                avatarLon,
+                cameraLat: cameraLatNow,
+                cameraLon: cameraLonNow,
+                cameraAltitude: viewer.altitude,
+                cameraTilt: viewer.tilt,
+                deadzoneRatio: DEFAULT_DEADZONE_RATIO,
+                scrollLerp: DEFAULT_SCROLL_LERP,
+                viewExtentOverride,
+            });
+            if (scroll.scrolled) {
+                // 初回スクロール時に detach する（初期表示の境界タイル欠けを防ぐ）
+                if (!tileCameraDetached) {
+                    viewer.detachTileCamera();
+                    tileCameraDetached = true;
+                }
+                // (1) camera.target を直接動かして滑らかに追従 (setter は呼ばない)
+                const dLat = scroll.lat - cameraLatNow;
+                const dLon = scroll.lon - cameraLonNow;
+                const metersPerDegLon =
+                    METERS_PER_DEGREE_LAT *
+                    Math.cos((cameraLatNow * Math.PI) / 180);
+                arcCamera.target.x += dLon * metersPerDegLon;
+                arcCamera.target.z += dLat * METERS_PER_DEGREE_LAT;
+
+                // (2) 距離スロットル + in-flight ガード付きでタイル refresh
+                const refLatNow = viewer.lat;
+                const refLonNow = viewer.lon;
+                const movedLat =
+                    (refLatNow - lastRefreshLat) * METERS_PER_DEGREE_LAT;
+                const movedLon =
+                    (refLonNow - lastRefreshLon) *
+                    METERS_PER_DEGREE_LAT *
+                    Math.cos((refLatNow * Math.PI) / 180);
+                const movedM = Math.hypot(movedLat, movedLon);
+                if (movedM >= SCROLL_REFRESH_DISTANCE_M) {
+                    triggerTileRefresh(timestamp);
                 }
             }
         }
@@ -469,16 +590,6 @@ const start = async (): Promise<void> => {
                 panM >= SCROLL_REFRESH_DISTANCE_M
             ) {
                 triggerTileRefresh(timestamp);
-            }
-        }
-
-        if (animationStarted) {
-            if (isMoving && !walking) {
-                viewer.playModelAnimation(MODEL_ID, WALK_ANIM);
-                walking = true;
-            } else if (!isMoving && walking) {
-                viewer.stopModelAnimation(MODEL_ID, WALK_ANIM);
-                walking = false;
             }
         }
 

--- a/src/demos/avatar-controller/index.ts
+++ b/src/demos/avatar-controller/index.ts
@@ -228,6 +228,8 @@ const start = async (): Promise<void> => {
     const pressedKeys = new Set<string>();
     const onKeyDown = (e: KeyboardEvent): void => {
         pressedKeys.add(e.code);
+        // Space はエッジトリガー（押した瞬間のみ）：着地後の即再ジャンプを防ぐ
+        if (e.code === "Space" && !e.repeat) jumpRequested = true;
     };
     const onKeyUp = (e: KeyboardEvent): void => {
         pressedKeys.delete(e.code);
@@ -435,7 +437,7 @@ const start = async (): Promise<void> => {
         const mag = moveVectorMagnitude(input);
 
         // --- ジャンプ開始判定 ---
-        const jumpTrigger = jumpRequested || gamepadJumpPressed || pressedKeys.has("Space");
+        const jumpTrigger = jumpRequested || gamepadJumpPressed;
         jumpRequested = false;
         gamepadJumpPressed = false;
         if (jumpTrigger && !isJumping(jumpState)) {

--- a/src/demos/avatar-controller/jump.ts
+++ b/src/demos/avatar-controller/jump.ts
@@ -5,7 +5,7 @@
  *
  * 物理モデル:
  * - 初速: v₀ = √(2 * g * h) — 指定高さ h に到達する鉛直初速
- * - 毎フレーム: altitude += velocity * dt, velocity -= gravity * dt
+ * - 毎フレーム: altitude += velocity * dt - 0.5 * g * dt² (等加速度の解析解), velocity -= gravity * dt
  * - 着地判定: altitude <= 0 → リセット
  *
  * 座標系:
@@ -82,8 +82,11 @@ export const tickJump = (
     if (dtSec <= 0) return state;
 
     const g = Math.max(gravity, 0.01);
+    // 等加速度の解析解: altitude += velocity * dt - 0.5 * g * dt²
+    // これにより任意の dt でも理論上の最高点 h = v₀²/(2g) を正確に再現できる。
+    // （velocity * dt のみだと peak で誤差が出る; newVelocity * dt は symplectic Euler で更に低くなる）
+    const newAltitude = state.altitude + state.velocity * dtSec - 0.5 * g * dtSec * dtSec;
     const newVelocity = state.velocity - g * dtSec;
-    const newAltitude = state.altitude + newVelocity * dtSec;
 
     // 着地判定
     if (newAltitude <= 0) {

--- a/src/demos/avatar-controller/jump.ts
+++ b/src/demos/avatar-controller/jump.ts
@@ -1,0 +1,104 @@
+/**
+ * ジャンプ物理モジュール (Issue #288)
+ *
+ * 純粋関数群。ジャンプの開始・毎フレーム更新・着地判定を提供する。
+ *
+ * 物理モデル:
+ * - 初速: v₀ = √(2 * g * h) — 指定高さ h に到達する鉛直初速
+ * - 毎フレーム: altitude += velocity * dt, velocity -= gravity * dt
+ * - 着地判定: altitude <= 0 → リセット
+ *
+ * 座標系:
+ * - altitude: 地表からの高さ (m)。0 = 地面。
+ * - velocity: 上向きが正 (m/s)。
+ */
+
+import type { MoveVector } from "./movement";
+
+/** ジャンプ状態 */
+export interface JumpState {
+    /** ジャンプ中か */
+    readonly active: boolean;
+    /** 現在の高度オフセット (m)。地面 = 0 */
+    readonly altitude: number;
+    /** 鉛直速度 (m/s)。上向き正 */
+    readonly velocity: number;
+    /** ジャンプ開始時にロックされた移動方向 */
+    readonly lockedDirection: MoveVector;
+}
+
+/** ジャンプしていない初期状態 */
+export const JUMP_IDLE: JumpState = {
+    active: false,
+    altitude: 0,
+    velocity: 0,
+    lockedDirection: { vx: 0, vy: 0 },
+};
+
+/** デフォルトのジャンプ高さ (MODEL_SCALE=50 のワールドで体感調整済み) */
+export const DEFAULT_JUMP_HEIGHT = 100;
+
+/** デフォルトの重力加速度 (9.81 × MODEL_SCALE でワールドスケールに合わせた値) */
+export const DEFAULT_GRAVITY = 9.81 * 50;
+
+/**
+ * ジャンプを開始する。
+ *
+ * @param jumpHeight ジャンプの最高到達高さ (m)
+ * @param gravity 重力加速度 (m/s²)
+ * @param direction ジャンプ開始時の移動入力（ロックされる）
+ * @returns 新しい JumpState（active=true、初速計算済み）
+ */
+export const startJump = (
+    jumpHeight: number,
+    gravity: number,
+    direction: MoveVector,
+): JumpState => {
+    const h = Math.max(jumpHeight, 0);
+    const g = Math.max(gravity, 0.01);
+    const v0 = Math.sqrt(2 * g * h);
+    return {
+        active: true,
+        altitude: 0,
+        velocity: v0,
+        lockedDirection: { vx: direction.vx, vy: direction.vy },
+    };
+};
+
+/**
+ * ジャンプの1フレーム更新。
+ *
+ * @param state 現在のジャンプ状態
+ * @param gravity 重力加速度 (m/s²)
+ * @param dtSec フレーム時間 (秒)
+ * @returns 更新後の JumpState。着地した場合は active=false。
+ */
+export const tickJump = (
+    state: JumpState,
+    gravity: number,
+    dtSec: number,
+): JumpState => {
+    if (!state.active) return state;
+    if (dtSec <= 0) return state;
+
+    const g = Math.max(gravity, 0.01);
+    const newVelocity = state.velocity - g * dtSec;
+    const newAltitude = state.altitude + newVelocity * dtSec;
+
+    // 着地判定
+    if (newAltitude <= 0) {
+        return JUMP_IDLE;
+    }
+
+    return {
+        active: true,
+        altitude: newAltitude,
+        velocity: newVelocity,
+        lockedDirection: state.lockedDirection,
+    };
+};
+
+/**
+ * ジャンプ中かどうかを返す。
+ */
+export const isJumping = (state: JumpState): boolean => state.active;

--- a/tests/jump.unit.spec.ts
+++ b/tests/jump.unit.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * `src/demos/avatar-controller/jump.ts` の unit test (Issue #288)。
+ *
+ * ジャンプ物理: startJump / tickJump / 着地判定 / 方向ロックを検証する。
+ */
+import { describe, it, expect } from "@jest/globals";
+
+import {
+    DEFAULT_GRAVITY,
+    DEFAULT_JUMP_HEIGHT,
+    isJumping,
+    JUMP_IDLE,
+    startJump,
+    tickJump,
+} from "../src/demos/avatar-controller/jump";
+
+describe("startJump", () => {
+    it("active=true で初速が正の値になる", () => {
+        const state = startJump(DEFAULT_JUMP_HEIGHT, DEFAULT_GRAVITY, { vx: 0, vy: 0 });
+        expect(state.active).toBe(true);
+        expect(state.velocity).toBeGreaterThan(0);
+        expect(state.altitude).toBe(0);
+    });
+
+    it("初速が v₀ = √(2*g*h) になる", () => {
+        const h = 100;
+        const g = 9.81;
+        const state = startJump(h, g, { vx: 0, vy: 0 });
+        const expected = Math.sqrt(2 * g * h);
+        expect(state.velocity).toBeCloseTo(expected, 5);
+    });
+
+    it("方向がロックされる", () => {
+        const dir = { vx: 0.5, vy: -0.3 };
+        const state = startJump(100, 9.81, dir);
+        expect(state.lockedDirection).toEqual(dir);
+    });
+
+    it("jumpHeight=0 なら初速 0", () => {
+        const state = startJump(0, 9.81, { vx: 0, vy: 0 });
+        expect(state.velocity).toBe(0);
+    });
+
+    it("負の jumpHeight は 0 にクランプされる", () => {
+        const state = startJump(-10, 9.81, { vx: 0, vy: 0 });
+        expect(state.velocity).toBe(0);
+    });
+});
+
+describe("tickJump", () => {
+    it("上昇中は altitude が増加する", () => {
+        const state = startJump(100, 9.81, { vx: 0, vy: 0 });
+        const next = tickJump(state, 9.81, 0.016);
+        expect(next.altitude).toBeGreaterThan(0);
+        expect(next.active).toBe(true);
+    });
+
+    it("velocity は重力で減少する", () => {
+        const state = startJump(100, 9.81, { vx: 0, vy: 0 });
+        const next = tickJump(state, 9.81, 0.016);
+        expect(next.velocity).toBeLessThan(state.velocity);
+    });
+
+    it("着地すると IDLE に戻る", () => {
+        // 大きな dt で確実に着地させる
+        const state = startJump(10, 9.81, { vx: 1, vy: 0 });
+        const landed = tickJump(state, 9.81, 100);
+        expect(landed.active).toBe(false);
+        expect(landed.altitude).toBe(0);
+        expect(landed.velocity).toBe(0);
+    });
+
+    it("active=false なら何もしない", () => {
+        const result = tickJump(JUMP_IDLE, 9.81, 0.016);
+        expect(result).toBe(JUMP_IDLE);
+    });
+
+    it("dtSec <= 0 なら状態を保持する", () => {
+        const state = startJump(100, 9.81, { vx: 0, vy: 0 });
+        expect(tickJump(state, 9.81, 0)).toBe(state);
+        expect(tickJump(state, 9.81, -1)).toBe(state);
+    });
+
+    it("lockedDirection はフレーム更新で変化しない", () => {
+        const dir = { vx: 0.7, vy: 0.2 };
+        const state = startJump(200, 9.81, dir);
+        const next = tickJump(state, 9.81, 0.016);
+        expect(next.lockedDirection).toEqual(dir);
+    });
+
+    it("十分な時間が経つと正確に着地する（放物運動）", () => {
+        const h = 50;
+        const g = 9.81;
+        // 理論的な滞空時間: t = 2 * v₀ / g = 2 * √(2gh) / g
+        const v0 = Math.sqrt(2 * g * h);
+        const totalTime = (2 * v0) / g;
+
+        // 小さいステップで積分
+        let state = startJump(h, g, { vx: 0, vy: 0 });
+        const dt = 0.001;
+        let time = 0;
+        while (state.active && time < totalTime * 2) {
+            state = tickJump(state, g, dt);
+            time += dt;
+        }
+        // 着地していること
+        expect(state.active).toBe(false);
+        // 滞空時間が理論値に近いこと（数値誤差 1% 以内）
+        expect(time).toBeCloseTo(totalTime, 1);
+    });
+});
+
+describe("isJumping", () => {
+    it("IDLE では false", () => {
+        expect(isJumping(JUMP_IDLE)).toBe(false);
+    });
+
+    it("startJump 後は true", () => {
+        const state = startJump(100, 9.81, { vx: 0, vy: 0 });
+        expect(isJumping(state)).toBe(true);
+    });
+});


### PR DESCRIPTION
## 概要

アバター操作デモにジャンプ機能を追加。

Closes #288

## 変更内容

- **新規** `src/demos/avatar-controller/jump.ts` — ジャンプ物理の純粋関数モジュール
- **変更** `src/demos/avatar-controller/index.ts` — 入力検出・状態管理・altitude反映・フォーカス制御
- **変更** `public/avatar-controller.html` — JUMPボタン(右下)・高さ/重力スライダー追加
- **新規** `tests/jump.unit.spec.ts` — 14テストケース

## 操作方法

| 入力 | アクション |
|------|-----------|
| Space キー | ジャンプ |
| Gamepad A ボタン | ジャンプ |
| 画面右下 JUMP ボタン | ジャンプ（タッチ用） |

## 仕様

- ジョイスティック方向にジャンプ（水平移動あり）
- ジャンプ中は方向ロック（着地まで変更不可）
- センター入力時はその場ジャンプ
- パネルでジャンプ高さ・重力加速度を調整可能
- パネル操作後にcanvasへフォーカス自動復帰

## 影響範囲

- avatar-controller デモのみ。ライブラリ本体・他デモへの影響なし。
- **歩行速度のデフォルトを 10 → 30 m/s に変更**（ジャンプとのバランス改善のため意図的に変更。TS・HTML両側同期済み）

## テスト結果

- `npm run test:unit`: 900テスト全合格
- `npm run lint`: パス
- `npm run typecheck`: パス