### PR TITLE
feat(geo): グローブ用マーカーを ECEF+地心 up で実装 (Phase 3 marker 先行 / #275)

### DIFF
--- a/src/demos/geospatial/index.ts
+++ b/src/demos/geospatial/index.ts
@@ -176,6 +176,16 @@ const start = async (): Promise<void> => {
         );
     }
 
+    // グローブマーカー（Phase 3）のデモ表示。`?marker=off` で無効化できる。既定は富士山頂に
+    // ラベル付きマーカーを 1 つ置き、接地・地心 up ポール・カメラ正対ラベルを実機確認する。
+    if (params.get("marker") !== "off") {
+        controller.markerManager.add({
+            lat: 35.360625,
+            lon: 138.727363,
+            text: { value: "富士山" },
+        });
+    }
+
     // render ループはシーン生成側ではなく呼び出し側（本デモ）で開始する
     // （GlobeScene は責務分離のためループを開始しない）。
     engine.runRenderLoop(() => controller.scene.render());

--- a/src/demos/geospatial/index.ts
+++ b/src/demos/geospatial/index.ts
@@ -49,6 +49,33 @@ const resolveNumber = (search: string, key: string, fallback: number): number =>
     return Number.isFinite(n) ? n : fallback;
 };
 
+/**
+ * デモ用マーカーアイコンの PNG data URL を生成する（赤丸＋白縁＋中央の白ドット）。
+ * WebGPU の ImageBitmap デコーダは SVG を扱えないため、Canvas で描いて PNG data URL にする
+ * （viewer デモの buildCircleIconUrl と同方針）。
+ */
+const buildMarkerIconUrl = (): string => {
+    const size = 64;
+    const c = document.createElement("canvas");
+    c.width = size;
+    c.height = size;
+    const ctx = c.getContext("2d");
+    if (!ctx) return "";
+    ctx.beginPath();
+    ctx.arc(32, 32, 28, 0, Math.PI * 2);
+    ctx.closePath();
+    ctx.fillStyle = "#e53935";
+    ctx.fill();
+    ctx.lineWidth = 3;
+    ctx.strokeStyle = "#ffffff";
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.arc(32, 32, 8, 0, Math.PI * 2);
+    ctx.fillStyle = "#ffffff";
+    ctx.fill();
+    return c.toDataURL("image/png");
+};
+
 const updateInfo = (text: string): void => {
     const el = document.getElementById("globe-info");
     if (el) el.textContent = text;
@@ -182,6 +209,7 @@ const start = async (): Promise<void> => {
         controller.markerManager.add({
             lat: 35.360625,
             lon: 138.727363,
+            icon: { url: buildMarkerIconUrl() },
             text: { value: "富士山" },
         });
     }

--- a/src/demos/geospatial/index.ts
+++ b/src/demos/geospatial/index.ts
@@ -206,10 +206,13 @@ const start = async (): Promise<void> => {
     // グローブマーカー（Phase 3）のデモ表示。`?marker=off` で無効化できる。既定は富士山頂に
     // ラベル付きマーカーを 1 つ置き、接地・地心 up ポール・カメラ正対ラベルを実機確認する。
     if (params.get("marker") !== "off") {
+        // 2d context 取得失敗時は空文字になり validateIconUrl が例外を投げるため、空なら
+        // icon を付けずにラベルのみで追加する（デモ起動を失敗させない）。
+        const iconUrl = buildMarkerIconUrl();
         controller.markerManager.add({
             lat: 35.360625,
             lon: 138.727363,
-            icon: { url: buildMarkerIconUrl() },
+            ...(iconUrl ? { icon: { url: iconUrl } } : {}),
             text: { value: "富士山" },
         });
     }

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -32,6 +32,7 @@ import {
     clampRadiusForGroundClearance,
 } from "../terrain/geo/cameraMapping";
 import { createGlobeTileManager, type GlobeTileManager, type GlobeTileSyncStats } from "../terrain/geo/globeTileManager";
+import { createGlobeMarkerManager, type GlobeMarkerManager } from "../terrain/geo/globeMarkerManager";
 
 /** グローブシーンの既定パラメータ（富士山周辺）。 */
 export const GLOBE_SCENE_DEFAULTS = {
@@ -123,6 +124,8 @@ export interface GlobeSceneController {
     scene: Scene;
     camera: GeospatialCamera;
     tileManager: GlobeTileManager;
+    /** グローブ用マーカー（Phase 3）。接地・地心 up ポール・カメラ正対ラベル。 */
+    markerManager: GlobeMarkerManager;
     dispose: () => void;
 }
 
@@ -332,6 +335,12 @@ export class GlobeScene {
             snapEnabled,
         });
 
+        // ---- グローブマーカー（Phase 3） ----
+        const markerManager = createGlobeMarkerManager({
+            scene,
+            terrainElevAt: (latDeg, lonDeg) => tileManager.terrainElevAt(latDeg, lonDeg),
+        });
+
         const lookAt = new Vector3();
         const cameraEcef = new Vector3();
         const seatCenter = new Vector3();
@@ -452,6 +461,8 @@ export class GlobeScene {
             const camGeo = ecefToGeodetic(camEcef);
             seatCenterOnTerrain(camGeo.altMeters);
             enforceGroundClearance(camEcef, camGeo);
+            // マーカーの接地・距離スケール更新（フレーム共有の camEcef を渡す）。
+            markerManager.update(camEcef);
             if (frame % GLOBE_SCENE_DEFAULTS.syncIntervalFrames === 0) syncTiles();
             frame++;
         });
@@ -468,10 +479,11 @@ export class GlobeScene {
             canvas.removeEventListener("pointerup", onPointerUp);
             canvas.removeEventListener("pointercancel", endDrag);
             canvas.removeEventListener("pointermove", onPointerMove);
+            markerManager.dispose();
             tileManager.dispose();
             scene.dispose();
         };
 
-        return { scene, camera, tileManager, dispose };
+        return { scene, camera, tileManager, markerManager, dispose };
     }
 }

