### PR TITLE
fix(terrain): stitch tiles across LOD boundaries at high zoom (#290)

### DIFF
--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -1357,6 +1357,9 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
 
     /** 新タイルの隣接タイル（同zoom、アクティブなもの）を再ステッチキューに追加 */
     const restitchNeighbors = (coord: TileCoord): void => {
+        // dispose 後に clearAllPendingRelease → releasePendingTile 経由で呼ばれても
+        // スケジューリングしない（タイマー残留・dispose 後 callback 発火を防ぐ）。
+        if (disposed) return;
         const { zoom: z, x, y } = coord;
         const deltas = [
             [0, -1], [0, 1], [-1, 0], [1, 0],

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -27,8 +27,8 @@ import {
     isInvalidElev,
     NO_DATA_SENTINEL,
 } from "./gsiTile";
-import { stitchTileEdges, stitchTileEdgesCrossLevel } from "./tileStitching";
-import type { CoarseEdgeNeighbor } from "./tileStitching";
+import { stitchTileEdges, stitchTileEdgesCrossLevel, selectCoarseEdgeNeighbors } from "./tileStitching";
+import type { CoarseEdgeNeighbor, CoarseTileSource } from "./tileStitching";
 import { createElevationWorkerPool, type ElevationWorkerPool } from "./elevationWorkerPool";
 
 export interface TileManagerOptions {
@@ -112,6 +112,15 @@ interface PendingReleaseTile {
     tileSize: number;
     /** 強制解放用タイマーID */
     timerId: ReturnType<typeof setTimeout>;
+    /**
+     * pendingRelease 中も隣接細タイルから cross-level 縫い合わせ参照されるため、
+     * cache が LRU で退避されても elevation を保持しておく (Issue #290)。
+     * filled が無い場合は raw elevation を利用する。
+     */
+    elevation: Float32Array;
+    filled?: Float32Array;
+    wasAllNaN?: boolean;
+    unblocked?: boolean;
 }
 
 const DEFAULT_MAX_CONCURRENT = 4;
@@ -120,12 +129,9 @@ const DEFAULT_CACHE_CAPACITY = 192;
 const DEFAULT_DEBOUNCE_MS = 200;
 /** Frustum 判定用の基準最大標高 (m) — 富士山 3776m + マージン */
 const MAX_BASE_ELEVATION = 4000;
-/**
- * クロスレベル縫い合わせを適用する「カメラ近傍」判定の距離係数。
- * タイル中心とカメラの 3D 距離が `tileSize × NEAR_DISTANCE_TILES_FACTOR` 以下なら近傍とみなす。
- * 値が大きいほど縫い合わせ対象が広がる。遠方タイルは隙間が視認しにくいため、近傍のみに限定する。
+/*
+ * 旧 NEAR_DISTANCE_TILES_FACTOR 定数は Issue #290 対応で isTileNearCamera と共に撤廃。
  */
-const NEAR_DISTANCE_TILES_FACTOR = 3;
 /** 旧タイルの強制解放までのタイムアウト (ms) */
 const PENDING_RELEASE_TIMEOUT_MS = 5000;
 
@@ -432,6 +438,9 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         textureRequestIds.set(pending.mesh, (textureRequestIds.get(pending.mesh) ?? 0) + 1);
         meshPool.release(pending.mesh);
         removePendingRelease(key);
+        // 解放した粗タイルにスナップしていた可能性のある隣接細 active タイルを
+        // 再ステッチして、スナップ元消失後の整合性を取り直す (Issue #290)。
+        restitchNeighbors(pending.coord);
     };
 
     /** pendingRelease を全てクリアする */
@@ -1128,28 +1137,14 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         };
     };
 
-    /**
-     * カメラがタイル中心に近いか判定する。
-     * タイル中心（XZ 平面上）とカメラ（target 原点ローカル）との 3D 距離が
-     * `tileSize × NEAR_DISTANCE_TILES_FACTOR` 以下なら true。
-     * クロスレベル縫い合わせを近傍に限定するために用いる。
+    /*
+     * 旧 isTileNearCamera ヘルパーは Issue #290 対応により撤廃。
+     * 高 zoom (例: 18) では tileSize が小さく、カメラ高度が少しでもあると
+     * 近傍判定が常に false になり cross-level 縫い合わせが走らず、zoom 17/18
+     * 混在境界で隙間が顕在化していた。現在は粗タイル隣接が存在する場合のみ
+     * `stitchTileEdgesCrossLevel` が実コストを発生させる no-op 安全な
+     * 設計のため、距離ゲートを撤廃して常時適用に切り替えている。
      */
-    const isTileNearCamera = (coord: TileCoord, tileSize: number): boolean => {
-        if (!currentCenter) return false;
-        const center = convertTileZoom(currentCenter, coord.zoom);
-        const { fracX, fracY } = computeSubTileOffset(currentCenter, coord.zoom);
-        const dx = coord.x - center.x;
-        const dy = coord.y - center.y;
-        const { wx, wz } = tileOffsetToWorld(dx - fracX, dy - fracY, tileSize);
-        // camera position は target 原点ローカル。タイル中心は y=0 平面。
-        const cx = camera.position.x - camera.target.x;
-        const cy = camera.position.y - camera.target.y;
-        const cz = camera.position.z - camera.target.z;
-        const ex = wx - cx;
-        const ez = wz - cz;
-        const dist = Math.sqrt(ex * ex + cy * cy + ez * ez);
-        return dist <= tileSize * NEAR_DISTANCE_TILES_FACTOR;
-    };
 
     /**
      * target タイルの 4 辺それぞれについて、辺を共有する粗 zoom のアクティブタイルを
@@ -1157,55 +1152,39 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
      * 同 zoom の隣接タイルが存在する場合はその辺は対象外（同 zoom の縫い合わせに任せる）。
      */
     const getCoarseEdgeNeighbors = (coord: TileCoord): CoarseEdgeNeighbor[] => {
-        const result: CoarseEdgeNeighbor[] = [];
-        const { zoom: z, x, y } = coord;
-        const dirs = [
-            { dir: "top" as const, ndx: 0, ndy: -1 },
-            { dir: "bottom" as const, ndx: 0, ndy: 1 },
-            { dir: "left" as const, ndx: -1, ndy: 0 },
-            { dir: "right" as const, ndx: 1, ndy: 0 },
-        ];
-        for (const d of dirs) {
-            // 同 zoom 隣接が存在すればクロスレベル不要
-            const sameZoomKey = toTileKey({ zoom: z, x: x + d.ndx, y: y + d.ndy });
-            if (activeTiles.has(sameZoomKey)) continue;
-
-            // 粗 zoom を z-1 から minZoom まで降順で探索（細かい粗 zoom を優先）
-            for (let zp = z - 1; zp >= minZoom; zp--) {
-                const diff = z - zp;
-                const scale = 1 << diff;
-                const subX = x & (scale - 1);
-                const subY = y & (scale - 1);
-                // target の辺が親タイルの境界辺と一致する条件
-                let onParentEdge: boolean;
-                switch (d.dir) {
-                    case "top": onParentEdge = subY === 0; break;
-                    case "bottom": onParentEdge = subY === scale - 1; break;
-                    case "left": onParentEdge = subX === 0; break;
-                    case "right": onParentEdge = subX === scale - 1; break;
+        const isSameZoomVisible = (c: { zoom: number; x: number; y: number }): boolean => {
+            const k = toTileKey(c);
+            // hiddenChildTiles に入っている同 zoom 隣接は実画面上は未描画 (親 pendingRelease を表示中)
+            // のため、cross-level 探索を継続させる (Issue #290)。
+            return activeTiles.has(k) && !hiddenChildTiles.has(k);
+        };
+        const lookupCoarse = (c: { zoom: number; x: number; y: number }): CoarseTileSource | undefined => {
+            const k = toTileKey(c);
+            // 優先: active な粗タイル（cache から elevation を取得）
+            if (activeTiles.has(k)) {
+                const entry = cache.get(k);
+                if (entry) {
+                    return {
+                        elevation: entry.filled ?? entry.elevation,
+                        wasAllNaN: entry.wasAllNaN,
+                        unblocked: entry.unblocked,
+                    };
                 }
-                if (!onParentEdge) continue;
-
-                const px = x >> diff;
-                const py = y >> diff;
-                const ncx = px + d.ndx;
-                const ncy = py + d.ndy;
-                const nKey = toTileKey({ zoom: zp, x: ncx, y: ncy });
-                if (!activeTiles.has(nKey)) continue;
-                const entry = cache.get(nKey);
-                if (!entry) continue;
-                if (entry.wasAllNaN && !entry.unblocked) continue;
-                result.push({
-                    elevation: entry.filled ?? entry.elevation,
-                    direction: d.dir,
-                    subX,
-                    subY,
-                    scale,
-                });
-                break;
             }
-        }
-        return result;
+            // フォールバック: pendingRelease 中の旧粗タイル (Issue #290)
+            // cache が LRU 退避済みでも pending entry は elevation を保持している。
+            const pending = pendingRelease.get(k);
+            if (pending) {
+                const entry = cache.get(k);
+                return {
+                    elevation: entry?.filled ?? entry?.elevation ?? pending.filled ?? pending.elevation,
+                    wasAllNaN: entry?.wasAllNaN ?? pending.wasAllNaN,
+                    unblocked: entry?.unblocked ?? pending.unblocked,
+                };
+            }
+            return undefined;
+        };
+        return selectCoarseEdgeNeighbors(coord, minZoom, isSameZoomVisible, lookupCoarse);
     };
 
     /** Web Worker による標高 → 頂点 / 法線変換のオフロード用プール */
@@ -1292,12 +1271,14 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
         const cacheEntryPre = cache.get(toTileKey(coord));
 
         // 異 zoom 隣接（粗タイル）と縫い合わせ。
-        // - 通常タイルはカメラ近傍のみ対象（再適用時の計算コスト抑制）
-        // - all-NaN タイルは同 zoom 近傍からシードが得られない場合があるため
-        //   カメラ距離に関わらず常に試行する
-        const tileSize = tileSizeForZoom(coord.zoom);
-        const crossLevel = !!cacheEntryPre?.wasAllNaN || isTileNearCamera(coord, tileSize);
-        const { stitched, hasSeed } = stitchAndCheckSeed(elevation, coord, crossLevel);
+        // - 粗タイル隣接が存在する場合のみ実コストが発生する純粋な no-op 安全な処理。
+        //   高 zoom (例: 18) ではタイル辺長が小さく、旧 `isTileNearCamera` ゲートが
+        //   ほぼ常に false となり cross-level が走らず、zoom 17/18 混在境界で
+        //   隙間が顕在化していた (Issue #290)。よって候補が無ければ no-op になる
+        //   stitchAndCheckSeed に常に crossLevel=true を渡し、近傍距離ゲートは撤廃する。
+        // - all-NaN タイルは同 zoom 近傍からシードが得られない場合があるため、
+        //   こちらも従来通り cross-level でシードを取りに行く（true なので包含）。
+        const { stitched, hasSeed } = stitchAndCheckSeed(elevation, coord, true);
 
         // NaN を埋める（BFS）
         // wasAllNaN でシードなしの場合、フロンティアが空で BFS は進まず
@@ -1406,7 +1387,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
             }
         }
 
-        if (restitchRafId === null) {
+        if (restitchRafId === null && typeof requestAnimationFrame === "function") {
             restitchRafId = requestAnimationFrame(flushRestitch);
         }
     };
@@ -1686,13 +1667,23 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
                         const timerId = setTimeout(() => {
                             releasePendingTile(key);
                         }, PENDING_RELEASE_TIMEOUT_MS);
+                        // cache が LRU 退避しても cross-level 縫い合わせから参照できるように
+                        // elevation/filled を pending entry に保持する (Issue #290)。
+                        const entry = cache.get(key);
                         addPendingRelease(key, {
                             key: tile.key,
                             coord: tile.coord,
                             mesh: tile.mesh,
                             tileSize: tile.tileSize,
                             timerId,
+                            elevation: entry?.elevation ?? new Float32Array(0),
+                            filled: entry?.filled,
+                            wasAllNaN: entry?.wasAllNaN,
+                            unblocked: entry?.unblocked,
                         });
+                        // pendingRelease に新規追加された粗タイルの境界に接する
+                        // 既存細 active タイルを再ステッチキューに積む (Issue #290)。
+                        restitchNeighbors(tile.coord);
                     }
                 } else {
                     // 横パン外 or hiddenChildTiles タイル: 即座にメッシュ解放

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -134,6 +134,14 @@ const MAX_BASE_ELEVATION = 4000;
  */
 /** 旧タイルの強制解放までのタイムアウト (ms) */
 const PENDING_RELEASE_TIMEOUT_MS = 5000;
+/**
+ * cache が LRU 退避済みで elevation を取得できない pendingRelease タイル向けの
+ * 共有センチネルバッファ。wasAllNaN=true / unblocked=false と組み合わせて使い、
+ * cross-level / queryLocalElevation の候補除外ゲートを通過させる目的のみに使う。
+ * 実際に標高値として読まれることはないため、全タイルで 1 インスタンスを共有して
+ * 毎回 new Float32Array(256*256) を確保するメモリスパイクを避ける。
+ */
+const EMPTY_NAN_ELEVATION = new Float32Array(TILE_SIZE * TILE_SIZE).fill(NaN);
 
 // 旧 applyElevation はインラインで使われていたが、Web Worker への移行に伴い
 // `elevationCompute.ts` の `applyElevationToPositions` に集約された。
@@ -1697,7 +1705,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
                             mesh: tile.mesh,
                             tileSize: tile.tileSize,
                             timerId,
-                            elevation: entry?.elevation ?? new Float32Array(TILE_SIZE * TILE_SIZE).fill(NaN),
+                            elevation: entry?.elevation ?? EMPTY_NAN_ELEVATION,
                             filled: entry?.filled,
                             wasAllNaN: entry?.wasAllNaN ?? true,
                             unblocked: entry?.unblocked ?? false,

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -1669,6 +1669,8 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
                         }, PENDING_RELEASE_TIMEOUT_MS);
                         // cache が LRU 退避しても cross-level 縫い合わせから参照できるように
                         // elevation/filled を pending entry に保持する (Issue #290)。
