### PR TITLE
feat(geo): グローブカメラ UX / URL 等価性 (Phase 2 / #275)

### DIFF
--- a/src/demos/geospatial/index.ts
+++ b/src/demos/geospatial/index.ts
@@ -1,5 +1,5 @@
 /**
- * グローブ地形デモエントリ (Issue #275 Phase 1)。
+ * グローブ地形デモエントリ (Issue #275 Phase 2)。
  *
  * 平面ワールドの各デモと併存する **並行スタック**。`scenes/globe.ts`（`GeospatialCamera` +
  * ECEF 楕円体 + floating origin）の地形エンジンを `/geospatial` で起動し、旧（平面）と
@@ -195,6 +195,6 @@ if (
 ) {
     start().catch((err) => {
         console.error("[geospatial] failed to start:", err);
-        updateInfo(`Geospatial Globe (#275 Phase 1)\n起動に失敗しました: ${String(err)}`);
+        updateInfo(`Geospatial Globe (#275 Phase 2)\n起動に失敗しました: ${String(err)}`);
     });
 }

--- a/src/demos/geospatial/index.ts
+++ b/src/demos/geospatial/index.ts
@@ -5,9 +5,11 @@
  * ECEF 楕円体 + floating origin）の地形エンジンを `/geospatial` で起動し、旧（平面）と
  * 新（グローブ）を一時併存させて実機比較できるようにする。
  *
- * URL クエリ:
+ * URL（既存共有形式と後方互換, Issue #275 Phase 2 / #64 / #254）:
+ * - パス/ハッシュ `@lat,lon,altitude,azimuth,tilt`（3D 共有形式。altitude ⇄ radius）
+ * - パス/ハッシュ `@lat,lon,Xz`（2D 互換ズームレベル形式。zoomLevel → radius へ換算して受理）
  * - `?engine=webgpu|webgl|webgl2`（既定: 自動。webgl/webgl2 は webgl2 に正規化）
- * - `?lat=&lon=&zoom=&radius=&azimuth=&tilt=`（既定: 富士山周辺）
+ * - `?lat=&lon=&zoom=&radius=&azimuth=&tilt=`（`@` パスが無い場合のフォールバック）
  * - `?map=photo`（航空写真。既定: 標準地図）
  * - `?snap=off`（クロスレベル標高スナップを無効化。比較用）
  */
@@ -17,7 +19,12 @@ import type { GeospatialCamera } from "@babylonjs/core/Cameras/geospatialCamera"
 import { createBabylonEngine } from "../../lib/internal/engineFactory";
 import type { EngineType } from "../../lib/types";
 import { clamp, type MapType } from "../../terrain/gsiTile";
-import { RAD2DEG } from "../../terrain/geo/ecef";
+import { yawPitchToUi } from "../../terrain/geo/cameraMapping";
+import {
+    parseCameraStateFromUrl,
+    createUrlUpdater,
+    zoomLevelToRadius,
+} from "../../terrain/urlState";
 import {
     GlobeScene,
     GLOBE_SCENE_DEFAULTS,
@@ -53,8 +60,12 @@ const start = async (): Promise<void> => {
 
     const search = location.search;
     const params = new URLSearchParams(search);
-    const lat = resolveNumber(search, "lat", GLOBE_SCENE_DEFAULTS.lat);
-    const lon = resolveNumber(search, "lon", GLOBE_SCENE_DEFAULTS.lon);
+    // 既存共有形式 `@lat,lon,...` がパス/ハッシュにあれば最優先で復元（後方互換）。
+    // なければ `?lat=&lon=&radius=&azimuth=&tilt=` のクエリにフォールバックする。
+    const hasAtPath = location.pathname.includes("/@") || location.hash.includes("@");
+    const atState = hasAtPath ? parseCameraStateFromUrl(location.href) : null;
+    const lat = atState?.lat ?? resolveNumber(search, "lat", GLOBE_SCENE_DEFAULTS.lat);
+    const lon = atState?.lon ?? resolveNumber(search, "lon", GLOBE_SCENE_DEFAULTS.lon);
     // URL 由来の minZoom は安全な範囲 [0, maxZoom] にクランプする
     // （負値・極端値だと toTileXY / 1<<zoom が壊れ、タイル選択が空になる）。
     const minZoom = clamp(
@@ -62,9 +73,14 @@ const start = async (): Promise<void> => {
         0,
         GLOBE_SCENE_DEFAULTS.maxZoom,
     );
-    const radius = resolveNumber(search, "radius", GLOBE_SCENE_DEFAULTS.radius);
-    const azimuth = resolveNumber(search, "azimuth", GLOBE_SCENE_DEFAULTS.azimuth);
-    const tilt = resolveNumber(search, "tilt", GLOBE_SCENE_DEFAULTS.tilt);
+    // altitude ⇄ radius は PoC で確認した等価関係。`@lat,lon,Xz`（zoomLevel）はカメラ生成後に
+    // canvasHeight/fov を使って radius へ換算する（zoomLevelToRadius）。
+    const radius =
+        atState?.zoomLevel !== undefined
+            ? GLOBE_SCENE_DEFAULTS.radius // zoomLevel はカメラ生成後に再設定（後段）
+            : (atState?.altitude ?? resolveNumber(search, "radius", GLOBE_SCENE_DEFAULTS.radius));
+    const azimuth = atState?.azimuth ?? resolveNumber(search, "azimuth", GLOBE_SCENE_DEFAULTS.azimuth);
+    const tilt = atState?.tilt ?? resolveNumber(search, "tilt", GLOBE_SCENE_DEFAULTS.tilt);
     const mapType: MapType = params.get("map") === "photo" ? "photo" : "std";
     const snapEnabled = params.get("snap") !== "off";
 
@@ -84,6 +100,30 @@ const start = async (): Promise<void> => {
     // onSyncStats はレンダーループ（createSceneWithController return 後）でのみ呼ばれるが、
     // controller への依存を避け floatingOriginMode は確定後の scene 参照から読む。
     let infoScene: Scene | undefined;
+    // カメラ状態を共有 URL（`@lat,lon,altitude,azimuth,tilt`）へ反映するデバウンス更新器。
+    // 既存デモ（viewer/timelapse）と同じ createUrlUpdater を使い、`/geospatial/@...` 形式で
+    // 出力する（vite.rewrites に geospatial 登録済みのためリロードでも復元できる）。
+    const urlUpdater = createUrlUpdater(1000);
+    // onSyncStats は毎 sync（数百 ms 間隔）で呼ばれるため、毎回 urlUpdater を呼ぶとデバウンスが
+    // 確定しない（タイマーが常にリセットされる）。カメラ状態が変化した時のみ更新を投げる。
+    let lastUrlState: { lat: number; lon: number; radius: number; yaw: number; pitch: number } | null = null;
+    const urlStateChanged = (
+        latDeg: number, lonDeg: number, radius: number, yaw: number, pitch: number,
+    ): boolean => {
+        const p = lastUrlState;
+        if (
+            p === null ||
+            Math.abs(latDeg - p.lat) > 1e-5 ||
+            Math.abs(lonDeg - p.lon) > 1e-5 ||
+            Math.abs(radius - p.radius) > 1 ||
+            Math.abs(yaw - p.yaw) > 1e-4 ||
+            Math.abs(pitch - p.pitch) > 1e-4
+        ) {
+            lastUrlState = { lat: latDeg, lon: lonDeg, radius, yaw, pitch };
+            return true;
+        }
+        return false;
+    };
     const controller = sceneFactory.createSceneWithController(engine, canvas, {
         lat,
         lon,
@@ -97,23 +137,44 @@ const start = async (): Promise<void> => {
             const zoomLabel =
                 s.minZoom !== null && s.maxZoom !== null ? `${s.minZoom}–${s.maxZoom}` : "-";
             const floatingOrigin = infoScene?.floatingOriginMode ?? "-";
-            // azimuth は 0–360 に正規化（JS の % は負値を返すため）。radius は注視点(center)
-            // からのカメラ距離で、鉛直高度(altitude)とは一致しないためラベルは radius とする。
-            const azimuthDeg = (((s.yaw * RAD2DEG) % 360) + 360) % 360;
+            // yaw/pitch[rad] → azimuth/tilt[deg]（azimuth は [0,360) 正規化）。
+            const { azimuthDeg, tiltDeg } = yawPitchToUi(s.yaw, s.pitch);
+            // 共有 URL を更新（altitude ⇄ radius 等価。3D 形式 `@lat,lon,altitude,azimuth,tilt`）。
+            // 状態が動いた時のみ投げ、停止後にデバウンスが確定するようにする。
+            if (urlStateChanged(s.latDeg, s.lonDeg, s.radius, s.yaw, s.pitch)) {
+                urlUpdater({
+                    lat: s.latDeg,
+                    lon: s.lonDeg,
+                    altitude: s.radius,
+                    azimuth: azimuthDeg,
+                    tilt: tiltDeg,
+                });
+            }
             updateInfo(
-                `Geospatial Globe (#275 Phase 1)\n` +
-                    `右ドラッグ=回転 / ホイール=ズーム\n` +
+                `Geospatial Globe (#275 Phase 2)\n` +
+                    `左ドラッグ=パン / 右ドラッグ=回転 / ホイール=ズーム / WASD=パン\n` +
                     `engine: ${engine.constructor.name} / floatingOrigin: ${floatingOrigin}\n` +
                     `fps: ${engine.getFps().toFixed(0)}\n` +
                     `lat,lon: ${s.latDeg.toFixed(4)}, ${s.lonDeg.toFixed(4)}\n` +
                     `azimuth: ${azimuthDeg.toFixed(1)}° / ` +
-                    `tilt: ${(s.pitch * RAD2DEG).toFixed(1)}° / radius: ${Math.round(s.radius)}m\n` +
+                    `tilt: ${tiltDeg.toFixed(1)}° / radius: ${Math.round(s.radius)}m\n` +
                     `LOD zoom: ${zoomLabel} / selected: ${s.selected.length} / ` +
                     `loaded: ${s.loadedCount} / loading: ${s.loadingCount}`,
             );
         },
     });
     infoScene = controller.scene;
+
+    // `@lat,lon,Xz`（2D 互換ズームレベル）指定時は、実 canvas 高さとカメラ fov を使って
+    // radius へ換算しカメラへ反映する（生成後でないと fov / clientHeight が確定しないため後段）。
+    if (atState?.zoomLevel !== undefined) {
+        controller.camera.radius = zoomLevelToRadius(
+            atState.zoomLevel,
+            Math.max(1, canvas.clientHeight),
+            lat,
+            controller.camera.fov,
+        );
+    }
 
     // render ループはシーン生成側ではなく呼び出し側（本デモ）で開始する
     // （GlobeScene は責務分離のためループを開始しない）。

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -21,7 +21,6 @@ import {
 } from "@babylonjs/core/Cameras/geospatialCamera";
 import { GeospatialClippingBehavior } from "@babylonjs/core/Behaviors/Cameras/geospatialClippingBehavior";
 import { Wgs84Ellipsoid } from "@babylonjs/core/Maths/math.geospatial.functions";
-import { Ray } from "@babylonjs/core/Culling/ray";
 
 import type { MapType } from "../terrain/gsiTile";
 import { DEG2RAD, geodeticToEcef, geodeticToEcefToRef, ecefToGeodetic } from "../terrain/geo/ecef";
@@ -29,7 +28,6 @@ import {
     cameraTangentBasisToRef,
     panCenterOnSphereToRef,
     clampRadiusForGroundClearance,
-    raySphereNearHitToRef,
 } from "../terrain/geo/cameraMapping";
 import { createGlobeTileManager, type GlobeTileManager, type GlobeTileSyncStats } from "../terrain/geo/globeTileManager";
 
@@ -181,12 +179,11 @@ export class GlobeScene {
         camera.addBehavior(new GeospatialClippingBehavior());
         camera.attachControl(true);
 
-        // zoom-to-cursor（カーソル下の地点へ寄るズーム）を有効化する。ネイティブ実装は
-        // ホイール毎に scene.pick でカーソル下の点を取り直すが、floating origin 下では
-        // レンダリング座標と真の ECEF メッシュ位置がずれてピックが毎回ブレ、ズームが揺れる
-        // （PoC で確認）。そこで handleZoom を差し替え、目標点を scene.pick 非依存の
-        // 「真の ECEF カメラ位置からのレイ × 地表球」の幾何交点で求める（後段で配線）。
-        camera.movement.zoomToCursor = true;
+        // ズームは注視点(画面中心)へ寄る半径のみのズームにする。zoom-to-cursor は毎フレーム
+        // 中心をカーソル方向へ動かすため、floating origin 下のピック誤差と相まってガタつく。
+        // zoom-to-cursor のレイ再構成は floating origin 維持と両立が難しく、Phase 2 では無効維持
+        // とする（PoC の判断踏襲）。
+        camera.movement.zoomToCursor = false;
 
         // ---- picking 非依存パン（左ドラッグ / WASD） ----
         // 既定の pan（左ドラッグ/キーボード）は scene.pick でグローブをヒットしてドラッグ平面を
@@ -355,32 +352,6 @@ export class GlobeScene {
                 .copyFrom(camera.center)
                 .subtractInPlace(lookAt.scaleInPlace(camera.radius));
             return cameraEcef;
-        };
-
-        // ---- zoom-to-cursor の目標点を scene.pick 非依存で求める差し替え ----
-        // ネイティブ handleZoom は毎ホイールで scene.pick(pointerX,pointerY) して
-        // computedPerFrameZoomPickPoint を更新するが、floating origin 下では点がブレてズームが
-        // 揺れる。ここでは真の ECEF カメラ位置からカーソル方向のレイを飛ばし、注視点と同じ地心距離
-        // （seat で地表に載っている）の球と交差させて目標点を求める。ホイール毎にのみ取り直し、
-        // ズームの慣性減衰中（新規ホイールなし）は handleZoom が呼ばれず目標点が固定されるため、
-        // 1 ジェスチャ中は固定目標へ滑らかに寄る（新しいホイールが来たら新カーソル位置で更新）。
-        const movement = camera.movement;
-        const zoomTarget = new Vector3();
-        const pickRay = new Ray(Vector3.Zero(), Vector3.Forward());
-        movement.handleZoom = (zoomDelta: number): void => {
-            if (zoomDelta === 0) return;
-            // ネイティブ同様に蓄積（per-frame の zoomDeltaCurrentFrame へ変換される）。
-            movement.zoomAccumulatedPixels += zoomDelta;
-            // カーソル方向のレイ（方向のみ使用。origin は floating origin オフセットを含むため捨てる）。
-            scene.createPickingRayToRef(scene.pointerX, scene.pointerY, null, pickRay, camera);
-            const camEcef = computeCameraEcef(); // 真の ECEF カメラ位置
-            const sphereRadius = camera.center.length(); // 注視点の地心距離（地表相当）
-            if (raySphereNearHitToRef(camEcef, pickRay.direction, sphereRadius, zoomTarget)) {
-                movement.computedPerFrameZoomPickPoint = zoomTarget;
-            } else {
-                // 空を指している → 注視点方向（lookAt）ズームにフォールバック。
-                movement.computedPerFrameZoomPickPoint = undefined;
-            }
         };
 
         const syncTiles = (): void => {

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -25,7 +25,6 @@ import { Wgs84Ellipsoid } from "@babylonjs/core/Maths/math.geospatial.functions"
 import type { MapType } from "../terrain/gsiTile";
 import { DEG2RAD, geodeticToEcef, geodeticToEcefToRef, ecefToGeodetic } from "../terrain/geo/ecef";
 import {
-    geographicTangentBasisToRef,
     cameraTangentBasisToRef,
     panCenterOnSphereToRef,
     clampRadiusForGroundClearance,
@@ -228,8 +227,6 @@ export class GlobeScene {
             if (e.button === 0) endDrag();
         };
         // パン用の再利用バッファ（毎フレーム/毎 move 呼び出しでの割当を避ける）。
-        const eastV = new Vector3();
-        const northV = new Vector3();
         const dragRight = new Vector3();
         const dragFwd = new Vector3();
         const dragLookAt = new Vector3();
@@ -268,7 +265,11 @@ export class GlobeScene {
         canvas.addEventListener("pointercancel", endDrag);
         canvas.addEventListener("pointermove", onPointerMove);
 
-        /** 押下中の WASD に応じて center を地理接線（北/東）方向へ高度比例で動かす。 */
+        /**
+         * 押下中の WASD に応じて center を **カメラの向き（前/右）基準** で高度比例移動する。
+         * 視点を回転（yaw 変更）すると前方向も追従し、左ドラッグパンと一貫した操作になる
+         * （北固定ではなく「画面で奥が W」）。真下視点では前後左右が定義できないためスキップ。
+         */
         const applyKeyboardPan = (): void => {
             if (pressed.size === 0) return;
             let fwd = 0;
@@ -278,12 +279,22 @@ export class GlobeScene {
             if (pressed.has("d")) side += 1;
             if (pressed.has("a")) side -= 1;
             if (fwd === 0 && side === 0) return;
-            if (!geographicTangentBasisToRef(camera.center, eastV, northV)) return; // 極
+            // カメラ→center 方向(lookAt)から地表接線の右・前を作り、視点回転に追従させる。
+            ComputeLookAtFromYawPitchToRef(
+                camera.yaw,
+                camera.pitch,
+                camera.center,
+                scene.useRightHandedSystem,
+                dragLookAt,
+            );
+            if (!cameraTangentBasisToRef(camera.center, dragLookAt, dragRight, dragFwd)) {
+                return; // 真下視点の特異点
+            }
 
             const dtSec = Math.min(0.05, engine.getDeltaTime() / 1000);
             const step = camera.radius * PAN_RATE_PER_SEC * dtSec;
-            tangent.copyFrom(northV).scaleInPlace(fwd);
-            tangent.addInPlace(eastV.scaleInPlace(side));
+            tangent.copyFrom(dragFwd).scaleInPlace(fwd);
+            tangent.addInPlace(dragRight.scaleInPlace(side));
             if (tangent.lengthSquared() < 1e-12) return;
             tangent.normalize().scaleInPlace(step);
             camera.center = panCenterOnSphereToRef(camera.center, tangent, panned);

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -25,7 +25,7 @@ import { GeospatialClippingBehavior } from "@babylonjs/core/Behaviors/Cameras/ge
 import { Wgs84Ellipsoid } from "@babylonjs/core/Maths/math.geospatial.functions";
 
 import type { MapType } from "../terrain/gsiTile";
-import { DEG2RAD, geodeticToEcef, geodeticToEcefToRef, ecefToGeodetic } from "../terrain/geo/ecef";
+import { DEG2RAD, geodeticToEcef, geodeticToEcefToRef, ecefToGeodetic, type Geodetic } from "../terrain/geo/ecef";
 import {
     cameraTangentBasisToRef,
     panCenterOnSphereToRef,
@@ -386,14 +386,14 @@ export class GlobeScene {
         // 追従強度はカメラの対地クリアランスでフェードし、十分高い位置では追従しない（高高度の
         // パンで地形の起伏に沿ってカメラ高度がばたつくのを防ぐ）。`zoomToCursor=false` のため
         // ズームは radius のみを変え center を動かさず、seat と競合しないので zoom 中もそのまま動く。
-        const seatCenterOnTerrain = (): void => {
+        // camAltMeters はカメラの楕円体高度（observer で 1 回だけ計算した値を共有）。
+        const seatCenterOnTerrain = (camAltMeters: number): void => {
             const g = ecefToGeodetic(camera.center);
             const elev = tileManager.terrainElevAt(g.latDeg, g.lonDeg);
             if (elev === null) return;
             centerElevation = elev; // SSE 距離評価の基準標高（追従の有無に関わらず最新化）
             // カメラの対地クリアランスで追従強度をフェード（FULL 以下で完全追従、ZERO 以上で停止）。
-            const camAlt = ecefToGeodetic(computeCameraEcef()).altMeters;
-            const clearance = camAlt - elev;
+            const clearance = camAltMeters - elev;
             const seatFactor = Math.max(
                 0,
                 Math.min(
@@ -412,9 +412,9 @@ export class GlobeScene {
         // カメラ地形衝突: カメラ位置が地形 + 最小クリアランスより低くなったら radius を増やして
         // 潜り込みを防ぐ。seat は注視点を地表へ載せるだけでカメラ自身の潜りは防がないため、
         // 近接ズーム/低高度パンの保険として明示実装する（PoC は seat による実用回避のみ）。
-        const enforceGroundClearance = (): void => {
-            const camEcef = computeCameraEcef(); // lookAt バッファも更新される
-            const camGeo = ecefToGeodetic(camEcef);
+        // camEcef / camGeo / lookAt は observer で 1 回だけ計算したものを共有する
+        // （seat → 衝突で computeCameraEcef / ecefToGeodetic を二重実行しないため）。
+        const enforceGroundClearance = (camEcef: Vector3, camGeo: Geodetic): void => {
             const terrain = tileManager.terrainElevAt(camGeo.latDeg, camGeo.lonDeg);
             if (terrain === null) return;
             // radius あたりのカメラ高度増加率 = カメラ地心 up・(center→camera 単位方向)。
@@ -445,8 +445,13 @@ export class GlobeScene {
         let frame = 0;
         const observer = scene.onBeforeRenderObservable.add(() => {
             applyKeyboardPan();
-            seatCenterOnTerrain();
-            enforceGroundClearance();
+            // カメラ ECEF と測地座標・lookAt を 1 フレーム 1 回だけ計算し、seat と衝突で共有する
+            // （ComputeLookAtFromYawPitchToRef と測地変換の二重実行を避ける）。seat は center を
+            // わずかに動かすため衝突はその直前のスナップショットを使うが、毎フレーム補正のため実用上問題ない。
+            const camEcef = computeCameraEcef(); // lookAt バッファも更新される
+            const camGeo = ecefToGeodetic(camEcef);
+            seatCenterOnTerrain(camGeo.altMeters);
+            enforceGroundClearance(camEcef, camGeo);
             if (frame % GLOBE_SCENE_DEFAULTS.syncIntervalFrames === 0) syncTiles();
             frame++;
         });

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -64,6 +64,15 @@ export const GLOBE_SCENE_DEFAULTS = {
 /** seat-on-terrain の追従残差 lerp 係数（LOD 切替時の段差緩和）。 */
 const SEAT_LERP = 0.5;
 
+/**
+ * seat-on-terrain（注視点の地形追従）を効かせるカメラ対地クリアランス[m]の範囲。
+ * カメラが地形から十分高い位置にあるときは追従させない（高高度のパンで地形の起伏に沿って
+ * カメラ高度がばたつくのを防ぐ）。`FULL` 以下で完全追従、`ZERO` 以上で追従停止、その間は線形に
+ * フェード（しきい値で急に切り替えるとズーム時に段差が出るため）。
+ */
+const SEAT_FULL_CLEARANCE = 3000;
+const SEAT_ZERO_CLEARANCE = 10000;
+
 /** 1 秒あたりの WASD パン距離 = radius（高度相当）× この係数。高度比例で自然な速度。 */
 const PAN_RATE_PER_SEC = 0.6;
 
@@ -371,19 +380,30 @@ export class GlobeScene {
             }
         };
 
-        // 注視点を地形表面へ追従させる（高標高地でカメラが地形下へ潜るのを防ぐ）。毎フレーム
-        // 実行する。zoom 中は zoom-to-point 側が 3D で地形追従するため seat を止める
-        // （ラスタ標高と pick 点の食い違いで引っ張り合うのを避ける）。
+        // 注視点を地形表面へ追従させる（地表付近でカメラが地形下へ潜るのを防ぐ）。毎フレーム実行。
+        // 追従強度はカメラの対地クリアランスでフェードし、十分高い位置では追従しない（高高度の
+        // パンで地形の起伏に沿ってカメラ高度がばたつくのを防ぐ）。`zoomToCursor=false` のため
+        // ズームは radius のみを変え center を動かさず、seat と競合しないので zoom 中もそのまま動く。
         const seatCenterOnTerrain = (): void => {
-            if (camera.movement.computedPerFrameZoomPickPoint) return;
             const g = ecefToGeodetic(camera.center);
             const elev = tileManager.terrainElevAt(g.latDeg, g.lonDeg);
             if (elev === null) return;
-            centerElevation = elev; // SSE 距離評価の基準標高
+            centerElevation = elev; // SSE 距離評価の基準標高（追従の有無に関わらず最新化）
+            // カメラの対地クリアランスで追従強度をフェード（FULL 以下で完全追従、ZERO 以上で停止）。
+            const camAlt = ecefToGeodetic(computeCameraEcef()).altMeters;
+            const clearance = camAlt - elev;
+            const seatFactor = Math.max(
+                0,
+                Math.min(
+                    1,
+                    (SEAT_ZERO_CLEARANCE - clearance) / (SEAT_ZERO_CLEARANCE - SEAT_FULL_CLEARANCE),
+                ),
+            );
+            if (seatFactor <= 0) return; // 十分高い → 地形に追従せず高度一定でパン
             geodeticToEcefToRef(g.latDeg, g.lonDeg, elev, seatCenter);
-            // 同 lat/lon のまま高度だけ地形標高へ。残差を lerp で滑らかに（LOD 切替時の段差緩和）。
+            // 同 lat/lon のまま高度だけ地形標高へ。残差を lerp で滑らかに（高度依存で強度を絞る）。
             // 毎フレーム呼ばれるため、LerpToRef で再利用バッファに書き割り当てを避ける。
-            Vector3.LerpToRef(camera.center, seatCenter, SEAT_LERP, seatLerp);
+            Vector3.LerpToRef(camera.center, seatCenter, SEAT_LERP * seatFactor, seatLerp);
             camera.center = seatLerp;
         };
 

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -193,14 +193,28 @@ export class GlobeScene {
         const onKeyUp = (e: KeyboardEvent): void => {
             pressed.delete(e.key.toLowerCase());
         };
+        // 押下状態のリセット。フォーカス喪失/タブ切替中は keyup が届かず押下が残り続け、
+        // 復帰後に意図せずパンし続けるのを防ぐ（blur / 非表示で全解除）。
+        const clearPressed = (): void => pressed.clear();
+        const onVisibilityChange = (): void => {
+            if (document.hidden) pressed.clear();
+        };
+        // keydown/keyup は canvas に付ける（グローバルなキー入力の横取りを避ける）。canvas が
+        // フォーカス可能でない/未フォーカスだとキーを拾えないため、tabIndex を確保し pointerdown
+        // 時にフォーカスする（呼び出し側の設定に依存せずシーン単体でも WASD が機能する）。
+        if (canvas.tabIndex < 0) canvas.tabIndex = 0;
         canvas.addEventListener("keydown", onKeyDown);
         canvas.addEventListener("keyup", onKeyUp);
+        canvas.addEventListener("blur", clearPressed);
+        window.addEventListener("blur", clearPressed);
+        document.addEventListener("visibilitychange", onVisibilityChange);
 
         // 左ドラッグ状態。
         let dragging = false;
         let lastX = 0;
         let lastY = 0;
         const onPointerDown = (e: PointerEvent): void => {
+            canvas.focus(); // WASD のためにフォーカスを確保（右/左/中ボタンいずれでも）
             if (e.button !== 0) return;
             dragging = true;
             lastX = e.clientX;
@@ -409,6 +423,9 @@ export class GlobeScene {
             scene.onBeforeRenderObservable.remove(observer);
             canvas.removeEventListener("keydown", onKeyDown);
             canvas.removeEventListener("keyup", onKeyUp);
+            canvas.removeEventListener("blur", clearPressed);
+            window.removeEventListener("blur", clearPressed);
+            document.removeEventListener("visibilitychange", onVisibilityChange);
             canvas.removeEventListener("pointerdown", onPointerDown);
             canvas.removeEventListener("pointerup", onPointerUp);
             canvas.removeEventListener("pointercancel", endDrag);

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -24,6 +24,12 @@ import { Wgs84Ellipsoid } from "@babylonjs/core/Maths/math.geospatial.functions"
 
 import type { MapType } from "../terrain/gsiTile";
 import { DEG2RAD, geodeticToEcef, geodeticToEcefToRef, ecefToGeodetic } from "../terrain/geo/ecef";
+import {
+    geographicTangentBasisToRef,
+    cameraTangentBasisToRef,
+    panCenterOnSphereToRef,
+    clampRadiusForGroundClearance,
+} from "../terrain/geo/cameraMapping";
 import { createGlobeTileManager, type GlobeTileManager, type GlobeTileSyncStats } from "../terrain/geo/globeTileManager";
 
 /** グローブシーンの既定パラメータ（富士山周辺）。 */
@@ -58,6 +64,15 @@ export const GLOBE_SCENE_DEFAULTS = {
 
 /** seat-on-terrain の追従残差 lerp 係数（LOD 切替時の段差緩和）。 */
 const SEAT_LERP = 0.5;
+
+/** 1 秒あたりの WASD パン距離 = radius（高度相当）× この係数。高度比例で自然な速度。 */
+const PAN_RATE_PER_SEC = 0.6;
+
+/** カメラ地形衝突: 地表からの最小クリアランス[m]（URL altitude 下限と整合）。 */
+const MIN_GROUND_CLEARANCE = 50;
+
+/** WASD パン対象キー。 */
+const PAN_KEYS = new Set(["w", "a", "s", "d"]);
 
 export interface GlobeSceneInitOptions {
     /** 初期注視点の緯度 [deg]。 */
@@ -158,7 +173,107 @@ export class GlobeScene {
 
         // ズームは注視点(画面中心)へ寄る半径のみのズームにする。zoom-to-cursor は毎フレーム
         // 中心をカーソル方向へ動かすため、floating origin 下のピック誤差と相まってガタつく。
+        // zoom-to-cursor のレイ再構成は floating origin 維持と両立が難しく、Phase 2 では無効維持
+        // とする（PoC の判断踏襲）。
         camera.movement.zoomToCursor = false;
+
+        // ---- picking 非依存パン（左ドラッグ / WASD） ----
+        // 既定の pan（左ドラッグ/キーボード）は scene.pick でグローブをヒットしてドラッグ平面を
+        // 作るが、useFloatingOrigin 下ではレンダリング座標と真の ECEF メッシュ位置がずれて
+        // ピックが外れ機能しない。floating origin（#275 の精度要件）を維持するため、
+        // camera.center を地表接線方向へ動かす独自パンを実装する。
+        const pressed = new Set<string>();
+        const onKeyDown = (e: KeyboardEvent): void => {
+            const k = e.key.toLowerCase();
+            if (PAN_KEYS.has(k)) {
+                pressed.add(k);
+                e.preventDefault();
+            }
+        };
+        const onKeyUp = (e: KeyboardEvent): void => {
+            pressed.delete(e.key.toLowerCase());
+        };
+        canvas.addEventListener("keydown", onKeyDown);
+        canvas.addEventListener("keyup", onKeyUp);
+
+        // 左ドラッグ状態。
+        let dragging = false;
+        let lastX = 0;
+        let lastY = 0;
+        const onPointerDown = (e: PointerEvent): void => {
+            if (e.button !== 0) return;
+            dragging = true;
+            lastX = e.clientX;
+            lastY = e.clientY;
+            canvas.setPointerCapture?.(e.pointerId);
+        };
+        const endDrag = (): void => {
+            dragging = false;
+        };
+        const onPointerUp = (e: PointerEvent): void => {
+            if (e.button === 0) endDrag();
+        };
+        // パン用の再利用バッファ（毎フレーム/毎 move 呼び出しでの割当を避ける）。
+        const eastV = new Vector3();
+        const northV = new Vector3();
+        const dragRight = new Vector3();
+        const dragFwd = new Vector3();
+        const dragLookAt = new Vector3();
+        const tangent = new Vector3();
+        const panned = new Vector3();
+
+        const onPointerMove = (e: PointerEvent): void => {
+            if (!dragging) return;
+            const dx = e.clientX - lastX;
+            const dy = e.clientY - lastY;
+            lastX = e.clientX;
+            lastY = e.clientY;
+            if (dx === 0 && dy === 0) return;
+
+            // カメラ→center 方向(lookAt)から地表接線の右・前方向を作る。
+            ComputeLookAtFromYawPitchToRef(
+                camera.yaw,
+                camera.pitch,
+                camera.center,
+                scene.useRightHandedSystem,
+                dragLookAt,
+            );
+            if (!cameraTangentBasisToRef(camera.center, dragLookAt, dragRight, dragFwd)) {
+                return; // 真下視点の特異点
+            }
+            // 注視点距離での地表 m/px（掴んだ点がほぼカーソル追従する縮尺）。
+            const fovHeightM = 2 * camera.radius * Math.tan(camera.fov / 2);
+            const mpp = fovHeightM / Math.max(1, canvas.clientHeight);
+            // マップを掴んで引く挙動: 右ドラッグ→center 西（content 右へ）、下ドラッグ→center 北（前方）。
+            tangent.copyFrom(dragRight).scaleInPlace(-dx * mpp);
+            tangent.addInPlace(dragFwd.scaleInPlace(dy * mpp));
+            camera.center = panCenterOnSphereToRef(camera.center, tangent, panned);
+        };
+        canvas.addEventListener("pointerdown", onPointerDown);
+        canvas.addEventListener("pointerup", onPointerUp);
+        canvas.addEventListener("pointercancel", endDrag);
+        canvas.addEventListener("pointermove", onPointerMove);
+
+        /** 押下中の WASD に応じて center を地理接線（北/東）方向へ高度比例で動かす。 */
+        const applyKeyboardPan = (): void => {
+            if (pressed.size === 0) return;
+            let fwd = 0;
+            let side = 0;
+            if (pressed.has("w")) fwd += 1;
+            if (pressed.has("s")) fwd -= 1;
+            if (pressed.has("d")) side += 1;
+            if (pressed.has("a")) side -= 1;
+            if (fwd === 0 && side === 0) return;
+            if (!geographicTangentBasisToRef(camera.center, eastV, northV)) return; // 極
+
+            const dtSec = Math.min(0.05, engine.getDeltaTime() / 1000);
+            const step = camera.radius * PAN_RATE_PER_SEC * dtSec;
+            tangent.copyFrom(northV).scaleInPlace(fwd);
+            tangent.addInPlace(eastV.scaleInPlace(side));
+            if (tangent.lengthSquared() < 1e-12) return;
+            tangent.normalize().scaleInPlace(step);
+            camera.center = panCenterOnSphereToRef(camera.center, tangent, panned);
+        };
 
         // ライト: 地表の up（地心法線）を基準に環境光 + 斜め方向の指向性ライト。
         const up = centerEcef.clone().normalize();
@@ -247,6 +362,31 @@ export class GlobeScene {
             camera.center = seatLerp;
         };
 
+        // カメラ地形衝突: カメラ位置が地形 + 最小クリアランスより低くなったら radius を増やして
+        // 潜り込みを防ぐ。seat は注視点を地表へ載せるだけでカメラ自身の潜りは防がないため、
+        // 近接ズーム/低高度パンの保険として明示実装する（PoC は seat による実用回避のみ）。
+        const enforceGroundClearance = (): void => {
+            const camEcef = computeCameraEcef(); // lookAt バッファも更新される
+            const camGeo = ecefToGeodetic(camEcef);
+            const terrain = tileManager.terrainElevAt(camGeo.latDeg, camGeo.lonDeg);
+            if (terrain === null) return;
+            // radius あたりのカメラ高度増加率 = カメラ地心 up・(center→camera 単位方向)。
+            // center→camera 単位方向は -lookAt/|lookAt|。computeCameraEcef は lookAt を
+            // radius 倍にスケール済み（|lookAt|=radius）なので、内積を |camEcef|·radius で割って
+            // 単位ベクトル同士の内積へ正規化する。
+            const denom = Math.max(1, camEcef.length()) * Math.max(1, camera.radius);
+            const dAltPerRadius =
+                -(camEcef.x * lookAt.x + camEcef.y * lookAt.y + camEcef.z * lookAt.z) / denom;
+            const newRadius = clampRadiusForGroundClearance(
+                camera.radius,
+                camGeo.altMeters,
+                terrain,
+                MIN_GROUND_CLEARANCE,
+                dAltPerRadius,
+            );
+            if (newRadius !== camera.radius) camera.radius = newRadius;
+        };
+
         // render ループは開始しない。DefaultScene と同じく、シーン生成と render ループ管理の
         // 責務を分離し、ループ開始は呼び出し側（デモ / 将来の JpmapTerrain 等）に委ねる
         // （二重起動・上書きを防ぐ）。本シーンのタイル同期は onBeforeRenderObservable で動く。
@@ -257,7 +397,9 @@ export class GlobeScene {
         // frame=0 の最初のフレームで即同期し、以降は syncIntervalFrames ごとに再評価する。
         let frame = 0;
         const observer = scene.onBeforeRenderObservable.add(() => {
+            applyKeyboardPan();
             seatCenterOnTerrain();
+            enforceGroundClearance();
             if (frame % GLOBE_SCENE_DEFAULTS.syncIntervalFrames === 0) syncTiles();
             frame++;
         });
@@ -265,6 +407,12 @@ export class GlobeScene {
         const dispose = (): void => {
             // render ループは呼び出し側の所有なので停止しない（呼び出し側が停止する）。
             scene.onBeforeRenderObservable.remove(observer);
+            canvas.removeEventListener("keydown", onKeyDown);
+            canvas.removeEventListener("keyup", onKeyUp);
+            canvas.removeEventListener("pointerdown", onPointerDown);
+            canvas.removeEventListener("pointerup", onPointerUp);
+            canvas.removeEventListener("pointercancel", endDrag);
+            canvas.removeEventListener("pointermove", onPointerMove);
             tileManager.dispose();
             scene.dispose();
         };

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -1,13 +1,15 @@
 /**
- * グローブ地形シーン (Issue #275 Phase 1)。
+ * グローブ地形シーン (Issue #275 Phase 1 + Phase 2)。
  *
  * 平面ワールドの `scenes/default.ts` に対する **並行構築** のグローブ（ECEF 楕円体 +
  * Large World Rendering の floating origin）シーン。`GeospatialCamera` を中核に、
  * `geo/globeTileManager` で動的 LOD タイルを描画し、注視点を地形表面へ追従させる。
  *
- * Phase 1 のスコープは「座標系・メッシュ生成・カメラ基盤・配置・LOD」の地形エンジン。
- * 注視点ズーム・seat-on-terrain・地心距離 LOD までを含む。picking 非依存パン / WASD /
- * zoom-to-cursor 再構成 / URL 等価性などのリッチなカメラ UX は Phase 2 で追加する。
+ * Phase 1: 「座標系・メッシュ生成・カメラ基盤・配置・LOD」の地形エンジン（注視点ズーム・
+ * seat-on-terrain・地心距離 LOD）。
+ * Phase 2: picking 非依存パン（左ドラッグ / WASD）・カメラ地形衝突・seat の対地クリアランス
+ * フェードを追加。zoom-to-cursor は seat との鉛直結合で揺れるため無効維持（中心ズーム。
+ * 再実装は Issue #327）。URL 等価性はデモ（`demos/geospatial/index.ts`）側で実装。
  */
 import { Scene } from "@babylonjs/core/scene";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -21,6 +21,7 @@ import {
 } from "@babylonjs/core/Cameras/geospatialCamera";
 import { GeospatialClippingBehavior } from "@babylonjs/core/Behaviors/Cameras/geospatialClippingBehavior";
 import { Wgs84Ellipsoid } from "@babylonjs/core/Maths/math.geospatial.functions";
+import { Ray } from "@babylonjs/core/Culling/ray";
 
 import type { MapType } from "../terrain/gsiTile";
 import { DEG2RAD, geodeticToEcef, geodeticToEcefToRef, ecefToGeodetic } from "../terrain/geo/ecef";
@@ -28,6 +29,7 @@ import {
     cameraTangentBasisToRef,
     panCenterOnSphereToRef,
     clampRadiusForGroundClearance,
+    raySphereNearHitToRef,
 } from "../terrain/geo/cameraMapping";
 import { createGlobeTileManager, type GlobeTileManager, type GlobeTileSyncStats } from "../terrain/geo/globeTileManager";
 
@@ -179,11 +181,12 @@ export class GlobeScene {
         camera.addBehavior(new GeospatialClippingBehavior());
         camera.attachControl(true);
 
-        // ズームは注視点(画面中心)へ寄る半径のみのズームにする。zoom-to-cursor は毎フレーム
-        // 中心をカーソル方向へ動かすため、floating origin 下のピック誤差と相まってガタつく。
-        // zoom-to-cursor のレイ再構成は floating origin 維持と両立が難しく、Phase 2 では無効維持
-        // とする（PoC の判断踏襲）。
-        camera.movement.zoomToCursor = false;
+        // zoom-to-cursor（カーソル下の地点へ寄るズーム）を有効化する。ネイティブ実装は
+        // ホイール毎に scene.pick でカーソル下の点を取り直すが、floating origin 下では
+        // レンダリング座標と真の ECEF メッシュ位置がずれてピックが毎回ブレ、ズームが揺れる
+        // （PoC で確認）。そこで handleZoom を差し替え、目標点を scene.pick 非依存の
+        // 「真の ECEF カメラ位置からのレイ × 地表球」の幾何交点で求める（後段で配線）。
+        camera.movement.zoomToCursor = true;
 
         // ---- picking 非依存パン（左ドラッグ / WASD） ----
         // 既定の pan（左ドラッグ/キーボード）は scene.pick でグローブをヒットしてドラッグ平面を
@@ -352,6 +355,32 @@ export class GlobeScene {
                 .copyFrom(camera.center)
                 .subtractInPlace(lookAt.scaleInPlace(camera.radius));
             return cameraEcef;
+        };
+
+        // ---- zoom-to-cursor の目標点を scene.pick 非依存で求める差し替え ----
+        // ネイティブ handleZoom は毎ホイールで scene.pick(pointerX,pointerY) して
+        // computedPerFrameZoomPickPoint を更新するが、floating origin 下では点がブレてズームが
+        // 揺れる。ここでは真の ECEF カメラ位置からカーソル方向のレイを飛ばし、注視点と同じ地心距離
+        // （seat で地表に載っている）の球と交差させて目標点を求める。ホイール毎にのみ取り直し、
+        // ズームの慣性減衰中（新規ホイールなし）は handleZoom が呼ばれず目標点が固定されるため、
+        // 1 ジェスチャ中は固定目標へ滑らかに寄る（新しいホイールが来たら新カーソル位置で更新）。
+        const movement = camera.movement;
+        const zoomTarget = new Vector3();
+        const pickRay = new Ray(Vector3.Zero(), Vector3.Forward());
+        movement.handleZoom = (zoomDelta: number): void => {
+            if (zoomDelta === 0) return;
+            // ネイティブ同様に蓄積（per-frame の zoomDeltaCurrentFrame へ変換される）。
+            movement.zoomAccumulatedPixels += zoomDelta;
+            // カーソル方向のレイ（方向のみ使用。origin は floating origin オフセットを含むため捨てる）。
+            scene.createPickingRayToRef(scene.pointerX, scene.pointerY, null, pickRay, camera);
+            const camEcef = computeCameraEcef(); // 真の ECEF カメラ位置
+            const sphereRadius = camera.center.length(); // 注視点の地心距離（地表相当）
+            if (raySphereNearHitToRef(camEcef, pickRay.direction, sphereRadius, zoomTarget)) {
+                movement.computedPerFrameZoomPickPoint = zoomTarget;
+            } else {
+                // 空を指している → 注視点方向（lookAt）ズームにフォールバック。
+                movement.computedPerFrameZoomPickPoint = undefined;
+            }
         };
 
         const syncTiles = (): void => {

--- a/src/terrain/geo/cameraMapping.ts
+++ b/src/terrain/geo/cameraMapping.ts
@@ -136,7 +136,9 @@ export const clampRadiusForGroundClearance = (
 ): number => {
     const deficit = terrainElevMeters + minClearance - camAltMeters;
     if (deficit <= 0) return radius; // 既にクリアランスを満たす
-    // 水平視（dAltPerRadius≈0）では radius を増やしても高度が上がらないので諦める（発散回避）。
-    if (dAltPerRadius < 1e-3) return radius;
-    return radius + deficit / dAltPerRadius;
+    // 水平視（dAltPerRadius≈0）や非有限値（NaN/Infinity）では radius を増やしても高度が
+    // 上がらない/壊れるので入力 radius を返す（NaN は比較が常に false のため明示判定する）。
+    if (!Number.isFinite(dAltPerRadius) || dAltPerRadius < 1e-3) return radius;
+    const next = radius + deficit / dAltPerRadius;
+    return Number.isFinite(next) ? next : radius;
 };

--- a/src/terrain/geo/cameraMapping.ts
+++ b/src/terrain/geo/cameraMapping.ts
@@ -114,6 +114,35 @@ export const panCenterOnSphereToRef = (
 };
 
 /**
+ * 原点 `origin` から単位方向 `dir` のレイと、**世界原点中心・半径 `sphereRadius` の球** との
+ * 手前側交点を `ref` に書き込む。zoom-to-cursor のカーソル下の目標点を `scene.pick` 非依存で
+ * 求める用途（floating origin 下では scene.pick が誤差を生み、毎回点がブレてズームが揺れるため、
+ * 真の ECEF カメラ位置とレイ方向から幾何的に交点を解く）。
+ *
+ * `dir` は単位ベクトル前提。カメラが球外（通常）なら手前の交点、球内（地中）なら奥側を返す。
+ *
+ * @returns 交点があり t>0 なら true（`ref` に交点）、レイが球を外す/背面なら false。
+ */
+export const raySphereNearHitToRef = (
+    origin: Vector3,
+    dir: Vector3,
+    sphereRadius: number,
+    ref: Vector3,
+): boolean => {
+    // |origin + t·dir|² = R²（dir は単位） → t² + b·t + c = 0, a=1。
+    const b = 2 * Vector3.Dot(origin, dir);
+    const c = origin.lengthSquared() - sphereRadius * sphereRadius;
+    const disc = b * b - 4 * c;
+    if (disc < 0) return false; // レイが球と交わらない（空を指している等）
+    const sq = Math.sqrt(disc);
+    let t = (-b - sq) / 2; // 手前側
+    if (t < 0) t = (-b + sq) / 2; // 手前が背面なら奥側（カメラが球内＝地中の保険）
+    if (t < 0) return false; // 両交点とも背面
+    ref.copyFrom(dir).scaleInPlace(t).addInPlace(origin);
+    return true;
+};
+
+/**
  * カメラが地形に潜らないための最小クリアランスを満たす `radius` を返す（カメラ地形衝突）。
  *
  * `GeospatialCamera` のカメラ位置は center/yaw/pitch/radius から導出されるため、潜り込みは

--- a/src/terrain/geo/cameraMapping.ts
+++ b/src/terrain/geo/cameraMapping.ts
@@ -1,0 +1,142 @@
+/**
+ * グローブカメラ（Issue #275 Phase 2）の UI/URL ⇄ `GeospatialCamera` マッピングと、
+ * floating origin 下で `scene.pick` に依存しないパン（地表接線移動）・カメラ地形衝突の純関数群。
+ *
+ * 既存（平面版）の UI / URL 共有は `azimuth`(方位) / `tilt`(チルト) / `altitude`(高度) を用いる。
+ * これを `GeospatialCamera` の `yaw` / `pitch` / `radius` / `center`(ECEF) と相互変換する。
+ * PoC（Issue #321 `geoMapping.ts`）の純関数を本体共有モジュールへ昇格したもの。
+ *
+ * 対応関係:
+ * - azimuth[deg] ⇄ yaw[rad]   （どちらも 0 = 北、+ = 東回り）
+ * - tilt[deg]    ⇄ pitch[rad] （0 = 直下、90 = 水平。既存 UI の「地面からの傾き」と同義）
+ *
+ * 本モジュールは `GeospatialCamera` を直接 import しない（jest 環境を軽く保つ）。`yaw`/`pitch`
+ * から視線（lookAt）を組む処理は Babylon の `ComputeLookAtFromYawPitchToRef` を呼ぶ
+ * 呼び出し側（`scenes/globe.ts`）が担い、本モジュールには算出済みのベクトルを渡す。
+ */
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+
+import { DEG2RAD, RAD2DEG } from "./ecef";
+
+/** ECEF 北極軸（`EcefFromLatLonAltToRef` 規約: X→経度0, Y→東経90°, Z→北極）。 */
+const ECEF_POLE = new Vector3(0, 0, 1);
+
+/** 接線基底が縮退（特異点）とみなす長さ二乗のしきい値。 */
+const DEGENERATE_EPS = 1e-12;
+
+/** 既存 UI の azimuth/tilt[deg] → `GeospatialCamera` の yaw/pitch[rad]。 */
+export const uiToYawPitch = (
+    azimuthDeg: number,
+    tiltDeg: number,
+): { yaw: number; pitch: number } => ({
+    yaw: azimuthDeg * DEG2RAD,
+    pitch: tiltDeg * DEG2RAD,
+});
+
+/** `GeospatialCamera` の yaw/pitch[rad] → 既存 UI の azimuth/tilt[deg]。 */
+export const yawPitchToUi = (
+    yaw: number,
+    pitch: number,
+): { azimuthDeg: number; tiltDeg: number } => ({
+    // azimuth は既存 URL 表現に合わせ [0, 360) に正規化（JS の % は負値を返すため二重剰余）。
+    azimuthDeg: (((yaw * RAD2DEG) % 360) + 360) % 360,
+    tiltDeg: pitch * RAD2DEG,
+});
+
+/**
+ * 注視点(center)の地表における **地理的接線基底**（東・北）を `ref` に書き込む。WASD パン用。
+ *
+ * 地心 up（center 正規化）と ECEF 北極軸の外積で東を、up×東 で北を作る。極（up が北極軸と平行）
+ * では東が定義できないため `false` を返す（呼び出し側はパンをスキップ）。
+ *
+ * @returns 基底を計算できたら true、極などの特異点で計算不能なら false。
+ */
+export const geographicTangentBasisToRef = (
+    center: Vector3,
+    eastRef: Vector3,
+    northRef: Vector3,
+): boolean => {
+    const r = center.length();
+    if (r < 1) return false;
+    const up = center.scale(1 / r);
+    Vector3.CrossToRef(ECEF_POLE, up, eastRef);
+    if (eastRef.lengthSquared() < DEGENERATE_EPS) return false;
+    eastRef.normalize();
+    Vector3.CrossToRef(up, eastRef, northRef); // 北
+    northRef.normalize();
+    return true;
+};
+
+/**
+ * 注視点(center)から見たカメラ視線(lookAt)を基準に、地表に沿った **右・前方向** を `ref` に書き込む。
+ * 左ドラッグパン用（「マップを掴む」操作の縮尺をカメラ向きに合わせる）。
+ *
+ * `lookAt` はカメラ→center 方向（`ComputeLookAtFromYawPitchToRef` の出力）。地心 up との外積で
+ * 画面右、up×右 で地表に沿った前方を作る。真下視点（lookAt ∥ up）では右が定義できず `false`。
+ *
+ * @returns 基底を計算できたら true、真下視点などの特異点で計算不能なら false。
+ */
+export const cameraTangentBasisToRef = (
+    center: Vector3,
+    lookAt: Vector3,
+    rightRef: Vector3,
+    fwdRef: Vector3,
+): boolean => {
+    const r = center.length();
+    if (r < 1) return false;
+    const up = center.scale(1 / r);
+    Vector3.CrossToRef(lookAt, up, rightRef);
+    if (rightRef.lengthSquared() < DEGENERATE_EPS) return false; // 真下視点
+    rightRef.normalize();
+    Vector3.CrossToRef(up, rightRef, fwdRef); // 地表に沿ったカメラ前方
+    fwdRef.normalize();
+    return true;
+};
+
+/**
+ * 注視点(center)を接線移動量 `tangentMove`[m] だけ動かし、地心距離 |center| を保つよう
+ * 球面へ再投影した結果を `ref` に書き込む。パン共通の後処理。
+ */
+export const panCenterOnSphereToRef = (
+    center: Vector3,
+    tangentMove: Vector3,
+    ref: Vector3,
+): Vector3 => {
+    const r = center.length();
+    ref.copyFrom(center).addInPlace(tangentMove);
+    const moved = ref.length();
+    if (moved < 1) {
+        ref.copyFrom(center);
+        return ref;
+    }
+    ref.scaleInPlace(r / moved); // 地心距離 r を保って球面上へ戻す
+    return ref;
+};
+
+/**
+ * カメラが地形に潜らないための最小クリアランスを満たす `radius` を返す（カメラ地形衝突）。
+ *
+ * `GeospatialCamera` のカメラ位置は center/yaw/pitch/radius から導出されるため、潜り込みは
+ * radius を増やして解消する。カメラ高度はおおむね radius に線形（係数 `dAltPerRadius`
+ * = カメラ位置での地心 up・(center→camera 方向)）で増えるので、不足分を 1 ステップで補う。
+ *
+ * @param radius            現在の radius[m]。
+ * @param camAltMeters      カメラの楕円体高度[m]（`ecefToGeodetic(cameraEcef).altMeters`）。
+ * @param terrainElevMeters カメラ直下の地形標高[m]（無ければ呼び出し側で 0）。
+ * @param minClearance      地表からの最小クリアランス[m]。
+ * @param dAltPerRadius     radius あたりのカメラ高度増加率（up・(center→camera 単位方向)）。
+ * @returns クリアランスを満たす radius[m]（潜っていなければ入力 radius のまま）。
+ */
+export const clampRadiusForGroundClearance = (
+    radius: number,
+    camAltMeters: number,
+    terrainElevMeters: number,
+    minClearance: number,
+    dAltPerRadius: number,
+): number => {
+    const deficit = terrainElevMeters + minClearance - camAltMeters;
+    if (deficit <= 0) return radius; // 既にクリアランスを満たす
+    // 水平視（dAltPerRadius≈0）では radius を増やしても高度が上がらないので諦める（発散回避）。
+    if (dAltPerRadius < 1e-3) return radius;
+    return radius + deficit / dAltPerRadius;
+};

--- a/src/terrain/geo/cameraMapping.ts
+++ b/src/terrain/geo/cameraMapping.ts
@@ -114,35 +114,6 @@ export const panCenterOnSphereToRef = (
 };
 
 /**
- * 原点 `origin` から単位方向 `dir` のレイと、**世界原点中心・半径 `sphereRadius` の球** との
- * 手前側交点を `ref` に書き込む。zoom-to-cursor のカーソル下の目標点を `scene.pick` 非依存で
- * 求める用途（floating origin 下では scene.pick が誤差を生み、毎回点がブレてズームが揺れるため、
- * 真の ECEF カメラ位置とレイ方向から幾何的に交点を解く）。
- *
- * `dir` は単位ベクトル前提。カメラが球外（通常）なら手前の交点、球内（地中）なら奥側を返す。
- *
- * @returns 交点があり t>0 なら true（`ref` に交点）、レイが球を外す/背面なら false。
- */
-export const raySphereNearHitToRef = (
-    origin: Vector3,
-    dir: Vector3,
-    sphereRadius: number,
-    ref: Vector3,
-): boolean => {
-    // |origin + t·dir|² = R²（dir は単位） → t² + b·t + c = 0, a=1。
-    const b = 2 * Vector3.Dot(origin, dir);
-    const c = origin.lengthSquared() - sphereRadius * sphereRadius;
-    const disc = b * b - 4 * c;
-    if (disc < 0) return false; // レイが球と交わらない（空を指している等）
-    const sq = Math.sqrt(disc);
-    let t = (-b - sq) / 2; // 手前側
-    if (t < 0) t = (-b + sq) / 2; // 手前が背面なら奥側（カメラが球内＝地中の保険）
-    if (t < 0) return false; // 両交点とも背面
-    ref.copyFrom(dir).scaleInPlace(t).addInPlace(origin);
-    return true;
-};
-
-/**
  * カメラが地形に潜らないための最小クリアランスを満たす `radius` を返す（カメラ地形衝突）。
  *
  * `GeospatialCamera` のカメラ位置は center/yaw/pitch/radius から導出されるため、潜り込みは

--- a/src/terrain/geo/index.ts
+++ b/src/terrain/geo/index.ts
@@ -10,6 +10,9 @@
  * - `globeLod`: 地心距離ベース Quadtree+SSE の可視タイル選択。
  * - `crossLevel`: LOD 境界のクロスレベル標高スナップ。
  * - `globeMesh`: 曲面タイルメッシュのジオメトリ生成（純粋関数）。
+ *
+ * Phase 2（カメラ・UX・URL）:
+ * - `cameraMapping`: UI/URL ⇄ GeospatialCamera マッピング・接線パン・地形衝突の純関数。
  */
 export * from "./ecef";
 export * from "./mapping";
@@ -17,3 +20,4 @@ export * from "./elevSample";
 export * from "./globeLod";
 export * from "./crossLevel";
 export * from "./globeMesh";
+export * from "./cameraMapping";

--- a/tests/geoCameraMapping.unit.spec.ts
+++ b/tests/geoCameraMapping.unit.spec.ts
@@ -151,4 +151,10 @@ describe("clampRadiusForGroundClearance", () => {
     it("水平視（dAltPerRadius≈0）では radius を増やさない（発散回避）", () => {
         expect(clampRadiusForGroundClearance(1000, 0, 1000, 300, 0)).toBe(1000);
     });
+
+    it("dAltPerRadius が非有限（NaN/Infinity）でも radius を破壊しない", () => {
+        // NaN は < 1e-3 判定を素通りするため明示ガードが必要（camera.radius=NaN 防止）。
+        expect(clampRadiusForGroundClearance(1000, 0, 1000, 300, NaN)).toBe(1000);
+        expect(clampRadiusForGroundClearance(1000, 0, 1000, 300, Infinity)).toBe(1000);
+    });
 });

--- a/tests/geoCameraMapping.unit.spec.ts
+++ b/tests/geoCameraMapping.unit.spec.ts
@@ -20,6 +20,7 @@ import {
     cameraTangentBasisToRef,
     panCenterOnSphereToRef,
     clampRadiusForGroundClearance,
+    raySphereNearHitToRef,
 } from "../src/terrain/geo/cameraMapping";
 
 describe("uiToYawPitch / yawPitchToUi", () => {
@@ -156,5 +157,38 @@ describe("clampRadiusForGroundClearance", () => {
         // NaN は < 1e-3 判定を素通りするため明示ガードが必要（camera.radius=NaN 防止）。
         expect(clampRadiusForGroundClearance(1000, 0, 1000, 300, NaN)).toBe(1000);
         expect(clampRadiusForGroundClearance(1000, 0, 1000, 300, Infinity)).toBe(1000);
+    });
+});
+
+describe("raySphereNearHitToRef", () => {
+    it("球の真上から直下視で半径上の点に当たる", () => {
+        const R = 6378137;
+        const origin = new Vector3(0, 0, R + 1000); // 球面の 1000m 上空
+        const dir = new Vector3(0, 0, -1); // 直下
+        const ref = new Vector3();
+        expect(raySphereNearHitToRef(origin, dir, R, ref)).toBe(true);
+        expect(ref.z).toBeCloseTo(R, 3); // 手前側（上面）= +Z 側の半径
+        expect(ref.x).toBeCloseTo(0, 3);
+        expect(ref.y).toBeCloseTo(0, 3);
+    });
+
+    it("斜めレイでも手前側の交点を返す（origin に近い方）", () => {
+        const R = 100;
+        const origin = new Vector3(0, 0, 200);
+        const dir = new Vector3(0.3, 0, -1).normalize();
+        const ref = new Vector3();
+        expect(raySphereNearHitToRef(origin, dir, R, ref)).toBe(true);
+        // 交点は球面上（半径 R）。
+        expect(ref.length()).toBeCloseTo(R, 3);
+        // 手前側＝ origin により近い（z>0 側）。
+        expect(ref.z).toBeGreaterThan(0);
+    });
+
+    it("球を外す方向（空を指す）は false", () => {
+        const R = 100;
+        const origin = new Vector3(0, 0, 200);
+        const dir = new Vector3(0, 0, 1); // 球から離れる向き
+        const ref = new Vector3();
+        expect(raySphereNearHitToRef(origin, dir, R, ref)).toBe(false);
     });
 });

--- a/tests/geoCameraMapping.unit.spec.ts
+++ b/tests/geoCameraMapping.unit.spec.ts
@@ -20,7 +20,6 @@ import {
     cameraTangentBasisToRef,
     panCenterOnSphereToRef,
     clampRadiusForGroundClearance,
-    raySphereNearHitToRef,
 } from "../src/terrain/geo/cameraMapping";
 
 describe("uiToYawPitch / yawPitchToUi", () => {
@@ -157,38 +156,5 @@ describe("clampRadiusForGroundClearance", () => {
         // NaN は < 1e-3 判定を素通りするため明示ガードが必要（camera.radius=NaN 防止）。
         expect(clampRadiusForGroundClearance(1000, 0, 1000, 300, NaN)).toBe(1000);
         expect(clampRadiusForGroundClearance(1000, 0, 1000, 300, Infinity)).toBe(1000);
-    });
-});
-
-describe("raySphereNearHitToRef", () => {
-    it("球の真上から直下視で半径上の点に当たる", () => {
-        const R = 6378137;
-        const origin = new Vector3(0, 0, R + 1000); // 球面の 1000m 上空
-        const dir = new Vector3(0, 0, -1); // 直下
-        const ref = new Vector3();
-        expect(raySphereNearHitToRef(origin, dir, R, ref)).toBe(true);
-        expect(ref.z).toBeCloseTo(R, 3); // 手前側（上面）= +Z 側の半径
-        expect(ref.x).toBeCloseTo(0, 3);
-        expect(ref.y).toBeCloseTo(0, 3);
-    });
-
-    it("斜めレイでも手前側の交点を返す（origin に近い方）", () => {
-        const R = 100;
-        const origin = new Vector3(0, 0, 200);
-        const dir = new Vector3(0.3, 0, -1).normalize();
-        const ref = new Vector3();
-        expect(raySphereNearHitToRef(origin, dir, R, ref)).toBe(true);
-        // 交点は球面上（半径 R）。
-        expect(ref.length()).toBeCloseTo(R, 3);
-        // 手前側＝ origin により近い（z>0 側）。
-        expect(ref.z).toBeGreaterThan(0);
-    });
-
-    it("球を外す方向（空を指す）は false", () => {
-        const R = 100;
-        const origin = new Vector3(0, 0, 200);
-        const dir = new Vector3(0, 0, 1); // 球から離れる向き
-        const ref = new Vector3();
-        expect(raySphereNearHitToRef(origin, dir, R, ref)).toBe(false);
     });
 });

--- a/tests/geoCameraMapping.unit.spec.ts
+++ b/tests/geoCameraMapping.unit.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * geo/cameraMapping の単体テスト (Issue #275 Phase 2)。
+ *
+ * - uiToYawPitch ⇄ yawPitchToUi の往復精度・azimuth 正規化（[0,360)）
+ * - geographicTangentBasisToRef: 東/北接線の直交性・既知点での向き・極の特異点
+ * - cameraTangentBasisToRef: 右/前接線の直交性・真下視点の特異点
+ * - panCenterOnSphereToRef: 地心距離保存・接線方向への移動
+ * - clampRadiusForGroundClearance: 潜り込み補正・既クリアランス・水平視の発散回避
+ */
+
+import { describe, it, expect } from "@jest/globals";
+
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+
+import { DEG2RAD, geodeticToEcef } from "../src/terrain/geo/ecef";
+import {
+    uiToYawPitch,
+    yawPitchToUi,
+    geographicTangentBasisToRef,
+    cameraTangentBasisToRef,
+    panCenterOnSphereToRef,
+    clampRadiusForGroundClearance,
+} from "../src/terrain/geo/cameraMapping";
+
+describe("uiToYawPitch / yawPitchToUi", () => {
+    it("azimuth/tilt[deg] → yaw/pitch[rad]", () => {
+        const { yaw, pitch } = uiToYawPitch(90, 60);
+        expect(yaw).toBeCloseTo(90 * DEG2RAD, 12);
+        expect(pitch).toBeCloseTo(60 * DEG2RAD, 12);
+    });
+
+    it("往復: ui → yawPitch → ui（[0,360) 内）", () => {
+        const samples: { az: number; tilt: number }[] = [
+            { az: 0, tilt: 0 },
+            { az: 45, tilt: 30 },
+            { az: 180, tilt: 90 },
+            { az: 359.9, tilt: 12.3 },
+        ];
+        for (const s of samples) {
+            const { yaw, pitch } = uiToYawPitch(s.az, s.tilt);
+            const { azimuthDeg, tiltDeg } = yawPitchToUi(yaw, pitch);
+            expect(azimuthDeg).toBeCloseTo(s.az, 9);
+            expect(tiltDeg).toBeCloseTo(s.tilt, 9);
+        }
+    });
+
+    it("azimuth は [0,360) に正規化（負 yaw / 周回）", () => {
+        // yaw = -90deg → 270deg
+        expect(yawPitchToUi(-90 * DEG2RAD, 0).azimuthDeg).toBeCloseTo(270, 9);
+        // yaw = 450deg → 90deg
+        expect(yawPitchToUi(450 * DEG2RAD, 0).azimuthDeg).toBeCloseTo(90, 9);
+    });
+});
+
+describe("geographicTangentBasisToRef", () => {
+    it("東/北/up が互いに直交（赤道本初子午線）", () => {
+        const center = geodeticToEcef(0, 0, 0);
+        const east = new Vector3();
+        const north = new Vector3();
+        expect(geographicTangentBasisToRef(center, east, north)).toBe(true);
+        const up = center.clone().normalize();
+        expect(Vector3.Dot(east, north)).toBeCloseTo(0, 9);
+        expect(Vector3.Dot(east, up)).toBeCloseTo(0, 9);
+        expect(Vector3.Dot(north, up)).toBeCloseTo(0, 9);
+        expect(east.length()).toBeCloseTo(1, 9);
+        expect(north.length()).toBeCloseTo(1, 9);
+    });
+
+    it("lat=0,lon=0 で東は +Y（東経90°方向）、北は +Z（北極方向）", () => {
+        const center = geodeticToEcef(0, 0, 0); // X 軸上
+        const east = new Vector3();
+        const north = new Vector3();
+        geographicTangentBasisToRef(center, east, north);
+        expect(east.y).toBeCloseTo(1, 9);
+        expect(north.z).toBeCloseTo(1, 9);
+    });
+
+    it("極では east が縮退し false", () => {
+        const center = geodeticToEcef(90, 0, 0); // ほぼ Z 軸上
+        const east = new Vector3();
+        const north = new Vector3();
+        expect(geographicTangentBasisToRef(center, east, north)).toBe(false);
+    });
+});
+
+describe("cameraTangentBasisToRef", () => {
+    it("right/fwd が center と直交し正規化される", () => {
+        const center = geodeticToEcef(35, 139, 0);
+        const up = center.clone().normalize();
+        // 真下より傾けた視線（up に直交しない適当な lookAt）。
+        const lookAt = up.scale(-1).add(new Vector3(0.3, 0, 0)).normalize();
+        const right = new Vector3();
+        const fwd = new Vector3();
+        expect(cameraTangentBasisToRef(center, lookAt, right, fwd)).toBe(true);
+        expect(Vector3.Dot(right, up)).toBeCloseTo(0, 9);
+        expect(Vector3.Dot(fwd, up)).toBeCloseTo(0, 9);
+        expect(Vector3.Dot(right, fwd)).toBeCloseTo(0, 9);
+        expect(right.length()).toBeCloseTo(1, 9);
+        expect(fwd.length()).toBeCloseTo(1, 9);
+    });
+
+    it("真下視点（lookAt ∥ up）では false", () => {
+        const center = geodeticToEcef(35, 139, 0);
+        const up = center.clone().normalize();
+        const lookAt = up.scale(-1); // 真下
+        const right = new Vector3();
+        const fwd = new Vector3();
+        expect(cameraTangentBasisToRef(center, lookAt, right, fwd)).toBe(false);
+    });
+});
+
+describe("panCenterOnSphereToRef", () => {
+    it("地心距離を保ったまま接線方向へ移動する", () => {
+        const center = geodeticToEcef(35, 139, 1000);
+        const r0 = center.length();
+        const east = new Vector3();
+        const north = new Vector3();
+        geographicTangentBasisToRef(center, east, north);
+        const move = east.scale(500); // 東へ 500m
+        const ref = new Vector3();
+        panCenterOnSphereToRef(center, move, ref);
+        // 地心距離は不変。
+        expect(ref.length()).toBeCloseTo(r0, 3);
+        // 東方向へ進んでいる（元 center との差が東成分正）。
+        const delta = ref.subtract(center);
+        expect(Vector3.Dot(delta, east)).toBeGreaterThan(0);
+    });
+
+    it("移動量ゼロなら center を保つ", () => {
+        const center = geodeticToEcef(0, 0, 0);
+        const ref = new Vector3();
+        panCenterOnSphereToRef(center, Vector3.Zero(), ref);
+        expect(ref.x).toBeCloseTo(center.x, 6);
+        expect(ref.y).toBeCloseTo(center.y, 6);
+        expect(ref.z).toBeCloseTo(center.z, 6);
+    });
+});
+
+describe("clampRadiusForGroundClearance", () => {
+    it("クリアランスを満たしていれば radius 不変", () => {
+        // camAlt=5000, terrain=1000, clearance=300 → 余裕あり
+        expect(clampRadiusForGroundClearance(60000, 5000, 1000, 300, 0.8)).toBe(60000);
+    });
+
+    it("潜り込み（camAlt < terrain+clearance）は radius を増やす", () => {
+        // deficit = 1000+300-1100 = 200, dAltPerRadius=0.5 → +400
+        const r = clampRadiusForGroundClearance(1000, 1100, 1000, 300, 0.5);
+        expect(r).toBeCloseTo(1400, 6);
+    });
+
+    it("水平視（dAltPerRadius≈0）では radius を増やさない（発散回避）", () => {
+        expect(clampRadiusForGroundClearance(1000, 0, 1000, 300, 0)).toBe(1000);
+    });
+});


### PR DESCRIPTION
## 概要

Issue #275 グローブ全面移行の **Phase 2: カメラ・UX・URL 等価性**。`GeospatialCamera`（ECEF 楕円体 + floating origin）のカメラ操作と URL 共有を、平面版と等価な体験へ揃える。既存平面スタックは未変更（並行構築）。

計画の正本: #275 コメント「段階移行計画」。PoC: #321 / PR #322。

## 変更点

### `src/terrain/geo/cameraMapping.ts`（新規・純関数）
PoC `geoMapping.ts` の知見を本体共有モジュールへ昇格。`GeospatialCamera` 非依存（jest 検証可）。
- `uiToYawPitch` / `yawPitchToUi`: azimuth/tilt[deg] ⇄ yaw/pitch[rad]（azimuth は [0,360) 正規化）
- `geographicTangentBasisToRef` / `cameraTangentBasisToRef`: picking 非依存パン用の接線基底（地理 N/E・カメラ右/前）。特異点（極・真下視点）は false
- `panCenterOnSphereToRef`: 地心距離を保つ球面パン
- `clampRadiusForGroundClearance`: カメラ地形衝突の radius クランプ（水平視の発散回避つき）

### `src/scenes/globe.ts`
- **picking 非依存パン**: floating origin 下で `scene.pick` が効かないため、左ドラッグ / WASD を地表接線移動で実装（`cameraMapping` を使用）
- **カメラ地形衝突**: 地表からの最小クリアランス 50m を毎フレーム適用（潜り込み防止）
- **ズーム**: zoom-to-cursor は floating origin との両立が難しく無効維持（注視点ズーム。PoC の判断踏襲）
- `dispose` で入力リスナを解除

### `src/demos/geospatial/index.ts`
- **URL 後方互換**: 既存 `urlState`（`parseCameraStateFromUrl` / `createUrlUpdater` / `zoomLevelToRadius`）を再利用し、`@lat,lon,altitude,azimuth,tilt`（3D 共有形式）と `@lat,lon,Xz`（2D 互換ズームレベル）をロード時に復元・sync 時に反映。altitude ⇄ radius 等価
- 状態変化時のみ URL 更新を投げ、毎 sync 呼び出しでデバウンスが確定しない問題を回避

### `tests/geoCameraMapping.unit.spec.ts`（新規）
往復精度・接線直交性・特異点・球面保存・衝突クランプを固定（13 ケース）。

## 影響範囲
- 画面: `/geospatial` デモのカメラ操作・URL 共有が拡充（左ドラッグ/WASD パン、URL 往復）
- API: `src/terrain/geo` に `cameraMapping` を追加（既存 export は不変）
- 既存平面デモ・スタックへの影響なし

## 検証（DoD）
- `npm run lint`（No issues）/ `npm run typecheck`（pass）/ `npm run test:unit`（**1034 passed**）
- headless（webgl2, Playwright）で `/geospatial` をロードし、WASD パンで center 移動・URL に `@lat,lon,...` 反映・`@lat,lon,altitude,azimuth,tilt` と `@lat,lon,Xz` からの状態復元・コンソールエラーなしを確認（検証スクリプトは `.tmp` で破棄）

🤖 Generated with [Claude Code](https://claude.com/claude-code)