### PR TITLE
feat(geo): グローブ用サークルを ECEF+地心 up で実装 (Phase 3 circle / #275)

### DIFF
--- a/src/demos/geospatial/index.ts
+++ b/src/demos/geospatial/index.ts
@@ -232,6 +232,18 @@ const start = async (): Promise<void> => {
         });
     }
 
+    // グローブサークル（Phase 3）のデモ表示。富士山を囲む半径 8km の円を地形ドレープで表示する。
+    // `?circle=off` で無効化できる。
+    if (params.get("circle") !== "off") {
+        controller.circleManager.add({
+            centerLat: 35.360625,
+            centerLon: 138.727363,
+            radiusMeters: 8000,
+            outlineColor: "#33aaff",
+            wallColor: "#33aaff",
+        });
+    }
+
     // render ループはシーン生成側ではなく呼び出し側（本デモ）で開始する
     // （GlobeScene は責務分離のためループを開始しない）。
     engine.runRenderLoop(() => controller.scene.render());

--- a/src/demos/geospatial/index.ts
+++ b/src/demos/geospatial/index.ts
@@ -241,6 +241,8 @@ const start = async (): Promise<void> => {
             radiusMeters: 8000,
             outlineColor: "#33aaff",
             wallColor: "#33aaff",
+            // 富士山頂(3776m)より高く浮かせて山に隠れないようにする（polygon と同じ）。
+            topAltitudeMeters: 6000,
         });
     }
 

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -34,6 +34,7 @@ import {
 import { createGlobeTileManager, type GlobeTileManager, type GlobeTileSyncStats } from "../terrain/geo/globeTileManager";
 import { createGlobeMarkerManager, type GlobeMarkerManager } from "../terrain/geo/globeMarkerManager";
 import { createGlobePolygonManager, type GlobePolygonManager } from "../terrain/geo/globePolygonManager";
+import { createGlobeCircleManager, type GlobeCircleManager } from "../terrain/geo/globeCircleManager";
 
 /** グローブシーンの既定パラメータ（富士山周辺）。 */
 export const GLOBE_SCENE_DEFAULTS = {
@@ -129,6 +130,8 @@ export interface GlobeSceneController {
     markerManager: GlobeMarkerManager;
     /** グローブ用ポリゴン（Phase 3）。接地アウトライン・地心 up カーテン壁。 */
     polygonManager: GlobePolygonManager;
+    /** グローブ用サークル（Phase 3）。中心+半径の円を閉ポリゴンとして描画。 */
+    circleManager: GlobeCircleManager;
     dispose: () => void;
 }
 
@@ -348,6 +351,11 @@ export class GlobeScene {
             scene,
             terrainElevAt: (latDeg, lonDeg) => tileManager.terrainElevAt(latDeg, lonDeg),
         });
+        // ---- グローブサークル（Phase 3） ----
+        const circleManager = createGlobeCircleManager({
+            scene,
+            terrainElevAt: (latDeg, lonDeg) => tileManager.terrainElevAt(latDeg, lonDeg),
+        });
 
         const lookAt = new Vector3();
         const cameraEcef = new Vector3();
@@ -471,8 +479,9 @@ export class GlobeScene {
             enforceGroundClearance(camEcef, camGeo);
             // マーカーの接地・距離スケール更新（フレーム共有の camEcef を渡す）。
             markerManager.update(camEcef);
-            // ポリゴンの地形再ドレープ（アウトライン・壁）。
+            // ポリゴン・サークルの地形再ドレープ（アウトライン・壁）。
             polygonManager.update();
+            circleManager.update();
             if (frame % GLOBE_SCENE_DEFAULTS.syncIntervalFrames === 0) syncTiles();
             frame++;
         });
@@ -491,10 +500,11 @@ export class GlobeScene {
             canvas.removeEventListener("pointermove", onPointerMove);
             markerManager.dispose();
             polygonManager.dispose();
+            circleManager.dispose();
             tileManager.dispose();
             scene.dispose();
         };
 
-        return { scene, camera, tileManager, markerManager, polygonManager, dispose };
+        return { scene, camera, tileManager, markerManager, polygonManager, circleManager, dispose };
     }
 }