+                        // entry が undefined（LRU 退避済み）の場合は NaN バッファを保持し、
+                        // wasAllNaN=true / unblocked=false で cross-level 候補から自動除外する。
                         const entry = cache.get(key);
                         addPendingRelease(key, {
                             key: tile.key,
@@ -1676,10 +1678,10 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
                             mesh: tile.mesh,
                             tileSize: tile.tileSize,
                             timerId,
-                            elevation: entry?.elevation ?? new Float32Array(0),
+                            elevation: entry?.elevation ?? new Float32Array(TILE_SIZE * TILE_SIZE).fill(NaN),
                             filled: entry?.filled,
-                            wasAllNaN: entry?.wasAllNaN,
-                            unblocked: entry?.unblocked,
+                            wasAllNaN: entry?.wasAllNaN ?? true,
+                            unblocked: entry?.unblocked ?? false,
                         });
                         // pendingRelease に新規追加された粗タイルの境界に接する
                         // 既存細 active タイルを再ステッチキューに積む (Issue #290)。

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -372,6 +372,8 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
     /** 再ステッチ待ちの隣接タイルキーを蓄積し、同一フレームで一括処理する */
     const pendingRestitch = new Set<TileKey>();
     let restitchRafId: number | null = null;
+    /** RAF 非対応環境（Node.js / SSR）用の setTimeout フォールバック ID */
+    let restitchTimerId: ReturnType<typeof setTimeout> | null = null;
     /** flushRestitch 内で実行中の applyStitchedElevation Promise 数 */
     let restitchingCount = 0;
 
