### PR TITLE
feat(geo): グローブ用ポリゴンを ECEF+地心 up で実装 (Phase 3 polygon / #275)

### DIFF
--- a/src/demos/geospatial/index.ts
+++ b/src/demos/geospatial/index.ts
@@ -227,6 +227,8 @@ const start = async (): Promise<void> => {
                 { lat: 35.36, lon: 138.76 },
             ],
             closed: true,
+            // 富士山頂(3776m)より高く浮かせて山に隠れないようにする。
+            topAltitudeMeters: 6000,
         });
     }
 

--- a/src/demos/geospatial/index.ts
+++ b/src/demos/geospatial/index.ts
@@ -217,6 +217,19 @@ const start = async (): Promise<void> => {
         });
     }
 
+    // グローブポリゴン（Phase 3）のデモ表示。富士山頂を囲む三角形を接地アウトライン＋
+    // 地心 up カーテン壁で表示する。`?polygon=off` で無効化できる。
+    if (params.get("polygon") !== "off") {
+        controller.polygonManager.add({
+            points: [
+                { lat: 35.38, lon: 138.70 },
+                { lat: 35.34, lon: 138.70 },
+                { lat: 35.36, lon: 138.76 },
+            ],
+            closed: true,
+        });
+    }
+
     // render ループはシーン生成側ではなく呼び出し側（本デモ）で開始する
     // （GlobeScene は責務分離のためループを開始しない）。
     engine.runRenderLoop(() => controller.scene.render());

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -33,6 +33,7 @@ import {
 } from "../terrain/geo/cameraMapping";
 import { createGlobeTileManager, type GlobeTileManager, type GlobeTileSyncStats } from "../terrain/geo/globeTileManager";
 import { createGlobeMarkerManager, type GlobeMarkerManager } from "../terrain/geo/globeMarkerManager";
+import { createGlobePolygonManager, type GlobePolygonManager } from "../terrain/geo/globePolygonManager";
 
 /** グローブシーンの既定パラメータ（富士山周辺）。 */
 export const GLOBE_SCENE_DEFAULTS = {
@@ -126,6 +127,8 @@ export interface GlobeSceneController {
     tileManager: GlobeTileManager;
     /** グローブ用マーカー（Phase 3）。接地・地心 up ポール・カメラ正対ラベル。 */
     markerManager: GlobeMarkerManager;
+    /** グローブ用ポリゴン（Phase 3）。接地アウトライン・地心 up カーテン壁。 */
+    polygonManager: GlobePolygonManager;
     dispose: () => void;
 }
 
@@ -340,6 +343,11 @@ export class GlobeScene {
             scene,
             terrainElevAt: (latDeg, lonDeg) => tileManager.terrainElevAt(latDeg, lonDeg),
         });
+        // ---- グローブポリゴン（Phase 3） ----
+        const polygonManager = createGlobePolygonManager({
+            scene,
+            terrainElevAt: (latDeg, lonDeg) => tileManager.terrainElevAt(latDeg, lonDeg),
+        });
 
         const lookAt = new Vector3();
         const cameraEcef = new Vector3();
@@ -463,6 +471,8 @@ export class GlobeScene {
             enforceGroundClearance(camEcef, camGeo);
             // マーカーの接地・距離スケール更新（フレーム共有の camEcef を渡す）。
             markerManager.update(camEcef);
+            // ポリゴンの地形再ドレープ（アウトライン・壁）。
+            polygonManager.update();
             if (frame % GLOBE_SCENE_DEFAULTS.syncIntervalFrames === 0) syncTiles();
             frame++;
         });
@@ -480,10 +490,11 @@ export class GlobeScene {
             canvas.removeEventListener("pointercancel", endDrag);
             canvas.removeEventListener("pointermove", onPointerMove);
             markerManager.dispose();
+            polygonManager.dispose();
             tileManager.dispose();
             scene.dispose();
         };
 
-        return { scene, camera, tileManager, markerManager, dispose };
+        return { scene, camera, tileManager, markerManager, polygonManager, dispose };
     }
 }

