### PR TITLE
feat(geospatial): Babylon.js Geospatial PoC (GeospatialCamera+ECEF+FloatingOrigin) (#321)

### DIFF
--- a/public/geospatial.html
+++ b/public/geospatial.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+
+  <title>jpmap_terrain – Geospatial PoC (#321)</title>
+  <meta name="description" content="Babylon.js 9.x Geospatial(GeospatialCamera + ECEF + Floating Origin) の実機検証 PoC">
+  <meta name="author" content="8ga3">
+    <style>
+      html,
+      body {
+        overflow: hidden;
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        padding: 0;
+      }
+
+      #root {
+        width: 100%;
+        height: 100%;
+        touch-action: none;
+      }
+
+      #poc-info {
+        position: absolute;
+        top: 8px;
+        left: 8px;
+        max-width: 360px;
+        padding: 8px 10px;
+        font: 12px/1.5 system-ui, sans-serif;
+        color: #fff;
+        background: rgba(0, 0, 0, 0.55);
+        border-radius: 6px;
+        pointer-events: none;
+        white-space: pre-line;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <div id="poc-info">Geospatial PoC (#321)
+ドラッグ=回転 / ホイール=ズーム / WASD=パン
+読み込み中…</div>
+    <script type="module" src="/src/demos/geospatial/index.ts"></script>
+  </body>
+
+</html>

--- a/public/geospatial.html
+++ b/public/geospatial.html
@@ -41,7 +41,7 @@
   <body>
     <div id="root"></div>
     <div id="poc-info">Geospatial PoC (#321)
-ドラッグ=回転 / ホイール=ズーム / WASD=パン
+左ドラッグ=パン / 右ドラッグ=回転 / ホイール=ズーム / WASD=パン
 読み込み中…</div>
     <script type="module" src="/src/demos/geospatial/index.ts"></script>
   </body>

--- a/src/demos/geospatial/crossLevel.ts
+++ b/src/demos/geospatial/crossLevel.ts
@@ -1,0 +1,168 @@
+/**
+ * Geospatial PoC: クロスレベル標高スナップ (Issue #321 / 親 #275)
+ *
+ * LOD 境界（細タイルが粗タイルに隣接）で残る陰影シームを消すため、細タイルの境界辺
+ * 頂点の標高を、隣接する粗タイルのメッシュ表面にスナップする。production の
+ * `src/terrain/tileStitching.ts`（`selectCoarseEdgeNeighbors` / `stitchTileEdgesCrossLevel`）
+ * と同じ考え方。標高スナップは ECEF 変換前の「標高値」に対する処理なので座標系非依存で、
+ * グローブ版にもそのまま適用できることを検証する。production には依存・改修しない。
+ */
+import { TILE_SIZE } from "../../terrain/gsiTile";
+
+/** タイル一意キー（globeLod.tileKey と同形式）。 */
+const key = (z: number, x: number, y: number): string => `${z}/${x}/${y}`;
+
+export type EdgeDir = "north" | "south" | "west" | "east";
+
+/** 細タイルの 1 辺がスナップ対象とする粗タイル。 */
+export interface CoarseEdge {
+    edge: EdgeDir;
+    coarseElev: Float32Array;
+    coarseX: number;
+    coarseY: number;
+    /** 親 1 辺あたりの細タイル数 = 2^(fineZoom - coarseZoom)。 */
+    scale: number;
+}
+
+export interface TileCoord {
+    zoom: number;
+    x: number;
+    y: number;
+}
+
+/**
+ * 細タイルの各辺について、隣接が粗タイルなら対応する粗タイル（CoarseEdge）を返す。
+ * production `selectCoarseEdgeNeighbors` と同じ判定:
+ * - 同 zoom 隣接が選択集合にあればクロスレベル不要（スキップ）。
+ * - そうでなければ z-1 → minZoom の順で、当該辺に接する粗タイルを探す。
+ *
+ * @returns edges: スナップ対象の辺。pending: 必要な粗タイルが選択済みだが標高未ロードで
+ *          ビルドを遅延すべき場合 true。
+ */
+export const selectCoarseEdges = (
+    coord: TileCoord,
+    isDesired: (k: string) => boolean,
+    getElev: (k: string) => Float32Array | undefined,
+    isFailed: (k: string) => boolean,
+    minZoom: number,
+): { edges: CoarseEdge[]; pending: boolean } => {
+    const { zoom: z, x, y } = coord;
+    const dirs: { dir: EdgeDir; dx: number; dy: number }[] = [
+        { dir: "north", dx: 0, dy: -1 },
+        { dir: "south", dx: 0, dy: 1 },
+        { dir: "west", dx: -1, dy: 0 },
+        { dir: "east", dx: 1, dy: 0 },
+    ];
+    const edges: CoarseEdge[] = [];
+    let pending = false;
+
+    for (const { dir, dx, dy } of dirs) {
+        // 同 zoom 隣接が選択されていればクロスレベル不要。
+        if (isDesired(key(z, x + dx, y + dy))) continue;
+
+        for (let zc = z - 1; zc >= minZoom; zc--) {
+            const diff = z - zc;
+            const scale = 1 << diff;
+            const subX = x & (scale - 1);
+            const subY = y & (scale - 1);
+            // この細タイルが粗親の当該辺に接しているか（接していなければ別の粗タイルが隣接）。
+            let onParentEdge: boolean;
+            switch (dir) {
+                case "north": onParentEdge = subY === 0; break;
+                case "south": onParentEdge = subY === scale - 1; break;
+                case "west": onParentEdge = subX === 0; break;
+                case "east": onParentEdge = subX === scale - 1; break;
+            }
+            if (!onParentEdge) continue;
+
+            const cx = (x + dx) >> diff;
+            const cy = (y + dy) >> diff;
+            const ck = key(zc, cx, cy);
+            if (!isDesired(ck)) continue;
+            const elev = getElev(ck);
+            if (!elev) {
+                // 粗タイルは選択済みだが標高ロード失敗ならスナップ不可、それ以外は遅延。
+                if (!isFailed(ck)) pending = true;
+                break;
+            }
+            edges.push({ edge: dir, coarseElev: elev, coarseX: cx, coarseY: cy, scale });
+            break;
+        }
+    }
+    return { edges, pending };
+};
+
+/** 粗メッシュ頂点の標高（buildTileMesh と同じピクセルサンプリング）。 */
+const coarseVertexElev = (
+    coarseElev: Float32Array,
+    gr: number,
+    gc: number,
+    segments: number,
+): number => {
+    const sx = Math.min(TILE_SIZE - 1, Math.round((gc / segments) * TILE_SIZE));
+    const sy = Math.min(TILE_SIZE - 1, Math.round((gr / segments) * TILE_SIZE));
+    const e = coarseElev[sy * TILE_SIZE + sx];
+    return Number.isFinite(e) ? e : 0;
+};
+
+/** 粗メッシュ表面の標高をグリッド座標 (gx,gy)∈[0,segments] で bilinear 評価。 */
+const sampleCoarseMeshElev = (
+    coarseElev: Float32Array,
+    gx: number,
+    gy: number,
+    segments: number,
+): number => {
+    const cx = Math.max(0, Math.min(segments, gx));
+    const cy = Math.max(0, Math.min(segments, gy));
+    const gx0 = Math.floor(cx);
+    const gy0 = Math.floor(cy);
+    const gx1 = Math.min(gx0 + 1, segments);
+    const gy1 = Math.min(gy0 + 1, segments);
+    const tx = cx - gx0;
+    const ty = cy - gy0;
+    const e00 = coarseVertexElev(coarseElev, gy0, gx0, segments);
+    const e10 = coarseVertexElev(coarseElev, gy0, gx1, segments);
+    const e01 = coarseVertexElev(coarseElev, gy1, gx0, segments);
+    const e11 = coarseVertexElev(coarseElev, gy1, gx1, segments);
+    const a = e00 * (1 - tx) + e10 * tx;
+    const b = e01 * (1 - tx) + e11 * tx;
+    return a * (1 - ty) + b * ty;
+};
+
+/**
+ * 細タイルの境界辺頂点の標高をスナップ値で返す（境界以外/対象外辺は null）。
+ *
+ * 細頂点のグローバルピクセル座標を粗タイルのローカルグリッド座標へ写像し、
+ * 粗メッシュ表面を bilinear 評価する。境界辺は粗メッシュの辺（gx か gy が 0/segments）
+ * 上に乗るため、bilinear は粗メッシュ辺上の線形補間に縮退し、隙間なく一致する。
+ */
+export const snapEdgeElevation = (
+    edges: readonly CoarseEdge[],
+    row: number,
+    col: number,
+    segments: number,
+    tx: number,
+    ty: number,
+    pxF: number,
+    pyF: number,
+): number | null => {
+    if (edges.length === 0) return null;
+    let edge: CoarseEdge | undefined;
+    // 角は北/南辺を優先（隣接細タイルとの角不一致を避けるため一方に固定）。
+    if (row === 0) edge = edges.find((e) => e.edge === "north");
+    else if (row === segments) edge = edges.find((e) => e.edge === "south");
+    if (!edge) {
+        if (col === 0) edge = edges.find((e) => e.edge === "west");
+        else if (col === segments) edge = edges.find((e) => e.edge === "east");
+    }
+    if (!edge) return null;
+
+    const fgx = tx * TILE_SIZE + pxF;
+    const fgy = ty * TILE_SIZE + pyF;
+    // 細グローバルピクセル → 粗ローカルピクセル[0,TILE_SIZE] → 粗グリッド[0,segments]。
+    const cgx = fgx / edge.scale - edge.coarseX * TILE_SIZE;
+    const cgy = fgy / edge.scale - edge.coarseY * TILE_SIZE;
+    const gx = (cgx / TILE_SIZE) * segments;
+    const gy = (cgy / TILE_SIZE) * segments;
+    return sampleCoarseMeshElev(edge.coarseElev, gx, gy, segments);
+};

--- a/src/demos/geospatial/geoMapping.ts
+++ b/src/demos/geospatial/geoMapping.ts
@@ -1,0 +1,92 @@
+/**
+ * Geospatial PoC: カメラ UI / URL 状態と GeospatialCamera のマッピング (Issue #321 / 親 #275)
+ *
+ * 既存（平面版）の UI / URL 共有は `azimuth`(方位) / `tilt`(チルト) / `altitude`(高度) と
+ * `@lat,lon,...` を用いる。これを GeospatialCamera の `yaw` / `pitch` / `radius` / `center`(ECEF)
+ * へ相互変換できるかを検証するための純関数群。
+ *
+ * 対応関係（本 PoC で確認）:
+ * - azimuth[deg] ⇄ yaw[rad]   （どちらも 0 = 北、+ = 東回り）
+ * - tilt[deg]    ⇄ pitch[rad] （0 = 直下、90 = 水平。既存 UI の「地面からの傾き」と同義）
+ * - altitude[m]  ⇄ radius     （注視点（center）からのカメラ距離。既存の ArcRotate radius と同義）
+ * - lat,lon      ⇄ center(ECEF)（往路: EcefFromLatLonAltToRef / 復路: 本ファイルの ecefToGeodetic）
+ */
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { Wgs84Ellipsoid } from "@babylonjs/core/Maths/math.geospatial.functions";
+
+export const DEG2RAD = Math.PI / 180;
+export const RAD2DEG = 180 / Math.PI;
+
+/** 測地座標（度・メートル）。 */
+export interface Geodetic {
+    latDeg: number;
+    lonDeg: number;
+    altMeters: number;
+}
+
+/**
+ * ECEF → 測地座標（WGS84）の逆変換。Bowring の閉形式（1 反復で mm 級精度）。
+ *
+ * 軸の規約は `EcefFromLatLonAltToRef` と同じ（X→経度0, Y→東経90°, Z→北極）。
+ */
+export const ecefToGeodetic = (ecef: Vector3): Geodetic => {
+    const a = Wgs84Ellipsoid.semiMajorAxis;
+    const b = Wgs84Ellipsoid.semiMinorAxis;
+    const e2 = Wgs84Ellipsoid.firstEccentricitySquared;
+    const ep2 = Wgs84Ellipsoid.secondEccentricitySquared;
+
+    const x = ecef.x;
+    const y = ecef.y;
+    const z = ecef.z;
+
+    const lon = Math.atan2(y, x);
+    const p = Math.hypot(x, y);
+    // 極（p≈0）の特異点を回避。
+    if (p < 1e-6) {
+        const latDeg = (z >= 0 ? 90 : -90);
+        return { latDeg, lonDeg: lon * RAD2DEG, altMeters: Math.abs(z) - b };
+    }
+    const theta = Math.atan2(z * a, p * b);
+    const sinT = Math.sin(theta);
+    const cosT = Math.cos(theta);
+    const lat = Math.atan2(
+        z + ep2 * b * sinT * sinT * sinT,
+        p - e2 * a * cosT * cosT * cosT,
+    );
+    const sinLat = Math.sin(lat);
+    const N = a / Math.sqrt(1 - e2 * sinLat * sinLat); // 卯酉線曲率半径
+    const alt = p / Math.cos(lat) - N;
+
+    return { latDeg: lat * RAD2DEG, lonDeg: lon * RAD2DEG, altMeters: alt };
+};
+
+/** 既存 UI の azimuth/tilt[deg] → GeospatialCamera の yaw/pitch[rad]。 */
+export const uiToYawPitch = (
+    azimuthDeg: number,
+    tiltDeg: number,
+): { yaw: number; pitch: number } => ({
+    yaw: azimuthDeg * DEG2RAD,
+    pitch: tiltDeg * DEG2RAD,
+});
+
+/** GeospatialCamera の yaw/pitch[rad] → 既存 UI の azimuth/tilt[deg]。 */
+export const yawPitchToUi = (
+    yaw: number,
+    pitch: number,
+): { azimuthDeg: number; tiltDeg: number } => {
+    // azimuth は 0..360 に正規化（既存 URL 表現に合わせる）。
+    let az = (yaw * RAD2DEG) % 360;
+    if (az < 0) az += 360;
+    return { azimuthDeg: az, tiltDeg: pitch * RAD2DEG };
+};
+
+/** `@lat,lon,altitude,azimuth,tilt` 形式の at-path を生成（既存 URL 共有形式と同じ）。 */
+export const toAtPath = (
+    latDeg: number,
+    lonDeg: number,
+    altitude: number,
+    azimuthDeg: number,
+    tiltDeg: number,
+): string =>
+    `@${latDeg.toFixed(6)},${lonDeg.toFixed(6)},${Math.round(altitude)},` +
+    `${azimuthDeg.toFixed(1)},${tiltDeg.toFixed(1)}`;

--- a/src/demos/geospatial/globeLod.ts
+++ b/src/demos/geospatial/globeLod.ts
@@ -62,18 +62,26 @@ export interface GlobeLodOptions {
      * 0 で半球、負値で地平線の少し裏まで許容。
      */
     horizonDotThreshold: number;
+    /**
+     * SSE 距離評価に使うタイル中心の基準標高[m]。
+     * 高標高地（富士山等）では実地表が海面より高く、タイル中心を alt=0 で評価すると
+     * カメラ↔タイルの距離が過大になり LOD が上がらない。中心付近の地形標高を渡すことで
+     * 距離が地表基準になり、近接時に高 zoom が選択される。省略時 0。
+     */
+    referenceAltitude?: number;
 }
 
-/** タイル中心の ECEF（標高 0）を ref に書き込む。 */
+/** タイル中心の ECEF（基準標高 alt）を ref に書き込む。 */
 const tileCenterEcefToRef = (
     zoom: number,
     x: number,
     y: number,
+    alt: number,
     ref: Vector3,
 ): { lat: number; lon: number } => {
     const { lat, lon } = tileCenterLatLon(x, y, zoom);
     EcefFromLatLonAltToRef(
-        { lat: lat * DEG2RAD, lon: lon * DEG2RAD, alt: 0 },
+        { lat: lat * DEG2RAD, lon: lon * DEG2RAD, alt },
         Wgs84Ellipsoid,
         ref,
     );
@@ -100,6 +108,7 @@ export const selectGlobeTiles = (opts: GlobeLodOptions): GlobeTile[] => {
         maxTiles,
         rootSearchRadius,
         horizonDotThreshold,
+        referenceAltitude = 0,
     } = opts;
 
     if (maxZoom < minZoom) return [];
@@ -121,7 +130,7 @@ export const selectGlobeTiles = (opts: GlobeLodOptions): GlobeTile[] => {
         const limit = 1 << zoom;
         if (x < 0 || x >= limit || y < 0 || y >= limit) return;
 
-        const { lat } = tileCenterEcefToRef(zoom, x, y, tileEcef);
+        const { lat } = tileCenterEcefToRef(zoom, x, y, referenceAltitude, tileEcef);
 
         // 地平線カリング: タイルの地心法線（= normalize(tileEcef)）とカメラ方向の内積。
         // 裏側（地球の向こう側）のタイルを除外する。

--- a/src/demos/geospatial/globeLod.ts
+++ b/src/demos/geospatial/globeLod.ts
@@ -1,0 +1,165 @@
+/**
+ * Geospatial PoC: グローブ向け LOD/SSE 選択 (Issue #321 / 親 #275)
+ *
+ * production の `src/terrain/visibleTiles.ts`（平面ワールド前提の Quadtree+SSE）を
+ * **グローブ（ECEF）向けに再定義した PoC 実装**。production には依存・改修しない。
+ *
+ * 平面版との差分（= 移行で再定義が必要な箇所の検証）:
+ * - タイル距離は AABB との XZ 最短距離＋カメラ高度の合成ではなく、
+ *   タイル中心 ECEF とカメラ ECEF の **素直な地心 3D 距離** を使う。
+ *   （平面版の `distanceFootprintToPoint` は「カメラが Y 拡張 AABB 内に入ると D=0」を
+ *     避けるためのハックで、グローブでは地心距離が常に正のため不要。）
+ * - 視錐台 6 平面カリングのかわりに、PoC では floating origin 下でも安定する
+ *   **地平線カリング（地心法線とカメラ方向の内積）** で裏側タイルを除外する。
+ * - SSE 式そのもの（`tileSizeMeters * viewportHeight / (distance * 2 tan(fov/2))`）は
+ *   座標系非依存でそのまま流用できる。
+ */
+import {
+    Wgs84Ellipsoid,
+    EcefFromLatLonAltToRef,
+} from "@babylonjs/core/Maths/math.geospatial.functions";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+
+import { tileCenterLatLon, tileEdgeMeters, toTileXY } from "../../terrain/gsiTile";
+
+const DEG2RAD = Math.PI / 180;
+
+/** LOD 選択されたタイル。 */
+export interface GlobeTile {
+    zoom: number;
+    x: number;
+    y: number;
+    /** タイル 1 辺の実距離 [m]（メッシュ生成・距離評価に流用可）。 */
+    tileSizeMeters: number;
+    /** カメラ ECEF からタイル中心 ECEF までの距離 [m]（maxTiles 打ち切り用）。 */
+    distance: number;
+}
+
+export interface GlobeLodOptions {
+    /** カメラの真の ECEF 位置。 */
+    cameraEcef: Vector3;
+    /** 中心緯度 [deg]（root 探索の中心）。 */
+    centerLat: number;
+    /** 中心経度 [deg]。 */
+    centerLon: number;
+    /** 最低ズーム（root）。 */
+    minZoom: number;
+    /** 最高ズーム（分割上限）。 */
+    maxZoom: number;
+    /** ビューポート高さ [px]。 */
+    viewportHeight: number;
+    /** 垂直 FOV [rad]。 */
+    verticalFov: number;
+    /** SSE 採用しきい値 [px]。大きいほど粗いタイルを早期受容。 */
+    sseThreshold: number;
+    /** 結果タイル数の上限。 */
+    maxTiles: number;
+    /** root タイル（minZoom）の探索半径（±N 格子）。 */
+    rootSearchRadius: number;
+    /**
+     * 地平線カリングの内積しきい値。
+     * `dot(normalize(tileEcef), normalize(cameraEcef)) < threshold` のタイルを裏側として除外。
+     * 0 で半球、負値で地平線の少し裏まで許容。
+     */
+    horizonDotThreshold: number;
+}
+
+/** タイル中心の ECEF（標高 0）を ref に書き込む。 */
+const tileCenterEcefToRef = (
+    zoom: number,
+    x: number,
+    y: number,
+    ref: Vector3,
+): { lat: number; lon: number } => {
+    const { lat, lon } = tileCenterLatLon(x, y, zoom);
+    EcefFromLatLonAltToRef(
+        { lat: lat * DEG2RAD, lon: lon * DEG2RAD, alt: 0 },
+        Wgs84Ellipsoid,
+        ref,
+    );
+    return { lat, lon };
+};
+
+/**
+ * グローブ向け Quadtree+SSE でカメラ近傍の可視タイルを選択する。
+ *
+ * root は中心 lat/lon の minZoom タイルを中心に ±rootSearchRadius 格子。
+ * 各ノードで「地平線カリング → SSE 判定」を行い、受容 or 4 子へ分割。
+ * 最後にカメラ距離の昇順で maxTiles 件に打ち切る。
+ */
+export const selectGlobeTiles = (opts: GlobeLodOptions): GlobeTile[] => {
+    const {
+        cameraEcef,
+        centerLat,
+        centerLon,
+        minZoom,
+        maxZoom,
+        viewportHeight,
+        verticalFov,
+        sseThreshold,
+        maxTiles,
+        rootSearchRadius,
+        horizonDotThreshold,
+    } = opts;
+
+    if (maxZoom < minZoom) return [];
+
+    const tanHalfFov = Math.max(1e-6, Math.tan(verticalFov / 2));
+    const sseDenomBase = 2 * tanHalfFov;
+    const camDir = cameraEcef.clone().normalize();
+
+    const accepted: GlobeTile[] = [];
+    const tileEcef = new Vector3();
+    // 暴発防止の訪問上限。
+    const maxVisited = Math.max(maxTiles, 256) * 32;
+    let visited = 0;
+
+    const traverse = (zoom: number, x: number, y: number): void => {
+        if (visited >= maxVisited) return;
+        visited++;
+
+        const limit = 1 << zoom;
+        if (x < 0 || x >= limit || y < 0 || y >= limit) return;
+
+        const { lat } = tileCenterEcefToRef(zoom, x, y, tileEcef);
+
+        // 地平線カリング: タイルの地心法線（= normalize(tileEcef)）とカメラ方向の内積。
+        // 裏側（地球の向こう側）のタイルを除外する。
+        const tileDir = tileEcef.clone().normalize();
+        if (Vector3.Dot(tileDir, camDir) < horizonDotThreshold) return;
+
+        const distance = Vector3.Distance(cameraEcef, tileEcef);
+        const tileSizeMeters = tileEdgeMeters(lat, zoom);
+
+        const accept =
+            zoom >= maxZoom ||
+            (tileSizeMeters * viewportHeight) / (Math.max(1, distance) * sseDenomBase) <=
+                sseThreshold;
+
+        if (accept) {
+            accepted.push({ zoom, x, y, tileSizeMeters, distance });
+            return;
+        }
+
+        const nz = zoom + 1;
+        for (let sy = 0; sy < 2; sy++) {
+            for (let sx = 0; sx < 2; sx++) {
+                traverse(nz, x * 2 + sx, y * 2 + sy);
+            }
+        }
+    };
+
+    const root = toTileXY(centerLat, centerLon, minZoom);
+    for (let dy = -rootSearchRadius; dy <= rootSearchRadius; dy++) {
+        for (let dx = -rootSearchRadius; dx <= rootSearchRadius; dx++) {
+            traverse(minZoom, root.x + dx, root.y + dy);
+        }
+    }
+
+    accepted.sort((a, b) => a.distance - b.distance);
+    return accepted.slice(0, maxTiles);
+};
+
+/** タイル一意キー。 */
+export const tileKey = (zoom: number, x: number, y: number): string =>
+    `${zoom}/${x}/${y}`;

--- a/src/demos/geospatial/index.ts
+++ b/src/demos/geospatial/index.ts
@@ -652,20 +652,6 @@ const start = async (): Promise<void> => {
         for (const t of tiles) loadTile(t);
         buildReadyTiles(tiles);
 
-        // orbit 中心を地形表面へ追従させる（中心を海面 alt=0 のままにすると、富士山等の
-        // 高標高地でズームインした際にカメラが地形下へ潜り、地表が背面カリングで消える）。
-        // 標高が読めたら中心高度を地形標高へイージングで寄せる（初回ロード時の段差を緩和）。
-        const elevAtCenter = terrainElevAt(camGeo.latDeg, camGeo.lonDeg);
-        if (elevAtCenter !== null) {
-            centerElevation = elevAtCenter; // 次 sync の SSE 基準標高に使う
-            EcefFromLatLonAltToRef(
-                { lat: camGeo.latDeg * DEG2RAD, lon: camGeo.lonDeg * DEG2RAD, alt: elevAtCenter },
-                Wgs84Ellipsoid,
-                seatCenter,
-            );
-            camera.center = Vector3.Lerp(camera.center, seatCenter, 0.35);
-        }
-
         // 統計表示。
         let minZ = Infinity;
         let maxZ = -Infinity;
@@ -696,10 +682,28 @@ const start = async (): Promise<void> => {
     };
 
     // 初回 + フレーム間引きで LOD を再評価する。
+    // orbit 中心を地形表面へ追従させる（高標高地でカメラが地形下へ潜るのを防ぐ）。
+    // 毎フレーム実行する。syncTiles（15 フレーム毎）でのみ補正すると、zoom-to-cursor が
+    // 毎フレーム中心を水平移動させる一方で高度補正が間引かれ、斜面でガタつくため。
+    const seatCenterOnTerrain = (): void => {
+        const g = ecefToGeodetic(camera.center);
+        const elev = terrainElevAt(g.latDeg, g.lonDeg);
+        if (elev === null) return;
+        centerElevation = elev; // SSE 距離評価の基準標高
+        EcefFromLatLonAltToRef(
+            { lat: g.latDeg * DEG2RAD, lon: g.lonDeg * DEG2RAD, alt: elev },
+            Wgs84Ellipsoid,
+            seatCenter,
+        );
+        // 同 lat/lon のまま高度だけ地形標高へ。残差を lerp で滑らかに（LOD 切替時の段差緩和）。
+        camera.center = Vector3.Lerp(camera.center, seatCenter, 0.5);
+    };
+
     syncTiles();
     let frame = 0;
     scene.onBeforeRenderObservable.add(() => {
         applyPan();
+        seatCenterOnTerrain();
         frame++;
         if (frame % DEFAULTS.syncIntervalFrames === 0) syncTiles();
     });

--- a/src/demos/geospatial/index.ts
+++ b/src/demos/geospatial/index.ts
@@ -297,6 +297,10 @@ const start = async (): Promise<void> => {
     // Large World Rendering: 真の ECEF（百万 m オーダー）でも精度を保つため floating origin を有効化。
     const scene = new Scene(engine, { useFloatingOrigin: true });
     scene.clearColor = new Color4(0.75, 0.86, 0.95, 1);
+    // EcefFromLatLonAltToRef は常に右手系 ECEF（X→経度0, Y→東経90°, Z→北極）を出力し、
+    // GeospatialCamera も scene.useRightHandedSystem を前提に視点を組む。既定の左手系の
+    // ままだと右手系データを鏡像で見るため東西が反転する。右手系に揃える。
+    scene.useRightHandedSystem = true;
 
     // GeospatialCamera: world 原点中心の球体惑星を周回する。
     const camera = new GeospatialCamera("geo-camera", scene, {

--- a/src/demos/geospatial/index.ts
+++ b/src/demos/geospatial/index.ts
@@ -183,7 +183,8 @@ const buildTileMesh = (
             const b = a + 1;
             const c = a + vertsPerSide;
             const d = c + 1;
-            surfaceIndices.push(a, c, b, b, c, d);
+            // 巻き順は法線が外向き（地心と反対）になる向き。表面が外を向く。
+            surfaceIndices.push(a, b, c, b, d, c);
         }
     }
 
@@ -208,12 +209,14 @@ const buildTileMesh = (
         return si;
     };
     // 連続する 2 周縁頂点とそのスカート頂点で壁（2 三角形）を張る。
-    // material は両面ライティング・backFaceCulling=false のため巻き順は問わない。
+    // 壁の表裏（外周のどちら向きが外か）を厳密に決めず両面分の三角形を出すことで、
+    // backFaceCulling=true でもスカートが常に見えるようにする（隙間隠しを確実にする）。
     const wallIndices: number[] = [];
     const addWall = (gA: number, gB: number): void => {
         const sA = addSkirtVertex(gA);
         const sB = addSkirtVertex(gB);
-        wallIndices.push(gA, gB, sA, gB, sB, sA);
+        wallIndices.push(gA, gB, sA, gB, sB, sA); // 表
+        wallIndices.push(gA, sA, gB, gB, sA, sB); // 裏（両面化）
     };
     for (let i = 0; i < segments; i++) {
         addWall(gridIndex(0, i), gridIndex(0, i + 1)); // 上辺
@@ -251,8 +254,9 @@ const buildTileMesh = (
     tex.wrapV = Texture.CLAMP_ADDRESSMODE;
     mat.diffuseTexture = tex;
     mat.specularColor = new Color3(0.02, 0.02, 0.02);
-    mat.backFaceCulling = false;
-    mat.twoSidedLighting = true;
+    // 巻き順を外向きに揃えたので片面描画（backFaceCulling=true）で正しく表が見える。
+    // スカート壁は両面分の三角形を出しているため culling 下でも見える。
+    mat.backFaceCulling = true;
     mesh.material = mat;
     return mesh;
 };

--- a/src/demos/geospatial/index.ts
+++ b/src/demos/geospatial/index.ts
@@ -47,6 +47,7 @@ import {
 } from "../../terrain/gsiTile";
 import { selectGlobeTiles, tileKey, type GlobeTile } from "./globeLod";
 import { ecefToGeodetic, uiToYawPitch, yawPitchToUi, toAtPath } from "./geoMapping";
+import { selectCoarseEdges, snapEdgeElevation, type CoarseEdge } from "./crossLevel";
 
 const DEMO_MOUNT_ID = "root";
 
@@ -127,6 +128,7 @@ const buildTileMesh = (
     elevation: Float32Array,
     segments: number,
     mapType: MapType,
+    edges: readonly CoarseEdge[],
 ): Mesh => {
     const totalPixels = TILE_SIZE * 2 ** zoom;
     const latLonAlt: ILatLonAltLike = { lat: 0, lon: 0, alt: 0 };
@@ -158,6 +160,9 @@ const buildTileMesh = (
             const sy = Math.min(TILE_SIZE - 1, Math.round(pyF));
             let elev = elevation[sy * TILE_SIZE + sx];
             if (!Number.isFinite(elev)) elev = 0;
+            // クロスレベル: 境界辺なら粗タイル表面へ標高をスナップ（陰影シーム解消）。
+            const snapped = snapEdgeElevation(edges, row, col, segments, tx, ty, pxF, pyF);
+            if (snapped !== null) elev = snapped;
 
             const { lat, lon } = pixelToLatLon(
                 tx * TILE_SIZE + pxF,
@@ -285,6 +290,8 @@ const start = async (): Promise<void> => {
     const tilt = resolveNumber(search, "tilt", DEFAULTS.tilt);
     const mapType: MapType =
         new URLSearchParams(search).get("map") === "photo" ? "photo" : "std";
+    // クロスレベル標高スナップの有効/無効（?snap=off で比較用に無効化）。
+    const snapEnabled = new URLSearchParams(search).get("snap") !== "off";
 
     const canvas = document.createElement("canvas");
     canvas.style.width = "100%";
@@ -411,6 +418,9 @@ const start = async (): Promise<void> => {
     // ---- 動的 LOD: カメラ ECEF を算出し、地心距離ベース SSE quadtree でタイルを選択 ----
     const loaded = new Map<string, Mesh>();
     const loading = new Set<string>();
+    // クロスレベルスナップのため、ビルド後も標高配列を保持する（隣接細タイルが参照）。
+    const elevCache = new Map<string, Float32Array>();
+    const failed = new Set<string>();
     const lookAt = new Vector3();
     const cameraEcef = new Vector3();
 
@@ -431,22 +441,47 @@ const start = async (): Promise<void> => {
     // 直近の LOD 選択キー集合（取得完了時に「まだ必要か」を判定するために参照する）。
     let desiredKeys = new Set<string>();
 
+    // 標高取得はキャッシュに溜めるだけ（メッシュ化は建築パスで行う）。
     const loadTile = (t: GlobeTile): void => {
         const key = tileKey(t.zoom, t.x, t.y);
-        if (loaded.has(key) || loading.has(key)) return;
+        if (elevCache.has(key) || loading.has(key) || failed.has(key)) return;
         loading.add(key);
         loadElevationTile(t.zoom, t.x, t.y)
             .then((elev) => {
                 loading.delete(key);
-                // 取得完了までにアンロード対象になっていなければメッシュ化する。
-                if (!desiredKeys.has(key)) return;
-                const mesh = buildTileMesh(scene, t.zoom, t.x, t.y, elev, DEFAULTS.segments, mapType);
-                loaded.set(key, mesh);
+                elevCache.set(key, elev);
             })
             .catch((e) => {
                 loading.delete(key);
+                failed.add(key);
                 console.warn(`[geospatial-poc] tile ${key} failed:`, e);
             });
+    };
+
+    /**
+     * 建築パス: 標高が揃った desired タイルをメッシュ化する。
+     * クロスレベルスナップに必要な粗タイル標高が未ロードなら遅延（次回 sync で再試行）。
+     */
+    const buildReadyTiles = (tiles: readonly GlobeTile[]): void => {
+        for (const t of tiles) {
+            const k = tileKey(t.zoom, t.x, t.y);
+            if (loaded.has(k)) continue;
+            const elev = elevCache.get(k);
+            if (!elev) continue; // 自身の標高が未ロード
+            const { edges, pending } = selectCoarseEdges(
+                t,
+                (kk) => desiredKeys.has(kk),
+                (kk) => elevCache.get(kk),
+                (kk) => failed.has(kk),
+                minZoom,
+            );
+            if (pending) continue; // 粗隣接の標高待ち
+            const mesh = buildTileMesh(
+                scene, t.zoom, t.x, t.y, elev, DEFAULTS.segments, mapType,
+                snapEnabled ? edges : [],
+            );
+            loaded.set(k, mesh);
+        }
     };
 
     const syncTiles = (): void => {
@@ -465,15 +500,19 @@ const start = async (): Promise<void> => {
         });
         desiredKeys = new Set(tiles.map((t) => tileKey(t.zoom, t.x, t.y)));
 
-        // 不要になったタイルを破棄。
+        // 不要になったタイルを破棄（メッシュ・標高キャッシュとも）。
         for (const [key, mesh] of loaded) {
             if (!desiredKeys.has(key)) {
                 mesh.dispose(false, true); // マテリアル・テクスチャごと破棄
                 loaded.delete(key);
             }
         }
-        // 新規タイルをロード。
+        for (const key of elevCache.keys()) {
+            if (!desiredKeys.has(key)) elevCache.delete(key);
+        }
+        // 新規タイルをロードし、標高が揃ったものを（クロスレベルスナップ付きで）建築。
         for (const t of tiles) loadTile(t);
+        buildReadyTiles(tiles);
 
         // 統計表示。
         let minZ = Infinity;

--- a/src/demos/geospatial/index.ts
+++ b/src/demos/geospatial/index.ts
@@ -37,7 +37,7 @@ import type { ILatLonAltLike } from "@babylonjs/core/Maths/math.geospatial";
 
 import { createBabylonEngine } from "../../lib/internal/engineFactory";
 import type { EngineType } from "../../lib/types";
-import { loadElevationTile, TILE_SIZE } from "../../terrain/gsiTile";
+import { loadElevationTile, tileEdgeMeters, TILE_SIZE } from "../../terrain/gsiTile";
 import { selectGlobeTiles, tileKey, type GlobeTile } from "./globeLod";
 
 const DEMO_MOUNT_ID = "root";
@@ -102,6 +102,10 @@ const pixelToLatLon = (
  * floating origin 下での Float32 頂点バッファ精度を担保するため、頂点はタイル中心の
  * ECEF アンカーからの **相対座標**（タイル内なので数百 m オーダー）で格納し、真の
  * ECEF（大きな値）は `mesh.position`（double 精度の world matrix 経由）に載せる。
+ *
+ * LOD 境界の T 字クラック対策として、タイル周縁から地心方向へ垂らす **スカート**
+ * （垂直フランジ）を付与する。隣接タイルの LOD を知らずに隙間を隠せる方式で、
+ * Cesium / Google Earth 等のグローブ地形レンダラーで標準的に使われる。
  */
 const buildTileMesh = (
     scene: Scene,
@@ -127,8 +131,9 @@ const buildTileMesh = (
     EcefFromLatLonAltToRef(latLonAlt, Wgs84Ellipsoid, anchor);
 
     const vertsPerSide = segments + 1;
-    const positions = new Float32Array(vertsPerSide * vertsPerSide * 3);
+    const positions: number[] = [];
     const ecef = new Vector3();
+    const gridIndex = (row: number, col: number): number => row * vertsPerSide + col;
 
     for (let row = 0; row < vertsPerSide; row++) {
         for (let col = 0; col < vertsPerSide; col++) {
@@ -150,32 +155,70 @@ const buildTileMesh = (
             latLonAlt.alt = elev;
             EcefFromLatLonAltToRef(latLonAlt, Wgs84Ellipsoid, ecef);
 
-            const vi = (row * vertsPerSide + col) * 3;
             // アンカー相対（小さな値）で格納する。
-            positions[vi] = ecef.x - anchor.x;
-            positions[vi + 1] = ecef.y - anchor.y;
-            positions[vi + 2] = ecef.z - anchor.z;
+            positions.push(ecef.x - anchor.x, ecef.y - anchor.y, ecef.z - anchor.z);
         }
     }
 
-    // インデックス（2 三角形 / セル）。
-    const indices: number[] = [];
+    // 地表メッシュのインデックス（2 三角形 / セル）。法線はこの地表面のみで計算する
+    // （スカート壁を含めるとエッジ頂点の法線が壁に引っ張られ、境界が暗い帯になる）。
+    const surfaceIndices: number[] = [];
     for (let row = 0; row < segments; row++) {
         for (let col = 0; col < segments; col++) {
-            const a = row * vertsPerSide + col;
+            const a = gridIndex(row, col);
             const b = a + 1;
             const c = a + vertsPerSide;
             const d = c + 1;
-            indices.push(a, c, b, b, c, d);
+            surfaceIndices.push(a, c, b, b, c, d);
         }
     }
 
+    // ---- スカート: 周縁頂点を地心方向へ押し下げた壁を追加して T 字クラックを隠す ----
+    // 深さはタイル辺長に比例（LOD 段差を吸収する程度）。粗タイルほど深く、上限あり。
+    const skirtDepth = Math.min(1500, Math.max(150, tileEdgeMeters(center.lat, zoom) * 0.05));
+    const down = anchor.clone().normalize().scaleInPlace(-skirtDepth); // 地心方向（タイル内ほぼ一定）
+    const skirtOf = new Map<number, number>();
+    const addSkirtVertex = (gi: number): number => {
+        const existing = skirtOf.get(gi);
+        if (existing !== undefined) return existing;
+        const base = gi * 3;
+        const si = positions.length / 3;
+        positions.push(
+            positions[base] + down.x,
+            positions[base + 1] + down.y,
+            positions[base + 2] + down.z,
+        );
+        skirtOf.set(gi, si);
+        return si;
+    };
+    // 連続する 2 周縁頂点とそのスカート頂点で壁（2 三角形）を張る。
+    // material は両面ライティング・backFaceCulling=false のため巻き順は問わない。
+    const wallIndices: number[] = [];
+    const addWall = (gA: number, gB: number): void => {
+        const sA = addSkirtVertex(gA);
+        const sB = addSkirtVertex(gB);
+        wallIndices.push(gA, gB, sA, gB, sB, sA);
+    };
+    for (let i = 0; i < segments; i++) {
+        addWall(gridIndex(0, i), gridIndex(0, i + 1)); // 上辺
+        addWall(gridIndex(segments, i), gridIndex(segments, i + 1)); // 下辺
+        addWall(gridIndex(i, 0), gridIndex(i + 1, 0)); // 左辺
+        addWall(gridIndex(i, segments), gridIndex(i + 1, segments)); // 右辺
+    }
+
+    // 法線は地表面のみで計算（スカート壁を除外）。スカート頂点の法線は元の周縁頂点に
+    // 揃え、壁が地表と同じ陰影になるようにする（暗い帯を防ぐ）。
     const normals: number[] = [];
-    VertexData.ComputeNormals(positions, indices, normals);
+    VertexData.ComputeNormals(positions, surfaceIndices, normals);
+    for (const [gi, si] of skirtOf) {
+        normals[si * 3] = normals[gi * 3];
+        normals[si * 3 + 1] = normals[gi * 3 + 1];
+        normals[si * 3 + 2] = normals[gi * 3 + 2];
+    }
 
     const vertexData = new VertexData();
     vertexData.positions = positions;
-    vertexData.indices = indices;
+    vertexData.indices = surfaceIndices.concat(wallIndices);
     vertexData.normals = normals;
 
     const mesh = new Mesh(`tile-${tileKey(zoom, tx, ty)}`, scene);

--- a/src/demos/geospatial/index.ts
+++ b/src/demos/geospatial/index.ts
@@ -5,17 +5,16 @@
  * Large World Rendering の floating origin）を最小構成で実機検証する **スタンドアロン** PoC。
  *
  * 重要: これは全面リライト着手前のフィージビリティ確認であり、既存の平面ワールド
- * スタック（`JpmapTerrain` / `scenes/default.ts` / `tileManager` 等）には一切依存・改修しない。
- * 流用するのは標高タイル取得 (`gsiTile.loadElevationTile`) のみ。
+ * スタック（`JpmapTerrain` / `scenes/default.ts` / `tileManager` / `visibleTiles` 等）には
+ * 一切依存・改修しない。流用するのは標高タイル取得 (`gsiTile.loadElevationTile`) と
+ * GSI 座標ヘルパのみ。
  *
- * 検証する判断材料:
- * - floating origin 下でのタイル精度（ジッタの有無）
- * - lat/lon/標高 → ECEF の頂点生成コストと既存取得層の流用度
- * - GeospatialCamera 入力でのパン/回転/ズームの操作感
+ * 第2反復: カメラ位置に応じた **動的 LOD（地心距離ベース SSE quadtree）** による
+ * タイルのロード/アンロードを `globeLod.selectGlobeTiles` で検証する。
  *
  * URL クエリ:
  * - `?engine=webgpu|webgl|webgl2`（既定: 自動。webgl/webgl2 は webgl2 に正規化）
- * - `?lat=&lon=&zoom=&radius=`（既定: 富士山周辺 / zoom 13 / radius 12000m）
+ * - `?lat=&lon=&zoom=&radius=`（既定: 富士山周辺 / center zoom 11 / radius 60000m）
  */
 import { Scene } from "@babylonjs/core/scene";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
@@ -25,7 +24,10 @@ import { DirectionalLight } from "@babylonjs/core/Lights/directionalLight";
 import { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { VertexData } from "@babylonjs/core/Meshes/mesh.vertexData";
 import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
-import { GeospatialCamera } from "@babylonjs/core/Cameras/geospatialCamera";
+import {
+    GeospatialCamera,
+    ComputeLookAtFromYawPitchToRef,
+} from "@babylonjs/core/Cameras/geospatialCamera";
 import { GeospatialClippingBehavior } from "@babylonjs/core/Behaviors/Cameras/geospatialClippingBehavior";
 import {
     Wgs84Ellipsoid,
@@ -35,21 +37,33 @@ import type { ILatLonAltLike } from "@babylonjs/core/Maths/math.geospatial";
 
 import { createBabylonEngine } from "../../lib/internal/engineFactory";
 import type { EngineType } from "../../lib/types";
-import { loadElevationTile, toTileXY, TILE_SIZE } from "../../terrain/gsiTile";
+import { loadElevationTile, TILE_SIZE } from "../../terrain/gsiTile";
+import { selectGlobeTiles, tileKey, type GlobeTile } from "./globeLod";
 
 const DEMO_MOUNT_ID = "root";
 
-/** PoC の既定表示パラメータ（富士山周辺）。 */
+/** PoC の既定表示・LOD パラメータ（富士山周辺）。 */
 const DEFAULTS = {
     lat: 35.3606,
     lon: 138.7274,
-    zoom: 13,
+    /** root（最低）ズーム。 */
+    minZoom: 11,
+    /** 最高ズーム（分割上限）。 */
+    maxZoom: 16,
     /** カメラ中心（地表）からの距離 [m]。 */
-    radius: 20000,
-    /** 中心タイルの周囲に何タイル読み込むか（片側）。3 → 7x7。 */
-    ring: 3,
-    /** タイルあたりの分割数（頂点は (seg+1)^2）。256px を間引いてグリッド化する。 */
-    segments: 48,
+    radius: 60000,
+    /** SSE 採用しきい値 [px]。 */
+    sseThreshold: 256 * 2.5,
+    /** 同時保持タイル数の上限。 */
+    maxTiles: 140,
+    /** root 探索半径（±N 格子）。 */
+    rootSearchRadius: 2,
+    /** 地平線カリングの内積しきい値。 */
+    horizonDotThreshold: 0.1,
+    /** タイルあたりの分割数（頂点は (seg+1)^2）。 */
+    segments: 32,
+    /** LOD 再評価の間隔（フレーム）。 */
+    syncIntervalFrames: 15,
 } as const;
 
 /** `?engine=` を解決する（viewer デモと同じ正規化）。 */
@@ -164,7 +178,7 @@ const buildTileMesh = (
     vertexData.indices = indices;
     vertexData.normals = normals;
 
-    const mesh = new Mesh(`tile-${zoom}-${tx}-${ty}`, scene);
+    const mesh = new Mesh(`tile-${tileKey(zoom, tx, ty)}`, scene);
     vertexData.applyToMesh(mesh);
     mesh.position.copyFrom(anchor);
     return mesh;
@@ -182,7 +196,7 @@ const start = async (): Promise<void> => {
     const search = location.search;
     const lat = resolveNumber(search, "lat", DEFAULTS.lat);
     const lon = resolveNumber(search, "lon", DEFAULTS.lon);
-    const zoom = Math.round(resolveNumber(search, "zoom", DEFAULTS.zoom));
+    const minZoom = Math.round(resolveNumber(search, "zoom", DEFAULTS.minZoom));
     const radius = resolveNumber(search, "radius", DEFAULTS.radius);
 
     const canvas = document.createElement("canvas");
@@ -218,7 +232,6 @@ const start = async (): Promise<void> => {
     camera.addBehavior(new GeospatialClippingBehavior());
 
     // GeospatialCamera はコンストラクタで既定入力（pointers/wheel/keyboard）を備える。
-    // 追加登録は不要で、attachControl だけ行う。
     camera.attachControl(true);
 
     // ライト: 地表の up（地心法線）を基準に環境光 + 斜め方向の指向性ライト。
@@ -226,7 +239,6 @@ const start = async (): Promise<void> => {
     const hemi = new HemisphericLight("hemi", up, scene);
     hemi.intensity = 0.55;
     hemi.groundColor = new Color3(0.3, 0.32, 0.3);
-    // up に直交する接線（東方向相当）を作り、太陽を斜め上から当てて起伏の陰影を出す。
     const ref = Math.abs(up.y) < 0.99 ? Vector3.Up() : Vector3.Right();
     const east = Vector3.Cross(ref, up).normalize();
     const sunDir = up.scale(-0.85).add(east.scale(0.5)).normalize();
@@ -236,45 +248,104 @@ const start = async (): Promise<void> => {
     const material = new StandardMaterial("terrain-mat", scene);
     material.diffuseColor = new Color3(0.55, 0.62, 0.5);
     material.specularColor = new Color3(0.05, 0.05, 0.05);
-    // メッシュの巻き順（法線の向き）に依存せず両面を正しく陰影付けする。
     material.backFaceCulling = false;
     material.twoSidedLighting = true;
 
     engine.runRenderLoop(() => scene.render());
     window.addEventListener("resize", () => engine.resize());
 
-    // 中心タイルとその周囲（ring）の標高タイルを取得して曲面メッシュ化する。
-    const { x: cx, y: cy } = toTileXY(lat, lon, zoom);
-    const ring = DEFAULTS.ring;
-    const coords: { x: number; y: number }[] = [];
-    for (let dy = -ring; dy <= ring; dy++) {
-        for (let dx = -ring; dx <= ring; dx++) {
-            coords.push({ x: cx + dx, y: cy + dy });
-        }
-    }
+    // ---- 動的 LOD: カメラ ECEF を算出し、地心距離ベース SSE quadtree でタイルを選択 ----
+    const loaded = new Map<string, Mesh>();
+    const loading = new Set<string>();
+    const lookAt = new Vector3();
+    const cameraEcef = new Vector3();
 
-    let loaded = 0;
-    let failed = 0;
-    await Promise.all(
-        coords.map(async ({ x, y }) => {
-            try {
-                const elev = await loadElevationTile(zoom, x, y);
-                const mesh = buildTileMesh(scene, zoom, x, y, elev, DEFAULTS.segments);
+    /** GeospatialCamera の center/yaw/pitch/radius から真の ECEF 位置を復元する。 */
+    const computeCameraEcef = (): Vector3 => {
+        ComputeLookAtFromYawPitchToRef(
+            camera.yaw,
+            camera.pitch,
+            camera.center,
+            scene.useRightHandedSystem,
+            lookAt,
+        );
+        // lookAt はカメラ→center 方向。カメラ位置 = center - lookAt * radius。
+        cameraEcef.copyFrom(camera.center).subtractInPlace(lookAt.scale(camera.radius));
+        return cameraEcef;
+    };
+
+    // 直近の LOD 選択キー集合（取得完了時に「まだ必要か」を判定するために参照する）。
+    let desiredKeys = new Set<string>();
+
+    const loadTile = (t: GlobeTile): void => {
+        const key = tileKey(t.zoom, t.x, t.y);
+        if (loaded.has(key) || loading.has(key)) return;
+        loading.add(key);
+        loadElevationTile(t.zoom, t.x, t.y)
+            .then((elev) => {
+                loading.delete(key);
+                // 取得完了までにアンロード対象になっていなければメッシュ化する。
+                if (!desiredKeys.has(key)) return;
+                const mesh = buildTileMesh(scene, t.zoom, t.x, t.y, elev, DEFAULTS.segments);
                 mesh.material = material;
-                loaded++;
-            } catch (e) {
-                failed++;
-                console.warn(`[geospatial-poc] tile z${zoom}/${x}/${y} failed:`, e);
+                loaded.set(key, mesh);
+            })
+            .catch((e) => {
+                loading.delete(key);
+                console.warn(`[geospatial-poc] tile ${key} failed:`, e);
+            });
+    };
+
+    const syncTiles = (): void => {
+        const tiles = selectGlobeTiles({
+            cameraEcef: computeCameraEcef(),
+            centerLat: lat,
+            centerLon: lon,
+            minZoom,
+            maxZoom: DEFAULTS.maxZoom,
+            viewportHeight: engine.getRenderHeight(),
+            verticalFov: camera.fov,
+            sseThreshold: DEFAULTS.sseThreshold,
+            maxTiles: DEFAULTS.maxTiles,
+            rootSearchRadius: DEFAULTS.rootSearchRadius,
+            horizonDotThreshold: DEFAULTS.horizonDotThreshold,
+        });
+        desiredKeys = new Set(tiles.map((t) => tileKey(t.zoom, t.x, t.y)));
+
+        // 不要になったタイルを破棄。
+        for (const [key, mesh] of loaded) {
+            if (!desiredKeys.has(key)) {
+                mesh.dispose();
+                loaded.delete(key);
             }
-            updateInfo(
-                `Geospatial PoC (#321)\n` +
-                    `ドラッグ=回転 / ホイール=ズーム / WASD=パン\n` +
-                    `engine: ${engine.constructor.name} / floatingOrigin: ${scene.floatingOriginMode}\n` +
-                    `center: ${lat.toFixed(4)}, ${lon.toFixed(4)} (zoom ${zoom})\n` +
-                    `tiles: ${loaded}/${coords.length} 読み込み${failed ? ` (失敗 ${failed})` : ""}`,
-            );
-        }),
-    );
+        }
+        // 新規タイルをロード。
+        for (const t of tiles) loadTile(t);
+
+        // 統計表示。
+        let minZ = Infinity;
+        let maxZ = -Infinity;
+        for (const t of tiles) {
+            if (t.zoom < minZ) minZ = t.zoom;
+            if (t.zoom > maxZ) maxZ = t.zoom;
+        }
+        updateInfo(
+            `Geospatial PoC (#321) — 動的 LOD\n` +
+                `ドラッグ=回転 / ホイール=ズーム / WASD=パン\n` +
+                `engine: ${engine.constructor.name} / floatingOrigin: ${scene.floatingOriginMode}\n` +
+                `fps: ${engine.getFps().toFixed(0)} / radius: ${(camera.radius / 1000).toFixed(1)}km\n` +
+                `LOD zoom: ${Number.isFinite(minZ) ? `${minZ}–${maxZ}` : "-"} / ` +
+                `selected: ${tiles.length} / loaded: ${loaded.size} / loading: ${loading.size}`,
+        );
+    };
+
+    // 初回 + フレーム間引きで LOD を再評価する。
+    syncTiles();
+    let frame = 0;
+    scene.onBeforeRenderObservable.add(() => {
+        frame++;
+        if (frame % DEFAULTS.syncIntervalFrames === 0) syncTiles();
+    });
 
     // デバッグ用に内部状態を露出（公開 API ではない）。
     if (process.env.NODE_ENV !== "production") {

--- a/src/demos/geospatial/index.ts
+++ b/src/demos/geospatial/index.ts
@@ -686,6 +686,11 @@ const start = async (): Promise<void> => {
     // 毎フレーム実行する。syncTiles（15 フレーム毎）でのみ補正すると、zoom-to-cursor が
     // 毎フレーム中心を水平移動させる一方で高度補正が間引かれ、斜面でガタつくため。
     const seatCenterOnTerrain = (): void => {
+        // ズーム中は seat を止める。wheel zoom(zoom-to-cursor)は毎フレーム「カーソル下の
+        // メッシュをピックした点」へ中心を 3D で寄せており、それ自体が地形追従している。
+        // ここでラスタ標高(terrainElevAt)へ寄せると、メッシュ pick 点とラスタ標高の食い違いで
+        // 毎フレーム引っ張り合い、揺れの原因になる。ズーム中は zoom 側に任せる。
+        if (camera.movement.computedPerFrameZoomPickPoint) return;
         const g = ecefToGeodetic(camera.center);
         const elev = terrainElevAt(g.latDeg, g.lonDeg);
         if (elev === null) return;

--- a/src/demos/geospatial/index.ts
+++ b/src/demos/geospatial/index.ts
@@ -1,0 +1,294 @@
+/**
+ * Geospatial PoC エントリ (Issue #321 / 親 #275)
+ *
+ * Babylon.js 9.x の Geospatial 機能（`GeospatialCamera` + ECEF 楕円体グローブ +
+ * Large World Rendering の floating origin）を最小構成で実機検証する **スタンドアロン** PoC。
+ *
+ * 重要: これは全面リライト着手前のフィージビリティ確認であり、既存の平面ワールド
+ * スタック（`JpmapTerrain` / `scenes/default.ts` / `tileManager` 等）には一切依存・改修しない。
+ * 流用するのは標高タイル取得 (`gsiTile.loadElevationTile`) のみ。
+ *
+ * 検証する判断材料:
+ * - floating origin 下でのタイル精度（ジッタの有無）
+ * - lat/lon/標高 → ECEF の頂点生成コストと既存取得層の流用度
+ * - GeospatialCamera 入力でのパン/回転/ズームの操作感
+ *
+ * URL クエリ:
+ * - `?engine=webgpu|webgl|webgl2`（既定: 自動。webgl/webgl2 は webgl2 に正規化）
+ * - `?lat=&lon=&zoom=&radius=`（既定: 富士山周辺 / zoom 13 / radius 12000m）
+ */
+import { Scene } from "@babylonjs/core/scene";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { Color3, Color4 } from "@babylonjs/core/Maths/math.color";
+import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight";
+import { DirectionalLight } from "@babylonjs/core/Lights/directionalLight";
+import { Mesh } from "@babylonjs/core/Meshes/mesh";
+import { VertexData } from "@babylonjs/core/Meshes/mesh.vertexData";
+import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
+import { GeospatialCamera } from "@babylonjs/core/Cameras/geospatialCamera";
+import { GeospatialClippingBehavior } from "@babylonjs/core/Behaviors/Cameras/geospatialClippingBehavior";
+import {
+    Wgs84Ellipsoid,
+    EcefFromLatLonAltToRef,
+} from "@babylonjs/core/Maths/math.geospatial.functions";
+import type { ILatLonAltLike } from "@babylonjs/core/Maths/math.geospatial";
+
+import { createBabylonEngine } from "../../lib/internal/engineFactory";
+import type { EngineType } from "../../lib/types";
+import { loadElevationTile, toTileXY, TILE_SIZE } from "../../terrain/gsiTile";
+
+const DEMO_MOUNT_ID = "root";
+
+/** PoC の既定表示パラメータ（富士山周辺）。 */
+const DEFAULTS = {
+    lat: 35.3606,
+    lon: 138.7274,
+    zoom: 13,
+    /** カメラ中心（地表）からの距離 [m]。 */
+    radius: 20000,
+    /** 中心タイルの周囲に何タイル読み込むか（片側）。3 → 7x7。 */
+    ring: 3,
+    /** タイルあたりの分割数（頂点は (seg+1)^2）。256px を間引いてグリッド化する。 */
+    segments: 48,
+} as const;
+
+/** `?engine=` を解決する（viewer デモと同じ正規化）。 */
+const resolveEngine = (search: string): EngineType | undefined => {
+    const value = new URLSearchParams(search).get("engine");
+    if (value === "webgpu") return "webgpu";
+    if (value === "webgl" || value === "webgl2") return "webgl2";
+    return undefined;
+};
+
+/** `?key=` を数値として解決する（未指定 / NaN は fallback）。 */
+const resolveNumber = (search: string, key: string, fallback: number): number => {
+    const raw = new URLSearchParams(search).get(key);
+    if (raw === null) return fallback;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : fallback;
+};
+
+const DEG2RAD = Math.PI / 180;
+
+/** XYZ タイルのグローバルピクセル座標 → 緯度経度[deg]（Web メルカトル逆変換）。 */
+const pixelToLatLon = (
+    globalPx: number,
+    globalPy: number,
+    totalPixels: number,
+): { lat: number; lon: number } => {
+    const lon = (globalPx / totalPixels) * 360 - 180;
+    const ny = globalPy / totalPixels;
+    const lat = (Math.atan(Math.sinh(Math.PI * (1 - 2 * ny))) * 180) / Math.PI;
+    return { lat, lon };
+};
+
+/**
+ * 1 タイルぶんの標高データから ECEF 曲面メッシュを生成する。
+ *
+ * floating origin 下での Float32 頂点バッファ精度を担保するため、頂点はタイル中心の
+ * ECEF アンカーからの **相対座標**（タイル内なので数百 m オーダー）で格納し、真の
+ * ECEF（大きな値）は `mesh.position`（double 精度の world matrix 経由）に載せる。
+ */
+const buildTileMesh = (
+    scene: Scene,
+    zoom: number,
+    tx: number,
+    ty: number,
+    elevation: Float32Array,
+    segments: number,
+): Mesh => {
+    const totalPixels = TILE_SIZE * 2 ** zoom;
+    const latLonAlt: ILatLonAltLike = { lat: 0, lon: 0, alt: 0 };
+
+    // タイル中心をアンカー ECEF とする。
+    const center = pixelToLatLon(
+        tx * TILE_SIZE + TILE_SIZE / 2,
+        ty * TILE_SIZE + TILE_SIZE / 2,
+        totalPixels,
+    );
+    latLonAlt.lat = center.lat * DEG2RAD;
+    latLonAlt.lon = center.lon * DEG2RAD;
+    latLonAlt.alt = 0;
+    const anchor = new Vector3();
+    EcefFromLatLonAltToRef(latLonAlt, Wgs84Ellipsoid, anchor);
+
+    const vertsPerSide = segments + 1;
+    const positions = new Float32Array(vertsPerSide * vertsPerSide * 3);
+    const ecef = new Vector3();
+
+    for (let row = 0; row < vertsPerSide; row++) {
+        for (let col = 0; col < vertsPerSide; col++) {
+            // タイル内ピクセル位置（0..TILE_SIZE）。最終頂点は端 (255) にクランプ。
+            const pxF = (col / segments) * TILE_SIZE;
+            const pyF = (row / segments) * TILE_SIZE;
+            const sx = Math.min(TILE_SIZE - 1, Math.round(pxF));
+            const sy = Math.min(TILE_SIZE - 1, Math.round(pyF));
+            let elev = elevation[sy * TILE_SIZE + sx];
+            if (!Number.isFinite(elev)) elev = 0;
+
+            const { lat, lon } = pixelToLatLon(
+                tx * TILE_SIZE + pxF,
+                ty * TILE_SIZE + pyF,
+                totalPixels,
+            );
+            latLonAlt.lat = lat * DEG2RAD;
+            latLonAlt.lon = lon * DEG2RAD;
+            latLonAlt.alt = elev;
+            EcefFromLatLonAltToRef(latLonAlt, Wgs84Ellipsoid, ecef);
+
+            const vi = (row * vertsPerSide + col) * 3;
+            // アンカー相対（小さな値）で格納する。
+            positions[vi] = ecef.x - anchor.x;
+            positions[vi + 1] = ecef.y - anchor.y;
+            positions[vi + 2] = ecef.z - anchor.z;
+        }
+    }
+
+    // インデックス（2 三角形 / セル）。
+    const indices: number[] = [];
+    for (let row = 0; row < segments; row++) {
+        for (let col = 0; col < segments; col++) {
+            const a = row * vertsPerSide + col;
+            const b = a + 1;
+            const c = a + vertsPerSide;
+            const d = c + 1;
+            indices.push(a, c, b, b, c, d);
+        }
+    }
+
+    const normals: number[] = [];
+    VertexData.ComputeNormals(positions, indices, normals);
+
+    const vertexData = new VertexData();
+    vertexData.positions = positions;
+    vertexData.indices = indices;
+    vertexData.normals = normals;
+
+    const mesh = new Mesh(`tile-${zoom}-${tx}-${ty}`, scene);
+    vertexData.applyToMesh(mesh);
+    mesh.position.copyFrom(anchor);
+    return mesh;
+};
+
+const updateInfo = (text: string): void => {
+    const el = document.getElementById("poc-info");
+    if (el) el.textContent = text;
+};
+
+const start = async (): Promise<void> => {
+    const mount = document.getElementById(DEMO_MOUNT_ID);
+    if (!mount) throw new Error(`#${DEMO_MOUNT_ID} mount element not found`);
+
+    const search = location.search;
+    const lat = resolveNumber(search, "lat", DEFAULTS.lat);
+    const lon = resolveNumber(search, "lon", DEFAULTS.lon);
+    const zoom = Math.round(resolveNumber(search, "zoom", DEFAULTS.zoom));
+    const radius = resolveNumber(search, "radius", DEFAULTS.radius);
+
+    const canvas = document.createElement("canvas");
+    canvas.style.width = "100%";
+    canvas.style.height = "100%";
+    canvas.style.display = "block";
+    mount.appendChild(canvas);
+
+    const engine = await createBabylonEngine(canvas, resolveEngine(search) ?? "webgpu");
+
+    // Large World Rendering: 真の ECEF（百万 m オーダー）でも精度を保つため floating origin を有効化。
+    const scene = new Scene(engine, { useFloatingOrigin: true });
+    scene.clearColor = new Color4(0.75, 0.86, 0.95, 1);
+
+    // GeospatialCamera: world 原点中心の球体惑星を周回する。
+    const camera = new GeospatialCamera("geo-camera", scene, {
+        planetRadius: Wgs84Ellipsoid.semiMajorAxis,
+    });
+
+    // 初期注視点（地表上の lat/lon）を真の ECEF として center に設定する。
+    const centerEcef = new Vector3();
+    EcefFromLatLonAltToRef(
+        { lat: lat * DEG2RAD, lon: lon * DEG2RAD, alt: 0 },
+        Wgs84Ellipsoid,
+        centerEcef,
+    );
+    camera.center = centerEcef;
+    camera.radius = radius;
+    camera.yaw = 0; // 北向き
+    camera.pitch = 1.05; // 0=直下, π/2=水平。斜め見下ろしの俯瞰。
+
+    // near/far の自動調整（高度に応じた depth 精度最適化）。
+    camera.addBehavior(new GeospatialClippingBehavior());
+
+    // GeospatialCamera はコンストラクタで既定入力（pointers/wheel/keyboard）を備える。
+    // 追加登録は不要で、attachControl だけ行う。
+    camera.attachControl(true);
+
+    // ライト: 地表の up（地心法線）を基準に環境光 + 斜め方向の指向性ライト。
+    const up = centerEcef.clone().normalize();
+    const hemi = new HemisphericLight("hemi", up, scene);
+    hemi.intensity = 0.55;
+    hemi.groundColor = new Color3(0.3, 0.32, 0.3);
+    // up に直交する接線（東方向相当）を作り、太陽を斜め上から当てて起伏の陰影を出す。
+    const ref = Math.abs(up.y) < 0.99 ? Vector3.Up() : Vector3.Right();
+    const east = Vector3.Cross(ref, up).normalize();
+    const sunDir = up.scale(-0.85).add(east.scale(0.5)).normalize();
+    const sun = new DirectionalLight("sun", sunDir, scene);
+    sun.intensity = 0.7;
+
+    const material = new StandardMaterial("terrain-mat", scene);
+    material.diffuseColor = new Color3(0.55, 0.62, 0.5);
+    material.specularColor = new Color3(0.05, 0.05, 0.05);
+    // メッシュの巻き順（法線の向き）に依存せず両面を正しく陰影付けする。
+    material.backFaceCulling = false;
+    material.twoSidedLighting = true;
+
+    engine.runRenderLoop(() => scene.render());
+    window.addEventListener("resize", () => engine.resize());
+
+    // 中心タイルとその周囲（ring）の標高タイルを取得して曲面メッシュ化する。
+    const { x: cx, y: cy } = toTileXY(lat, lon, zoom);
+    const ring = DEFAULTS.ring;
+    const coords: { x: number; y: number }[] = [];
+    for (let dy = -ring; dy <= ring; dy++) {
+        for (let dx = -ring; dx <= ring; dx++) {
+            coords.push({ x: cx + dx, y: cy + dy });
+        }
+    }
+
+    let loaded = 0;
+    let failed = 0;
+    await Promise.all(
+        coords.map(async ({ x, y }) => {
+            try {
+                const elev = await loadElevationTile(zoom, x, y);
+                const mesh = buildTileMesh(scene, zoom, x, y, elev, DEFAULTS.segments);
+                mesh.material = material;
+                loaded++;
+            } catch (e) {
+                failed++;
+                console.warn(`[geospatial-poc] tile z${zoom}/${x}/${y} failed:`, e);
+            }
+            updateInfo(
+                `Geospatial PoC (#321)\n` +
+                    `ドラッグ=回転 / ホイール=ズーム / WASD=パン\n` +
+                    `engine: ${engine.constructor.name} / floatingOrigin: ${scene.floatingOriginMode}\n` +
+                    `center: ${lat.toFixed(4)}, ${lon.toFixed(4)} (zoom ${zoom})\n` +
+                    `tiles: ${loaded}/${coords.length} 読み込み${failed ? ` (失敗 ${failed})` : ""}`,
+            );
+        }),
+    );
+
+    // デバッグ用に内部状態を露出（公開 API ではない）。
+    if (process.env.NODE_ENV !== "production") {
+        (window as unknown as { scene: Scene }).scene = scene;
+        (window as unknown as { camera: GeospatialCamera }).camera = camera;
+    }
+};
+
+if (
+    typeof document !== "undefined" &&
+    document.getElementById(DEMO_MOUNT_ID) !== null
+) {
+    start().catch((err) => {
+        console.error("[geospatial-poc] failed to start:", err);
+        updateInfo(`Geospatial PoC (#321)\n起動に失敗しました: ${String(err)}`);
+    });
+}

--- a/src/demos/geospatial/index.ts
+++ b/src/demos/geospatial/index.ts
@@ -371,6 +371,11 @@ const start = async (): Promise<void> => {
     // GeospatialCamera はコンストラクタで既定入力（pointers/wheel/keyboard）を備える。
     camera.attachControl(true);
 
+    // ズームはカーソル追従(zoom-to-cursor)を無効化し、注視点(center=画面中心)へ寄る
+    // 半径のみのズームにする。zoom-to-cursor は毎フレーム中心をカーソル方向へ動かすため
+    // ズーム中に位置がずれて見える（floating origin 下のピック誤差も相まってガタつく）。
+    camera.movement.zoomToCursor = false;
+
     // ---- WASD パン（picking に依存しない独自実装） ----
     // 既定の pan（キーボード/左ドラッグ）は scene.pick でグローブをヒットしてドラッグ平面を
     // 作るが、useFloatingOrigin 下ではレンダリング座標と真の ECEF メッシュ位置がずれ、

--- a/src/demos/geospatial/index.ts
+++ b/src/demos/geospatial/index.ts
@@ -24,6 +24,7 @@ import { DirectionalLight } from "@babylonjs/core/Lights/directionalLight";
 import { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { VertexData } from "@babylonjs/core/Meshes/mesh.vertexData";
 import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
+import { Texture } from "@babylonjs/core/Materials/Textures/texture";
 import {
     GeospatialCamera,
     ComputeLookAtFromYawPitchToRef,
@@ -37,7 +38,13 @@ import type { ILatLonAltLike } from "@babylonjs/core/Maths/math.geospatial";
 
 import { createBabylonEngine } from "../../lib/internal/engineFactory";
 import type { EngineType } from "../../lib/types";
-import { loadElevationTile, tileEdgeMeters, TILE_SIZE } from "../../terrain/gsiTile";
+import {
+    loadElevationTile,
+    tileEdgeMeters,
+    textureUrl,
+    TILE_SIZE,
+    type MapType,
+} from "../../terrain/gsiTile";
 import { selectGlobeTiles, tileKey, type GlobeTile } from "./globeLod";
 
 const DEMO_MOUNT_ID = "root";
@@ -114,6 +121,7 @@ const buildTileMesh = (
     ty: number,
     elevation: Float32Array,
     segments: number,
+    mapType: MapType,
 ): Mesh => {
     const totalPixels = TILE_SIZE * 2 ** zoom;
     const latLonAlt: ILatLonAltLike = { lat: 0, lon: 0, alt: 0 };
@@ -132,6 +140,7 @@ const buildTileMesh = (
 
     const vertsPerSide = segments + 1;
     const positions: number[] = [];
+    const uvs: number[] = [];
     const ecef = new Vector3();
     const gridIndex = (row: number, col: number): number => row * vertsPerSide + col;
 
@@ -157,6 +166,11 @@ const buildTileMesh = (
 
             // アンカー相対（小さな値）で格納する。
             positions.push(ecef.x - anchor.x, ecef.y - anchor.y, ecef.z - anchor.z);
+
+            // UV: タイル画像に対応。col→u（西→東）、row=0 は北端。
+            // 地理院タイル画像は row=0 が北。Babylon は invertY=true で texture を
+            // 上下反転して読むため、v は row/segments（北端 row0 → v0）でそのまま整合する。
+            uvs.push(col / segments, row / segments);
         }
     }
 
@@ -188,6 +202,8 @@ const buildTileMesh = (
             positions[base + 1] + down.y,
             positions[base + 2] + down.z,
         );
+        // スカート頂点の UV は元の周縁頂点と同じ（辺のテクセルを縦に引き延ばす）。
+        uvs.push(uvs[gi * 2], uvs[gi * 2 + 1]);
         skirtOf.set(gi, si);
         return si;
     };
@@ -220,10 +236,24 @@ const buildTileMesh = (
     vertexData.positions = positions;
     vertexData.indices = surfaceIndices.concat(wallIndices);
     vertexData.normals = normals;
+    vertexData.uvs = uvs;
 
     const mesh = new Mesh(`tile-${tileKey(zoom, tx, ty)}`, scene);
     vertexData.applyToMesh(mesh);
     mesh.position.copyFrom(anchor);
+
+    // 地理院タイル画像を diffuseTexture として適用（同一 z/x/y）。地形の陰影は
+    // ライティングで残しつつ、テクスチャで地図表現にする。タイルごとに専有し、
+    // アンロード時に mesh.dispose(_, true) でテクスチャごと破棄する。
+    const mat = new StandardMaterial(`tile-mat-${tileKey(zoom, tx, ty)}`, scene);
+    const tex = new Texture(textureUrl(mapType, zoom, tx, ty), scene);
+    tex.wrapU = Texture.CLAMP_ADDRESSMODE;
+    tex.wrapV = Texture.CLAMP_ADDRESSMODE;
+    mat.diffuseTexture = tex;
+    mat.specularColor = new Color3(0.02, 0.02, 0.02);
+    mat.backFaceCulling = false;
+    mat.twoSidedLighting = true;
+    mesh.material = mat;
     return mesh;
 };
 
@@ -241,6 +271,8 @@ const start = async (): Promise<void> => {
     const lon = resolveNumber(search, "lon", DEFAULTS.lon);
     const minZoom = Math.round(resolveNumber(search, "zoom", DEFAULTS.minZoom));
     const radius = resolveNumber(search, "radius", DEFAULTS.radius);
+    const mapType: MapType =
+        new URLSearchParams(search).get("map") === "photo" ? "photo" : "std";
 
     const canvas = document.createElement("canvas");
     canvas.style.width = "100%";
@@ -355,12 +387,6 @@ const start = async (): Promise<void> => {
     const sun = new DirectionalLight("sun", sunDir, scene);
     sun.intensity = 0.7;
 
-    const material = new StandardMaterial("terrain-mat", scene);
-    material.diffuseColor = new Color3(0.55, 0.62, 0.5);
-    material.specularColor = new Color3(0.05, 0.05, 0.05);
-    material.backFaceCulling = false;
-    material.twoSidedLighting = true;
-
     engine.runRenderLoop(() => scene.render());
     window.addEventListener("resize", () => engine.resize());
 
@@ -396,8 +422,7 @@ const start = async (): Promise<void> => {
                 loading.delete(key);
                 // 取得完了までにアンロード対象になっていなければメッシュ化する。
                 if (!desiredKeys.has(key)) return;
-                const mesh = buildTileMesh(scene, t.zoom, t.x, t.y, elev, DEFAULTS.segments);
-                mesh.material = material;
+                const mesh = buildTileMesh(scene, t.zoom, t.x, t.y, elev, DEFAULTS.segments, mapType);
                 loaded.set(key, mesh);
             })
             .catch((e) => {
@@ -425,7 +450,7 @@ const start = async (): Promise<void> => {
         // 不要になったタイルを破棄。
         for (const [key, mesh] of loaded) {
             if (!desiredKeys.has(key)) {
-                mesh.dispose();
+                mesh.dispose(false, true); // マテリアル・テクスチャごと破棄
                 loaded.delete(key);
             }
         }

--- a/src/demos/geospatial/index.ts
+++ b/src/demos/geospatial/index.ts
@@ -46,6 +46,7 @@ import {
     type MapType,
 } from "../../terrain/gsiTile";
 import { selectGlobeTiles, tileKey, type GlobeTile } from "./globeLod";
+import { ecefToGeodetic, uiToYawPitch, yawPitchToUi, toAtPath } from "./geoMapping";
 
 const DEMO_MOUNT_ID = "root";
 
@@ -59,6 +60,10 @@ const DEFAULTS = {
     maxZoom: 16,
     /** カメラ中心（地表）からの距離 [m]。 */
     radius: 60000,
+    /** 方位[deg]（0=北, +=東回り）→ yaw。 */
+    azimuth: 0,
+    /** チルト[deg]（0=直下, 90=水平）→ pitch。 */
+    tilt: 60,
     /** SSE 採用しきい値 [px]。 */
     sseThreshold: 256 * 2.5,
     /** 同時保持タイル数の上限。 */
@@ -276,6 +281,8 @@ const start = async (): Promise<void> => {
     const lon = resolveNumber(search, "lon", DEFAULTS.lon);
     const minZoom = Math.round(resolveNumber(search, "zoom", DEFAULTS.minZoom));
     const radius = resolveNumber(search, "radius", DEFAULTS.radius);
+    const azimuth = resolveNumber(search, "azimuth", DEFAULTS.azimuth);
+    const tilt = resolveNumber(search, "tilt", DEFAULTS.tilt);
     const mapType: MapType =
         new URLSearchParams(search).get("map") === "photo" ? "photo" : "std";
 
@@ -316,8 +323,10 @@ const start = async (): Promise<void> => {
     );
     camera.center = centerEcef;
     camera.radius = radius;
-    camera.yaw = 0; // 北向き
-    camera.pitch = 1.05; // 0=直下, π/2=水平。斜め見下ろしの俯瞰。
+    // 既存 UI の azimuth/tilt[deg] を yaw/pitch[rad] にマッピングして初期化。
+    const initYP = uiToYawPitch(azimuth, tilt);
+    camera.yaw = initYP.yaw;
+    camera.pitch = initYP.pitch;
 
     // near/far の自動調整（高度に応じた depth 精度最適化）。
     camera.addBehavior(new GeospatialClippingBehavior());
@@ -473,11 +482,23 @@ const start = async (): Promise<void> => {
             if (t.zoom < minZ) minZ = t.zoom;
             if (t.zoom > maxZ) maxZ = t.zoom;
         }
+
+        // ---- カメラ状態 ⇄ 既存 UI/URL のマッピングを実演 ----
+        // GeospatialCamera(yaw/pitch/radius/center) から既存 UI 表現(azimuth/tilt/altitude/lat,lon)を逆算。
+        const { azimuthDeg, tiltDeg } = yawPitchToUi(camera.yaw, camera.pitch);
+        const geo = ecefToGeodetic(camera.center); // center(ECEF) → 測地 lat/lon
+        const atPath = toAtPath(geo.latDeg, geo.lonDeg, camera.radius, azimuthDeg, tiltDeg);
+        // 既存と同じ共有 URL 形式を hash に反映（往復可能であることの実証）。
+        history.replaceState(null, "", `#${atPath}`);
+
         updateInfo(
-            `Geospatial PoC (#321) — 動的 LOD\n` +
+            `Geospatial PoC (#321) — 動的 LOD + UI/URL マッピング\n` +
                 `ドラッグ=回転 / ホイール=ズーム / WASD=パン\n` +
                 `engine: ${engine.constructor.name} / floatingOrigin: ${scene.floatingOriginMode}\n` +
-                `fps: ${engine.getFps().toFixed(0)} / radius: ${(camera.radius / 1000).toFixed(1)}km\n` +
+                `fps: ${engine.getFps().toFixed(0)}\n` +
+                `lat,lon: ${geo.latDeg.toFixed(4)}, ${geo.lonDeg.toFixed(4)}\n` +
+                `azimuth: ${azimuthDeg.toFixed(1)}° / tilt: ${tiltDeg.toFixed(1)}° / ` +
+                `altitude: ${Math.round(camera.radius)}m\n` +
                 `LOD zoom: ${Number.isFinite(minZ) ? `${minZ}–${maxZ}` : "-"} / ` +
                 `selected: ${tiles.length} / loaded: ${loaded.size} / loading: ${loading.size}`,
         );

--- a/src/demos/geospatial/index.ts
+++ b/src/demos/geospatial/index.ts
@@ -167,10 +167,11 @@ const buildTileMesh = (
             // アンカー相対（小さな値）で格納する。
             positions.push(ecef.x - anchor.x, ecef.y - anchor.y, ecef.z - anchor.z);
 
-            // UV: タイル画像に対応。col→u（西→東）、row=0 は北端。
-            // 地理院タイル画像は row=0 が北。Babylon は invertY=true で texture を
-            // 上下反転して読むため、v は row/segments（北端 row0 → v0）でそのまま整合する。
-            uvs.push(col / segments, row / segments);
+            // UV: col→u（西→東）。地理院タイル画像は row=0（pyF=0）が北端。
+            // Babylon の既定 Texture は invertY=true で、v=1 が画像上端（=北）、
+            // v=0 が下端（=南）に対応する。よって北端頂点(row=0)は v=1 にする必要があり、
+            // v = 1 - row/segments とする（row/segments だと per-tile で南北が反転する）。
+            uvs.push(col / segments, 1 - row / segments);
         }
     }
 

--- a/src/demos/geospatial/index.ts
+++ b/src/demos/geospatial/index.ts
@@ -203,7 +203,14 @@ const start = async (): Promise<void> => {
     canvas.style.width = "100%";
     canvas.style.height = "100%";
     canvas.style.display = "block";
+    // キーボード入力（WASD/矢印）は scene.onKeyboardObservable 経由で、canvas が
+    // フォーカスを持つ必要がある。tabIndex を付与し、ポインタ操作時にフォーカスを当てる
+    // （pointer/wheel はフォーカス不要だがキーボードは必須）。
+    canvas.tabIndex = 0;
+    canvas.style.outline = "none";
+    canvas.addEventListener("pointerdown", () => canvas.focus());
     mount.appendChild(canvas);
+    canvas.focus();
 
     const engine = await createBabylonEngine(canvas, resolveEngine(search) ?? "webgpu");
 
@@ -233,6 +240,66 @@ const start = async (): Promise<void> => {
 
     // GeospatialCamera はコンストラクタで既定入力（pointers/wheel/keyboard）を備える。
     camera.attachControl(true);
+
+    // ---- WASD パン（picking に依存しない独自実装） ----
+    // 既定の pan（キーボード/左ドラッグ）は scene.pick でグローブをヒットしてドラッグ平面を
+    // 作るが、useFloatingOrigin 下ではレンダリング座標と真の ECEF メッシュ位置がずれ、
+    // ピックが外れて pan が機能しない。floating origin（#275 の精度要件）を維持するため、
+    // camera.center を地理的接線（北/東）方向へ高度比例で移動させる独自パンを実装する。
+    const pressed = new Set<string>();
+    const PAN_KEYS = new Set(["w", "a", "s", "d"]);
+    const onKeyDown = (e: KeyboardEvent): void => {
+        const k = e.key.toLowerCase();
+        if (PAN_KEYS.has(k)) {
+            pressed.add(k);
+            e.preventDefault();
+        }
+    };
+    const onKeyUp = (e: KeyboardEvent): void => {
+        pressed.delete(e.key.toLowerCase());
+    };
+    canvas.addEventListener("keydown", onKeyDown);
+    canvas.addEventListener("keyup", onKeyUp);
+
+    /** 1 秒あたりのパン距離 = radius（高度相当）× この係数。高度に比例した自然な速度。 */
+    const PAN_RATE_PER_SEC = 0.6;
+    const POLE = new Vector3(0, 0, 1); // ECEF 北極軸（EcefFromLatLonAltToRef 規約）
+    const eastV = new Vector3();
+    const northV = new Vector3();
+    const tangent = new Vector3();
+
+    const applyPan = (): void => {
+        if (pressed.size === 0) return;
+        const c = camera.center;
+        const r = c.length();
+        if (r < 1) return;
+        const upV = c.scale(1 / r);
+        // 地心 up と北極軸から東/北の接線基底を作る。
+        Vector3.CrossToRef(POLE, upV, eastV);
+        if (eastV.lengthSquared() < 1e-12) eastV.copyFromFloats(1, 0, 0);
+        eastV.normalize();
+        Vector3.CrossToRef(upV, eastV, northV); // 北
+        northV.normalize();
+
+        let fwd = 0;
+        let side = 0;
+        if (pressed.has("w")) fwd += 1;
+        if (pressed.has("s")) fwd -= 1;
+        if (pressed.has("d")) side += 1;
+        if (pressed.has("a")) side -= 1;
+        if (fwd === 0 && side === 0) return;
+
+        const dtSec = Math.min(0.05, engine.getDeltaTime() / 1000);
+        const step = camera.radius * PAN_RATE_PER_SEC * dtSec;
+        tangent.copyFromFloats(0, 0, 0);
+        tangent.addInPlace(northV.scale(fwd)).addInPlace(eastV.scale(side));
+        tangent.normalize().scaleInPlace(step);
+
+        // center を接線方向へ移動し、地心距離 r を保つように再正規化して球面上に戻す。
+        const moved = c.add(tangent);
+        moved.normalize().scaleInPlace(r);
+        camera.center = moved;
+    };
 
     // ライト: 地表の up（地心法線）を基準に環境光 + 斜め方向の指向性ライト。
     const up = centerEcef.clone().normalize();
@@ -343,6 +410,7 @@ const start = async (): Promise<void> => {
     syncTiles();
     let frame = 0;
     scene.onBeforeRenderObservable.add(() => {
+        applyPan();
         frame++;
         if (frame % DEFAULTS.syncIntervalFrames === 0) syncTiles();
     });

--- a/src/demos/geospatial/index.ts
+++ b/src/demos/geospatial/index.ts
@@ -401,6 +401,68 @@ const start = async (): Promise<void> => {
         camera.center = moved;
     };
 
+    // ---- 左ドラッグパン（picking 非依存） ----
+    // 既定の左ドラッグパンは scene.pick 依存で floating origin 下では no-op のため、
+    // WASD と同様に camera.center を地表接線へ動かす独自実装で「マップを掴む」操作を提供する。
+    // ドラッグのピクセル移動量を、注視点距離での地表 m/px に換算してパン量とする。
+    let dragging = false;
+    let lastX = 0;
+    let lastY = 0;
+    const dragLookAt = new Vector3();
+    const dragUp = new Vector3();
+    const dragRight = new Vector3();
+    const dragFwd = new Vector3();
+    canvas.addEventListener("pointerdown", (e) => {
+        if (e.button !== 0) return;
+        dragging = true;
+        lastX = e.clientX;
+        lastY = e.clientY;
+        canvas.setPointerCapture?.(e.pointerId);
+    });
+    const endDrag = (): void => {
+        dragging = false;
+    };
+    canvas.addEventListener("pointerup", (e) => {
+        if (e.button === 0) endDrag();
+    });
+    canvas.addEventListener("pointercancel", endDrag);
+    canvas.addEventListener("pointermove", (e) => {
+        if (!dragging) return;
+        const dx = e.clientX - lastX;
+        const dy = e.clientY - lastY;
+        lastX = e.clientX;
+        lastY = e.clientY;
+        if (dx === 0 && dy === 0) return;
+
+        const c = camera.center;
+        const r = c.length();
+        if (r < 1) return;
+        c.scaleToRef(1 / r, dragUp); // 地心 up
+        // カメラ→center 方向（lookAt）から地表接線の右・前方向を作る。
+        ComputeLookAtFromYawPitchToRef(
+            camera.yaw,
+            camera.pitch,
+            c,
+            scene.useRightHandedSystem,
+            dragLookAt,
+        );
+        Vector3.CrossToRef(dragLookAt, dragUp, dragRight);
+        if (dragRight.lengthSquared() < 1e-12) return; // 真下視点の特異点
+        dragRight.normalize();
+        Vector3.CrossToRef(dragUp, dragRight, dragFwd); // 地表に沿ったカメラ前方
+        dragFwd.normalize();
+
+        // 注視点距離での地表 m/px（掴んだ点がほぼカーソル追従する縮尺）。
+        const fovHeightM = 2 * camera.radius * Math.tan(camera.fov / 2);
+        const mpp = fovHeightM / Math.max(1, canvas.clientHeight);
+        // マップを掴んで引く挙動: 掴んだ地点がカーソルに追従する向き。
+        // 右ドラッグ→center 西（content 右へ）、下ドラッグ→center 前方=北（content 下へ）。
+        const move = dragRight.scale(-dx * mpp).addInPlace(dragFwd.scale(dy * mpp));
+        const moved = c.add(move);
+        moved.normalize().scaleInPlace(r);
+        camera.center = moved;
+    });
+
     // ライト: 地表の up（地心法線）を基準に環境光 + 斜め方向の指向性ライト。
     const up = centerEcef.clone().normalize();
     const hemi = new HemisphericLight("hemi", up, scene);
@@ -532,7 +594,7 @@ const start = async (): Promise<void> => {
 
         updateInfo(
             `Geospatial PoC (#321) — 動的 LOD + UI/URL マッピング\n` +
-                `ドラッグ=回転 / ホイール=ズーム / WASD=パン\n` +
+                `左ドラッグ=パン / 右ドラッグ=回転 / ホイール=ズーム / WASD=パン\n` +
                 `engine: ${engine.constructor.name} / floatingOrigin: ${scene.floatingOriginMode}\n` +
                 `fps: ${engine.getFps().toFixed(0)}\n` +
                 `lat,lon: ${geo.latDeg.toFixed(4)}, ${geo.lonDeg.toFixed(4)}\n` +

--- a/src/demos/geospatial/index.ts
+++ b/src/demos/geospatial/index.ts
@@ -42,6 +42,7 @@ import {
     loadElevationTile,
     tileEdgeMeters,
     textureUrl,
+    toTileXY,
     TILE_SIZE,
     type MapType,
 } from "../../terrain/gsiTile";
@@ -57,8 +58,11 @@ const DEFAULTS = {
     lon: 138.7274,
     /** root（最低）ズーム。 */
     minZoom: 11,
-    /** 最高ズーム（分割上限）。 */
-    maxZoom: 16,
+    /** 最高ズーム（分割上限）。テクスチャ（std/photo）は z18 まで対応。 */
+    maxZoom: 18,
+    /** ジオメトリ（標高）の最高ズーム。GSI DEM(dem5a/5b) は z15 まで。
+     *  z16-18 は z15 祖先の標高をサブサンプルして使う（テクスチャのみ高解像度）。 */
+    geomMaxZoom: 15,
     /** カメラ中心（地表）からの距離 [m]。 */
     radius: 60000,
     /** 方位[deg]（0=北, +=東回り）→ yaw。 */
@@ -120,16 +124,41 @@ const pixelToLatLon = (
  * （垂直フランジ）を付与する。隣接タイルの LOD を知らずに隙間を隠せる方式で、
  * Cesium / Google Earth 等のグローブ地形レンダラーで標準的に使われる。
  */
+/** 標高ラスタ（TILE_SIZE 角）をローカルピクセル座標で bilinear サンプル（無効値は 0）。 */
+const sampleElevBilinear = (elev: Float32Array, px: number, py: number): number => {
+    const cx = Math.max(0, Math.min(TILE_SIZE - 1, px));
+    const cy = Math.max(0, Math.min(TILE_SIZE - 1, py));
+    const x0 = Math.floor(cx);
+    const y0 = Math.floor(cy);
+    const x1 = Math.min(x0 + 1, TILE_SIZE - 1);
+    const y1 = Math.min(y0 + 1, TILE_SIZE - 1);
+    const fx = cx - x0;
+    const fy = cy - y0;
+    const g = (x: number, y: number): number => {
+        const v = elev[y * TILE_SIZE + x];
+        return Number.isFinite(v) ? v : 0;
+    };
+    const a = g(x0, y0) * (1 - fx) + g(x1, y0) * fx;
+    const b = g(x0, y1) * (1 - fx) + g(x1, y1) * fx;
+    return a * (1 - fy) + b * fy;
+};
+
 const buildTileMesh = (
     scene: Scene,
     zoom: number,
     tx: number,
     ty: number,
-    elevation: Float32Array,
+    // ジオメトリ用標高タイル（DEM 上限 z15 まで。z16-18 タイルは z15 祖先を使う）。
+    geomElev: Float32Array,
+    geomZoom: number,
+    geomX: number,
+    geomY: number,
     segments: number,
     mapType: MapType,
     edges: readonly CoarseEdge[],
 ): Mesh => {
+    // この描画タイル(zoom)の 1 ピクセルが geom タイルの 1/geomScale ピクセルに対応。
+    const geomScale = 2 ** (zoom - geomZoom);
     const totalPixels = TILE_SIZE * 2 ** zoom;
     const latLonAlt: ILatLonAltLike = { lat: 0, lon: 0, alt: 0 };
 
@@ -153,14 +182,15 @@ const buildTileMesh = (
 
     for (let row = 0; row < vertsPerSide; row++) {
         for (let col = 0; col < vertsPerSide; col++) {
-            // タイル内ピクセル位置（0..TILE_SIZE）。最終頂点は端 (255) にクランプ。
+            // タイル内ピクセル位置（0..TILE_SIZE）。
             const pxF = (col / segments) * TILE_SIZE;
             const pyF = (row / segments) * TILE_SIZE;
-            const sx = Math.min(TILE_SIZE - 1, Math.round(pxF));
-            const sy = Math.min(TILE_SIZE - 1, Math.round(pyF));
-            let elev = elevation[sy * TILE_SIZE + sx];
-            if (!Number.isFinite(elev)) elev = 0;
-            // クロスレベル: 境界辺なら粗タイル表面へ標高をスナップ（陰影シーム解消）。
+            // この頂点のグローバルピクセル(zoom)→ geom タイルのローカルピクセルへ写像し、
+            // geom 標高（z16-18 は z15 祖先）を bilinear サンプル。
+            const glx = (tx * TILE_SIZE + pxF) / geomScale - geomX * TILE_SIZE;
+            const gly = (ty * TILE_SIZE + pyF) / geomScale - geomY * TILE_SIZE;
+            let elev = sampleElevBilinear(geomElev, glx, gly);
+            // クロスレベル: 境界辺なら粗タイル表面へ標高をスナップ（陰影シーム解消、z<=15 のみ）。
             const snapped = snapEdgeElevation(edges, row, col, segments, tx, ty, pxF, pyF);
             if (snapped !== null) elev = snapped;
 
@@ -503,54 +533,93 @@ const start = async (): Promise<void> => {
     // 直近の LOD 選択キー集合（取得完了時に「まだ必要か」を判定するために参照する）。
     let desiredKeys = new Set<string>();
 
-    // 標高取得はキャッシュに溜めるだけ（メッシュ化は建築パスで行う）。
+    // 描画タイル(zoom 最大18) → ジオメトリ用標高タイル(最大 geomMaxZoom=15)の対応。
+    const geomCoordOf = (t: GlobeTile): { gz: number; gx: number; gy: number } => {
+        const gz = Math.min(t.zoom, DEFAULTS.geomMaxZoom);
+        const d = t.zoom - gz;
+        return { gz, gx: t.x >> d, gy: t.y >> d };
+    };
+
+    /**
+     * 緯度経度の地形標高[m]を、読み込み済みの「最も詳細な」geom タイルから bilinear 取得。
+     * z15→minZoom を探索し最初に見つかったものを使う（無ければ null）。
+     * 遠景では粗い標高で中心を地形へ持ち上げ、近づくほど精細化してブートストラップする
+     * （高標高地で中心を海面のままにするとカメラが地形下へ潜るのを防ぐ）。
+     */
+    const terrainElevAt = (latDeg: number, lonDeg: number): number | null => {
+        const latRad = latDeg * DEG2RAD;
+        for (let gz = DEFAULTS.geomMaxZoom; gz >= minZoom; gz--) {
+            const { x, y } = toTileXY(latDeg, lonDeg, gz);
+            const e = elevCache.get(tileKey(gz, x, y));
+            if (!e) continue;
+            const total = TILE_SIZE * 2 ** gz;
+            const gpx = ((lonDeg + 180) / 360) * total;
+            const gpy = ((1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) / 2) * total;
+            return sampleElevBilinear(e, gpx - x * TILE_SIZE, gpy - y * TILE_SIZE);
+        }
+        return null;
+    };
+    const seatCenter = new Vector3();
+    // SSE 距離評価の基準標高（中心付近の地形標高）。前 sync の値を次 sync で使う。
+    let centerElevation = 0;
+
+    // 標高取得（geom タイル単位）はキャッシュに溜めるだけ。z16-18 は z15 を共有しデデュプされる。
     const loadTile = (t: GlobeTile): void => {
-        const key = tileKey(t.zoom, t.x, t.y);
-        if (elevCache.has(key) || loading.has(key) || failed.has(key)) return;
-        loading.add(key);
-        loadElevationTile(t.zoom, t.x, t.y)
+        const { gz, gx, gy } = geomCoordOf(t);
+        const gk = tileKey(gz, gx, gy);
+        if (elevCache.has(gk) || loading.has(gk) || failed.has(gk)) return;
+        loading.add(gk);
+        loadElevationTile(gz, gx, gy)
             .then((elev) => {
-                loading.delete(key);
-                elevCache.set(key, elev);
+                loading.delete(gk);
+                elevCache.set(gk, elev);
             })
             .catch((e) => {
-                loading.delete(key);
-                failed.add(key);
-                console.warn(`[geospatial-poc] tile ${key} failed:`, e);
+                loading.delete(gk);
+                failed.add(gk);
+                console.warn(`[geospatial-poc] geom tile ${gk} failed:`, e);
             });
     };
 
     /**
-     * 建築パス: 標高が揃った desired タイルをメッシュ化する。
-     * クロスレベルスナップに必要な粗タイル標高が未ロードなら遅延（次回 sync で再試行）。
+     * 建築パス: geom 標高が揃った desired タイルをメッシュ化する。
+     * - ジオメトリは geom タイル(<=z15)からサブサンプル。テクスチャは描画 zoom(<=z18)。
+     * - クロスレベルスナップは zoom<=geomMaxZoom の境界でのみ適用（z16-18 は z15 を共有し連続）。
      */
     const buildReadyTiles = (tiles: readonly GlobeTile[]): void => {
         for (const t of tiles) {
             const k = tileKey(t.zoom, t.x, t.y);
             if (loaded.has(k)) continue;
-            const elev = elevCache.get(k);
-            if (!elev) continue; // 自身の標高が未ロード
-            const { edges, pending } = selectCoarseEdges(
-                t,
-                (kk) => desiredKeys.has(kk),
-                (kk) => elevCache.get(kk),
-                (kk) => failed.has(kk),
-                minZoom,
-            );
-            if (pending) continue; // 粗隣接の標高待ち
+            const { gz, gx, gy } = geomCoordOf(t);
+            const geomElev = elevCache.get(tileKey(gz, gx, gy));
+            if (!geomElev) continue; // geom 標高が未ロード（または no-data 失敗）
+
+            let edges: readonly CoarseEdge[] = [];
+            if (snapEnabled && t.zoom <= DEFAULTS.geomMaxZoom) {
+                const r = selectCoarseEdges(
+                    t,
+                    (kk) => desiredKeys.has(kk),
+                    (kk) => elevCache.get(kk),
+                    (kk) => failed.has(kk),
+                    minZoom,
+                );
+                if (r.pending) continue; // 粗隣接の標高待ち
+                edges = r.edges;
+            }
             const mesh = buildTileMesh(
-                scene, t.zoom, t.x, t.y, elev, DEFAULTS.segments, mapType,
-                snapEnabled ? edges : [],
+                scene, t.zoom, t.x, t.y, geomElev, gz, gx, gy, DEFAULTS.segments, mapType, edges,
             );
             loaded.set(k, mesh);
         }
     };
 
     const syncTiles = (): void => {
+        // root 探索はカメラの現在の注視点(center)を追従する（パン後もカメラ直下を選択）。
+        const camGeo = ecefToGeodetic(camera.center);
         const tiles = selectGlobeTiles({
             cameraEcef: computeCameraEcef(),
-            centerLat: lat,
-            centerLon: lon,
+            centerLat: camGeo.latDeg,
+            centerLon: camGeo.lonDeg,
             minZoom,
             maxZoom: DEFAULTS.maxZoom,
             viewportHeight: engine.getRenderHeight(),
@@ -559,22 +628,43 @@ const start = async (): Promise<void> => {
             maxTiles: DEFAULTS.maxTiles,
             rootSearchRadius: DEFAULTS.rootSearchRadius,
             horizonDotThreshold: DEFAULTS.horizonDotThreshold,
+            referenceAltitude: centerElevation,
         });
         desiredKeys = new Set(tiles.map((t) => tileKey(t.zoom, t.x, t.y)));
+        // 必要な geom 標高タイルのキー集合（z16-18 は z15 祖先を共有）。
+        const neededGeom = new Set(tiles.map((t) => {
+            const { gz, gx, gy } = geomCoordOf(t);
+            return tileKey(gz, gx, gy);
+        }));
 
-        // 不要になったタイルを破棄（メッシュ・標高キャッシュとも）。
+        // 不要になったメッシュを破棄。
         for (const [key, mesh] of loaded) {
             if (!desiredKeys.has(key)) {
                 mesh.dispose(false, true); // マテリアル・テクスチャごと破棄
                 loaded.delete(key);
             }
         }
+        // 不要になった geom 標高キャッシュを破棄（必要 geom キー集合で判定）。
         for (const key of elevCache.keys()) {
-            if (!desiredKeys.has(key)) elevCache.delete(key);
+            if (!neededGeom.has(key)) elevCache.delete(key);
         }
         // 新規タイルをロードし、標高が揃ったものを（クロスレベルスナップ付きで）建築。
         for (const t of tiles) loadTile(t);
         buildReadyTiles(tiles);
+
+        // orbit 中心を地形表面へ追従させる（中心を海面 alt=0 のままにすると、富士山等の
+        // 高標高地でズームインした際にカメラが地形下へ潜り、地表が背面カリングで消える）。
+        // 標高が読めたら中心高度を地形標高へイージングで寄せる（初回ロード時の段差を緩和）。
+        const elevAtCenter = terrainElevAt(camGeo.latDeg, camGeo.lonDeg);
+        if (elevAtCenter !== null) {
+            centerElevation = elevAtCenter; // 次 sync の SSE 基準標高に使う
+            EcefFromLatLonAltToRef(
+                { lat: camGeo.latDeg * DEG2RAD, lon: camGeo.lonDeg * DEG2RAD, alt: elevAtCenter },
+                Wgs84Ellipsoid,
+                seatCenter,
+            );
+            camera.center = Vector3.Lerp(camera.center, seatCenter, 0.35);
+        }
 
         // 統計表示。
         let minZ = Infinity;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,6 +34,7 @@ const HTML_ENTRIES = [
     "boids",
     "flight",
     "artillery",
+    "geospatial", // PoC: Babylon.js Geospatial 検証 (#321)
 ];
 
 const input = Object.fromEntries(

--- a/vite.rewrites.ts
+++ b/vite.rewrites.ts
@@ -29,6 +29,7 @@ const DEMO_NAMES = [
     "boids",
     "flight",
     "artillery",
+    "geospatial", // PoC: Babylon.js Geospatial 検証 (#321)
 ];
 
 export const demoAtPathRewrites: DemoRewrite[] = DEMO_NAMES.flatMap((name) => [


### PR DESCRIPTION
Closes #321 / 親 #275

## 概要

Babylon.js 9.x Geospatial への全面移行（#275）の**実現可能性検証 PoC**。
既存の平面ワールドスタック（`JpmapTerrain` / `scenes/default.ts` / `tileManager` 等）には
一切依存・改修せず、スタンドアロンの並行エントリとして追加する。流用するのは標高タイル取得
（`gsiTile.loadElevationTile`）のみ。

## 変更内容

- `public/geospatial.html` — PoC エントリ（`#root` + 操作ヒント表示）
- `src/demos/geospatial/index.ts` — `GeospatialCamera` + `useFloatingOrigin` な `Scene`
  + `GeospatialClippingBehavior` の最小構成。各頂点を lat/lon/標高 → ECEF（`Wgs84Ellipsoid`）
  で曲面メッシュ化
- `vite.config.ts` / `vite.rewrites.ts` — `geospatial` エントリを登録（既存への変更はこの2行のみ）

### 精度設計（Large World Rendering）

Float32 頂点バッファの精度劣化を避けるため、頂点はタイル中心アンカー相対の小座標で格納し、
真の ECEF（百万 m オーダー）は `mesh.position`（double 精度の world matrix 経由）へ載せる。
`useFloatingOrigin: true` と組み合わせ、近距離でもジッタなく描画できることを確認。

## 影響範囲

- 画面: 新規 PoC ページ `/geospatial` のみ。既存デモ・公開 API には影響なし。
- API/型: 変更なし。
- ドキュメント: なし（PoC のため）。

## 検証

headless WebGPU（Playwright）で確認:
- ✅ WebGPU 起動・`floatingOrigin: true` 有効
- ✅ GSI 標高タイル 49/49 取得
- ✅ 富士山の3D地形が ECEF グローブ上（地平線の湾曲つき）に描画
- ✅ `npm run lint` / `npm run typecheck` 通過、ページエラー・入力警告なし

ローカル確認: `npm start` → http://localhost:8080/geospatial （`?lat=&lon=&zoom=&radius=` で地点変更可）

> Draft: 検証所見の記録と次の検証項目（LOD/SSE のグローブ向け再定義など）を #321 で詰めてから Ready 化する想定。

## スクリーンショット

<img width="1000" height="700" alt="geo-poc" src="https://github.com/user-attachments/assets/6ad83801-ffa4-4ec1-bf7f-037b9689966c" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)