@@ -1324,6 +1326,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
     /** 蓄積された再ステッチ対象タイルを一括処理する */
     const flushRestitch = (): void => {
         restitchRafId = null;
+        restitchTimerId = null;
         const promises: Promise<void>[] = [];
         for (const key of pendingRestitch) {
             const neighborTile = activeTiles.get(key);
@@ -1387,8 +1390,14 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
             }
         }
 
-        if (restitchRafId === null && typeof requestAnimationFrame === "function") {
-            restitchRafId = requestAnimationFrame(flushRestitch);
+        if (restitchRafId === null && restitchTimerId === null) {
+            if (typeof requestAnimationFrame === "function") {
+                restitchRafId = requestAnimationFrame(flushRestitch);
+            } else {
+                // RAF 非対応環境（SSR / Node.js / 一部テスト）向けフォールバック。
+                // scheduleTextureFlush と同様に setTimeout(..., 16) で次フレーム相当に遅延する。
+                restitchTimerId = setTimeout(flushRestitch, 16);
+            }
         }
     };
 
@@ -1956,6 +1965,10 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
                 cancelAnimationFrame(restitchRafId);
                 restitchRafId = null;
             }
+            if (restitchTimerId !== null) {
+                clearTimeout(restitchTimerId);
+                restitchTimerId = null;
+            }
             pendingRestitch.clear();
             restitchingCount = 0;
             clearAllPendingRelease();