--- a/src/terrain/geo/globePolygonManager.ts
+++ b/src/terrain/geo/globePolygonManager.ts
@@ -31,6 +31,12 @@ export interface GlobePolygonOptions {
     points: readonly LatLonPoint[];
     /** 末尾と先頭を結んで輪を閉じる。default false。 */
     closed?: boolean;
+    /**
+     * 指定すると top（アウトライン／壁の上端）を地形標高ではなく **この楕円体高度[m] 固定** で
+     * 描く（壁は alt=0 までのカーテン）。山などに隠れないよう高く浮かせたいときに使う。
+     * 未指定なら地形標高でドレープする。
+     */
+    topAltitudeMeters?: number;
     /** アウトライン色（hex）。 */
     outlineColor?: string;
     /** 壁色（hex）。 */
@@ -53,6 +59,8 @@ interface GlobePolygonNode {
     id: string;
     points: readonly LatLonPoint[];
     closed: boolean;
+    /** top を固定する楕円体高度[m]（undefined なら地形ドレープ）。 */
+    topAltitudeMeters?: number;
     wallsEnabled: boolean;
     enabled: boolean;
     lineMesh: LinesMesh;
@@ -91,13 +99,18 @@ export const createGlobePolygonManager = (
     let seq = 0;
     let disposed = false;
 
-    /** 各頂点の標高を取得（null は直前値→0 フォールバック）し、ECEF パスを返す。 */
+    /** top の各頂点標高を決め（固定高度 or 地形ドレープ）、ECEF パスを返す。 */
     const buildPaths = (node: GlobePolygonNode): { top: Vector3[]; bottom: Vector3[] } => {
-        const elevs = node.points.map((p, i) => {
-            const q = terrainElevAt(p.lat, p.lon);
-            if (q !== null) node.lastElevs[i] = q;
-            return node.lastElevs[i] ?? 0;
-        });
+        const elevs =
+            node.topAltitudeMeters != null
+                ? // 固定高度: 地形に依らず一定（山に隠れないよう浮かせる）。
+                  node.points.map(() => node.topAltitudeMeters as number)
+                : // 地形ドレープ: null（前景タイル未ロード）は頂点ごとに直前値→0 フォールバック。
+                  node.points.map((p, i) => {
+                      const q = terrainElevAt(p.lat, p.lon);
+                      if (q !== null) node.lastElevs[i] = q;
+                      return node.lastElevs[i] ?? 0;
+                  });
         return buildDrapedPolygonPaths(node.points, elevs, node.closed);
     };
 
@@ -115,6 +128,7 @@ export const createGlobePolygonManager = (
             id,
             points: opts.points.map((p) => ({ lat: p.lat, lon: p.lon })),
             closed,
+            topAltitudeMeters: opts.topAltitudeMeters,
             wallsEnabled,
             enabled,
             // 後で代入（lineMesh/wallMesh は paths から生成）。

--- a/src/terrain/geo/globePolygonManager.ts
+++ b/src/terrain/geo/globePolygonManager.ts
@@ -17,7 +17,6 @@ import { CreateRibbon } from "@babylonjs/core/Meshes/Builders/ribbonBuilder";
 import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
 import { Color3 } from "@babylonjs/core/Maths/math.color";
 
-import { RENDERING_GROUP_ID } from "../marker";
 import { buildDrapedPolygonPaths, type LatLonPoint } from "./overlayPlacement";
 
 /** グローブポリゴンの既定値。 */
@@ -134,7 +133,9 @@ export const createGlobePolygonManager = (
             GLOBE_POLYGON_DEFAULTS.outlineColor,
         );
         lineMesh.isPickable = false;
-        lineMesh.renderingGroupId = RENDERING_GROUP_ID;
+        // 地形と同じ既定レンダリンググループ(0)に置き、深度テストで地形と交差・遮蔽させる
+        // （別グループ=1 だとグループ間で深度がクリアされ、常に地形の上に描かれて壁が地中へ
+        // 潜らない。マーカーは「常に手前」が望ましいため 1 だが、ポリゴン壁は地形と交差させる）。
 
         // 壁（カーテン）: top（地表）と bottom（楕円体面）の 2 パスの Ribbon。両面表示。
         const wallMesh = CreateRibbon(
@@ -152,7 +153,7 @@ export const createGlobePolygonManager = (
         wallMat.backFaceCulling = false;
         wallMesh.material = wallMat;
         wallMesh.isPickable = false;
-        wallMesh.renderingGroupId = RENDERING_GROUP_ID;
+        // 壁も既定グループ(0)。半透明だが地形の深度に対してテストされ、地中部分は遮蔽される。
 
         node.lineMesh = lineMesh;
         node.wallMesh = wallMesh;

--- a/src/terrain/geo/globePolygonManager.ts
+++ b/src/terrain/geo/globePolygonManager.ts
@@ -9,7 +9,7 @@
  * 本スライスのスコープはアウトライン＋壁。点マーカー／垂線／ラベル／辺ラベルの parity は後続。
  */
 import type { Scene } from "@babylonjs/core/scene";
-import type { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { Mesh } from "@babylonjs/core/Meshes/mesh";
 import type { LinesMesh } from "@babylonjs/core/Meshes/linesMesh";
 import { CreateLines } from "@babylonjs/core/Meshes/Builders/linesBuilder";
@@ -17,7 +17,11 @@ import { CreateRibbon } from "@babylonjs/core/Meshes/Builders/ribbonBuilder";
 import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
 import { Color3 } from "@babylonjs/core/Maths/math.color";
 
-import { buildDrapedPolygonPaths, type LatLonPoint } from "./overlayPlacement";
+import {
+    drapedPolygonPathLength,
+    writeDrapedPolygonPathsToRef,
+    type LatLonPoint,
+} from "./overlayPlacement";
 
 /** グローブポリゴンの既定値。 */
 const GLOBE_POLYGON_DEFAULTS = {
@@ -68,6 +72,11 @@ interface GlobePolygonNode {
     wallMat: StandardMaterial;
     /** 各頂点の直近に取得できた地形標高[m]（null=未取得）。前景未ロード時のフォールバック。 */
     lastElevs: (number | null)[];
+    /** 毎フレーム再利用するパスバッファ（割り当て回避）。top=上端 / bottom=楕円体面。 */
+    top: Vector3[];
+    bottom: Vector3[];
+    /** top 各頂点の標高[m]の再利用バッファ。 */
+    elevs: number[];
 }
 
 export interface GlobePolygonManager {
@@ -99,19 +108,21 @@ export const createGlobePolygonManager = (
     let seq = 0;
     let disposed = false;
 
-    /** top の各頂点標高を決め（固定高度 or 地形ドレープ）、ECEF パスを返す。 */
-    const buildPaths = (node: GlobePolygonNode): { top: Vector3[]; bottom: Vector3[] } => {
-        const elevs =
-            node.topAltitudeMeters != null
-                ? // 固定高度: 地形に依らず一定（山に隠れないよう浮かせる）。
-                  node.points.map(() => node.topAltitudeMeters as number)
-                : // 地形ドレープ: null（前景タイル未ロード）は頂点ごとに直前値→0 フォールバック。
-                  node.points.map((p, i) => {
-                      const q = terrainElevAt(p.lat, p.lon);
-                      if (q !== null) node.lastElevs[i] = q;
-                      return node.lastElevs[i] ?? 0;
-                  });
-        return buildDrapedPolygonPaths(node.points, elevs, node.closed);
+    /** top の各頂点標高を決め（固定高度 or 地形ドレープ）、node.top/bottom を in-place 更新する。 */
+    const buildPaths = (node: GlobePolygonNode): void => {
+        if (node.topAltitudeMeters != null) {
+            // 固定高度: 地形に依らず一定（山に隠れないよう浮かせる）。
+            for (let i = 0; i < node.elevs.length; i++) node.elevs[i] = node.topAltitudeMeters;
+        } else {
+            // 地形ドレープ: null（前景タイル未ロード）は頂点ごとに直前値→0 フォールバック。
+            for (let i = 0; i < node.points.length; i++) {
+                const p = node.points[i];
+                const q = terrainElevAt(p.lat, p.lon);
+                if (q !== null) node.lastElevs[i] = q;
+                node.elevs[i] = node.lastElevs[i] ?? 0;
+            }
+        }
+        writeDrapedPolygonPathsToRef(node.points, node.elevs, node.closed, node.top, node.bottom);
     };
 
     const add = (opts: GlobePolygonOptions): string => {
@@ -124,6 +135,7 @@ export const createGlobePolygonManager = (
         const wallsEnabled = opts.wallsEnabled ?? true;
         const enabled = opts.enabled ?? true;
 
+        const pathLen = drapedPolygonPathLength(opts.points.length, closed);
         const node: GlobePolygonNode = {
             id,
             points: opts.points.map((p) => ({ lat: p.lat, lon: p.lon })),
@@ -136,25 +148,29 @@ export const createGlobePolygonManager = (
             wallMesh: undefined as unknown as Mesh,
             wallMat: undefined as unknown as StandardMaterial,
             lastElevs: opts.points.map(() => null),
+            top: Array.from({ length: pathLen }, () => new Vector3()),
+            bottom: Array.from({ length: pathLen }, () => new Vector3()),
+            elevs: opts.points.map(() => 0),
         };
 
-        const { top, bottom } = buildPaths(node);
+        buildPaths(node); // node.top / node.bottom を初期化
 
         // アウトライン: 地表ドレープした頂点を結ぶ線（点数固定 → instance で更新可能）。
-        const lineMesh = CreateLines(`${id}-outline`, { points: top, updatable: true }, scene);
+        const lineMesh = CreateLines(`${id}-outline`, { points: node.top, updatable: true }, scene);
         lineMesh.color = toColor3(
             opts.outlineColor ?? GLOBE_POLYGON_DEFAULTS.outlineColor,
             GLOBE_POLYGON_DEFAULTS.outlineColor,
         );
         lineMesh.isPickable = false;
-        // 地形と同じ既定レンダリンググループ(0)に置き、深度テストで地形と交差・遮蔽させる
-        // （別グループ=1 だとグループ間で深度がクリアされ、常に地形の上に描かれて壁が地中へ
-        // 潜らない。マーカーは「常に手前」が望ましいため 1 だが、ポリゴン壁は地形と交差させる）。
+        // 地形と同じレンダリンググループ(0)に置き、深度テストで地形と交差・遮蔽させる（別グループ=1
+        // だとグループ間で深度がクリアされ常に地形の上に描かれて壁が地中へ潜らない。マーカーは
+        // 「常に手前」が望ましいため 1 だが、ポリゴン壁は地形と交差させる）。既定値に依存せず明示する。
+        lineMesh.renderingGroupId = 0;
 
         // 壁（カーテン）: top（地表）と bottom（楕円体面）の 2 パスの Ribbon。両面表示。
         const wallMesh = CreateRibbon(
             `${id}-wall`,
-            { pathArray: [top, bottom], updatable: true, sideOrientation: Mesh.DOUBLESIDE },
+            { pathArray: [node.top, node.bottom], updatable: true, sideOrientation: Mesh.DOUBLESIDE },
             scene,
         );
         const wallMat = new StandardMaterial(`${id}-wall-mat`, scene);
@@ -163,11 +179,15 @@ export const createGlobePolygonManager = (
             GLOBE_POLYGON_DEFAULTS.wallColor,
         );
         wallMat.alpha = opts.wallOpacity ?? GLOBE_POLYGON_DEFAULTS.wallOpacity;
+        // 半透明（alpha<1）では深度プリパスを有効化して z-fight / ブレンド順の乱れを防ぐ
+        // （平面版 polygon/circle と同様）。
+        if (wallMat.alpha < 1) wallMat.needDepthPrePass = true;
         wallMat.disableLighting = true;
         wallMat.backFaceCulling = false;
         wallMesh.material = wallMat;
         wallMesh.isPickable = false;
-        // 壁も既定グループ(0)。半透明だが地形の深度に対してテストされ、地中部分は遮蔽される。
+        // 壁も同グループ(0)に明示。半透明だが地形の深度に対してテストされ地中部分は遮蔽される。
+        wallMesh.renderingGroupId = 0;
 
         node.lineMesh = lineMesh;
         node.wallMesh = wallMesh;
@@ -205,13 +225,13 @@ export const createGlobePolygonManager = (
         if (nodes.size === 0) return;
         for (const node of nodes.values()) {
             if (!node.enabled) continue;
-            const { top, bottom } = buildPaths(node);
+            buildPaths(node); // node.top / node.bottom を in-place 更新
             // instance 更新（点数は不変）。アウトラインと壁を再ドレープ。
-            CreateLines(`${node.id}-outline`, { points: top, instance: node.lineMesh }, scene);
+            CreateLines(`${node.id}-outline`, { points: node.top, instance: node.lineMesh }, scene);
             if (node.wallsEnabled) {
                 CreateRibbon(
                     `${node.id}-wall`,
-                    { pathArray: [top, bottom], instance: node.wallMesh },
+                    { pathArray: [node.top, node.bottom], instance: node.wallMesh },
                     scene,
                 );
             }

--- a/src/terrain/geo/globePolygonManager.ts
+++ b/src/terrain/geo/globePolygonManager.ts
@@ -1,0 +1,213 @@
+/**
+ * グローブ用ポリゴンマネージャ (Issue #275 Phase 3, polygon スライス)。
+ *
+ * 平面版（`polygonManager` + `polygon`）に対する **並行構築** のグローブ実装。頂点列を地形標高で
+ * 接地し、ECEF アウトライン（線）と、地表 → 楕円体面（alt=0）へ地心方向に落とす「壁（カーテン）」
+ * を描く。配置は `overlayPlacement.buildDrapedPolygonPaths`（ECEF + 地心 up）で、`scene.pick`
+ * には依存しない。平面版 `polygonManager` には手を加えない。
+ *
+ * 本スライスのスコープはアウトライン＋壁。点マーカー／垂線／ラベル／辺ラベルの parity は後続。
+ */
+import type { Scene } from "@babylonjs/core/scene";
+import type { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { Mesh } from "@babylonjs/core/Meshes/mesh";
+import type { LinesMesh } from "@babylonjs/core/Meshes/linesMesh";
+import { CreateLines } from "@babylonjs/core/Meshes/Builders/linesBuilder";
+import { CreateRibbon } from "@babylonjs/core/Meshes/Builders/ribbonBuilder";
+import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
+import { Color3 } from "@babylonjs/core/Maths/math.color";
+
+import { RENDERING_GROUP_ID } from "../marker";
+import { buildDrapedPolygonPaths, type LatLonPoint } from "./overlayPlacement";
+
+/** グローブポリゴンの既定値。 */
+const GLOBE_POLYGON_DEFAULTS = {
+    outlineColor: "#ffcc00",
+    wallColor: "#ffcc00",
+    wallOpacity: 0.25,
+} as const;
+
+export interface GlobePolygonOptions {
+    /** 頂点列（最低 2 点）。 */
+    points: readonly LatLonPoint[];
+    /** 末尾と先頭を結んで輪を閉じる。default false。 */
+    closed?: boolean;
+    /** アウトライン色（hex）。 */
+    outlineColor?: string;
+    /** 壁色（hex）。 */
+    wallColor?: string;
+    /** 壁の不透明度 [0,1]。 */
+    wallOpacity?: number;
+    /** 壁（カーテン）の表示。default true。 */
+    wallsEnabled?: boolean;
+    /** default true。 */
+    enabled?: boolean;
+}
+
+export interface GlobePolygonManagerDeps {
+    scene: Scene;
+    /** 緯度経度の地形標高[m]（無ければ null）。`globeTileManager.terrainElevAt` を渡す。 */
+    terrainElevAt: (latDeg: number, lonDeg: number) => number | null;
+}
+
+interface GlobePolygonNode {
+    id: string;
+    points: readonly LatLonPoint[];
+    closed: boolean;
+    wallsEnabled: boolean;
+    enabled: boolean;
+    lineMesh: LinesMesh;
+    wallMesh: Mesh;
+    wallMat: StandardMaterial;
+    /** 各頂点の直近に取得できた地形標高[m]（null=未取得）。前景未ロード時のフォールバック。 */
+    lastElevs: (number | null)[];
+}
+
+export interface GlobePolygonManager {
+    add(opts: GlobePolygonOptions): string;
+    remove(id: string): void;
+    setEnabled(id: string, enabled: boolean): void;
+    /** 毎フレーム: 地形標高へ再ドレープ（アウトライン・壁を更新）。 */
+    update(): void;
+    dispose(): void;
+}
+
+/** hex 文字列を Color3 に。非 hex（CSS color 等）は既定色へフォールバック。 */
+const toColor3 = (hex: string, fallbackHex: string): Color3 => {
+    try {
+        return Color3.FromHexString(hex);
+    } catch {
+        return Color3.FromHexString(fallbackHex);
+    }
+};
+
+/**
+ * グローブ用ポリゴンマネージャを生成する。
+ */
+export const createGlobePolygonManager = (
+    deps: GlobePolygonManagerDeps,
+): GlobePolygonManager => {
+    const { scene, terrainElevAt } = deps;
+    const nodes = new Map<string, GlobePolygonNode>();
+    let seq = 0;
+    let disposed = false;
+
+    /** 各頂点の標高を取得（null は直前値→0 フォールバック）し、ECEF パスを返す。 */
+    const buildPaths = (node: GlobePolygonNode): { top: Vector3[]; bottom: Vector3[] } => {
+        const elevs = node.points.map((p, i) => {
+            const q = terrainElevAt(p.lat, p.lon);
+            if (q !== null) node.lastElevs[i] = q;
+            return node.lastElevs[i] ?? 0;
+        });
+        return buildDrapedPolygonPaths(node.points, elevs, node.closed);
+    };
+
+    const add = (opts: GlobePolygonOptions): string => {
+        if (disposed) throw new Error("GlobePolygonManager.add: called after dispose");
+        if (opts.points.length < 2) {
+            throw new Error("GlobePolygonManager.add: points requires at least 2 vertices");
+        }
+        const id = `globe-polygon-${seq++}`;
+        const closed = opts.closed ?? false;
+        const wallsEnabled = opts.wallsEnabled ?? true;
+        const enabled = opts.enabled ?? true;
+
+        const node: GlobePolygonNode = {
+            id,
+            points: opts.points.map((p) => ({ lat: p.lat, lon: p.lon })),
+            closed,
+            wallsEnabled,
+            enabled,
+            // 後で代入（lineMesh/wallMesh は paths から生成）。
+            lineMesh: undefined as unknown as LinesMesh,
+            wallMesh: undefined as unknown as Mesh,
+            wallMat: undefined as unknown as StandardMaterial,
+            lastElevs: opts.points.map(() => null),
+        };
+
+        const { top, bottom } = buildPaths(node);
+
+        // アウトライン: 地表ドレープした頂点を結ぶ線（点数固定 → instance で更新可能）。
+        const lineMesh = CreateLines(`${id}-outline`, { points: top, updatable: true }, scene);
+        lineMesh.color = toColor3(
+            opts.outlineColor ?? GLOBE_POLYGON_DEFAULTS.outlineColor,
+            GLOBE_POLYGON_DEFAULTS.outlineColor,
+        );
+        lineMesh.isPickable = false;
+        lineMesh.renderingGroupId = RENDERING_GROUP_ID;
+
+        // 壁（カーテン）: top（地表）と bottom（楕円体面）の 2 パスの Ribbon。両面表示。
+        const wallMesh = CreateRibbon(
+            `${id}-wall`,
+            { pathArray: [top, bottom], updatable: true, sideOrientation: Mesh.DOUBLESIDE },
+            scene,
+        );
+        const wallMat = new StandardMaterial(`${id}-wall-mat`, scene);
+        wallMat.emissiveColor = toColor3(
+            opts.wallColor ?? GLOBE_POLYGON_DEFAULTS.wallColor,
+            GLOBE_POLYGON_DEFAULTS.wallColor,
+        );
+        wallMat.alpha = opts.wallOpacity ?? GLOBE_POLYGON_DEFAULTS.wallOpacity;
+        wallMat.disableLighting = true;
+        wallMat.backFaceCulling = false;
+        wallMesh.material = wallMat;
+        wallMesh.isPickable = false;
+        wallMesh.renderingGroupId = RENDERING_GROUP_ID;
+
+        node.lineMesh = lineMesh;
+        node.wallMesh = wallMesh;
+        node.wallMat = wallMat;
+
+        lineMesh.setEnabled(enabled);
+        wallMesh.setEnabled(enabled && wallsEnabled);
+        nodes.set(id, node);
+        return id;
+    };
+
+    const remove = (id: string): void => {
+        const node = nodes.get(id);
+        if (!node) {
+            console.warn(`[globe-polygon] remove: id "${id}" not found`);
+            return;
+        }
+        node.lineMesh.dispose();
+        node.wallMesh.dispose();
+        node.wallMat.dispose();
+        nodes.delete(id);
+    };
+
+    const setEnabled = (id: string, enabled: boolean): void => {
+        if (disposed) throw new Error("GlobePolygonManager.setEnabled: called after dispose");
+        const node = nodes.get(id);
+        if (!node) throw new Error(`GlobePolygonManager.setEnabled: id "${id}" not found`);
+        node.enabled = enabled;
+        node.lineMesh.setEnabled(enabled);
+        node.wallMesh.setEnabled(enabled && node.wallsEnabled);
+    };
+
+    const update = (): void => {
+        if (disposed) throw new Error("GlobePolygonManager.update: called after dispose");
+        if (nodes.size === 0) return;
+        for (const node of nodes.values()) {
+            if (!node.enabled) continue;
+            const { top, bottom } = buildPaths(node);
+            // instance 更新（点数は不変）。アウトラインと壁を再ドレープ。
+            CreateLines(`${node.id}-outline`, { points: top, instance: node.lineMesh }, scene);
+            if (node.wallsEnabled) {
+                CreateRibbon(
+                    `${node.id}-wall`,
+                    { pathArray: [top, bottom], instance: node.wallMesh },
+                    scene,
+                );
+            }
+        }
+    };
+
+    const dispose = (): void => {
+        if (disposed) return;
+        disposed = true;
+        for (const id of [...nodes.keys()]) remove(id);
+    };
+
+    return { add, remove, setEnabled, update, dispose };
+};

--- a/src/terrain/geo/index.ts
+++ b/src/terrain/geo/index.ts
@@ -17,6 +17,7 @@
  * Phase 3（オーバーレイ）:
  * - `overlayPlacement`: ECEF + 地心 up の配置・距離スケール・線高さの純関数。
  * - `globeMarkerManager`: グローブ用マーカー（接地・地心 up ポール・カメラ正対ラベル）。
+ * - `globePolygonManager`: グローブ用ポリゴン（接地アウトライン・地心 up カーテン壁）。
  */
 export * from "./ecef";
 export * from "./mapping";
@@ -27,3 +28,4 @@ export * from "./globeMesh";
 export * from "./cameraMapping";
 export * from "./overlayPlacement";
 export * from "./globeMarkerManager";
+export * from "./globePolygonManager";

--- a/src/terrain/geo/overlayPlacement.ts
+++ b/src/terrain/geo/overlayPlacement.ts
@@ -8,7 +8,13 @@
  */
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 
-import { geodeticToEcefToRef } from "./ecef";
+import { geodeticToEcef, geodeticToEcefToRef } from "./ecef";
+
+/** 緯度経度 1 点（オーバーレイ頂点）。 */
+export interface LatLonPoint {
+    lat: number;
+    lon: number;
+}
 
 /**
  * スケール基準距離 [m]。カメラ距離がこの値で scale=1、それ以上は distance/refDistance 倍して
@@ -74,4 +80,30 @@ export const computeOverlayDistanceScaleFromDistance = (
 export const computeOverlayLineHeight = (distanceM: number): number => {
     const h = distanceM * 0.1;
     return Math.min(LINE_HEIGHT_MAX, Math.max(LINE_HEIGHT_MIN, h));
+};
+
+/**
+ * グローブポリゴンの ECEF パスを生成する（純関数）。
+ * - `top`: 各頂点を地形標高 `elevs[i]` で接地した ECEF（アウトライン／壁の上端）。
+ * - `bottom`: 同 lat/lon の楕円体面（alt=0）の ECEF（壁＝カーテンの下端）。
+ *
+ * `closed` かつ頂点 2 つ以上のとき、先頭頂点を末尾へ複製して輪を閉じる。
+ * Babylon の `CreateLines`/`CreateRibbon` の path 配列としてそのまま渡せる。
+ */
+export const buildDrapedPolygonPaths = (
+    points: readonly LatLonPoint[],
+    elevs: readonly number[],
+    closed: boolean,
+): { top: Vector3[]; bottom: Vector3[] } => {
+    const top: Vector3[] = [];
+    const bottom: Vector3[] = [];
+    for (let i = 0; i < points.length; i++) {
+        top.push(geodeticToEcef(points[i].lat, points[i].lon, elevs[i] ?? 0));
+        bottom.push(geodeticToEcef(points[i].lat, points[i].lon, 0));
+    }
+    if (closed && points.length >= 2) {
+        top.push(top[0].clone());
+        bottom.push(bottom[0].clone());
+    }
+    return { top, bottom };
 };

--- a/src/terrain/geo/overlayPlacement.ts
+++ b/src/terrain/geo/overlayPlacement.ts
@@ -8,7 +8,7 @@
  */
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 
-import { geodeticToEcef, geodeticToEcefToRef } from "./ecef";
+import { geodeticToEcefToRef } from "./ecef";
 
 /** 緯度経度 1 点（オーバーレイ頂点）。 */
 export interface LatLonPoint {
@@ -95,15 +95,39 @@ export const buildDrapedPolygonPaths = (
     elevs: readonly number[],
     closed: boolean,
 ): { top: Vector3[]; bottom: Vector3[] } => {
-    const top: Vector3[] = [];
-    const bottom: Vector3[] = [];
+    const len = drapedPolygonPathLength(points.length, closed);
+    const top = Array.from({ length: len }, () => new Vector3());
+    const bottom = Array.from({ length: len }, () => new Vector3());
+    writeDrapedPolygonPathsToRef(points, elevs, closed, top, bottom);
+    return { top, bottom };
+};
+
+/**
+ * `closed` を考慮したパス配列長（`buildDrapedPolygonPaths` の top/bottom の要素数）。
+ * 呼び出し側が再利用バッファを確保するために使う。
+ */
+export const drapedPolygonPathLength = (
+    pointCount: number,
+    closed: boolean,
+): number => pointCount + (closed && pointCount >= 2 ? 1 : 0);
+
+/**
+ * `buildDrapedPolygonPaths` の in-place 版。事前確保した `topRef`/`bottomRef`
+ * （長さは {@link drapedPolygonPathLength}）へ書き込み、毎フレーム更新の割り当てを避ける。
+ */
+export const writeDrapedPolygonPathsToRef = (
+    points: readonly LatLonPoint[],
+    elevs: readonly number[],
+    closed: boolean,
+    topRef: Vector3[],
+    bottomRef: Vector3[],
+): void => {
     for (let i = 0; i < points.length; i++) {
-        top.push(geodeticToEcef(points[i].lat, points[i].lon, elevs[i] ?? 0));
-        bottom.push(geodeticToEcef(points[i].lat, points[i].lon, 0));
+        geodeticToEcefToRef(points[i].lat, points[i].lon, elevs[i] ?? 0, topRef[i]);
+        geodeticToEcefToRef(points[i].lat, points[i].lon, 0, bottomRef[i]);
     }
     if (closed && points.length >= 2) {
-        top.push(top[0].clone());
-        bottom.push(bottom[0].clone());
+        topRef[points.length].copyFrom(topRef[0]);
+        bottomRef[points.length].copyFrom(bottomRef[0]);
     }
-    return { top, bottom };
 };

--- a/tests/geoOverlayPlacement.unit.spec.ts
+++ b/tests/geoOverlayPlacement.unit.spec.ts
@@ -16,6 +16,7 @@ import {
     computeOverlayDistanceScale,
     computeOverlayDistanceScaleFromDistance,
     computeOverlayLineHeight,
+    buildDrapedPolygonPaths,
     OVERLAY_REF_DISTANCE_M,
 } from "../src/terrain/geo/overlayPlacement";
 
@@ -101,5 +102,42 @@ describe("computeOverlayLineHeight", () => {
     });
     it("上限 10000m", () => {
         expect(computeOverlayLineHeight(1_000_000)).toBe(10000); // 100000 → 上限
+    });
+});
+
+describe("buildDrapedPolygonPaths", () => {
+    const pts = [
+        { lat: 35.3, lon: 138.7 },
+        { lat: 35.4, lon: 138.8 },
+        { lat: 35.3, lon: 138.9 },
+    ];
+
+    it("top は地形標高・bottom は楕円体面（alt=0）の ECEF", () => {
+        const elevs = [1000, 2000, 1500];
+        const { top, bottom } = buildDrapedPolygonPaths(pts, elevs, false);
+        expect(top.length).toBe(3);
+        expect(bottom.length).toBe(3);
+        for (let i = 0; i < 3; i++) {
+            // top は bottom より地心距離が標高ぶん大きい。
+            expect(top[i].length()).toBeGreaterThan(bottom[i].length());
+            expect(top[i].length() - bottom[i].length()).toBeCloseTo(elevs[i], 0);
+            // bottom は楕円体面の既知点と一致。
+            const b = geodeticToEcef(pts[i].lat, pts[i].lon, 0);
+            expect(Vector3.Distance(bottom[i], b)).toBeLessThan(1e-3);
+        }
+    });
+
+    it("closed=true は先頭頂点を末尾へ複製して輪を閉じる", () => {
+        const { top, bottom } = buildDrapedPolygonPaths(pts, [0, 0, 0], true);
+        expect(top.length).toBe(4);
+        expect(bottom.length).toBe(4);
+        expect(Vector3.Distance(top[0], top[3])).toBeLessThan(1e-6);
+        expect(Vector3.Distance(bottom[0], bottom[3])).toBeLessThan(1e-6);
+    });
+
+    it("elevs が欠損（undefined）でも 0 扱いで落ちない", () => {
+        const { top } = buildDrapedPolygonPaths(pts, [], false);
+        expect(top.length).toBe(3);
+        expect(Number.isFinite(top[0].length())).toBe(true);
     });
 });

--- a/tests/globePolygonManager.unit.spec.ts
+++ b/tests/globePolygonManager.unit.spec.ts
@@ -1,0 +1,201 @@
+/**
+ * GlobePolygonManager の振る舞い (Issue #275 Phase 3)。
+ *
+ * Babylon のメッシュビルダー（CreateLines / CreateRibbon）・StandardMaterial を軽量スタブに
+ * 差し替え、CRUD / enabled / update（再ドレープ）/ dispose 後ガード / 2 点未満の検証 /
+ * 非 hex 色フォールバックを検証する（buildDrapedPolygonPaths は実物）。
+ */
+import { jest } from "@jest/globals";
+
+interface StubMesh {
+    name: string;
+    color: unknown;
+    isPickable: boolean;
+    renderingGroupId: number;
+    material: unknown;
+    enabled: boolean;
+    disposeCount: number;
+    setEnabled: (v: boolean) => void;
+    dispose: () => void;
+}
+
+const createdLines: StubMesh[] = [];
+const createdRibbons: StubMesh[] = [];
+const lineInstanceUpdates: number[] = [];
+const ribbonInstanceUpdates: number[] = [];
+
+const stub = (name: string, bucket: StubMesh[]): StubMesh => {
+    const m: StubMesh = {
+        name,
+        color: null,
+        isPickable: true,
+        renderingGroupId: 0,
+        material: null,
+        enabled: true,
+        disposeCount: 0,
+        setEnabled(v: boolean) {
+            this.enabled = v;
+        },
+        dispose() {
+            this.disposeCount++;
+        },
+    };
+    bucket.push(m);
+    return m;
+};
+
+jest.unstable_mockModule("@babylonjs/core/Meshes/Builders/linesBuilder", () => ({
+    CreateLines: (name: string, opts: { instance?: StubMesh }) => {
+        if (opts.instance) {
+            lineInstanceUpdates.push(1);
+            return opts.instance;
+        }
+        return stub(name, createdLines);
+    },
+}));
+
+jest.unstable_mockModule("@babylonjs/core/Meshes/Builders/ribbonBuilder", () => ({
+    CreateRibbon: (name: string, opts: { instance?: StubMesh }) => {
+        if (opts.instance) {
+            ribbonInstanceUpdates.push(1);
+            return opts.instance;
+        }
+        return stub(name, createdRibbons);
+    },
+}));
+
+jest.unstable_mockModule("@babylonjs/core/Materials/standardMaterial", () => ({
+    StandardMaterial: class {
+        emissiveColor: unknown = null;
+        alpha = 1;
+        disableLighting = false;
+        backFaceCulling = true;
+        disposeCount = 0;
+        constructor(public name: string) {}
+        dispose(): void {
+            this.disposeCount++;
+        }
+    },
+}));
+
+// Mesh.DOUBLESIDE 定数のみ使用するため軽量スタブ。
+jest.unstable_mockModule("@babylonjs/core/Meshes/mesh", () => ({
+    Mesh: { DOUBLESIDE: 2 },
+}));
+
+jest.unstable_mockModule("../src/terrain/marker", () => ({ RENDERING_GROUP_ID: 1 }));
+
+const { createGlobePolygonManager } = await import(
+    "../src/terrain/geo/globePolygonManager"
+);
+const { describe, it, expect, beforeEach } = await import("@jest/globals");
+
+const pts3 = [
+    { lat: 35.3, lon: 138.7 },
+    { lat: 35.4, lon: 138.8 },
+    { lat: 35.3, lon: 138.9 },
+];
+
+const makeManager = () => {
+    const terrainElevAt: (lat: number, lon: number) => number | null = jest.fn(() => 1000);
+    const mgr = createGlobePolygonManager({ scene: {} as never, terrainElevAt });
+    return { mgr, terrainElevAt };
+};
+
+beforeEach(() => {
+    createdLines.length = 0;
+    createdRibbons.length = 0;
+    lineInstanceUpdates.length = 0;
+    ribbonInstanceUpdates.length = 0;
+});
+
+describe("add / CRUD", () => {
+    it("アウトライン線と壁 Ribbon を生成し、isPickable=false / renderingGroupId=1", () => {
+        const { mgr } = makeManager();
+        mgr.add({ points: pts3, closed: true });
+        expect(createdLines.length).toBe(1);
+        expect(createdRibbons.length).toBe(1);
+        expect(createdLines[0].isPickable).toBe(false);
+        expect(createdLines[0].renderingGroupId).toBe(1);
+        expect(createdRibbons[0].isPickable).toBe(false);
+        expect(createdRibbons[0].renderingGroupId).toBe(1);
+    });
+
+    it("2 点未満は throw", () => {
+        const { mgr } = makeManager();
+        expect(() => mgr.add({ points: [{ lat: 35, lon: 139 }] })).toThrow(/at least 2/);
+    });
+
+    it("remove で線・壁・マテリアルが dispose される", () => {
+        const { mgr } = makeManager();
+        const id = mgr.add({ points: pts3 });
+        mgr.remove(id);
+        expect(createdLines[0].disposeCount).toBe(1);
+        expect(createdRibbons[0].disposeCount).toBe(1);
+    });
+
+    it("remove 未存在 id は warn + no-op", () => {
+        const { mgr } = makeManager();
+        const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+        expect(() => mgr.remove("nope")).not.toThrow();
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('id "nope" not found'));
+        warn.mockRestore();
+    });
+
+    it("setEnabled で線・壁の表示が切り替わる（壁は wallsEnabled も考慮）", () => {
+        const { mgr } = makeManager();
+        const id = mgr.add({ points: pts3, wallsEnabled: true });
+        mgr.setEnabled(id, false);
+        expect(createdLines[0].enabled).toBe(false);
+        expect(createdRibbons[0].enabled).toBe(false);
+        mgr.setEnabled(id, true);
+        expect(createdLines[0].enabled).toBe(true);
+        expect(createdRibbons[0].enabled).toBe(true);
+    });
+
+    it("wallsEnabled=false なら壁は無効で生成される", () => {
+        const { mgr } = makeManager();
+        mgr.add({ points: pts3, wallsEnabled: false });
+        expect(createdRibbons[0].enabled).toBe(false);
+    });
+});
+
+describe("update", () => {
+    it("有効ポリゴンは instance 更新される", () => {
+        const { mgr, terrainElevAt } = makeManager();
+        mgr.add({ points: pts3, closed: true });
+        mgr.update();
+        expect(terrainElevAt).toHaveBeenCalled();
+        expect(lineInstanceUpdates.length).toBe(1);
+        expect(ribbonInstanceUpdates.length).toBe(1);
+    });
+
+    it("wallsEnabled=false は壁の instance 更新をしない", () => {
+        const { mgr } = makeManager();
+        mgr.add({ points: pts3, wallsEnabled: false });
+        mgr.update();
+        expect(lineInstanceUpdates.length).toBe(1);
+        expect(ribbonInstanceUpdates.length).toBe(0);
+    });
+});
+
+describe("dispose 後ガード", () => {
+    it("dispose 後の add/setEnabled/update は throw、二重 dispose は安全", () => {
+        const { mgr } = makeManager();
+        const id = mgr.add({ points: pts3 });
+        mgr.dispose();
+        expect(() => mgr.add({ points: pts3 })).toThrow(/after dispose/);
+        expect(() => mgr.setEnabled(id, false)).toThrow(/after dispose/);
+        expect(() => mgr.update()).toThrow(/after dispose/);
+        expect(() => mgr.dispose()).not.toThrow();
+    });
+});
+
+describe("色フォールバック", () => {
+    it("非 hex の outline/wall 色でも throw しない", () => {
+        const { mgr } = makeManager();
+        expect(() =>
+            mgr.add({ points: pts3, outlineColor: "red", wallColor: "blue" }),
+        ).not.toThrow();
+    });
+});

--- a/tests/globePolygonManager.unit.spec.ts
+++ b/tests/globePolygonManager.unit.spec.ts
@@ -68,6 +68,7 @@ jest.unstable_mockModule("@babylonjs/core/Materials/standardMaterial", () => ({
     StandardMaterial: class {
         emissiveColor: unknown = null;
         alpha = 1;
+        needDepthPrePass = false;
         disableLighting = false;
         backFaceCulling = true;
         disposeCount = 0;
@@ -156,6 +157,14 @@ describe("add / CRUD", () => {
         const { mgr } = makeManager();
         mgr.add({ points: pts3, wallsEnabled: false });
         expect(createdRibbons[0].enabled).toBe(false);
+    });
+
+    it("半透明壁(alpha<1)は needDepthPrePass=true、不透明なら false", () => {
+        const { mgr } = makeManager();
+        mgr.add({ points: pts3 }); // 既定 wallOpacity 0.25 → 半透明
+        expect((createdRibbons[0].material as { needDepthPrePass: boolean }).needDepthPrePass).toBe(true);
+        mgr.add({ points: pts3, wallOpacity: 1 }); // 不透明
+        expect((createdRibbons[1].material as { needDepthPrePass: boolean }).needDepthPrePass).toBe(false);
     });
 });
 

--- a/tests/globePolygonManager.unit.spec.ts
+++ b/tests/globePolygonManager.unit.spec.ts
@@ -83,8 +83,6 @@ jest.unstable_mockModule("@babylonjs/core/Meshes/mesh", () => ({
     Mesh: { DOUBLESIDE: 2 },
 }));
 
-jest.unstable_mockModule("../src/terrain/marker", () => ({ RENDERING_GROUP_ID: 1 }));
-
 const { createGlobePolygonManager } = await import(
     "../src/terrain/geo/globePolygonManager"
 );
@@ -110,15 +108,16 @@ beforeEach(() => {
 });
 
 describe("add / CRUD", () => {
-    it("アウトライン線と壁 Ribbon を生成し、isPickable=false / renderingGroupId=1", () => {
+    it("アウトライン線と壁 Ribbon を生成し、isPickable=false / 既定グループ0（地形と交差）", () => {
         const { mgr } = makeManager();
         mgr.add({ points: pts3, closed: true });
         expect(createdLines.length).toBe(1);
         expect(createdRibbons.length).toBe(1);
         expect(createdLines[0].isPickable).toBe(false);
-        expect(createdLines[0].renderingGroupId).toBe(1);
+        // 地形と深度交差させるため既定グループ0（スタブ初期値 0 のまま＝設定しない）。
+        expect(createdLines[0].renderingGroupId).toBe(0);
         expect(createdRibbons[0].isPickable).toBe(false);
-        expect(createdRibbons[0].renderingGroupId).toBe(1);
+        expect(createdRibbons[0].renderingGroupId).toBe(0);
     });
 
     it("2 点未満は throw", () => {

--- a/tests/globePolygonManager.unit.spec.ts
+++ b/tests/globePolygonManager.unit.spec.ts
@@ -29,7 +29,8 @@ const stub = (name: string, bucket: StubMesh[]): StubMesh => {
         name,
         color: null,
         isPickable: true,
-        renderingGroupId: 0,
+        // マネージャが 0 を明示設定することを検証するため、非 0 で初期化する。
+        renderingGroupId: -1,
         material: null,
         enabled: true,
         disposeCount: 0,
@@ -115,7 +116,8 @@ describe("add / CRUD", () => {
         expect(createdLines.length).toBe(1);
         expect(createdRibbons.length).toBe(1);
         expect(createdLines[0].isPickable).toBe(false);
-        // 地形と深度交差させるため既定グループ0（スタブ初期値 0 のまま＝設定しない）。
+        // 地形と深度交差させるため、マネージャが renderingGroupId=0 を明示設定する
+        // （スタブ初期値 -1 から 0 へ変わることで設定を検証）。
         expect(createdLines[0].renderingGroupId).toBe(0);
         expect(createdRibbons[0].isPickable).toBe(false);
         expect(createdRibbons[0].renderingGroupId).toBe(0);
@@ -132,6 +134,9 @@ describe("add / CRUD", () => {
         mgr.remove(id);
         expect(createdLines[0].disposeCount).toBe(1);
         expect(createdRibbons[0].disposeCount).toBe(1);
+        // 壁マテリアルも dispose される（リークしない）。
+        const wallMat = createdRibbons[0].material as { disposeCount: number };
+        expect(wallMat.disposeCount).toBe(1);
     });
 
     it("remove 未存在 id は warn + no-op", () => {

--- a/tests/globePolygonManager.unit.spec.ts
+++ b/tests/globePolygonManager.unit.spec.ts
@@ -178,6 +178,16 @@ describe("update", () => {
     });
 });
 
+describe("topAltitudeMeters（固定高度）", () => {
+    it("固定高度指定時は terrainElevAt を呼ばずに一定高度で描く", () => {
+        const { mgr, terrainElevAt } = makeManager();
+        mgr.add({ points: pts3, closed: true, topAltitudeMeters: 6000 });
+        mgr.update();
+        // 地形に依らないので terrainElevAt は呼ばれない。
+        expect(terrainElevAt).not.toHaveBeenCalled();
+    });
+});
+
 describe("dispose 後ガード", () => {
     it("dispose 後の add/setEnabled/update は throw、二重 dispose は安全", () => {
         const { mgr } = makeManager();


### PR DESCRIPTION
## 概要

Issue #275 Phase 3（オーバーレイの ECEF 化）の **polygon スライス**。方針どおり「グローブ専用を並行構築」＋「marker→**polygon**→circle→model の順」。本スライスのスコープは**アウトライン＋壁（カーテン）**。点マーカー／垂線／ラベル parity は後続。

## 変更点

### `src/terrain/geo/overlayPlacement.ts`
- `buildDrapedPolygonPaths` / `writeDrapedPolygonPathsToRef`（純関数）: 頂点列を地形標高（または固定高度）で接地した ECEF（`top`）と楕円体面 alt=0 の ECEF（`bottom`）のパスを生成。`closed` は先頭を末尾へ複製して閉じる。in-place 版で毎フレーム更新の割り当てを回避。

### `src/terrain/geo/globePolygonManager.ts`（新規）
- `top` を結ぶ**アウトライン**（`CreateLines`）と、`top→bottom` の**壁**（`CreateRibbon`, 両面）を生成。
- 毎フレーム `update()` で `terrainElevAt` により**再ドレープ**（instance 更新・in-place バッファ）。標高 `null` は頂点ごとに直前値を保持。`topAltitudeMeters` 指定時は固定高度で浮かせる（地形に依存しない）。
- 色は非 hex でも既定へフォールバック、`isPickable=false`、**`renderingGroupId=0`（地形と同じ深度空間で交差・遮蔽）を明示**。半透明壁（alpha<1）は `needDepthPrePass=true`。
- dispose 後ガード（`add`/`setEnabled`/`update`=throw、`remove`=warn、`dispose` 冪等）、2 点未満は throw。

### `src/scenes/globe.ts`
- `GlobeSceneController` に `polygonManager` を追加。observer で `update()`、`dispose` で破棄。

### `demos/geospatial/index.ts`
- 富士山頂を囲む三角形ポリゴンを `topAltitudeMeters: 6000` で表示（`?polygon=off` で無効化）。

### テスト
- `geoOverlayPlacement`（buildDrapedPolygonPaths 等）、`globePolygonManager`（CRUD/update/dispose ガード/色フォールバック/固定高度/needDepthPrePass）。

## 影響範囲
- 画面: `/geospatial` にグローブポリゴン（アウトライン＋壁）が表示される
- API: `geo` に polygon 配置ヘルパ / globePolygonManager を追加、`GlobeSceneController.polygonManager` を追加。既存平面ポリゴンへの影響なし

## 検証（DoD）
- `npm run lint` / `typecheck` / `test:unit`（**1078 passed**）
- headless（webgl2）で `/geospatial` をロードし、アウトライン/壁の生成・`isPickable=false`・`renderingGroupId=0`（地形と交差）・`needDepthPrePass=true`・壁が地表/固定高度に接地・（タイル 404 以外の）エラーなしを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)