--- a/src/terrain/geo/globeCircleManager.ts
+++ b/src/terrain/geo/globeCircleManager.ts
@@ -1,0 +1,105 @@
+/**
+ * グローブ用サークルマネージャ (Issue #275 Phase 3, circle スライス)。
+ *
+ * 平面版（`circleManager` + `circle`）に対する **並行構築** のグローブ実装。中心 + 半径 + 分割数から
+ * 円周上の lat/lon 点列を生成し、**閉じたポリゴン**として `globePolygonManager` に委譲して描画する
+ * （アウトライン＋地心 up カーテン壁・地形ドレープ・深度交差は polygon と共通）。これにより
+ * 円専用の描画コードを重複させず、polygon の堅牢化（dispose ガード等）をそのまま享受する。
+ */
+import {
+    createGlobePolygonManager,
+    type GlobePolygonManagerDeps,
+} from "./globePolygonManager";
+import { generateGeodesicRing } from "./overlayPlacement";
+
+/** サークルの分割数の既定・範囲。 */
+const DEFAULT_SEGMENTS = 64;
+const MIN_SEGMENTS = 3;
+const MAX_SEGMENTS = 512;
+
+export interface GlobeCircleOptions {
+    /** 中心の緯度 [deg]。 */
+    centerLat: number;
+    /** 中心の経度 [deg]。 */
+    centerLon: number;
+    /** 半径 [m]（> 0）。 */
+    radiusMeters: number;
+    /** 円周の分割数（既定 64、[3, 512]）。 */
+    segments?: number;
+    /** アウトライン色（hex）。 */
+    outlineColor?: string;
+    /** 壁色（hex）。 */
+    wallColor?: string;
+    /** 壁の不透明度 [0,1]。 */
+    wallOpacity?: number;
+    /** 壁（カーテン）の表示。default true。 */
+    wallsEnabled?: boolean;
+    /** top を固定する楕円体高度[m]（未指定なら地形ドレープ）。 */
+    topAltitudeMeters?: number;
+    /** default true。 */
+    enabled?: boolean;
+}
+
+export type GlobeCircleManagerDeps = GlobePolygonManagerDeps;
+
+export interface GlobeCircleManager {
+    /** サークルを追加し、id を返す。 */
+    add(opts: GlobeCircleOptions): string;
+    /** サークルを削除する。 */
+    remove(id: string): void;
+    /** 表示/非表示を切り替える。 */
+    setEnabled(id: string, enabled: boolean): void;
+    /** 毎フレーム: 地形へ再ドレープ。 */
+    update(): void;
+    /** 全サークルを破棄する。 */
+    dispose(): void;
+}
+
+/**
+ * グローブ用サークルマネージャを生成する（内部に専用の `GlobePolygonManager` を持つ）。
+ */
+export const createGlobeCircleManager = (
+    deps: GlobeCircleManagerDeps,
+): GlobeCircleManager => {
+    // サークル専用のポリゴンマネージャ（ユーザーポリゴンとは別インスタンス）。
+    const polygons = createGlobePolygonManager(deps);
+
+    const add = (opts: GlobeCircleOptions): string => {
+        if (!(opts.radiusMeters > 0)) {
+            throw new Error(
+                `GlobeCircleManager.add: radiusMeters must be > 0 (got ${opts.radiusMeters})`,
+            );
+        }
+        const segments = opts.segments ?? DEFAULT_SEGMENTS;
+        if (!Number.isInteger(segments) || segments < MIN_SEGMENTS || segments > MAX_SEGMENTS) {
+            throw new Error(
+                `GlobeCircleManager.add: segments must be an integer in [${MIN_SEGMENTS}, ${MAX_SEGMENTS}] (got ${segments})`,
+            );
+        }
+        const points = generateGeodesicRing(
+            opts.centerLat,
+            opts.centerLon,
+            opts.radiusMeters,
+            segments,
+        );
+        // 閉じたポリゴンとして描画（始点・終点を結ぶ）。スタイルはそのまま委譲。
+        return polygons.add({
+            points,
+            closed: true,
+            outlineColor: opts.outlineColor,
+            wallColor: opts.wallColor,
+            wallOpacity: opts.wallOpacity,
+            wallsEnabled: opts.wallsEnabled,
+            topAltitudeMeters: opts.topAltitudeMeters,
+            enabled: opts.enabled,
+        });
+    };
+
+    return {
+        add,
+        remove: (id) => polygons.remove(id),
+        setEnabled: (id, enabled) => polygons.setEnabled(id, enabled),
+        update: () => polygons.update(),
+        dispose: () => polygons.dispose(),
+    };
+};