@@ -1992,6 +2005,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
                 && textureJobQueue.length === 0
                 && pendingTextureCount === 0
                 && restitchRafId === null
+                && restitchTimerId === null
                 && restitchingCount === 0;
         },
 

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -1545,11 +1545,18 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
             // 表示メッシュと異なる標高データを返すとアバターが地面に潜る原因になる。
             if (hiddenChildTiles.has(key)) continue;
             if (!activeTiles.has(key) && !pendingRelease.has(key)) continue;
-            const entry = cache.get(key);
-            if (!entry) continue;
+            // cache が LRU 退避済みの pendingRelease タイルは PendingReleaseTile に保持した
+            // elevation/filled をフォールバックとして使う (Issue #290)。
+            const cacheEntry = cache.get(key);
+            const pendingEntry = cacheEntry ? undefined : pendingRelease.get(key);
+            if (!cacheEntry && !pendingEntry) continue;
+            const wasAllNaN = cacheEntry ? cacheEntry.wasAllNaN : pendingEntry!.wasAllNaN;
+            const unblocked = cacheEntry ? cacheEntry.unblocked : pendingEntry!.unblocked;
             // まだ解決できていない all-NaN タイルはスキップ
-            if (entry.wasAllNaN && !entry.unblocked) continue;
-            const data = entry.filled ?? entry.elevation;
+            if (wasAllNaN && !unblocked) continue;
+            const data = cacheEntry
+                ? (cacheEntry.filled ?? cacheEntry.elevation)
+                : (pendingEntry!.filled ?? pendingEntry!.elevation);
             const fx = tileXFloat - tileXInt;
             const fy = tileYFloat - tileYInt;
 

