### PR TITLE
fix: align demo portal card heights per row

### DIFF
--- a/public/portal.html
+++ b/public/portal.html
@@ -46,6 +46,8 @@
 
     li.demo-card a {
       display: block;
+      height: 100%;
+      box-sizing: border-box;
       padding: 20px 20px 22px;
       background: rgba(255, 255, 255, 0.04);
       border: 1px solid rgba(255, 255, 255, 0.08);


### PR DESCRIPTION
## 変更内容

`portal.html` の `li.demo-card a` に `height: 100%` と `box-sizing: border-box` を追加し、CSS Grid の行内ストレッチによりカード高さを行ごとに揃えます。

Closes #299