--- a/src/terrain/geo/globeMarkerManager.ts
+++ b/src/terrain/geo/globeMarkerManager.ts
@@ -237,7 +237,12 @@ export const createGlobeMarkerManager = (
 
     const remove = (id: string): void => {
         const node = nodes.get(id);
-        if (!node) return;
+        if (!node) {
+            // 平面版 MarkerManager/CircleManager と同様、未存在 id は warn + no-op にして
+            // 呼び出し側のバグを検知しやすくする。
+            console.warn(`[globe-marker] remove: id "${id}" not found`);
+            return;
+        }
         node.lineMesh.dispose();
         node.lineMat.dispose();
         if (node.iconText && !node.iconText.disposed) {
@@ -250,8 +255,10 @@ export const createGlobeMarkerManager = (
     };
 
     const setEnabled = (id: string, enabled: boolean): void => {
+        // 平面版と同様、dispose 後・未存在 id は throw して呼び出しミスを早期検出する。
+        if (disposed) throw new Error("GlobeMarkerManager.setEnabled: called after dispose");
         const node = nodes.get(id);
-        if (!node) return;
+        if (!node) throw new Error(`GlobeMarkerManager.setEnabled: id "${id}" not found`);
         node.enabled = enabled;
         node.lineMesh.setEnabled(enabled);
         node.iconText?.mesh.setEnabled(enabled);

--- a/src/terrain/geo/globeMarkerManager.ts
+++ b/src/terrain/geo/globeMarkerManager.ts
@@ -265,6 +265,8 @@ export const createGlobeMarkerManager = (
     };
 
     const update = (camEcef: Vector3): void => {
+        // 平面版 MarkerManager.update と同様、dispose 後の呼び出しは throw して検知する。
+        if (disposed) throw new Error("GlobeMarkerManager.update: called after dispose");
         if (nodes.size === 0) return;
         for (const node of nodes.values()) {
             if (!node.enabled) continue;

--- a/src/terrain/geo/globeMarkerManager.ts
+++ b/src/terrain/geo/globeMarkerManager.ts
@@ -30,7 +30,7 @@ import {
 } from "../marker";
 import {
     groundPlacementToRef,
-    computeOverlayDistanceScale,
+    computeOverlayDistanceScaleFromDistance,
     computeOverlayLineHeight,
 } from "./overlayPlacement";
 
@@ -63,7 +63,6 @@ interface GlobeMarkerNode {
     id: string;
     lat: number;
     lon: number;
-    lineColor: string;
     poleBaseDiameter: number;
     iconText: IconTextMeshes | null;
     lineMesh: Mesh;
@@ -128,7 +127,17 @@ export const createGlobeMarkerManager = (
         const id = `globe-marker-${seq++}`;
         const icon = resolveIcon(opts.icon);
         // 平面版 addMarker と同様、icon.url の危険なスキーム（javascript: 等）を拒否する。
-        if (icon) validateIconUrl(icon.url);
+        // validateIconUrl は "addMarker:" 始まりのメッセージで投げるため、発生箇所（このマネージャ
+        // と marker id）を含めて投げ直し、デバッグしやすくする。
+        if (icon) {
+            try {
+                validateIconUrl(icon.url);
+            } catch (e) {
+                throw new Error(
+                    `GlobeMarkerManager.add (${id}): ${e instanceof Error ? e.message : String(e)}`,
+                );
+            }
+        }
         const text = resolveText(opts.text);
         const iconText = createIconTextMesh(scene, id, icon, text);
         // ラベルもピック対象から外す（地形ピック等の妨げにしない）。
@@ -164,7 +173,6 @@ export const createGlobeMarkerManager = (
             id,
             lat: opts.lat,
             lon: opts.lon,
-            lineColor,
             poleBaseDiameter: opts.line?.width ?? GLOBE_MARKER_DEFAULTS.poleBaseDiameter,
             iconText,
             lineMesh,
@@ -206,8 +214,9 @@ export const createGlobeMarkerManager = (
             const elev = terrainElevAt(node.lat, node.lon) ?? 0;
             // 地表 ECEF と地心 up。
             groundPlacementToRef(node.lat, node.lon, elev, pos, up);
+            // 距離は 1 回だけ算出し、スケールと線高さで再利用（sqrt の二重計算を避ける）。
             const dist = Vector3.Distance(camEcef, pos);
-            const distScale = computeOverlayDistanceScale(camEcef, pos);
+            const distScale = computeOverlayDistanceScaleFromDistance(dist);
             const lineHeight = computeOverlayLineHeight(dist);
 
             // ポール: 地心 up 沿い、地表から lineHeight。径は距離スケールでスクリーン定。

--- a/src/terrain/geo/globeMarkerManager.ts
+++ b/src/terrain/geo/globeMarkerManager.ts
@@ -68,6 +68,12 @@ interface GlobeMarkerNode {
     lineMesh: Mesh;
     lineMat: StandardMaterial;
     enabled: boolean;
+    /**
+     * 直近に取得できた地形標高[m]（未取得は null）。前景タイルが一時的に未ロードで
+     * `terrainElevAt` が null を返したとき、これを保持してマーカーが楕円体表面（elev=0）へ
+     * 落ちるのを防ぐ（被覆の根本改善は #329）。
+     */
+    lastElev: number | null;
 }
 
 export interface GlobeMarkerManager {
@@ -181,6 +187,7 @@ export const createGlobeMarkerManager = (
             lineMesh,
             lineMat,
             enabled,
+            lastElev: null,
         };
         lineMesh.setEnabled(enabled);
         iconText?.mesh.setEnabled(enabled);
@@ -214,7 +221,11 @@ export const createGlobeMarkerManager = (
         if (nodes.size === 0) return;
         for (const node of nodes.values()) {
             if (!node.enabled) continue;
-            const elev = terrainElevAt(node.lat, node.lon) ?? 0;
+            // 取得できた標高は保持し、null（前景タイル未ロード等）のときは直前値へフォールバック
+            // して楕円体表面へ落ちるのを防ぐ（初回ロード前のみ 0=楕円体面）。被覆の根本改善は #329。
+            const queried = terrainElevAt(node.lat, node.lon);
+            if (queried !== null) node.lastElev = queried;
+            const elev = node.lastElev ?? 0;
             // 地表 ECEF と地心 up。
             groundPlacementToRef(node.lat, node.lon, elev, pos, up);
             // 距離は 1 回だけ算出し、スケールと線高さで再利用（sqrt の二重計算を避ける）。

--- a/src/terrain/geo/globeMarkerManager.ts
+++ b/src/terrain/geo/globeMarkerManager.ts
@@ -32,6 +32,7 @@ import {
     groundPlacementToRef,
     computeOverlayDistanceScaleFromDistance,
     computeOverlayLineHeight,
+    OVERLAY_REF_DISTANCE_M,
 } from "./overlayPlacement";
 
 /** グローブマーカーの既定値（線の色・基準ポール径[m]）。 */
@@ -131,6 +132,43 @@ export const createGlobeMarkerManager = (
     const tmp = new Vector3();
     const quat = new Quaternion();
 
+    /**
+     * 1 マーカーを地形へ接地し、ポール（高さ/径/向き）とラベル位置を更新する。
+     * `camEcef` 省略時（add の初期配置）は基準距離でスケール/高さを仮置きし、原点 (0,0,0)
+     * 表示のチラつきを防ぐ（次フレームの update で camEcef ベースに補正される）。
+     */
+    const placeNode = (node: GlobeMarkerNode, camEcef?: Vector3): void => {
+        // 取得できた標高は保持し、null（前景タイル未ロード等）は直前値へフォールバック
+        // して楕円体表面へ落ちるのを防ぐ（初回ロード前のみ 0=楕円体面）。被覆の根本改善は #329。
+        const queried = terrainElevAt(node.lat, node.lon);
+        if (queried !== null) node.lastElev = queried;
+        const elev = node.lastElev ?? 0;
+        // 地表 ECEF と地心 up。
+        groundPlacementToRef(node.lat, node.lon, elev, pos, up);
+        // 距離は 1 回だけ算出し、スケールと線高さで再利用（sqrt の二重計算を避ける）。
+        // camEcef なし（初期配置）は基準距離で仮置き。
+        const dist = camEcef ? Vector3.Distance(camEcef, pos) : OVERLAY_REF_DISTANCE_M;
+        const distScale = computeOverlayDistanceScaleFromDistance(dist);
+        const lineHeight = computeOverlayLineHeight(dist);
+
+        // ポール: 地心 up 沿い、地表から lineHeight。径は距離スケールでスクリーン定。
+        orientYToUpToRef(up, quat);
+        node.lineMesh.rotationQuaternion!.copyFrom(quat);
+        const diameter = node.poleBaseDiameter * distScale;
+        node.lineMesh.scaling.set(diameter, lineHeight, diameter);
+        // 中点 = 地表 + up*(lineHeight/2)。
+        tmp.copyFrom(up).scaleInPlace(lineHeight / 2);
+        node.lineMesh.position.copyFrom(pos).addInPlace(tmp);
+
+        // アイコン/ラベル: ポール上端の少し上。BILLBOARDMODE_ALL なので向きは自動。
+        if (node.iconText) {
+            node.iconText.mesh.scaling.set(distScale, distScale, distScale);
+            const textHalf = (node.iconText.heightWorld * distScale) / 2;
+            tmp.copyFrom(up).scaleInPlace(lineHeight + textHalf);
+            node.iconText.mesh.position.copyFrom(pos).addInPlace(tmp);
+        }
+    };
+
     const add = (opts: GlobeMarkerOptions): string => {
         if (disposed) throw new Error("GlobeMarkerManager.add: called after dispose");
         const id = `globe-marker-${seq++}`;
@@ -189,6 +227,8 @@ export const createGlobeMarkerManager = (
             enabled,
             lastElev: null,
         };
+        // 初期配置（camEcef なし）。update が走る前の原点 (0,0,0) 表示チラつきを防ぐ。
+        placeNode(node);
         lineMesh.setEnabled(enabled);
         iconText?.mesh.setEnabled(enabled);
         nodes.set(id, node);
@@ -221,34 +261,7 @@ export const createGlobeMarkerManager = (
         if (nodes.size === 0) return;
         for (const node of nodes.values()) {
             if (!node.enabled) continue;
-            // 取得できた標高は保持し、null（前景タイル未ロード等）のときは直前値へフォールバック
-            // して楕円体表面へ落ちるのを防ぐ（初回ロード前のみ 0=楕円体面）。被覆の根本改善は #329。
-            const queried = terrainElevAt(node.lat, node.lon);
-            if (queried !== null) node.lastElev = queried;
-            const elev = node.lastElev ?? 0;
-            // 地表 ECEF と地心 up。
-            groundPlacementToRef(node.lat, node.lon, elev, pos, up);
-            // 距離は 1 回だけ算出し、スケールと線高さで再利用（sqrt の二重計算を避ける）。
-            const dist = Vector3.Distance(camEcef, pos);
-            const distScale = computeOverlayDistanceScaleFromDistance(dist);
-            const lineHeight = computeOverlayLineHeight(dist);
-
-            // ポール: 地心 up 沿い、地表から lineHeight。径は距離スケールでスクリーン定。
-            orientYToUpToRef(up, quat);
-            node.lineMesh.rotationQuaternion!.copyFrom(quat);
-            const diameter = node.poleBaseDiameter * distScale;
-            node.lineMesh.scaling.set(diameter, lineHeight, diameter);
-            // 中点 = 地表 + up*(lineHeight/2)。
-            tmp.copyFrom(up).scaleInPlace(lineHeight / 2);
-            node.lineMesh.position.copyFrom(pos).addInPlace(tmp);
-
-            // アイコン/ラベル: ポール上端の少し上。BILLBOARDMODE_ALL なので向きは自動。
-            if (node.iconText) {
-                node.iconText.mesh.scaling.set(distScale, distScale, distScale);
-                const textHalf = (node.iconText.heightWorld * distScale) / 2;
-                tmp.copyFrom(up).scaleInPlace(lineHeight + textHalf);
-                node.iconText.mesh.position.copyFrom(pos).addInPlace(tmp);
-            }
+            placeNode(node, camEcef);
         }
     };
 

--- a/src/terrain/geo/globeMarkerManager.ts
+++ b/src/terrain/geo/globeMarkerManager.ts
@@ -116,6 +116,8 @@ export const createGlobeMarkerManager = (
     const { scene, terrainElevAt } = deps;
     const nodes = new Map<string, GlobeMarkerNode>();
     let seq = 0;
+    // dispose 後の use-after-dispose を防ぐフラグ（平面版 MarkerManager と同様）。
+    let disposed = false;
 
     // 毎フレーム再利用するスクラッチ。
     const pos = new Vector3();
@@ -124,6 +126,7 @@ export const createGlobeMarkerManager = (
     const quat = new Quaternion();
 
     const add = (opts: GlobeMarkerOptions): string => {
+        if (disposed) throw new Error("GlobeMarkerManager.add: called after dispose");
         const id = `globe-marker-${seq++}`;
         const icon = resolveIcon(opts.icon);
         // 平面版 addMarker と同様、icon.url の危険なスキーム（javascript: 等）を拒否する。
@@ -239,6 +242,8 @@ export const createGlobeMarkerManager = (
     };
 
     const dispose = (): void => {
+        if (disposed) return; // 二重 dispose を安全に無視する
+        disposed = true;
         for (const id of [...nodes.keys()]) remove(id);
     };
 

--- a/src/terrain/geo/globeMarkerManager.ts
+++ b/src/terrain/geo/globeMarkerManager.ts
@@ -1,0 +1,214 @@
+/**
+ * グローブ用マーカーマネージャ (Issue #275 Phase 3, marker 先行スライス)。
+ *
+ * 平面版（`markerManager` + `marker`）に対する **並行構築** のグローブ実装。緯度経度に
+ * 地形標高で接地し、地心 up 方向へドロップ線（ポール）を立て、アイコン/ラベルは
+ * `marker.createIconTextMesh`（BILLBOARDMODE_ALL = カメラ正対）を再利用して表示する。
+ * 配置は ECEF + 地心 up（`overlayPlacement`）で、`scene.pick` には依存しない。
+ *
+ * 平面版 `markerManager` には手を加えない（再利用するのは座標系非依存の描画部のみ）。
+ */
+import type { Scene } from "@babylonjs/core/scene";
+import { Vector3, Quaternion } from "@babylonjs/core/Maths/math.vector";
+import type { Mesh } from "@babylonjs/core/Meshes/mesh";
+import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
+import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
+import { Color3 } from "@babylonjs/core/Maths/math.color";
+
+import type {
+    MarkerIconOptions,
+    MarkerTextOptions,
+    MarkerLineOptions,
+} from "../../lib/types";
+import {
+    createIconTextMesh,
+    resolveIcon,
+    resolveText,
+    type IconTextMeshes,
+} from "../marker";
+import {
+    groundPlacementToRef,
+    computeOverlayDistanceScale,
+    computeOverlayLineHeight,
+} from "./overlayPlacement";
+
+/** グローブマーカーの既定値（線の色・基準ポール径[m]）。 */
+const GLOBE_MARKER_DEFAULTS = {
+    lineColor: "#ff3030",
+    /** 基準距離でのポール径[m]。距離スケールに比例させてスクリーン定にする。 */
+    poleBaseDiameter: 2,
+} as const;
+
+export interface GlobeMarkerOptions {
+    /** 緯度 [deg]。 */
+    lat: number;
+    /** 経度 [deg]。 */
+    lon: number;
+    icon?: MarkerIconOptions;
+    text?: MarkerTextOptions;
+    line?: MarkerLineOptions;
+    /** 既定 true。 */
+    enabled?: boolean;
+}
+
+export interface GlobeMarkerManagerDeps {
+    scene: Scene;
+    /** 緯度経度の地形標高[m]（無ければ null）。`globeTileManager.terrainElevAt` を渡す。 */
+    terrainElevAt: (latDeg: number, lonDeg: number) => number | null;
+}
+
+interface GlobeMarkerNode {
+    id: string;
+    lat: number;
+    lon: number;
+    lineColor: string;
+    poleBaseDiameter: number;
+    iconText: IconTextMeshes | null;
+    lineMesh: Mesh;
+    lineMat: StandardMaterial;
+    enabled: boolean;
+}
+
+export interface GlobeMarkerManager {
+    /** マーカーを追加し、id を返す。 */
+    add(opts: GlobeMarkerOptions): string;
+    /** マーカーを削除する。 */
+    remove(id: string): void;
+    /** 表示/非表示を切り替える。 */
+    setEnabled(id: string, enabled: boolean): void;
+    /**
+     * 毎フレーム: 地形標高へ接地・距離スケール・ポール向き（地心 up）を更新する。
+     * `cameraEcef` は呼び出し側がフレーム単位で 1 回計算した値を渡す（再計算回避）。
+     */
+    update(cameraEcef: Vector3): void;
+    /** 全マーカーを破棄する。 */
+    dispose(): void;
+}
+
+/** local +Y（シリンダ軸）を up へ向ける回転を ref に書き込む。 */
+const LOCAL_Y = new Vector3(0, 1, 0);
+const orientYToUpToRef = (up: Vector3, ref: Quaternion): void => {
+    const cos = Vector3.Dot(LOCAL_Y, up);
+    const axis = Vector3.Cross(LOCAL_Y, up);
+    const sin = axis.length();
+    if (sin < 1e-9) {
+        // up が +Y とほぼ平行。同方向なら無回転、逆向きなら 180°（任意軸 X）。
+        if (cos >= 0) ref.copyFromFloats(0, 0, 0, 1);
+        else Quaternion.RotationAxisToRef(new Vector3(1, 0, 0), Math.PI, ref);
+        return;
+    }
+    axis.scaleInPlace(1 / sin);
+    Quaternion.RotationAxisToRef(axis, Math.atan2(sin, cos), ref);
+};
+
+/**
+ * グローブ用マーカーマネージャを生成する。
+ */
+export const createGlobeMarkerManager = (
+    deps: GlobeMarkerManagerDeps,
+): GlobeMarkerManager => {
+    const { scene, terrainElevAt } = deps;
+    const nodes = new Map<string, GlobeMarkerNode>();
+    let seq = 0;
+
+    // 毎フレーム再利用するスクラッチ。
+    const pos = new Vector3();
+    const up = new Vector3();
+    const tmp = new Vector3();
+    const quat = new Quaternion();
+
+    const add = (opts: GlobeMarkerOptions): string => {
+        const id = `globe-marker-${seq++}`;
+        const icon = resolveIcon(opts.icon);
+        const text = resolveText(opts.text);
+        const iconText = createIconTextMesh(scene, id, icon, text);
+
+        const lineColor = opts.line?.color ?? GLOBE_MARKER_DEFAULTS.lineColor;
+        // ドロップ線は地心 up 沿いの細いシリンダ（ポール）。高さ/径は update で毎フレーム決める。
+        const lineMesh = MeshBuilder.CreateCylinder(
+            `${id}-line`,
+            { height: 1, diameter: 1, tessellation: 8 },
+            scene,
+        );
+        lineMesh.rotationQuaternion = new Quaternion();
+        const lineMat = new StandardMaterial(`${id}-line-mat`, scene);
+        lineMat.emissiveColor = Color3.FromHexString(lineColor);
+        lineMat.disableLighting = true;
+        lineMesh.material = lineMat;
+
+        const enabled = opts.enabled ?? true;
+        const node: GlobeMarkerNode = {
+            id,
+            lat: opts.lat,
+            lon: opts.lon,
+            lineColor,
+            poleBaseDiameter: opts.line?.width ?? GLOBE_MARKER_DEFAULTS.poleBaseDiameter,
+            iconText,
+            lineMesh,
+            lineMat,
+            enabled,
+        };
+        lineMesh.setEnabled(enabled);
+        iconText?.mesh.setEnabled(enabled);
+        nodes.set(id, node);
+        return id;
+    };
+
+    const remove = (id: string): void => {
+        const node = nodes.get(id);
+        if (!node) return;
+        node.lineMesh.dispose();
+        node.lineMat.dispose();
+        if (node.iconText && !node.iconText.disposed) {
+            node.iconText.disposed = true;
+            node.iconText.texture.dispose();
+            node.iconText.material.dispose();
+            node.iconText.mesh.dispose();
+        }
+        nodes.delete(id);
+    };
+
+    const setEnabled = (id: string, enabled: boolean): void => {
+        const node = nodes.get(id);
+        if (!node) return;
+        node.enabled = enabled;
+        node.lineMesh.setEnabled(enabled);
+        node.iconText?.mesh.setEnabled(enabled);
+    };
+
+    const update = (camEcef: Vector3): void => {
+        if (nodes.size === 0) return;
+        for (const node of nodes.values()) {
+            if (!node.enabled) continue;
+            const elev = terrainElevAt(node.lat, node.lon) ?? 0;
+            // 地表 ECEF と地心 up。
+            groundPlacementToRef(node.lat, node.lon, elev, pos, up);
+            const dist = Vector3.Distance(camEcef, pos);
+            const distScale = computeOverlayDistanceScale(camEcef, pos);
+            const lineHeight = computeOverlayLineHeight(dist);
+
+            // ポール: 地心 up 沿い、地表から lineHeight。径は距離スケールでスクリーン定。
+            orientYToUpToRef(up, quat);
+            node.lineMesh.rotationQuaternion!.copyFrom(quat);
+            const diameter = node.poleBaseDiameter * distScale;
+            node.lineMesh.scaling.set(diameter, lineHeight, diameter);
+            // 中点 = 地表 + up*(lineHeight/2)。
+            tmp.copyFrom(up).scaleInPlace(lineHeight / 2);
+            node.lineMesh.position.copyFrom(pos).addInPlace(tmp);
+
+            // アイコン/ラベル: ポール上端の少し上。BILLBOARDMODE_ALL なので向きは自動。
+            if (node.iconText) {
+                node.iconText.mesh.scaling.set(distScale, distScale, distScale);
+                const textHalf = (node.iconText.heightWorld * distScale) / 2;
+                tmp.copyFrom(up).scaleInPlace(lineHeight + textHalf);
+                node.iconText.mesh.position.copyFrom(pos).addInPlace(tmp);
+            }
+        }
+    };
+
+    const dispose = (): void => {
+        for (const id of [...nodes.keys()]) remove(id);
+    };
+
+    return { add, remove, setEnabled, update, dispose };
+};

--- a/src/terrain/geo/globeMarkerManager.ts
+++ b/src/terrain/geo/globeMarkerManager.ts
@@ -24,6 +24,8 @@ import {
     createIconTextMesh,
     resolveIcon,
     resolveText,
+    validateIconUrl,
+    RENDERING_GROUP_ID,
     type IconTextMeshes,
 } from "../marker";
 import {
@@ -85,20 +87,25 @@ export interface GlobeMarkerManager {
     dispose(): void;
 }
 
-/** local +Y（シリンダ軸）を up へ向ける回転を ref に書き込む。 */
+/** local +Y（シリンダ軸）/ 180°フォールバック軸の定数（再利用・不変）。 */
 const LOCAL_Y = new Vector3(0, 1, 0);
+const FLIP_AXIS = new Vector3(1, 0, 0);
+/** orientYToUpToRef の回転軸スクラッチ（毎フレーム・マーカー数ぶん呼ばれるため割当回避）。 */
+const orientAxis = new Vector3();
+
+/** local +Y（シリンダ軸）を up へ向ける回転を ref に書き込む。割当なし（CrossToRef + 再利用軸）。 */
 const orientYToUpToRef = (up: Vector3, ref: Quaternion): void => {
     const cos = Vector3.Dot(LOCAL_Y, up);
-    const axis = Vector3.Cross(LOCAL_Y, up);
-    const sin = axis.length();
+    Vector3.CrossToRef(LOCAL_Y, up, orientAxis);
+    const sin = orientAxis.length();
     if (sin < 1e-9) {
         // up が +Y とほぼ平行。同方向なら無回転、逆向きなら 180°（任意軸 X）。
         if (cos >= 0) ref.copyFromFloats(0, 0, 0, 1);
-        else Quaternion.RotationAxisToRef(new Vector3(1, 0, 0), Math.PI, ref);
+        else Quaternion.RotationAxisToRef(FLIP_AXIS, Math.PI, ref);
         return;
     }
-    axis.scaleInPlace(1 / sin);
-    Quaternion.RotationAxisToRef(axis, Math.atan2(sin, cos), ref);
+    orientAxis.scaleInPlace(1 / sin);
+    Quaternion.RotationAxisToRef(orientAxis, Math.atan2(sin, cos), ref);
 };
 
 /**
@@ -120,8 +127,12 @@ export const createGlobeMarkerManager = (
     const add = (opts: GlobeMarkerOptions): string => {
         const id = `globe-marker-${seq++}`;
         const icon = resolveIcon(opts.icon);
+        // 平面版 addMarker と同様、icon.url の危険なスキーム（javascript: 等）を拒否する。
+        if (icon) validateIconUrl(icon.url);
         const text = resolveText(opts.text);
         const iconText = createIconTextMesh(scene, id, icon, text);
+        // ラベルもピック対象から外す（地形ピック等の妨げにしない）。
+        if (iconText) iconText.mesh.isPickable = false;
 
         const lineColor = opts.line?.color ?? GLOBE_MARKER_DEFAULTS.lineColor;
         // ドロップ線は地心 up 沿いの細いシリンダ（ポール）。高さ/径は update で毎フレーム決める。
@@ -131,8 +142,20 @@ export const createGlobeMarkerManager = (
             scene,
         );
         lineMesh.rotationQuaternion = new Quaternion();
+        // ポールはピック対象外＋ラベル/平面マーカーと同じ描画レイヤーに揃える。
+        lineMesh.isPickable = false;
+        lineMesh.renderingGroupId = RENDERING_GROUP_ID;
         const lineMat = new StandardMaterial(`${id}-line-mat`, scene);
-        lineMat.emissiveColor = Color3.FromHexString(lineColor);
+        // MarkerLineOptions.color は CSS color も許容するが Color3.FromHexString は hex 専用。
+        // 非 hex 指定では例外になるため try/catch で既定色にフォールバックする
+        // （将来的に CSS color → Color3 変換を追加予定）。
+        let lineColor3: Color3;
+        try {
+            lineColor3 = Color3.FromHexString(lineColor);
+        } catch {
+            lineColor3 = Color3.FromHexString(GLOBE_MARKER_DEFAULTS.lineColor);
+        }
+        lineMat.emissiveColor = lineColor3;
         lineMat.disableLighting = true;
         lineMesh.material = lineMat;
 

--- a/src/terrain/geo/index.ts
+++ b/src/terrain/geo/index.ts
@@ -13,6 +13,10 @@
  *
  * Phase 2（カメラ・UX・URL）:
  * - `cameraMapping`: UI/URL ⇄ GeospatialCamera マッピング・接線パン・地形衝突の純関数。
+ *
+ * Phase 3（オーバーレイ）:
+ * - `overlayPlacement`: ECEF + 地心 up の配置・距離スケール・線高さの純関数。
+ * - `globeMarkerManager`: グローブ用マーカー（接地・地心 up ポール・カメラ正対ラベル）。
  */
 export * from "./ecef";
 export * from "./mapping";
@@ -21,3 +25,5 @@ export * from "./globeLod";
 export * from "./crossLevel";
 export * from "./globeMesh";
 export * from "./cameraMapping";
+export * from "./overlayPlacement";
+export * from "./globeMarkerManager";

--- a/src/terrain/geo/overlayPlacement.ts
+++ b/src/terrain/geo/overlayPlacement.ts
@@ -48,11 +48,23 @@ export const computeOverlayDistanceScale = (
     cameraEcef: Vector3,
     posEcef: Vector3,
     refDistanceM: number = OVERLAY_REF_DISTANCE_M,
+): number =>
+    computeOverlayDistanceScaleFromDistance(
+        Vector3.Distance(cameraEcef, posEcef),
+        refDistanceM,
+    );
+
+/**
+ * 既に算出済みの距離 [m] からスクリーン定スケール係数を計算する（下限あり）。
+ * 距離を別途使う呼び出し側で `Vector3.Distance` の二重計算（sqrt）を避けるための入口。
+ */
+export const computeOverlayDistanceScaleFromDistance = (
+    distanceM: number,
+    refDistanceM: number = OVERLAY_REF_DISTANCE_M,
 ): number => {
     // 0 以下の基準距離は不正（Infinity/-Infinity を防ぐ）。既定値へフォールバックする。
     const ref = refDistanceM > 0 ? refDistanceM : OVERLAY_REF_DISTANCE_M;
-    const dist = Vector3.Distance(cameraEcef, posEcef);
-    return Math.max(dist / ref, MIN_SCALE);
+    return Math.max(distanceM / ref, MIN_SCALE);
 };
 
 /**

--- a/src/terrain/geo/overlayPlacement.ts
+++ b/src/terrain/geo/overlayPlacement.ts
@@ -1,0 +1,63 @@
+/**
+ * グローブオーバーレイ（Issue #275 Phase 3）の配置ユーティリティ（純関数）。
+ *
+ * 平面版（`overlayCoords.ts`）は wx/wz と +Y up を前提とするが、グローブでは位置ごとに up
+ * （地心方向）が変わる。本モジュールは「緯度経度＋標高 → ECEF 位置と地心 up」「カメラ距離に
+ * 応じたスクリーン定スケール」「ドロップ線高さ」を ECEF ベースで提供する。平面オーバーレイ
+ * とは独立（並行構築）で、`GeospatialCamera` を直接 import しない（jest 環境を軽く保つ）。
+ */
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+
+import { geodeticToEcefToRef } from "./ecef";
+
+/**
+ * スケール基準距離 [m]。カメラ距離がこの値で scale=1、それ以上は distance/refDistance 倍して
+ * スクリーン空間サイズを一定に保つ（平面版 `REF_DISTANCE_M` と同義）。
+ */
+export const OVERLAY_REF_DISTANCE_M = 1000;
+
+/** スケール下限（近距離での過大スケール抑制）。 */
+const MIN_SCALE = 0.1;
+
+/** ドロップ線高さの下限・上限 [m]（平面版 computeDynamicLineHeight と同レンジ）。 */
+const LINE_HEIGHT_MIN = 100;
+const LINE_HEIGHT_MAX = 10000;
+
+/**
+ * 緯度経度＋標高 → 地表 ECEF 位置（`posRef`）と地心 up（`upRef`）を書き込む。
+ * up は位置ベクトルの正規化（楕円体の厳密法線ではなく地心方向の近似だが、オーバーレイの
+ * 立ち上がり方向としては十分）。
+ */
+export const groundPlacementToRef = (
+    latDeg: number,
+    lonDeg: number,
+    elevMeters: number,
+    posRef: Vector3,
+    upRef: Vector3,
+): void => {
+    geodeticToEcefToRef(latDeg, lonDeg, elevMeters, posRef);
+    upRef.copyFrom(posRef);
+    const len = upRef.length();
+    if (len > 0) upRef.scaleInPlace(1 / len);
+};
+
+/**
+ * カメラ ECEF とオーバーレイ ECEF 位置からスクリーン定スケール係数を計算する（下限あり）。
+ */
+export const computeOverlayDistanceScale = (
+    cameraEcef: Vector3,
+    posEcef: Vector3,
+    refDistanceM: number = OVERLAY_REF_DISTANCE_M,
+): number => {
+    const dist = Vector3.Distance(cameraEcef, posEcef);
+    return Math.max(dist / refDistanceM, MIN_SCALE);
+};
+
+/**
+ * カメラ距離に応じたドロップ線高さ [m]。距離に比例（×0.1）しつつ [100, 10000] にクランプし、
+ * 遠景でも近景でも見た目の立ち上がりを安定させる（平面版 computeDynamicLineHeight 相当）。
+ */
+export const computeOverlayLineHeight = (distanceM: number): number => {
+    const h = distanceM * 0.1;
+    return Math.min(LINE_HEIGHT_MAX, Math.max(LINE_HEIGHT_MIN, h));
+};

--- a/src/terrain/geo/overlayPlacement.ts
+++ b/src/terrain/geo/overlayPlacement.ts
@@ -49,8 +49,10 @@ export const computeOverlayDistanceScale = (
     posEcef: Vector3,
     refDistanceM: number = OVERLAY_REF_DISTANCE_M,
 ): number => {
+    // 0 以下の基準距離は不正（Infinity/-Infinity を防ぐ）。既定値へフォールバックする。
+    const ref = refDistanceM > 0 ? refDistanceM : OVERLAY_REF_DISTANCE_M;
     const dist = Vector3.Distance(cameraEcef, posEcef);
-    return Math.max(dist / refDistanceM, MIN_SCALE);
+    return Math.max(dist / ref, MIN_SCALE);
 };
 
 /**

--- a/src/terrain/marker.ts
+++ b/src/terrain/marker.ts
@@ -68,7 +68,9 @@ const resolveLine = (line: MarkerLineOptions | undefined): Required<MarkerLineOp
     height: line?.height ?? MARKER_DEFAULTS.line.height,
 });
 
-const resolveIcon = (
+// グローブ版オーバーレイ（#275 Phase 3, geo/globeMarkerManager）が同じアイコン/ラベル描画を
+// 再利用するため export する（座標系非依存のビルボード描画。平面版の挙動は不変）。
+export const resolveIcon = (
     icon: MarkerIconOptions | undefined,
 ): Required<MarkerIconOptions> | null => {
     if (!icon) return null;
@@ -79,7 +81,7 @@ const resolveIcon = (
     };
 };
 
-const resolveText = (
+export const resolveText = (
     text: MarkerTextOptions | undefined,
 ): Required<MarkerTextOptions> | null => {
     if (!text) return null;
@@ -172,7 +174,7 @@ const createLineMesh = (
     return { mesh, material, texture };
 };
 
-interface IconTextMeshes {
+export interface IconTextMeshes {
     mesh: Mesh;
     material: StandardMaterial;
     texture: DynamicTexture;
@@ -197,7 +199,7 @@ interface IconTextMeshes {
  * - 板の幅は max(textWidth, iconWidth) に揃え、両領域とも水平中央に配置する。
  * - 板の左右はアスペクト維持のためテクスチャと同サイズ（dpr 換算）。
  */
-const createIconTextMesh = (
+export const createIconTextMesh = (
     scene: Scene,
     id: string,
     icon: Required<MarkerIconOptions> | null,

--- a/src/terrain/marker.ts
+++ b/src/terrain/marker.ts
@@ -27,7 +27,9 @@ import {
 export const RENDERING_GROUP_ID = 1;
 const MAX_DT_SIZE = 1024;
 
-const ALLOWED_PROTOCOLS = new Set(["http:", "https:", "data:"]);/**
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:", "data:"]);
+
+/**
  * `icon.url` を検証する。`javascript:` / `vbscript:` 等の危険スキームを拒否する。
  *
  * - 空文字: 例外

--- a/src/terrain/marker.ts
+++ b/src/terrain/marker.ts
@@ -23,7 +23,8 @@ import {
     type MarkerUpdate,
 } from "../lib/types";
 
-const RENDERING_GROUP_ID = 1;
+// グローブ版オーバーレイ（#275 Phase 3）が同じ描画レイヤーに揃えるため export する。
+export const RENDERING_GROUP_ID = 1;
 const MAX_DT_SIZE = 1024;
 
 const ALLOWED_PROTOCOLS = new Set(["http:", "https:", "data:"]);/**

--- a/tests/geoOverlayPlacement.unit.spec.ts
+++ b/tests/geoOverlayPlacement.unit.spec.ts
@@ -14,6 +14,7 @@ import { geodeticToEcef } from "../src/terrain/geo/ecef";
 import {
     groundPlacementToRef,
     computeOverlayDistanceScale,
+    computeOverlayDistanceScaleFromDistance,
     computeOverlayLineHeight,
     OVERLAY_REF_DISTANCE_M,
 } from "../src/terrain/geo/overlayPlacement";
@@ -69,6 +70,25 @@ describe("computeOverlayDistanceScale", () => {
         expect(computeOverlayDistanceScale(cam, pos, 0)).toBeCloseTo(1, 9);
         expect(computeOverlayDistanceScale(cam, pos, -100)).toBeCloseTo(1, 9);
         expect(Number.isFinite(computeOverlayDistanceScale(cam, pos, 0))).toBe(true);
+    });
+});
+
+describe("computeOverlayDistanceScaleFromDistance", () => {
+    it("距離からスケールを算出（基準で1・2倍で2・下限0.1）", () => {
+        expect(computeOverlayDistanceScaleFromDistance(OVERLAY_REF_DISTANCE_M)).toBeCloseTo(1, 9);
+        expect(computeOverlayDistanceScaleFromDistance(2 * OVERLAY_REF_DISTANCE_M)).toBeCloseTo(2, 9);
+        expect(computeOverlayDistanceScaleFromDistance(1)).toBe(0.1);
+    });
+    it("computeOverlayDistanceScale と一致する", () => {
+        const cam = new Vector3(0, 0, 0);
+        const pos = new Vector3(3 * OVERLAY_REF_DISTANCE_M, 0, 0);
+        expect(computeOverlayDistanceScaleFromDistance(Vector3.Distance(cam, pos))).toBeCloseTo(
+            computeOverlayDistanceScale(cam, pos),
+            9,
+        );
+    });
+    it("refDistanceM<=0 は既定値フォールバック", () => {
+        expect(computeOverlayDistanceScaleFromDistance(OVERLAY_REF_DISTANCE_M, 0)).toBeCloseTo(1, 9);
     });
 });
 

--- a/tests/geoOverlayPlacement.unit.spec.ts
+++ b/tests/geoOverlayPlacement.unit.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * geo/overlayPlacement の単体テスト (Issue #275 Phase 3)。
+ *
+ * - groundPlacementToRef: 位置が球面上（地心距離≈標高+曲率半径）・up が地心方向の単位ベクトル
+ * - computeOverlayDistanceScale: 距離比例・下限 0.1
+ * - computeOverlayLineHeight: 距離比例・[100,10000] クランプ
+ */
+
+import { describe, it, expect } from "@jest/globals";
+
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+
+import { geodeticToEcef } from "../src/terrain/geo/ecef";
+import {
+    groundPlacementToRef,
+    computeOverlayDistanceScale,
+    computeOverlayLineHeight,
+    OVERLAY_REF_DISTANCE_M,
+} from "../src/terrain/geo/overlayPlacement";
+
+describe("groundPlacementToRef", () => {
+    it("位置は geodeticToEcef と一致し、up は地心方向の単位ベクトル", () => {
+        const pos = new Vector3();
+        const up = new Vector3();
+        groundPlacementToRef(35.3606, 138.7274, 3776, pos, up);
+        const expected = geodeticToEcef(35.3606, 138.7274, 3776);
+        expect(pos.x).toBeCloseTo(expected.x, 3);
+        expect(pos.y).toBeCloseTo(expected.y, 3);
+        expect(pos.z).toBeCloseTo(expected.z, 3);
+        // up は単位ベクトルで position と同方向（地心 up）。
+        expect(up.length()).toBeCloseTo(1, 9);
+        const posDir = pos.clone().normalize();
+        expect(Vector3.Dot(up, posDir)).toBeCloseTo(1, 9);
+    });
+
+    it("赤道本初子午線・標高0 では +X 方向、up=+X", () => {
+        const pos = new Vector3();
+        const up = new Vector3();
+        groundPlacementToRef(0, 0, 0, pos, up);
+        expect(up.x).toBeCloseTo(1, 9);
+        expect(up.y).toBeCloseTo(0, 9);
+        expect(up.z).toBeCloseTo(0, 9);
+    });
+});
+
+describe("computeOverlayDistanceScale", () => {
+    it("距離 = 基準距離 で scale=1", () => {
+        const cam = new Vector3(0, 0, 0);
+        const pos = new Vector3(OVERLAY_REF_DISTANCE_M, 0, 0);
+        expect(computeOverlayDistanceScale(cam, pos)).toBeCloseTo(1, 9);
+    });
+
+    it("距離 2倍 で scale=2", () => {
+        const cam = new Vector3(0, 0, 0);
+        const pos = new Vector3(2 * OVERLAY_REF_DISTANCE_M, 0, 0);
+        expect(computeOverlayDistanceScale(cam, pos)).toBeCloseTo(2, 9);
+    });
+
+    it("近距離は下限 0.1 にクランプ", () => {
+        const cam = new Vector3(0, 0, 0);
+        const pos = new Vector3(1, 0, 0); // 1m
+        expect(computeOverlayDistanceScale(cam, pos)).toBe(0.1);
+    });
+});
+
+describe("computeOverlayLineHeight", () => {
+    it("距離比例（×0.1）", () => {
+        expect(computeOverlayLineHeight(20000)).toBeCloseTo(2000, 6);
+    });
+    it("下限 100m", () => {
+        expect(computeOverlayLineHeight(100)).toBe(100); // 100*0.1=10 → 下限 100
+    });
+    it("上限 10000m", () => {
+        expect(computeOverlayLineHeight(1_000_000)).toBe(10000); // 100000 → 上限
+    });
+});

--- a/tests/geoOverlayPlacement.unit.spec.ts
+++ b/tests/geoOverlayPlacement.unit.spec.ts
@@ -61,6 +61,15 @@ describe("computeOverlayDistanceScale", () => {
         const pos = new Vector3(1, 0, 0); // 1m
         expect(computeOverlayDistanceScale(cam, pos)).toBe(0.1);
     });
+
+    it("refDistanceM が 0 以下なら既定値へフォールバック（Infinity 防止）", () => {
+        const cam = new Vector3(0, 0, 0);
+        const pos = new Vector3(OVERLAY_REF_DISTANCE_M, 0, 0);
+        // ref=0 / 負値 → 既定 OVERLAY_REF_DISTANCE_M 扱いで scale=1（Infinity にならない）。
+        expect(computeOverlayDistanceScale(cam, pos, 0)).toBeCloseTo(1, 9);
+        expect(computeOverlayDistanceScale(cam, pos, -100)).toBeCloseTo(1, 9);
+        expect(Number.isFinite(computeOverlayDistanceScale(cam, pos, 0))).toBe(true);
+    });
 });
 
 describe("computeOverlayLineHeight", () => {

--- a/tests/globeMarkerManager.unit.spec.ts
+++ b/tests/globeMarkerManager.unit.spec.ts
@@ -163,6 +163,19 @@ describe("CRUD", () => {
         mgr.setEnabled(id, true);
         expect(createdCylinders[0].enabled).toBe(true);
     });
+
+    it("remove は未存在 id で warn + no-op（throw しない）", () => {
+        const { mgr } = makeManager();
+        const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+        expect(() => mgr.remove("nope")).not.toThrow();
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('id "nope" not found'));
+        warn.mockRestore();
+    });
+
+    it("setEnabled は未存在 id で throw する", () => {
+        const { mgr } = makeManager();
+        expect(() => mgr.setEnabled("nope", false)).toThrow(/not found/);
+    });
 });
 
 describe("update", () => {
@@ -223,6 +236,13 @@ describe("dispose 後ガード", () => {
         mgr.add({ lat: 35, lon: 139, text: { value: "A" } });
         mgr.dispose();
         expect(() => mgr.dispose()).not.toThrow();
+    });
+
+    it("dispose 後の setEnabled は throw する", () => {
+        const { mgr } = makeManager();
+        const id = mgr.add({ lat: 35, lon: 139, text: { value: "A" } });
+        mgr.dispose();
+        expect(() => mgr.setEnabled(id, false)).toThrow(/after dispose/);
     });
 });
 

--- a/tests/globeMarkerManager.unit.spec.ts
+++ b/tests/globeMarkerManager.unit.spec.ts
@@ -244,6 +244,13 @@ describe("dispose 後ガード", () => {
         mgr.dispose();
         expect(() => mgr.setEnabled(id, false)).toThrow(/after dispose/);
     });
+
+    it("dispose 後の update は throw する", () => {
+        const { mgr } = makeManager();
+        mgr.add({ lat: 35, lon: 139, text: { value: "A" } });
+        mgr.dispose();
+        expect(() => mgr.update(new Vector3(7_000_000, 0, 0))).toThrow(/after dispose/);
+    });
 });
 
 describe("icon URL 検証の投げ直し", () => {

--- a/tests/globeMarkerManager.unit.spec.ts
+++ b/tests/globeMarkerManager.unit.spec.ts
@@ -180,6 +180,24 @@ describe("update", () => {
         // scaling.y は初期 1 のまま（update でいじられない）。
         expect(createdCylinders[0].scaling.y).toBe(1);
     });
+
+    it("terrainElevAt が null のときは直前標高を保持する（楕円体へ落とさない）", () => {
+        // 1 回目は 5000m、2 回目は null（前景タイル未ロード相当）。
+        const terrainElevAt = jest
+            .fn<(lat: number, lon: number) => number | null>()
+            .mockReturnValueOnce(5000)
+            .mockReturnValueOnce(null);
+        const mgr = createGlobeMarkerManager({ scene: {} as never, terrainElevAt });
+        mgr.add({ lat: 35, lon: 139, text: { value: "A" } });
+        const cam = new Vector3(7_000_000, 0, 0);
+        mgr.update(cam); // elev=5000 を保持
+        const after5000 = createdCylinders[0].position.clone();
+        mgr.update(cam); // null → 直前 5000 を維持
+        // 2 回目の位置が 1 回目とほぼ同じ（楕円体面へ落ちて位置が大きく変わらない）。
+        expect(Vector3.Distance(createdCylinders[0].position, after5000)).toBeLessThan(1);
+        // 5000m 接地は楕円体面(elev=0)より地心距離が ~5000m 大きいことの傍証として、十分大きい。
+        expect(createdCylinders[0].position.length()).toBeGreaterThan(6_300_000);
+    });
 });
 
 describe("dispose 後ガード", () => {

--- a/tests/globeMarkerManager.unit.spec.ts
+++ b/tests/globeMarkerManager.unit.spec.ts
@@ -1,0 +1,219 @@
+/**
+ * GlobeMarkerManager の振る舞い (Issue #275 Phase 3)。
+ *
+ * Babylon の Mesh / Material 実体と marker.ts の描画部を軽量スタブに差し替え、
+ * CRUD / enable / update / dispose 後ガード / validateIconUrl 投げ直し /
+ * 非 hex 線色フォールバックを検証する（Vector3 / Quaternion / Color3 / overlayPlacement は実物）。
+ */
+import { jest } from "@jest/globals";
+
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+
+/** スタブ mesh（position / scaling は実 Vector3 で copyFrom/addInPlace/set を効かせる）。 */
+interface StubMesh {
+    name: string;
+    rotationQuaternion: unknown;
+    isPickable: boolean;
+    renderingGroupId: number;
+    scaling: Vector3;
+    position: Vector3;
+    material: unknown;
+    enabled: boolean;
+    disposeCount: number;
+    setEnabled: (v: boolean) => void;
+    dispose: () => void;
+}
+
+const createdCylinders: StubMesh[] = [];
+const createStubMesh = (name: string): StubMesh => {
+    const m: StubMesh = {
+        name,
+        rotationQuaternion: null,
+        isPickable: true,
+        renderingGroupId: 0,
+        scaling: new Vector3(1, 1, 1),
+        position: new Vector3(),
+        material: null,
+        enabled: true,
+        disposeCount: 0,
+        setEnabled(v: boolean) {
+            this.enabled = v;
+        },
+        dispose() {
+            this.disposeCount++;
+        },
+    };
+    return m;
+};
+
+jest.unstable_mockModule("@babylonjs/core/Meshes/meshBuilder", () => ({
+    MeshBuilder: {
+        CreateCylinder: (name: string): StubMesh => {
+            const m = createStubMesh(name);
+            createdCylinders.push(m);
+            return m;
+        },
+    },
+}));
+
+jest.unstable_mockModule("@babylonjs/core/Materials/standardMaterial", () => ({
+    StandardMaterial: class {
+        emissiveColor: unknown = null;
+        disableLighting = false;
+        disposeCount = 0;
+        constructor(public name: string) {}
+        dispose(): void {
+            this.disposeCount++;
+        }
+    },
+}));
+
+const validateIconUrl = jest.fn((url: string) => {
+    if (/^javascript:/i.test(url.trim())) {
+        throw new Error("addMarker: icon.url has disallowed scheme: javascript:");
+    }
+});
+
+const createdIconTexts: { mesh: { enabled: boolean; isPickable: boolean }; disposed: boolean }[] = [];
+jest.unstable_mockModule("../src/terrain/marker", () => ({
+    RENDERING_GROUP_ID: 1,
+    validateIconUrl,
+    resolveIcon: (icon?: { url: string }) =>
+        icon ? { url: icon.url, width: 24, height: 24 } : null,
+    resolveText: (text?: { value: string }) => (text ? { value: text.value } : null),
+    createIconTextMesh: (_scene: unknown, _id: string, icon: unknown, text: unknown) => {
+        if (!icon && !text) return null;
+        const it = {
+            mesh: {
+                isPickable: true,
+                scaling: new Vector3(1, 1, 1),
+                position: new Vector3(),
+                enabled: true,
+                setEnabled(v: boolean) {
+                    this.enabled = v;
+                },
+                dispose() {},
+            },
+            material: { dispose() {} },
+            texture: { dispose() {} },
+            heightWorld: 10,
+            iconHeightWorld: 0,
+            textHeightWorld: 10,
+            widthWorld: 10,
+            disposed: false,
+        };
+        createdIconTexts.push(it);
+        return it;
+    },
+}));
+
+const { createGlobeMarkerManager } = await import(
+    "../src/terrain/geo/globeMarkerManager"
+);
+const { describe, it, expect, beforeEach } = await import("@jest/globals");
+
+const makeManager = () => {
+    // 2 引数型の変数として宣言し（toHaveBeenCalledWith(lat,lon) のため）、本体は引数未使用の mock。
+    const terrainElevAt: (lat: number, lon: number) => number | null = jest.fn(() => 1000);
+    const mgr = createGlobeMarkerManager({ scene: {} as never, terrainElevAt });
+    return { mgr, terrainElevAt };
+};
+
+beforeEach(() => {
+    createdCylinders.length = 0;
+    createdIconTexts.length = 0;
+    validateIconUrl.mockClear();
+});
+
+describe("CRUD", () => {
+    it("add は一意な id を返し、ポール mesh を生成する", () => {
+        const { mgr } = makeManager();
+        const id1 = mgr.add({ lat: 35, lon: 139, text: { value: "A" } });
+        const id2 = mgr.add({ lat: 36, lon: 140, text: { value: "B" } });
+        expect(id1).not.toBe(id2);
+        expect(createdCylinders.length).toBe(2);
+    });
+
+    it("ポールは isPickable=false / renderingGroupId=1", () => {
+        const { mgr } = makeManager();
+        mgr.add({ lat: 35, lon: 139, text: { value: "A" } });
+        expect(createdCylinders[0].isPickable).toBe(false);
+        expect(createdCylinders[0].renderingGroupId).toBe(1);
+    });
+
+    it("remove でポール mesh が dispose される", () => {
+        const { mgr } = makeManager();
+        const id = mgr.add({ lat: 35, lon: 139, text: { value: "A" } });
+        mgr.remove(id);
+        expect(createdCylinders[0].disposeCount).toBe(1);
+    });
+
+    it("setEnabled でポールの表示状態が切り替わる", () => {
+        const { mgr } = makeManager();
+        const id = mgr.add({ lat: 35, lon: 139, text: { value: "A" } });
+        mgr.setEnabled(id, false);
+        expect(createdCylinders[0].enabled).toBe(false);
+        mgr.setEnabled(id, true);
+        expect(createdCylinders[0].enabled).toBe(true);
+    });
+});
+
+describe("update", () => {
+    it("接地・距離スケールでポールの高さ/位置/向きを更新する", () => {
+        const { mgr, terrainElevAt } = makeManager();
+        mgr.add({ lat: 35, lon: 139, text: { value: "A" } });
+        const camEcef = new Vector3(7_000_000, 0, 0); // 地表から十分離れた位置
+        mgr.update(camEcef);
+        expect(terrainElevAt).toHaveBeenCalledWith(35, 139);
+        // 線高さ（scaling.y）が正・向き（rotationQuaternion）が設定される。
+        expect(createdCylinders[0].scaling.y).toBeGreaterThan(0);
+        expect(createdCylinders[0].rotationQuaternion).not.toBeNull();
+        // 位置が原点から動いている（地表 ECEF + up*h/2）。
+        expect(createdCylinders[0].position.length()).toBeGreaterThan(0);
+    });
+
+    it("無効マーカーは更新しない", () => {
+        const { mgr } = makeManager();
+        const id = mgr.add({ lat: 35, lon: 139, text: { value: "A" } });
+        mgr.setEnabled(id, false);
+        mgr.update(new Vector3(7_000_000, 0, 0));
+        // scaling.y は初期 1 のまま（update でいじられない）。
+        expect(createdCylinders[0].scaling.y).toBe(1);
+    });
+});
+
+describe("dispose 後ガード", () => {
+    it("dispose 後の add は throw する", () => {
+        const { mgr } = makeManager();
+        mgr.dispose();
+        expect(() => mgr.add({ lat: 35, lon: 139, text: { value: "A" } })).toThrow(
+            /after dispose/,
+        );
+    });
+
+    it("二重 dispose は安全（throw しない）", () => {
+        const { mgr } = makeManager();
+        mgr.add({ lat: 35, lon: 139, text: { value: "A" } });
+        mgr.dispose();
+        expect(() => mgr.dispose()).not.toThrow();
+    });
+});
+
+describe("icon URL 検証の投げ直し", () => {
+    it("危険スキームは GlobeMarkerManager.add 由来 + id を含めて投げ直す", () => {
+        const { mgr } = makeManager();
+        expect(() =>
+            mgr.add({ lat: 35, lon: 139, icon: { url: "javascript:alert(1)" } }),
+        ).toThrow(/GlobeMarkerManager\.add \(globe-marker-\d+\):/);
+        expect(validateIconUrl).toHaveBeenCalled();
+    });
+});
+
+describe("線色フォールバック", () => {
+    it("非 hex の CSS color でも例外にならない（既定色フォールバック）", () => {
+        const { mgr } = makeManager();
+        expect(() =>
+            mgr.add({ lat: 35, lon: 139, text: { value: "A" }, line: { color: "red" } }),
+        ).not.toThrow();
+    });
+});

--- a/tests/globeMarkerManager.unit.spec.ts
+++ b/tests/globeMarkerManager.unit.spec.ts
@@ -134,6 +134,13 @@ describe("CRUD", () => {
         expect(createdCylinders.length).toBe(2);
     });
 
+    it("add 直後に初期配置され、原点 (0,0,0) のままにならない", () => {
+        const { mgr } = makeManager();
+        mgr.add({ lat: 35, lon: 139, text: { value: "A" } });
+        // update を呼ぶ前でも placeNode により地表へ配置済み（チラつき防止）。
+        expect(createdCylinders[0].position.length()).toBeGreaterThan(6_000_000);
+    });
+
     it("ポールは isPickable=false / renderingGroupId=1", () => {
         const { mgr } = makeManager();
         mgr.add({ lat: 35, lon: 139, text: { value: "A" } });
@@ -172,30 +179,32 @@ describe("update", () => {
         expect(createdCylinders[0].position.length()).toBeGreaterThan(0);
     });
 
-    it("無効マーカーは更新しない", () => {
+    it("無効マーカーは update で変化しない（add の初期配置のまま）", () => {
         const { mgr } = makeManager();
         const id = mgr.add({ lat: 35, lon: 139, text: { value: "A" } });
+        const yAfterAdd = createdCylinders[0].scaling.y; // add の初期配置で設定済み
         mgr.setEnabled(id, false);
         mgr.update(new Vector3(7_000_000, 0, 0));
-        // scaling.y は初期 1 のまま（update でいじられない）。
-        expect(createdCylinders[0].scaling.y).toBe(1);
+        // 無効なので update では更新されない（初期配置の値のまま）。
+        expect(createdCylinders[0].scaling.y).toBe(yAfterAdd);
     });
 
     it("terrainElevAt が null のときは直前標高を保持する（楕円体へ落とさない）", () => {
-        // 1 回目は 5000m、2 回目は null（前景タイル未ロード相当）。
-        const terrainElevAt = jest
-            .fn<(lat: number, lon: number) => number | null>()
-            .mockReturnValueOnce(5000)
-            .mockReturnValueOnce(null);
+        // 標高 5000m → 途中で null（前景タイル未ロード相当）に変化させる。
+        let elevReturn: number | null = 5000;
+        const terrainElevAt: (lat: number, lon: number) => number | null = jest.fn(
+            () => elevReturn,
+        );
         const mgr = createGlobeMarkerManager({ scene: {} as never, terrainElevAt });
-        mgr.add({ lat: 35, lon: 139, text: { value: "A" } });
+        mgr.add({ lat: 35, lon: 139, text: { value: "A" } }); // lastElev=5000
         const cam = new Vector3(7_000_000, 0, 0);
-        mgr.update(cam); // elev=5000 を保持
+        mgr.update(cam); // elev=5000
         const after5000 = createdCylinders[0].position.clone();
+        elevReturn = null;
         mgr.update(cam); // null → 直前 5000 を維持
-        // 2 回目の位置が 1 回目とほぼ同じ（楕円体面へ落ちて位置が大きく変わらない）。
+        // 位置がほぼ同じ（楕円体面へ落ちて大きく変わらない）。
         expect(Vector3.Distance(createdCylinders[0].position, after5000)).toBeLessThan(1);
-        // 5000m 接地は楕円体面(elev=0)より地心距離が ~5000m 大きいことの傍証として、十分大きい。
+        // 5000m 接地は楕円体面(elev=0)より地心距離が大きいことの傍証として十分大きい。
         expect(createdCylinders[0].position.length()).toBeGreaterThan(6_300_000);
     });
 });


### PR DESCRIPTION
## 概要

Issue #275 グローブ全面移行の **Phase 3（オーバーレイの ECEF 化）** の **marker 先行スライス**。方針はユーザー合意のとおり「**グローブ専用オーバーレイを並行構築**」（既存平面オーバーレイは未改修）＋「**marker 先行**」。後続 PR で polygon / circle / model を進める。

## 変更点

### `src/terrain/geo/overlayPlacement.ts`（新規・純関数）
- `groundPlacementToRef`: 緯度経度＋標高 → ECEF 位置と地心 up
- `computeOverlayDistanceScale`: カメラ ECEF 距離のスクリーン定スケール（下限 0.1）
- `computeOverlayLineHeight`: 距離比例のドロップ線高さ（[100,10000] クランプ）
- `scene.pick` 非依存・`GeospatialCamera` 非依存（jest 可）

### `src/terrain/geo/globeMarkerManager.ts`（新規）
- 緯度経度に**地形標高で接地**し、**地心 up 沿いのドロップ線（シリンダ）**を立て、アイコン/ラベルは `marker.createIconTextMesh`（BILLBOARDMODE_ALL=カメラ正対、座標系非依存）を再利用
- 毎フレーム `update(cameraEcef)` で接地・距離スケール・ポール向き（地心 up）を更新（カメラ ECEF はフレーム共有値を受け取り再計算しない）

### `src/terrain/marker.ts`
- 座標系非依存の描画部 `createIconTextMesh` / `resolveIcon` / `resolveText` / `IconTextMeshes` を **additive export**（平面版の挙動は不変）

### `src/scenes/globe.ts`
- `GlobeSceneController` に `markerManager` を追加。observer のフレーム共有 `camEcef` で `update`、`dispose` で破棄

### `demos/geospatial/index.ts`
- 富士山頂にラベル付きマーカーを表示（`?marker=off` で無効化）

### テスト
- `tests/geoOverlayPlacement.unit.spec.ts`（新規8ケース）

## 影響範囲
- 画面: `/geospatial` にグローブマーカーが表示される
- API: `src/terrain/geo` に overlayPlacement / globeMarkerManager を追加、`GlobeSceneController.markerManager` を追加。`marker.ts` は additive export のみ（既存平面マーカーへの影響なし）

## 検証（DoD）
- `npm run lint`（No issues）/ `npm run typecheck`（pass）/ `npm run test:unit`（**1043 passed**）
- headless（webgl2, Playwright）で `/geospatial` をロードし、マーカーのライン/ラベル mesh 生成・富士山位置への接地・**ポール軸が地心 up と一致（dot=1.0）**・コンソールエラーなしを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)