--- a/src/terrain/tileStitching.ts
+++ b/src/terrain/tileStitching.ts
@@ -127,6 +127,88 @@ export const stitchTileEdges = (
     }
 };
 
+/** タイル座標（zoom/x/y）。stitching ユーティリティ内では tileManager とは独立に扱う。 */
+export interface CoarseTileCoord {
+    zoom: number;
+    x: number;
+    y: number;
+}
+
+/**
+ * `selectCoarseEdgeNeighbors` のための粗タイル参照ソース。
+ * elevation はそのままクロスレベル縫い合わせに使われる（filled 優先）。
+ * - `wasAllNaN && !unblocked` の場合は誤伝搬防止のため候補から除外する。
+ */
+export interface CoarseTileSource {
+    elevation: Float32Array;
+    wasAllNaN?: boolean;
+    unblocked?: boolean;
+}
+
+/**
+ * クロスレベル縫い合わせ候補（粗タイル隣接）を選定する純関数。
+ *
+ * tileManager の active/pendingRelease/hidden 状態を抽象化したコールバックで受け取り、
+ * pure に判定する。Issue #290 の対応として:
+ *  - 同 zoom 隣接が「描画中（active かつ hidden でない）」場合のみクロスレベルを抑止する
+ *  - 粗 zoom 候補は active だけでなく `pendingRelease` 中の旧タイルも参照する
+ *
+ * @param coord 対象タイル座標
+ * @param minZoom 最小 zoom（粗 zoom 探索の下限）
+ * @param isSameZoomVisible 同 zoom 隣接が実画面に出ているかを判定（true なら cross-level 不要）
+ * @param lookupCoarse 粗 zoom 隣接の参照ソースを返す。存在しない場合は undefined
+ */
+export const selectCoarseEdgeNeighbors = (
+    coord: CoarseTileCoord,
+    minZoom: number,
+    isSameZoomVisible: (c: CoarseTileCoord) => boolean,
+    lookupCoarse: (c: CoarseTileCoord) => CoarseTileSource | undefined,
+): CoarseEdgeNeighbor[] => {
+    const result: CoarseEdgeNeighbor[] = [];
+    const { zoom: z, x, y } = coord;
+    const dirs = [
+        { dir: "top" as const, ndx: 0, ndy: -1 },
+        { dir: "bottom" as const, ndx: 0, ndy: 1 },
+        { dir: "left" as const, ndx: -1, ndy: 0 },
+        { dir: "right" as const, ndx: 1, ndy: 0 },
+    ];
+    for (const d of dirs) {
+        // 同 zoom 隣接が実画面に出ていればクロスレベル不要
+        if (isSameZoomVisible({ zoom: z, x: x + d.ndx, y: y + d.ndy })) continue;
+
+        // 粗 zoom を z-1 から minZoom まで降順で探索（細かい粗 zoom を優先）
+        for (let zp = z - 1; zp >= minZoom; zp--) {
+            const diff = z - zp;
+            const scale = 1 << diff;
+            const subX = x & (scale - 1);
+            const subY = y & (scale - 1);
+            let onParentEdge: boolean;
+            switch (d.dir) {
+                case "top": onParentEdge = subY === 0; break;
+                case "bottom": onParentEdge = subY === scale - 1; break;
+                case "left": onParentEdge = subX === 0; break;
+                case "right": onParentEdge = subX === scale - 1; break;
+            }
+            if (!onParentEdge) continue;
+
+            const px = x >> diff;
+            const py = y >> diff;
+            const src = lookupCoarse({ zoom: zp, x: px + d.ndx, y: py + d.ndy });
+            if (!src) continue;
+            if (src.wasAllNaN && !src.unblocked) continue;
+            result.push({
+                elevation: src.elevation,
+                direction: d.dir,
+                subX,
+                subY,
+                scale,
+            });
+            break;
+        }
+    }
+    return result;
+};
+
 /** クロスレベル縫い合わせで参照する粗タイル隣接情報 */
 export interface CoarseEdgeNeighbor {
     /** 粗タイルの標高データ（target と同じ tileSize 解像度） */

--- a/tests/tileStitching.unit.spec.ts
+++ b/tests/tileStitching.unit.spec.ts
@@ -3,10 +3,12 @@ import {
     nanMean,
     stitchTileEdges,
     stitchTileEdgesCrossLevel,
+    selectCoarseEdgeNeighbors,
 } from "../src/terrain/tileStitching";
 import type {
     StitchNeighbors,
     CoarseEdgeNeighbor,
+    CoarseTileSource,
 } from "../src/terrain/tileStitching";
 
 // --- nanMean ---
@@ -433,5 +435,124 @@ describe("stitchTileEdgesCrossLevel", () => {
         // 角は変わらない
         expect(target[0]).toBe(0);
         expect(target[SS - 1]).toBe(0);
+    });
+});
+
+// --- selectCoarseEdgeNeighbors (Issue #290) ---
+
+describe("selectCoarseEdgeNeighbors", () => {
+    const makeElev = (v: number, size = 4): Float32Array => new Float32Array(size * size).fill(v);
+
+    it("同 zoom 隣接が描画中のときは cross-level 候補に含めない", () => {
+        // 全方向の同 zoom 隣接が visible → 結果は空
+        const coord = { zoom: 14, x: 14546, y: 6450 };
+        const result = selectCoarseEdgeNeighbors(
+            coord,
+            12,
+            () => true,
+            () => ({ elevation: makeElev(100) }),
+        );
+        expect(result).toEqual([]);
+    });
+
+    it("同 zoom 隣接が hidden（描画されていない）扱いなら粗タイル探索を続行する", () => {
+        // isSameZoomVisible は常に false（hidden 相当）
+        // 親 zoom=13 の上辺（subY===0 の場合）にのみ粗タイルあり
+        const coord = { zoom: 14, x: 14546, y: 6450 }; // subX=0, subY=0 at scale=2 (zoom 13)
+        const coarseElev = makeElev(200);
+        const calls: Array<{ zoom: number; x: number; y: number }> = [];
+        const result = selectCoarseEdgeNeighbors(
+            coord,
+            13,
+            () => false,
+            (c) => {
+                calls.push(c);
+                // top 方向のみヒット (zoom=13 の上隣)
+                if (c.zoom === 13 && c.x === 7273 && c.y === 3224) {
+                    return { elevation: coarseElev };
+                }
+                return undefined;
+            },
+        );
+        // 少なくとも top 方向で粗タイルが見つかる
+        const top = result.find((r) => r.direction === "top");
+        expect(top).toBeDefined();
+        expect(top!.elevation).toBe(coarseElev);
+        expect(top!.scale).toBe(2);
+    });
+
+    it("pendingRelease 相当の粗タイルソースもクロスレベル候補として参照できる", () => {
+        // 「active には無いが pending には有る」状況を lookupCoarse 単一フックで表現
+        const coord = { zoom: 14, x: 14546, y: 6450 }; // top 辺で粗タイル(zoom=13)に接する
+        const pendingElev = makeElev(300);
+        const result = selectCoarseEdgeNeighbors(
+            coord,
+            13,
+            () => false, // 同 zoom 隣接は描画されていない
+            (c): CoarseTileSource | undefined => {
+                if (c.zoom === 13 && c.x === 7273 && c.y === 3224) {
+                    return { elevation: pendingElev };
+                }
+                return undefined;
+            },
+        );
+        const top = result.find((r) => r.direction === "top");
+        expect(top).toBeDefined();
+        expect(top!.elevation).toBe(pendingElev);
+    });
+
+    it("wasAllNaN && !unblocked の粗タイルは候補から除外される", () => {
+        const coord = { zoom: 14, x: 14546, y: 6450 };
+        const result = selectCoarseEdgeNeighbors(
+            coord,
+            13,
+            () => false,
+            () => ({ elevation: makeElev(0), wasAllNaN: true, unblocked: false }),
+        );
+        expect(result).toEqual([]);
+    });
+
+    it("wasAllNaN でも unblocked なら候補に含まれる", () => {
+        const coord = { zoom: 14, x: 14546, y: 6450 };
+        const elev = makeElev(50);
+        const result = selectCoarseEdgeNeighbors(
+            coord,
+            13,
+            () => false,
+            (c) => {
+                if (c.zoom === 13 && c.x === 7273 && c.y === 3224) {
+                    return { elevation: elev, wasAllNaN: true, unblocked: true };
+                }
+                return undefined;
+            },
+        );
+        const top = result.find((r) => r.direction === "top");
+        expect(top).toBeDefined();
+        expect(top!.elevation).toBe(elev);
+    });
+
+    it("lookupCoarse が全て undefined なら結果は空", () => {
+        const coord = { zoom: 14, x: 14546, y: 6450 };
+        const result = selectCoarseEdgeNeighbors(
+            coord,
+            12,
+            () => false,
+            () => undefined,
+        );
+        expect(result).toEqual([]);
+    });
+
+    it("親辺に位置する方向のみ候補を返す（subX=0, subY=0 は top/left のみ）", () => {
+        // scale=2 で subX=0, subY=0 → top と left が親辺、bottom と right は親内部
+        const coord = { zoom: 14, x: 14546, y: 6450 };
+        const elev = new Float32Array(4 * 4).fill(1);
+        const result = selectCoarseEdgeNeighbors(
+            coord,
+            13,
+            () => false,
+            () => ({ elevation: elev }),
+        );
+        const dirs = result.map((r) => r.direction).sort();
+        expect(dirs).toEqual(["left", "top"]);
     });
 });

