### PR TITLE
feat(geo): グローブ地形の座標基盤ユーティリティ (Phase 0 / #275)

### DIFF
--- a/src/terrain/geo/ecef.ts
+++ b/src/terrain/geo/ecef.ts
@@ -3,8 +3,8 @@
  *
  * グローブ地形（Issue #275）の座標基盤。Babylon.js の `EcefFromLatLonAltToRef`
  * （測地→ECEF）に対し、本モジュールは度数入力のラッパと、ECEF→測地の逆変換
- * （Bowring 閉形式）を提供する。PoC（Issue #321 / `geoMapping.ts`）の純関数を
- * 本体共有モジュールへ昇格したもの。
+ * （Bowring 閉形式）を提供する。PoC（Issue #321）の純関数を本体共有モジュールへ
+ * 昇格したもの。
  *
  * 軸の規約は Babylon の `EcefFromLatLonAltToRef` と同一:
  * - X 軸 → 経度 0°（本初子午線）

--- a/src/terrain/geo/ecef.ts
+++ b/src/terrain/geo/ecef.ts
@@ -1,0 +1,96 @@
+/**
+ * ECEF（Earth-Centered, Earth-Fixed / WGS84）座標と測地座標の相互変換。
+ *
+ * グローブ地形（Issue #275）の座標基盤。Babylon.js の `EcefFromLatLonAltToRef`
+ * （測地→ECEF）に対し、本モジュールは度数入力のラッパと、ECEF→測地の逆変換
+ * （Bowring 閉形式）を提供する。PoC（Issue #321 / `geoMapping.ts`）の純関数を
+ * 本体共有モジュールへ昇格したもの。
+ *
+ * 軸の規約は Babylon の `EcefFromLatLonAltToRef` と同一:
+ * - X 軸 → 経度 0°（本初子午線）
+ * - Y 軸 → 東経 90°
+ * - Z 軸 → 北極
+ */
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import {
+    EcefFromLatLonAltToRef,
+    Wgs84Ellipsoid,
+} from "@babylonjs/core/Maths/math.geospatial.functions";
+import type { ILatLonAltLike } from "@babylonjs/core/Maths/math.geospatial";
+
+export const DEG2RAD = Math.PI / 180;
+export const RAD2DEG = 180 / Math.PI;
+
+/** 測地座標（度・メートル）。 */
+export interface Geodetic {
+    /** 緯度[deg]。 */
+    latDeg: number;
+    /** 経度[deg]。 */
+    lonDeg: number;
+    /** 楕円体面からの高度[m]。 */
+    altMeters: number;
+}
+
+/** 度数の測地座標を radian の `ILatLonAltLike` に詰める内部バッファ。 */
+const scratchLatLonAlt: ILatLonAltLike = { lat: 0, lon: 0, alt: 0 };
+
+/**
+ * 測地座標（度・メートル）→ ECEF[m]。Babylon の `EcefFromLatLonAltToRef` の
+ * 度数入力ラッパ。結果を `ref` に書き込んで返す（アロケーション回避）。
+ */
+export const geodeticToEcefToRef = (
+    latDeg: number,
+    lonDeg: number,
+    altMeters: number,
+    ref: Vector3,
+): Vector3 => {
+    scratchLatLonAlt.lat = latDeg * DEG2RAD;
+    scratchLatLonAlt.lon = lonDeg * DEG2RAD;
+    scratchLatLonAlt.alt = altMeters;
+    EcefFromLatLonAltToRef(scratchLatLonAlt, Wgs84Ellipsoid, ref);
+    return ref;
+};
+
+/** 測地座標（度・メートル）→ ECEF[m]。新規 `Vector3` を返す簡易版。 */
+export const geodeticToEcef = (
+    latDeg: number,
+    lonDeg: number,
+    altMeters: number,
+): Vector3 => geodeticToEcefToRef(latDeg, lonDeg, altMeters, new Vector3());
+
+/**
+ * ECEF[m] → 測地座標（WGS84）の逆変換。Bowring の閉形式（1 反復で mm 級精度）。
+ *
+ * 軸の規約は `geodeticToEcef` / Babylon の `EcefFromLatLonAltToRef` と同じ
+ * （X→経度0, Y→東経90°, Z→北極）。
+ */
+export const ecefToGeodetic = (ecef: Vector3): Geodetic => {
+    const a = Wgs84Ellipsoid.semiMajorAxis;
+    const b = Wgs84Ellipsoid.semiMinorAxis;
+    const e2 = Wgs84Ellipsoid.firstEccentricitySquared;
+    const ep2 = Wgs84Ellipsoid.secondEccentricitySquared;
+
+    const x = ecef.x;
+    const y = ecef.y;
+    const z = ecef.z;
+
+    const lon = Math.atan2(y, x);
+    const p = Math.hypot(x, y);
+    // 極（p≈0）の特異点を回避。
+    if (p < 1e-6) {
+        const latDeg = z >= 0 ? 90 : -90;
+        return { latDeg, lonDeg: lon * RAD2DEG, altMeters: Math.abs(z) - b };
+    }
+    const theta = Math.atan2(z * a, p * b);
+    const sinT = Math.sin(theta);
+    const cosT = Math.cos(theta);
+    const lat = Math.atan2(
+        z + ep2 * b * sinT * sinT * sinT,
+        p - e2 * a * cosT * cosT * cosT,
+    );
+    const sinLat = Math.sin(lat);
+    const N = a / Math.sqrt(1 - e2 * sinLat * sinLat); // 卯酉線曲率半径
+    const alt = p / Math.cos(lat) - N;
+
+    return { latDeg: lat * RAD2DEG, lonDeg: lon * RAD2DEG, altMeters: alt };
+};

--- a/src/terrain/geo/index.ts
+++ b/src/terrain/geo/index.ts
@@ -1,0 +1,8 @@
+/**
+ * グローブ地形（Issue #275）の座標基盤ユーティリティのバレル。
+ *
+ * - `ecef`: ECEF（WGS84）⇄ 測地座標の相互変換。
+ * - `mapping`: Web メルカトルのグローバルピクセル ⇄ 緯度経度。
+ */
+export * from "./ecef";
+export * from "./mapping";

--- a/src/terrain/geo/mapping.ts
+++ b/src/terrain/geo/mapping.ts
@@ -11,7 +11,17 @@
  * NOTE: データ取得層 `gsiTile.ts`（`toTileXY` / `tileCenterLatLon`）はタイル整数座標
  * 単位の変換で温存対象。本モジュールはサブピクセル精度のグローバルピクセル変換を担う。
  */
-import { TILE_SIZE } from "../gsiTile";
+import { TILE_SIZE, clamp } from "../gsiTile";
+
+/**
+ * Web メルカトルの緯度有効域[deg]。±この緯度で投影が ±無限大に発散するため、
+ * `gsiTile.toTileXY` と同じ値でクランプする。
+ */
+export const MERCATOR_MAX_LAT = 85.05112878;
+
+/** 経度を [-180, 180) に正規化する（`gsiTile.toTileXY` と同じ式）。 */
+const normalizeLon = (lonDeg: number): number =>
+    ((((lonDeg + 180) % 360) + 360) % 360) - 180;
 
 /** zoom レベル全体のグローバルピクセル幅（= 高さ）。 */
 export const totalPixelsForZoom = (zoom: number): number =>
@@ -19,6 +29,14 @@ export const totalPixelsForZoom = (zoom: number): number =>
 
 /**
  * グローバルピクセル座標 → 緯度経度[deg]（Web メルカトル逆変換）。
+ *
+ * 範囲外入力に対する堅牢化として `globalPx/globalPy` を [0, totalPixels] にクランプし、
+ * lon を [-180, 180]、lat をメルカトル有効域内に収める。
+ *
+ * NOTE: lon は「ラップ（正規化）」ではなく「クランプ」する。逆変換で lon をラップすると、
+ * 最東端タイル右端（globalPx=totalPixels, lon=180）が -180 へ飛び、1 タイルが経度 360° に
+ * 跨る不正メッシュになる。連続したピクセル→経度の単調写像を保つためクランプとする
+ * （順変換 `latLonToPixel` 側では入力 lon の正規化が正しいので、そちらでのみ正規化する）。
  *
  * @param globalPx 西→東のグローバルピクセル X。
  * @param globalPy 北→南のグローバルピクセル Y。
@@ -29,8 +47,10 @@ export const pixelToLatLon = (
     globalPy: number,
     totalPixels: number,
 ): { lat: number; lon: number } => {
-    const lon = (globalPx / totalPixels) * 360 - 180;
-    const ny = globalPy / totalPixels;
+    const px = clamp(globalPx, 0, totalPixels);
+    const py = clamp(globalPy, 0, totalPixels);
+    const lon = (px / totalPixels) * 360 - 180;
+    const ny = py / totalPixels;
     const lat = (Math.atan(Math.sinh(Math.PI * (1 - 2 * ny))) * 180) / Math.PI;
     return { lat, lon };
 };
@@ -39,7 +59,11 @@ export const pixelToLatLon = (
  * 緯度経度[deg] → グローバルピクセル座標（Web メルカトル順変換）。
  * `pixelToLatLon` の逆関数。
  *
- * @param latDeg 緯度[deg]（メルカトル有効範囲 ±85.05112878° 前提）。
+ * `gsiTile.toTileXY` と挙動を揃えるため、緯度を ±{@link MERCATOR_MAX_LAT} にクランプし
+ * （`Math.log(tan+sec)` の発散 → `Infinity/NaN` を防ぐ）、経度を [-180, 180) に正規化してから
+ * 変換する。
+ *
+ * @param latDeg 緯度[deg]。
  * @param lonDeg 経度[deg]。
  * @param totalPixels `totalPixelsForZoom(zoom)`。
  */
@@ -48,10 +72,18 @@ export const latLonToPixel = (
     lonDeg: number,
     totalPixels: number,
 ): { px: number; py: number } => {
-    const latRad = (latDeg * Math.PI) / 180;
-    const px = ((lonDeg + 180) / 360) * totalPixels;
-    const py =
+    const latClamped = clamp(latDeg, -MERCATOR_MAX_LAT, MERCATOR_MAX_LAT);
+    const lonNormalized = normalizeLon(lonDeg);
+    const latRad = (latClamped * Math.PI) / 180;
+    // 出力も [0, totalPixels] に収める。MERCATOR_MAX_LAT は丸め値のため、緯度上限ちょうどで
+    // py が ±数 e-5 px だけ域外に出る。`gsiTile.toTileXY` が最終的にタイル整数を [0, n-1] へ
+    // クランプするのと同じ定義域をピクセル粒度で保証する。
+    const px = clamp(((lonNormalized + 180) / 360) * totalPixels, 0, totalPixels);
+    const py = clamp(
         ((1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) / 2) *
-        totalPixels;
+            totalPixels,
+        0,
+        totalPixels,
+    );
     return { px, py };
 };

--- a/src/terrain/geo/mapping.ts
+++ b/src/terrain/geo/mapping.ts
@@ -1,0 +1,57 @@
+/**
+ * Web メルカトル（XYZ タイル）のグローバルピクセル座標と緯度経度の相互変換。
+ *
+ * グローブ地形（Issue #275）で、タイルのピクセル格子を ECEF 頂点へ写すための
+ * 前段。PoC（Issue #321）でメッシュ生成・標高サンプルに散在していた
+ * メルカトル変換式を集約したもの。
+ *
+ * 「グローバルピクセル座標」は zoom 全体を 1 枚の画像とみなしたときの通し座標で、
+ * 原点は左上（北西端）。`totalPixels = TILE_SIZE * 2^zoom`。X は西→東、Y は北→南。
+ *
+ * NOTE: データ取得層 `gsiTile.ts`（`toTileXY` / `tileCenterLatLon`）はタイル整数座標
+ * 単位の変換で温存対象。本モジュールはサブピクセル精度のグローバルピクセル変換を担う。
+ */
+import { TILE_SIZE } from "../gsiTile";
+
+/** zoom レベル全体のグローバルピクセル幅（= 高さ）。 */
+export const totalPixelsForZoom = (zoom: number): number =>
+    TILE_SIZE * 2 ** zoom;
+
+/**
+ * グローバルピクセル座標 → 緯度経度[deg]（Web メルカトル逆変換）。
+ *
+ * @param globalPx 西→東のグローバルピクセル X。
+ * @param globalPy 北→南のグローバルピクセル Y。
+ * @param totalPixels `totalPixelsForZoom(zoom)`。
+ */
+export const pixelToLatLon = (
+    globalPx: number,
+    globalPy: number,
+    totalPixels: number,
+): { lat: number; lon: number } => {
+    const lon = (globalPx / totalPixels) * 360 - 180;
+    const ny = globalPy / totalPixels;
+    const lat = (Math.atan(Math.sinh(Math.PI * (1 - 2 * ny))) * 180) / Math.PI;
+    return { lat, lon };
+};
+
+/**
+ * 緯度経度[deg] → グローバルピクセル座標（Web メルカトル順変換）。
+ * `pixelToLatLon` の逆関数。
+ *
+ * @param latDeg 緯度[deg]（メルカトル有効範囲 ±85.05112878° 前提）。
+ * @param lonDeg 経度[deg]。
+ * @param totalPixels `totalPixelsForZoom(zoom)`。
+ */
+export const latLonToPixel = (
+    latDeg: number,
+    lonDeg: number,
+    totalPixels: number,
+): { px: number; py: number } => {
+    const latRad = (latDeg * Math.PI) / 180;
+    const px = ((lonDeg + 180) / 360) * totalPixels;
+    const py =
+        ((1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) / 2) *
+        totalPixels;
+    return { px, py };
+};

--- a/src/terrain/geo/mapping.ts
+++ b/src/terrain/geo/mapping.ts
@@ -57,11 +57,16 @@ export const pixelToLatLon = (
 
 /**
  * 緯度経度[deg] → グローバルピクセル座標（Web メルカトル順変換）。
- * `pixelToLatLon` の逆関数。
+ * 域内入力に対しては `pixelToLatLon` の逆関数。
  *
  * `gsiTile.toTileXY` と挙動を揃えるため、緯度を ±{@link MERCATOR_MAX_LAT} にクランプし
  * （`Math.log(tan+sec)` の発散 → `Infinity/NaN` を防ぐ）、経度を [-180, 180) に正規化してから
  * 変換する。
+ *
+ * NOTE: 経度を [-180, 180) に正規化するため、境界では厳密な逆にならない。`pixelToLatLon` が
+ * 返し得る lon=180°（globalPx=totalPixels）は本関数では -180°（px=0）として扱う。球面上は
+ * 同一経線で幾何学的に等価なので問題ないが、この 1 点では `latLonToPixel(pixelToLatLon(p)) === p`
+ * が px について成り立たない。
  *
  * @param latDeg 緯度[deg]。
  * @param lonDeg 経度[deg]。

--- a/tests/geoEcef.unit.spec.ts
+++ b/tests/geoEcef.unit.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * geo/ecef の単体テスト (Issue #275 Phase 0)。
+ *
+ * - geodeticToEcef ⇄ ecefToGeodetic の往復精度（mm 級）を検証
+ * - 既知の基準点（赤道・本初子午線・北極）で軸規約（X→経度0, Y→東経90°, Z→北極）を固定
+ * - geodeticToEcefToRef が ref を書き換えて返す（アロケーション回避）ことを確認
+ */
+
+import { describe, it, expect } from "@jest/globals";
+
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { Wgs84Ellipsoid } from "@babylonjs/core/Maths/math.geospatial.functions";
+
+import {
+    DEG2RAD,
+    RAD2DEG,
+    geodeticToEcef,
+    geodeticToEcefToRef,
+    ecefToGeodetic,
+} from "../src/terrain/geo/ecef";
+
+describe("定数", () => {
+    it("DEG2RAD / RAD2DEG が逆数関係", () => {
+        expect(DEG2RAD * RAD2DEG).toBeCloseTo(1, 12);
+        expect(180 * DEG2RAD).toBeCloseTo(Math.PI, 12);
+    });
+});
+
+describe("軸規約（既知の基準点）", () => {
+    it("lat=0,lon=0,alt=0 → X 軸上（semiMajorAxis）", () => {
+        const v = geodeticToEcef(0, 0, 0);
+        expect(v.x).toBeCloseTo(Wgs84Ellipsoid.semiMajorAxis, 3);
+        expect(v.y).toBeCloseTo(0, 3);
+        expect(v.z).toBeCloseTo(0, 3);
+    });
+
+    it("lat=0,lon=90 → Y 軸上（東経90°）", () => {
+        const v = geodeticToEcef(0, 90, 0);
+        expect(v.x).toBeCloseTo(0, 3);
+        expect(v.y).toBeCloseTo(Wgs84Ellipsoid.semiMajorAxis, 3);
+        expect(v.z).toBeCloseTo(0, 3);
+    });
+
+    it("北極（lat=90）→ Z 軸上（semiMinorAxis）", () => {
+        const v = geodeticToEcef(90, 0, 0);
+        expect(v.x).toBeCloseTo(0, 3);
+        expect(v.y).toBeCloseTo(0, 3);
+        expect(v.z).toBeCloseTo(Wgs84Ellipsoid.semiMinorAxis, 3);
+    });
+});
+
+describe("往復精度 geodetic → ecef → geodetic", () => {
+    const samples: { name: string; lat: number; lon: number; alt: number }[] = [
+        { name: "東京", lat: 35.681236, lon: 139.767125, alt: 40 },
+        { name: "富士山頂", lat: 35.360833, lon: 138.727500, alt: 3776 },
+        { name: "南半球高高度", lat: -33.8688, lon: 151.2093, alt: 12000 },
+        { name: "赤道", lat: 0, lon: 0, alt: 0 },
+        { name: "高緯度", lat: 80, lon: -170, alt: 500 },
+        { name: "海面下", lat: 24.0, lon: 123.0, alt: -50 },
+    ];
+
+    for (const s of samples) {
+        it(`${s.name} が mm 級で往復する`, () => {
+            const ecef = geodeticToEcef(s.lat, s.lon, s.alt);
+            const g = ecefToGeodetic(ecef);
+            // 緯度経度は 1e-9 度（≒0.1mm）級、高度は 1e-3 m（mm）級。
+            expect(g.latDeg).toBeCloseTo(s.lat, 8);
+            expect(g.lonDeg).toBeCloseTo(s.lon, 8);
+            expect(g.altMeters).toBeCloseTo(s.alt, 3);
+        });
+    }
+});
+
+describe("極の特異点", () => {
+    it("ecefToGeodetic が北極で lat=90 を返す", () => {
+        const g = ecefToGeodetic(new Vector3(0, 0, Wgs84Ellipsoid.semiMinorAxis));
+        expect(g.latDeg).toBe(90);
+        expect(g.altMeters).toBeCloseTo(0, 3);
+    });
+
+    it("ecefToGeodetic が南極で lat=-90 を返す", () => {
+        const g = ecefToGeodetic(new Vector3(0, 0, -Wgs84Ellipsoid.semiMinorAxis));
+        expect(g.latDeg).toBe(-90);
+        expect(g.altMeters).toBeCloseTo(0, 3);
+    });
+});
+
+describe("geodeticToEcefToRef", () => {
+    it("ref を書き換えて同一参照を返す", () => {
+        const ref = new Vector3(1, 2, 3);
+        const ret = geodeticToEcefToRef(35, 139, 0, ref);
+        expect(ret).toBe(ref);
+        expect(ref.x).not.toBe(1);
+    });
+
+    it("geodeticToEcef と同じ値を返す", () => {
+        const a = geodeticToEcef(12.34, -56.78, 100);
+        const b = geodeticToEcefToRef(12.34, -56.78, 100, new Vector3());
+        expect(b.x).toBeCloseTo(a.x, 6);
+        expect(b.y).toBeCloseTo(a.y, 6);
+        expect(b.z).toBeCloseTo(a.z, 6);
+    });
+});

--- a/tests/geoEcef.unit.spec.ts
+++ b/tests/geoEcef.unit.spec.ts
@@ -63,7 +63,8 @@ describe("往復精度 geodetic → ecef → geodetic", () => {
         it(`${s.name} が mm 級で往復する`, () => {
             const ecef = geodeticToEcef(s.lat, s.lon, s.alt);
             const g = ecefToGeodetic(ecef);
-            // 緯度経度は 1e-9 度（≒0.1mm）級、高度は 1e-3 m（mm）級。
+            // toBeCloseTo(x, 8) の許容誤差は |Δ| < 0.5e-8 度。緯度では ≒0.5mm 級
+            // （0.5e-8 度 × 111320 m/度）、高度は toBeCloseTo(x, 3) で 0.5e-3 m（sub-mm）級。
             expect(g.latDeg).toBeCloseTo(s.lat, 8);
             expect(g.lonDeg).toBeCloseTo(s.lon, 8);
             expect(g.altMeters).toBeCloseTo(s.alt, 3);

--- a/tests/geoMapping.unit.spec.ts
+++ b/tests/geoMapping.unit.spec.ts
@@ -13,8 +13,9 @@ import {
     totalPixelsForZoom,
     pixelToLatLon,
     latLonToPixel,
+    MERCATOR_MAX_LAT,
 } from "../src/terrain/geo/mapping";
-import { TILE_SIZE, tileCenterLatLon } from "../src/terrain/gsiTile";
+import { TILE_SIZE, tileCenterLatLon, toTileXY } from "../src/terrain/gsiTile";
 
 describe("totalPixelsForZoom", () => {
     it("TILE_SIZE * 2^zoom", () => {
@@ -91,5 +92,79 @@ describe("gsiTile との整合", () => {
         const want = tileCenterLatLon(tx, ty, zoom);
         expect(got.lat).toBeCloseTo(want.lat, 9);
         expect(got.lon).toBeCloseTo(want.lon, 9);
+    });
+});
+
+describe("latLonToPixel の堅牢化（クランプ/正規化）", () => {
+    const total = totalPixelsForZoom(15);
+
+    it("緯度はメルカトル有効域 ±MERCATOR_MAX_LAT にクランプされ py は有限", () => {
+        const beyond = latLonToPixel(89, 0, total); // 有効域超
+        const atLimit = latLonToPixel(MERCATOR_MAX_LAT, 0, total);
+        expect(Number.isFinite(beyond.py)).toBe(true);
+        expect(beyond.py).toBeCloseTo(atLimit.py, 6);
+        // クランプにより py は [0, total] 内（北端 0 付近）。
+        expect(beyond.py).toBeGreaterThanOrEqual(0);
+        expect(beyond.py).toBeLessThanOrEqual(total);
+    });
+
+    it("南側も同様にクランプされる", () => {
+        const beyond = latLonToPixel(-89, 0, total);
+        const atLimit = latLonToPixel(-MERCATOR_MAX_LAT, 0, total);
+        expect(beyond.py).toBeCloseTo(atLimit.py, 6);
+        expect(beyond.py).toBeLessThanOrEqual(total);
+    });
+
+    it("経度は [-180,180) に正規化される（lon=190 → -170 相当）", () => {
+        const wrapped = latLonToPixel(0, 190, total);
+        const normalized = latLonToPixel(0, -170, total);
+        expect(wrapped.px).toBeCloseTo(normalized.px, 6);
+        expect(wrapped.px).toBeGreaterThanOrEqual(0);
+        expect(wrapped.px).toBeLessThanOrEqual(total);
+    });
+
+    it("域外入力でも px/py は有限かつ [0,total] 内", () => {
+        for (const [lat, lon] of [
+            [89, 200],
+            [-89, -200],
+            [120, 540],
+        ]) {
+            const { px, py } = latLonToPixel(lat, lon, total);
+            expect(Number.isFinite(px)).toBe(true);
+            expect(Number.isFinite(py)).toBe(true);
+            expect(px).toBeGreaterThanOrEqual(0);
+            expect(px).toBeLessThanOrEqual(total);
+            expect(py).toBeGreaterThanOrEqual(0);
+            expect(py).toBeLessThanOrEqual(total);
+        }
+    });
+
+    it("域内の点はピクセル→タイル整数で gsiTile.toTileXY と一致する", () => {
+        const zoom = 12;
+        const t = totalPixelsForZoom(zoom);
+        const lat = 35.681236;
+        const lon = 139.767125;
+        const { px, py } = latLonToPixel(lat, lon, t);
+        const want = toTileXY(lat, lon, zoom);
+        expect(Math.floor(px / TILE_SIZE)).toBe(want.x);
+        expect(Math.floor(py / TILE_SIZE)).toBe(want.y);
+    });
+});
+
+describe("pixelToLatLon の堅牢化（範囲外クランプ）", () => {
+    const total = totalPixelsForZoom(10);
+
+    it("範囲外の globalPy はクランプされ lat はメルカトル有効域内", () => {
+        const over = pixelToLatLon(total / 2, total * 2, total); // 南へ振り切り
+        const under = pixelToLatLon(total / 2, -total, total); // 北へ振り切り
+        expect(over.lat).toBeCloseTo(-MERCATOR_MAX_LAT, 6);
+        expect(under.lat).toBeCloseTo(MERCATOR_MAX_LAT, 6);
+    });
+
+    it("範囲外の globalPx はクランプされ lon は [-180,180] 内（ラップしない）", () => {
+        const east = pixelToLatLon(total * 3, total / 2, total);
+        const west = pixelToLatLon(-total, total / 2, total);
+        expect(east.lon).toBeCloseTo(180, 6); // ラップせず東端へクランプ
+        expect(west.lon).toBeCloseTo(-180, 6);
     });
 });

--- a/tests/geoMapping.unit.spec.ts
+++ b/tests/geoMapping.unit.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * geo/mapping の単体テスト (Issue #275 Phase 0)。
+ *
+ * - pixelToLatLon ⇄ latLonToPixel の往復精度
+ * - totalPixelsForZoom が TILE_SIZE * 2^zoom
+ * - 端・中心の既知点（北西端・中心・経度方向の線形性）で規約を固定
+ * - 既存 gsiTile.tileCenterLatLon との整合（タイル中心ピクセル → 同じ緯度経度）
+ */
+
+import { describe, it, expect } from "@jest/globals";
+
+import {
+    totalPixelsForZoom,
+    pixelToLatLon,
+    latLonToPixel,
+} from "../src/terrain/geo/mapping";
+import { TILE_SIZE, tileCenterLatLon } from "../src/terrain/gsiTile";
+
+describe("totalPixelsForZoom", () => {
+    it("TILE_SIZE * 2^zoom", () => {
+        expect(totalPixelsForZoom(0)).toBe(TILE_SIZE);
+        expect(totalPixelsForZoom(1)).toBe(TILE_SIZE * 2);
+        expect(totalPixelsForZoom(15)).toBe(TILE_SIZE * 2 ** 15);
+    });
+});
+
+describe("pixelToLatLon 既知点", () => {
+    it("北西端 (0,0) は lon=-180, lat≈85.0511", () => {
+        const total = totalPixelsForZoom(10);
+        const { lat, lon } = pixelToLatLon(0, 0, total);
+        expect(lon).toBeCloseTo(-180, 9);
+        expect(lat).toBeCloseTo(85.0511287798, 6);
+    });
+
+    it("中心 (total/2) は lat=0, lon=0", () => {
+        const total = totalPixelsForZoom(10);
+        const { lat, lon } = pixelToLatLon(total / 2, total / 2, total);
+        expect(lat).toBeCloseTo(0, 9);
+        expect(lon).toBeCloseTo(0, 9);
+    });
+
+    it("経度はピクセル X に線形", () => {
+        const total = totalPixelsForZoom(8);
+        const a = pixelToLatLon(0, total / 2, total).lon;
+        const b = pixelToLatLon(total / 4, total / 2, total).lon;
+        expect(b - a).toBeCloseTo(90, 9);
+    });
+});
+
+describe("往復精度 latLon → pixel → latLon", () => {
+    const samples: { name: string; lat: number; lon: number }[] = [
+        { name: "東京", lat: 35.681236, lon: 139.767125 },
+        { name: "赤道本初子午線", lat: 0, lon: 0 },
+        { name: "南半球", lat: -33.8688, lon: 151.2093 },
+        { name: "高緯度", lat: 80, lon: -179.9 },
+        { name: "メルカトル境界付近", lat: 85.0, lon: 122.0 },
+    ];
+
+    for (const s of samples) {
+        it(`${s.name} が往復する`, () => {
+            const total = totalPixelsForZoom(15);
+            const { px, py } = latLonToPixel(s.lat, s.lon, total);
+            const { lat, lon } = pixelToLatLon(px, py, total);
+            expect(lat).toBeCloseTo(s.lat, 9);
+            expect(lon).toBeCloseTo(s.lon, 9);
+        });
+    }
+});
+
+describe("往復精度 pixel → latLon → pixel", () => {
+    it("任意ピクセルが往復する", () => {
+        const total = totalPixelsForZoom(12);
+        const px0 = 123456.7;
+        const py0 = 98765.4;
+        const { lat, lon } = pixelToLatLon(px0, py0, total);
+        const { px, py } = latLonToPixel(lat, lon, total);
+        expect(px).toBeCloseTo(px0, 4);
+        expect(py).toBeCloseTo(py0, 4);
+    });
+});
+
+describe("gsiTile との整合", () => {
+    it("タイル中心ピクセルが tileCenterLatLon と一致", () => {
+        const zoom = 14;
+        const tx = 14552;
+        const ty = 6451;
+        const total = totalPixelsForZoom(zoom);
+        const centerPx = (tx + 0.5) * TILE_SIZE;
+        const centerPy = (ty + 0.5) * TILE_SIZE;
+        const got = pixelToLatLon(centerPx, centerPy, total);
+        const want = tileCenterLatLon(tx, ty, zoom);
+        expect(got.lat).toBeCloseTo(want.lat, 9);
+        expect(got.lon).toBeCloseTo(want.lon, 9);
+    });
+});


### PR DESCRIPTION
## 概要

Issue #275「Babylon.js 9.x の Geospatial を使って全面的に書き直す」段階移行計画の **Phase 0（基盤ユーティリティ）**。PoC (#321) の幾何系純関数を本体共有モジュール `src/terrain/geo/` へ昇格する。

**既存コードへの影響はなし（追加のみ）。** 後続の Phase 1（グローブ地形エンジン）以降がこのモジュールを土台にする。

## 変更内容

- `src/terrain/geo/ecef.ts`: 測地座標(度)⇄ECEF(WGS84) 変換
  - `geodeticToEcef` / `geodeticToEcefToRef`（Babylon `EcefFromLatLonAltToRef` の度数入力ラッパ）
  - `ecefToGeodetic`（Bowring 閉形式の逆変換, mm 級精度）
  - `Geodetic` 型・`DEG2RAD` / `RAD2DEG`
- `src/terrain/geo/mapping.ts`: Web メルカトルのグローバルピクセル⇄緯度経度を集約
  - `totalPixelsForZoom` / `pixelToLatLon` / `latLonToPixel`
- `src/terrain/geo/index.ts`: バレル
- `tests/geoEcef.unit.spec.ts` / `tests/geoMapping.unit.spec.ts`: 往復精度・軸規約・極特異点・既存 `gsiTile` 整合（25 ケース）

## 影響範囲

- 画面/API/挙動: 変更なし（新規モジュールの追加のみ。既存からの参照なし）
- ドキュメント: 後続フェーズでグローブ実装が既定化される際に spec/ を更新予定（Phase 5）

## 検証（Definition of Done）

- `npm run lint`: クリーン
- `npm run typecheck`: クリーン
- `npm run test:unit`: 全 978 件パス（新規 25 件含む）

Refs #275 / PoC #321 (#322)

🤖 Generated with [Claude Code](https://claude.com/claude-code)