--- a/src/terrain/geo/index.ts
+++ b/src/terrain/geo/index.ts
@@ -18,6 +18,7 @@
  * - `overlayPlacement`: ECEF + 地心 up の配置・距離スケール・線高さの純関数。
  * - `globeMarkerManager`: グローブ用マーカー（接地・地心 up ポール・カメラ正対ラベル）。
  * - `globePolygonManager`: グローブ用ポリゴン（接地アウトライン・地心 up カーテン壁）。
+ * - `globeCircleManager`: グローブ用サークル（中心+半径→閉ポリゴンに委譲）。
  */
 export * from "./ecef";
 export * from "./mapping";
@@ -29,3 +30,4 @@ export * from "./cameraMapping";
 export * from "./overlayPlacement";
 export * from "./globeMarkerManager";
 export * from "./globePolygonManager";
+export * from "./globeCircleManager";

--- a/src/terrain/geo/overlayPlacement.ts
+++ b/src/terrain/geo/overlayPlacement.ts
@@ -96,6 +96,15 @@ export const generateGeodesicRing = (
     radiusMeters: number,
     segments: number,
 ): LatLonPoint[] => {
+    // 公開 API のため自身で検証して呼び出し側のバグを早期検出する（JSDoc の「segments 個の点」を保証）。
+    if (!(radiusMeters > 0)) {
+        throw new Error(`generateGeodesicRing: radiusMeters must be > 0 (got ${radiusMeters})`);
+    }
+    if (!Number.isInteger(segments) || segments < 3) {
+        throw new Error(
+            `generateGeodesicRing: segments must be an integer >= 3 (got ${segments})`,
+        );
+    }
     const latRad = (centerLat * Math.PI) / 180;
     const metersPerDegLon = METERS_PER_DEGREE_LAT * Math.max(1e-6, Math.cos(latRad));
     const ring: LatLonPoint[] = [];

--- a/src/terrain/geo/overlayPlacement.ts
+++ b/src/terrain/geo/overlayPlacement.ts
@@ -25,6 +25,9 @@ export const OVERLAY_REF_DISTANCE_M = 1000;
 /** スケール下限（近距離での過大スケール抑制）。 */
 const MIN_SCALE = 0.1;
 
+/** 緯度 1 度あたりのメートル（平面版と同じ近似）。円周点生成の等距離近似に使う。 */
+const METERS_PER_DEGREE_LAT = 111320;
+
 /** ドロップ線高さの下限・上限 [m]（平面版 computeDynamicLineHeight と同レンジ）。 */
 const LINE_HEIGHT_MIN = 100;
 const LINE_HEIGHT_MAX = 10000;
@@ -80,6 +83,30 @@ export const computeOverlayDistanceScaleFromDistance = (
 export const computeOverlayLineHeight = (distanceM: number): number => {
     const h = distanceM * 0.1;
     return Math.min(LINE_HEIGHT_MAX, Math.max(LINE_HEIGHT_MIN, h));
+};
+
+/**
+ * 中心 lat/lon から半径 `radiusMeters` の円周上の lat/lon 点列を生成する（純関数）。
+ * 局所等距離近似（緯度方向 111320 m/deg、経度方向はその cos(lat) 倍）で、数十 km までの円に十分。
+ * 返すのは `segments` 個の点（始点 = θ=0、北方向）。輪を閉じるのは描画側（closed）に委ねる。
+ */
+export const generateGeodesicRing = (
+    centerLat: number,
+    centerLon: number,
+    radiusMeters: number,
+    segments: number,
+): LatLonPoint[] => {
+    const latRad = (centerLat * Math.PI) / 180;
+    const metersPerDegLon = METERS_PER_DEGREE_LAT * Math.max(1e-6, Math.cos(latRad));
+    const ring: LatLonPoint[] = [];
+    for (let i = 0; i < segments; i++) {
+        const theta = (i / segments) * 2 * Math.PI;
+        // θ=0 を北（+lat）、+ を東回り（+lon）にする。
+        const dLat = (radiusMeters * Math.cos(theta)) / METERS_PER_DEGREE_LAT;
+        const dLon = (radiusMeters * Math.sin(theta)) / metersPerDegLon;
+        ring.push({ lat: centerLat + dLat, lon: centerLon + dLon });
+    }
+    return ring;
 };
 
 /**

--- a/tests/geoOverlayPlacement.unit.spec.ts
+++ b/tests/geoOverlayPlacement.unit.spec.ts
@@ -164,4 +164,11 @@ describe("generateGeodesicRing", () => {
         expect(ring[0].lon).toBeCloseTo(139, 6);
         expect(ring[0].lat).toBeGreaterThan(35);
     });
+
+    it("radius<=0・非整数/3未満 segments は throw", () => {
+        expect(() => generateGeodesicRing(35, 139, 0, 8)).toThrow(/radiusMeters/);
+        expect(() => generateGeodesicRing(35, 139, -1, 8)).toThrow(/radiusMeters/);
+        expect(() => generateGeodesicRing(35, 139, 5000, 2)).toThrow(/segments/);
+        expect(() => generateGeodesicRing(35, 139, 5000, 8.5)).toThrow(/segments/);
+    });
 });

--- a/tests/geoOverlayPlacement.unit.spec.ts
+++ b/tests/geoOverlayPlacement.unit.spec.ts
@@ -17,6 +17,7 @@ import {
     computeOverlayDistanceScaleFromDistance,
     computeOverlayLineHeight,
     buildDrapedPolygonPaths,
+    generateGeodesicRing,
     OVERLAY_REF_DISTANCE_M,
 } from "../src/terrain/geo/overlayPlacement";
 
@@ -139,5 +140,28 @@ describe("buildDrapedPolygonPaths", () => {
         const { top } = buildDrapedPolygonPaths(pts, [], false);
         expect(top.length).toBe(3);
         expect(Number.isFinite(top[0].length())).toBe(true);
+    });
+});
+
+describe("generateGeodesicRing", () => {
+    it("segments 個の点を返す", () => {
+        expect(generateGeodesicRing(35, 139, 5000, 8).length).toBe(8);
+        expect(generateGeodesicRing(35, 139, 5000, 64).length).toBe(64);
+    });
+
+    it("各点は中心からほぼ radius の距離（ECEF, 誤差 2% 未満）", () => {
+        const radius = 5000;
+        const center = geodeticToEcef(35, 139, 0);
+        const ring = generateGeodesicRing(35, 139, radius, 32);
+        for (const p of ring) {
+            const d = Vector3.Distance(center, geodeticToEcef(p.lat, p.lon, 0));
+            expect(Math.abs(d - radius) / radius).toBeLessThan(0.02);
+        }
+    });
+
+    it("θ=0 の始点は中心の真北（lon 不変・lat 増）", () => {
+        const ring = generateGeodesicRing(35, 139, 5000, 8);
+        expect(ring[0].lon).toBeCloseTo(139, 6);
+        expect(ring[0].lat).toBeGreaterThan(35);
     });
 });

--- a/tests/globeCircleManager.unit.spec.ts
+++ b/tests/globeCircleManager.unit.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * GlobeCircleManager の振る舞い (Issue #275 Phase 3)。
+ *
+ * 内部の GlobePolygonManager をスタブに差し替え、サークルが「閉ポリゴン + 円周点列」へ委譲される
+ * こと、半径/分割数の検証、CRUD/update/dispose の委譲を検証する。
+ */
+import { jest } from "@jest/globals";
+
+interface AddCall {
+    points: { lat: number; lon: number }[];
+    closed?: boolean;
+    outlineColor?: string;
+}
+const addCalls: AddCall[] = [];
+const removeCalls: string[] = [];
+const setEnabledCalls: [string, boolean][] = [];
+let updateCount = 0;
+let disposeCount = 0;
+
+jest.unstable_mockModule("../src/terrain/geo/globePolygonManager", () => ({
+    createGlobePolygonManager: () => ({
+        add: (opts: AddCall) => {
+            addCalls.push(opts);
+            return `globe-polygon-${addCalls.length - 1}`;
+        },
+        remove: (id: string) => removeCalls.push(id),
+        setEnabled: (id: string, e: boolean) => setEnabledCalls.push([id, e]),
+        update: () => {
+            updateCount++;
+        },
+        dispose: () => {
+            disposeCount++;
+        },
+    }),
+}));
+
+const { createGlobeCircleManager } = await import(
+    "../src/terrain/geo/globeCircleManager"
+);
+const { describe, it, expect, beforeEach } = await import("@jest/globals");
+
+const makeManager = () =>
+    createGlobeCircleManager({ scene: {} as never, terrainElevAt: () => 0 });
+
+beforeEach(() => {
+    addCalls.length = 0;
+    removeCalls.length = 0;
+    setEnabledCalls.length = 0;
+    updateCount = 0;
+    disposeCount = 0;
+});
+
+describe("add", () => {
+    it("円周点列を持つ閉ポリゴンとして委譲する", () => {
+        const mgr = makeManager();
+        const id = mgr.add({ centerLat: 35, centerLon: 139, radiusMeters: 5000, segments: 16 });
+        expect(addCalls.length).toBe(1);
+        expect(addCalls[0].closed).toBe(true);
+        expect(addCalls[0].points.length).toBe(16);
+        expect(id).toBe("globe-polygon-0");
+    });
+
+    it("segments 既定は 64", () => {
+        const mgr = makeManager();
+        mgr.add({ centerLat: 35, centerLon: 139, radiusMeters: 5000 });
+        expect(addCalls[0].points.length).toBe(64);
+    });
+
+    it("スタイル（色）を委譲する", () => {
+        const mgr = makeManager();
+        mgr.add({ centerLat: 35, centerLon: 139, radiusMeters: 5000, outlineColor: "#abcdef" });
+        expect(addCalls[0].outlineColor).toBe("#abcdef");
+    });
+
+    it("radius <= 0 は throw", () => {
+        const mgr = makeManager();
+        expect(() => mgr.add({ centerLat: 35, centerLon: 139, radiusMeters: 0 })).toThrow(
+            /radiusMeters/,
+        );
+    });
+
+    it("segments が範囲外は throw", () => {
+        const mgr = makeManager();
+        expect(() =>
+            mgr.add({ centerLat: 35, centerLon: 139, radiusMeters: 5000, segments: 2 }),
+        ).toThrow(/segments/);
+        expect(() =>
+            mgr.add({ centerLat: 35, centerLon: 139, radiusMeters: 5000, segments: 1000 }),
+        ).toThrow(/segments/);
+    });
+});
+
+describe("委譲（remove/setEnabled/update/dispose）", () => {
+    it("各操作が内部ポリゴンマネージャへ委譲される", () => {
+        const mgr = makeManager();
+        const id = mgr.add({ centerLat: 35, centerLon: 139, radiusMeters: 5000 });
+        mgr.setEnabled(id, false);
+        mgr.update();
+        mgr.remove(id);
+        mgr.dispose();
+        expect(setEnabledCalls).toEqual([[id, false]]);
+        expect(updateCount).toBe(1);
+        expect(removeCalls).toEqual([id]);
+        expect(disposeCount).toBe(1);
+    });
+});


### PR DESCRIPTION
## 概要

Issue #275 Phase 3（オーバーレイの ECEF 化）の **circle スライス**。方針どおり「グローブ専用を並行構築」＋「marker→polygon→**circle**→model の順」。

中心 + 半径 + 分割数から円周点列を生成し、**閉じたポリゴンとして `globePolygonManager` に委譲**して描画する。これによりアウトライン＋地心 up カーテン壁・地形ドレープ・深度交差・dispose ガード等を polygon と共通化し、円専用の描画コード重複を回避。

## 変更点

### `src/terrain/geo/overlayPlacement.ts`
- `generateGeodesicRing`（純関数）: 中心 lat/lon から半径 `radiusMeters` の円周上に `segments` 個の lat/lon 点を局所等距離近似で生成。

### `src/terrain/geo/globeCircleManager.ts`（新規）
- 内部に専用 `GlobePolygonManager` を持ち、`add(center/radius/segments/style)` → 円周点列の**閉ポリゴン**へ委譲。`radius>0`・`segments∈[3,512]` を検証。`remove`/`setEnabled`/`update`/`dispose` は委譲。

### `src/scenes/globe.ts`
- `GlobeSceneController` に `circleManager` を追加。observer で `update()`、`dispose` で破棄。

### `demos/geospatial/index.ts`
- 富士山中心・半径 8km の円を表示（`?circle=off` で無効化）。

### テスト
- `generateGeodesicRing`（点数・半径精度 2%未満・始点北）、`globeCircleManager`（委譲・半径/分割数検証）。

## 影響範囲
- 画面: `/geospatial` にグローブサークルが表示される
- API: `geo` に `generateGeodesicRing` / `globeCircleManager` を追加、`GlobeSceneController.circleManager` を追加。既存平面サークルへの影響なし

## 検証（DoD）
- `npm run lint` / `typecheck` / `test:unit`（**1087 passed**）
- headless（webgl2）で `/geospatial` をロードし、サークルのアウトライン/壁生成・`renderingGroupId=0`（地形と交差）・地表接地・（タイル 404 以外の）エラーなしを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)