--- a/tests/tileStitching.unit.spec.ts
+++ b/tests/tileStitching.unit.spec.ts
@@ -474,6 +474,8 @@ describe("selectCoarseEdgeNeighbors", () => {
                 return undefined;
             },
         );
+        // hidden 扱いのときも coarse zoom=13 への lookupCoarse が実際に呼ばれている（探索継続の証明）
+        expect(calls).toContainEqual({ zoom: 13, x: 7273, y: 3224 });
         // 少なくとも top 方向で粗タイルが見つかる
         const top = result.find((r) => r.direction === "top");
         expect(top).toBeDefined();


### PR DESCRIPTION
Closes #290

## 概要

zoom 17/18 が混在する境界でタイル間の隙間（特に山岳地帯で顕著）を解消する。

## 根本原因

1. `getCoarseEdgeNeighbors` が `pendingRelease` 中の旧粗タイルを参照対象から外しており、LOD-up 遷移中の新細タイルが旧粗タイルへスナップできなかった（#268 の副作用）。
2. `applyStitchedElevation` の cross-level ゲート `isTileNearCamera`（`tileSize × 3` 以内）が、zoom 18（tileSize ≈ 75m）ではカメラ高度があるとほぼ常に false となり、cross-level 縫い合わせが **一切走らない**。結果、zoom 17/18 混在境界の隙間が顕在化していた。

## 修正

- `tileStitching.ts`: 候補選定ロジックを純関数 `selectCoarseEdgeNeighbors` に抽出（テスト容易化）
- `tileManager.ts`:
  - 同
  - cross-level 候補に `pendingRelease` 中の旧粗タイルを許可
  - `PendingReleaseTile` に `elevation`/`filled` 等を保持し cache LRU 退避時のフォールバック
  - pendingRelease 入り直後 / 解放直後に `restitchNeighbors` を起動
  - cross-level 距離ゲート `isTileNearCamera` を撤廃（候補無しなら no-op で安全・軽量）
- `tileStitching.unit.spec.ts`: `selectCoarseEdgeNeighbors` のテスト7件追加

## 検証

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test:unit` ✅（41 suites / 920 tests）

## 影響範囲

- 描画ロジック（src/terrain/）
- Follow モード（#245）の重処理経路には影響なし（`repositionActiveTilesGeom` 側を経由するため）

## 関連 Issue

- Parent: #290
- Related: #268（旧タイル遅延解放）, #245（Follow パフォーマンス）