### PR TITLE
feat(geo): グローブ用モデルを ECEF+地心 up で実装 (Phase 3 model 完 / #275)

### DIFF
--- a/src/demos/geospatial/index.ts
+++ b/src/demos/geospatial/index.ts
@@ -16,6 +16,7 @@
 import type { Scene } from "@babylonjs/core/scene";
 import type { GeospatialCamera } from "@babylonjs/core/Cameras/geospatialCamera";
 
+import humanGlbUrl from "../../../assets/human.glb";
 import { createBabylonEngine } from "../../lib/internal/engineFactory";
 import type { EngineType } from "../../lib/types";
 import { clamp, type MapType } from "../../terrain/gsiTile";
@@ -243,6 +244,17 @@ const start = async (): Promise<void> => {
             wallColor: "#33aaff",
             // 富士山頂(3776m)より高く浮かせて山に隠れないようにする（polygon と同じ）。
             topAltitudeMeters: 6000,
+        });
+    }
+
+    // グローブモデル（Phase 3）のデモ表示。富士山頂に human.glb を接地し、地心 up へ起立させる。
+    // human.glb は約 1m なので地形上で視認できるよう拡大する。`?model=off` で無効化できる。
+    if (params.get("model") !== "off") {
+        controller.modelManager.add({
+            url: humanGlbUrl,
+            lat: 35.360625,
+            lon: 138.727363,
+            scale: 400,
         });
     }
 

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -35,6 +35,7 @@ import { createGlobeTileManager, type GlobeTileManager, type GlobeTileSyncStats 
 import { createGlobeMarkerManager, type GlobeMarkerManager } from "../terrain/geo/globeMarkerManager";
 import { createGlobePolygonManager, type GlobePolygonManager } from "../terrain/geo/globePolygonManager";
 import { createGlobeCircleManager, type GlobeCircleManager } from "../terrain/geo/globeCircleManager";
+import { createGlobeModelManager, type GlobeModelManager } from "../terrain/geo/globeModelManager";
 
 /** グローブシーンの既定パラメータ（富士山周辺）。 */
 export const GLOBE_SCENE_DEFAULTS = {
@@ -132,6 +133,8 @@ export interface GlobeSceneController {
     polygonManager: GlobePolygonManager;
     /** グローブ用サークル（Phase 3）。中心+半径の円を閉ポリゴンとして描画。 */
     circleManager: GlobeCircleManager;
+    /** グローブ用モデル（Phase 3）。glb/gltf を接地し地心 up へ起立。 */
+    modelManager: GlobeModelManager;
     dispose: () => void;
 }
 
@@ -356,6 +359,11 @@ export class GlobeScene {
             scene,
             terrainElevAt: (latDeg, lonDeg) => tileManager.terrainElevAt(latDeg, lonDeg),
         });
+        // ---- グローブモデル（Phase 3） ----
+        const modelManager = createGlobeModelManager({
+            scene,
+            terrainElevAt: (latDeg, lonDeg) => tileManager.terrainElevAt(latDeg, lonDeg),
+        });
 
         const lookAt = new Vector3();
         const cameraEcef = new Vector3();
@@ -482,6 +490,8 @@ export class GlobeScene {
             // ポリゴン・サークルの地形再ドレープ（アウトライン・壁）。
             polygonManager.update();
             circleManager.update();
+            // モデルの接地・起立更新。
+            modelManager.update();
             if (frame % GLOBE_SCENE_DEFAULTS.syncIntervalFrames === 0) syncTiles();
             frame++;
         });
@@ -501,10 +511,20 @@ export class GlobeScene {
             markerManager.dispose();
             polygonManager.dispose();
             circleManager.dispose();
+            modelManager.dispose();
             tileManager.dispose();
             scene.dispose();
         };
 
-        return { scene, camera, tileManager, markerManager, polygonManager, circleManager, dispose };
+        return {
+            scene,
+            camera,
+            tileManager,
+            markerManager,
+            polygonManager,
+            circleManager,
+            modelManager,
+            dispose,
+        };
     }
 }

--- a/src/terrain/geo/globeModelManager.ts
+++ b/src/terrain/geo/globeModelManager.ts
@@ -95,6 +95,12 @@ export const createGlobeModelManager = (
         try {
             await importLoaderForUrl(url);
             const result = await ImportMeshAsync(url, scene);
+            // 本マネージャはアニメーション制御 API を持たないため、AnimationGroup はロード直後に
+            // 停止・破棄してリークを防ぐ（平面版 modelManager は remove/dispose 時に破棄）。
+            for (const ag of result.animationGroups) {
+                ag.stop();
+                ag.dispose();
+            }
             if (node.cancelled) {
                 for (const m of result.meshes) m.dispose();
                 return;

--- a/src/terrain/geo/globeModelManager.ts
+++ b/src/terrain/geo/globeModelManager.ts
@@ -1,0 +1,180 @@
+/**
+ * グローブ用モデルマネージャ (Issue #275 Phase 3, model スライス)。
+ *
+ * 平面版（`modelManager`）に対する **並行構築** のグローブ実装。glb/gltf モデルを lat/lon に接地し、
+ * **ローカル +Y を地心 up へ向けて「立たせる」**（`overlayPlacement.surfaceOrientationToRef`）。
+ * 配置は ECEF（`groundPlacementToRef`）で `scene.pick` 非依存。平面版 `modelManager` は未改修で、
+ * ローダー登録（`importLoaderForUrl`）のみ座標系非依存のため再利用する。
+ */
+import type { Scene } from "@babylonjs/core/scene";
+import { Vector3, Quaternion } from "@babylonjs/core/Maths/math.vector";
+import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
+import type { AbstractMesh } from "@babylonjs/core/Meshes/abstractMesh";
+import { ImportMeshAsync } from "@babylonjs/core/Loading/sceneLoader";
+
+import { importLoaderForUrl } from "../modelManager";
+import { groundPlacementToRef, surfaceOrientationToRef } from "./overlayPlacement";
+
+export interface GlobeModelOptions {
+    /** モデルファイルの URL（glb/gltf）。 */
+    url: string;
+    /** 緯度 [deg]。 */
+    lat: number;
+    /** 経度 [deg]。 */
+    lon: number;
+    /** 地表からの高さオフセット [m]（default 0）。 */
+    altitudeOffsetMeters?: number;
+    /** 方位 [deg]（0=北, +=東回り。モデルのローカル +Z が向く方向）。default 0。 */
+    headingDeg?: number;
+    /** 一様スケール（default 1）。 */
+    scale?: number;
+    /** default true。 */
+    enabled?: boolean;
+}
+
+export interface GlobeModelManagerDeps {
+    scene: Scene;
+    /** 緯度経度の地形標高[m]（無ければ null）。`globeTileManager.terrainElevAt` を渡す。 */
+    terrainElevAt: (latDeg: number, lonDeg: number) => number | null;
+}
+
+interface GlobeModelNode {
+    id: string;
+    lat: number;
+    lon: number;
+    altitudeOffsetMeters: number;
+    headingDeg: number;
+    scale: number;
+    enabled: boolean;
+    root: TransformNode;
+    meshes: AbstractMesh[];
+    /** ロード完了フラグ（完了まで placeNode しない）。 */
+    loaded: boolean;
+    /** dispose/remove 済みフラグ（非同期ロード結果の破棄判定）。 */
+    cancelled: boolean;
+    /** 直近に取得できた地形標高[m]（null=未取得）。前景未ロード時のフォールバック。 */
+    lastElev: number | null;
+}
+
+export interface GlobeModelManager {
+    add(opts: GlobeModelOptions): string;
+    remove(id: string): void;
+    setEnabled(id: string, enabled: boolean): void;
+    /** 毎フレーム: ロード済みモデルを地形へ接地し地心 up へ向ける。 */
+    update(): void;
+    dispose(): void;
+}
+
+/**
+ * グローブ用モデルマネージャを生成する。
+ */
+export const createGlobeModelManager = (
+    deps: GlobeModelManagerDeps,
+): GlobeModelManager => {
+    const { scene, terrainElevAt } = deps;
+    const nodes = new Map<string, GlobeModelNode>();
+    let seq = 0;
+    let disposed = false;
+    const quat = new Quaternion(); // 向き計算スクラッチ
+    const upScratch = new Vector3(); // groundPlacementToRef の up 受け（未使用だが要引数）
+
+    /** モデルを地形へ接地（標高 null は直前値→0）し、地心 up へ向ける。 */
+    const placeNode = (node: GlobeModelNode): void => {
+        const q = terrainElevAt(node.lat, node.lon);
+        if (q !== null) node.lastElev = q;
+        const elev = (node.lastElev ?? 0) + node.altitudeOffsetMeters;
+        // root.position（真の ECEF）へ接地。向きは root.position から地心 up を算出して決める。
+        groundPlacementToRef(node.lat, node.lon, elev, node.root.position, upScratch);
+        if (surfaceOrientationToRef(node.root.position, node.headingDeg, quat)) {
+            if (!node.root.rotationQuaternion) node.root.rotationQuaternion = new Quaternion();
+            node.root.rotationQuaternion.copyFrom(quat);
+        }
+    };
+
+    const loadModel = async (node: GlobeModelNode, url: string): Promise<void> => {
+        try {
+            await importLoaderForUrl(url);
+            const result = await ImportMeshAsync(url, scene);
+            if (node.cancelled) {
+                for (const m of result.meshes) m.dispose();
+                return;
+            }
+            node.meshes = result.meshes;
+            // 最上位ノードのみ root の子にする（スキン階層の内部親子は触らない）。
+            for (const m of result.meshes) {
+                if (!m.parent) m.parent = node.root;
+            }
+            node.root.scaling.setAll(node.scale);
+            node.root.setEnabled(node.enabled);
+            node.loaded = true;
+            placeNode(node); // 初期配置（原点表示のチラつき防止）
+        } catch (err) {
+            if (!node.cancelled) {
+                console.error(`[globe-model] failed to load "${node.id}" from "${url}":`, err);
+            }
+        }
+    };
+
+    const add = (opts: GlobeModelOptions): string => {
+        if (disposed) throw new Error("GlobeModelManager.add: called after dispose");
+        const id = `globe-model-${seq++}`;
+        const root = new TransformNode(`${id}-root`, scene);
+        root.rotationQuaternion = new Quaternion();
+        const enabled = opts.enabled ?? true;
+        root.setEnabled(enabled);
+        const node: GlobeModelNode = {
+            id,
+            lat: opts.lat,
+            lon: opts.lon,
+            altitudeOffsetMeters: opts.altitudeOffsetMeters ?? 0,
+            headingDeg: opts.headingDeg ?? 0,
+            scale: opts.scale ?? 1,
+            enabled,
+            root,
+            meshes: [],
+            loaded: false,
+            cancelled: false,
+            lastElev: null,
+        };
+        nodes.set(id, node);
+        void loadModel(node, opts.url);
+        return id;
+    };
+
+    const remove = (id: string): void => {
+        const node = nodes.get(id);
+        if (!node) {
+            console.warn(`[globe-model] remove: id "${id}" not found`);
+            return;
+        }
+        node.cancelled = true;
+        for (const m of node.meshes) m.dispose();
+        node.root.dispose();
+        nodes.delete(id);
+    };
+
+    const setEnabled = (id: string, enabled: boolean): void => {
+        if (disposed) throw new Error("GlobeModelManager.setEnabled: called after dispose");
+        const node = nodes.get(id);
+        if (!node) throw new Error(`GlobeModelManager.setEnabled: id "${id}" not found`);
+        node.enabled = enabled;
+        node.root.setEnabled(enabled);
+    };
+
+    const update = (): void => {
+        if (disposed) throw new Error("GlobeModelManager.update: called after dispose");
+        if (nodes.size === 0) return;
+        for (const node of nodes.values()) {
+            if (!node.enabled || !node.loaded) continue;
+            placeNode(node);
+        }
+    };
+
+    const dispose = (): void => {
+        if (disposed) return;
+        disposed = true;
+        for (const id of [...nodes.keys()]) remove(id);
+    };
+
+    return { add, remove, setEnabled, update, dispose };
+};

--- a/src/terrain/geo/globeModelManager.ts
+++ b/src/terrain/geo/globeModelManager.ts
@@ -80,8 +80,8 @@ export const createGlobeModelManager = (
 
     /** モデルを地形へ接地（標高 null は直前値→0）し、地心 up へ向ける。 */
     const placeNode = (node: GlobeModelNode): void => {
-        const q = terrainElevAt(node.lat, node.lon);
-        if (q !== null) node.lastElev = q;
+        const elevOrNull = terrainElevAt(node.lat, node.lon);
+        if (elevOrNull !== null) node.lastElev = elevOrNull;
         const elev = (node.lastElev ?? 0) + node.altitudeOffsetMeters;
         // root.position（真の ECEF）へ接地。向きは root.position から地心 up を算出して決める。
         groundPlacementToRef(node.lat, node.lon, elev, node.root.position, upScratch);

--- a/src/terrain/geo/index.ts
+++ b/src/terrain/geo/index.ts
@@ -19,6 +19,7 @@
  * - `globeMarkerManager`: グローブ用マーカー（接地・地心 up ポール・カメラ正対ラベル）。
  * - `globePolygonManager`: グローブ用ポリゴン（接地アウトライン・地心 up カーテン壁）。
  * - `globeCircleManager`: グローブ用サークル（中心+半径→閉ポリゴンに委譲）。
+ * - `globeModelManager`: グローブ用モデル（接地・地心 up へ起立）。
  */
 export * from "./ecef";
 export * from "./mapping";
@@ -31,3 +32,4 @@ export * from "./overlayPlacement";
 export * from "./globeMarkerManager";
 export * from "./globePolygonManager";
 export * from "./globeCircleManager";
+export * from "./globeModelManager";

--- a/src/terrain/geo/overlayPlacement.ts
+++ b/src/terrain/geo/overlayPlacement.ts
@@ -6,9 +6,9 @@
  * 応じたスクリーン定スケール」「ドロップ線高さ」を ECEF ベースで提供する。平面オーバーレイ
  * とは独立（並行構築）で、`GeospatialCamera` を直接 import しない（jest 環境を軽く保つ）。
  */
-import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { Vector3, Quaternion, Matrix } from "@babylonjs/core/Maths/math.vector";
 
-import { geodeticToEcefToRef } from "./ecef";
+import { DEG2RAD, geodeticToEcefToRef } from "./ecef";
 
 /** 緯度経度 1 点（オーバーレイ頂点）。 */
 export interface LatLonPoint {
@@ -83,6 +83,49 @@ export const computeOverlayDistanceScaleFromDistance = (
 export const computeOverlayLineHeight = (distanceM: number): number => {
     const h = distanceM * 0.1;
     return Math.min(LINE_HEIGHT_MAX, Math.max(LINE_HEIGHT_MIN, h));
+};
+
+// surfaceOrientationToRef のスクラッチ（毎フレーム・モデル数ぶん呼ばれるため割り当て回避）。
+const ORI_POLE = new Vector3(0, 0, 1);
+const _oriUp = new Vector3();
+const _oriEast = new Vector3();
+const _oriNorth = new Vector3();
+const _oriFwd = new Vector3();
+const _oriTmp = new Vector3();
+const _oriX = new Vector3();
+const _oriMat = new Matrix();
+
+/**
+ * 地表 ECEF 位置に置くモデル等の **向き（回転クォータニオン）** を `ref` に書き込む。
+ * モデルのローカル +Y を地心 up へ、ローカル +Z を方位 `headingDeg`（0=北, +=東回り）方向へ向ける
+ * （地表で「立つ」姿勢）。極（東が定義できない）では `false` を返す（呼び出し側は向き更新をスキップ）。
+ *
+ * @returns 計算できたら true（`ref` に回転）、極などの特異点で false。
+ */
+export const surfaceOrientationToRef = (
+    positionEcef: Vector3,
+    headingDeg: number,
+    ref: Quaternion,
+): boolean => {
+    const r = positionEcef.length();
+    if (r < 1) return false;
+    positionEcef.scaleToRef(1 / r, _oriUp); // 地心 up
+    Vector3.CrossToRef(ORI_POLE, _oriUp, _oriEast);
+    if (_oriEast.lengthSquared() < 1e-12) return false; // 極
+    _oriEast.normalize();
+    Vector3.CrossToRef(_oriUp, _oriEast, _oriNorth); // 北
+    _oriNorth.normalize();
+    // forward = north*cos(h) + east*sin(h)（0=北, +=東回り）。
+    const h = headingDeg * DEG2RAD;
+    _oriFwd.copyFrom(_oriNorth).scaleInPlace(Math.cos(h));
+    _oriTmp.copyFrom(_oriEast).scaleInPlace(Math.sin(h));
+    _oriFwd.addInPlace(_oriTmp).normalize();
+    // 右手系の正規直交基底 {x=up×fwd, y=up, z=fwd} から回転行列→クォータニオン。
+    Vector3.CrossToRef(_oriUp, _oriFwd, _oriX);
+    _oriX.normalize();
+    Matrix.FromXYZAxesToRef(_oriX, _oriUp, _oriFwd, _oriMat);
+    Quaternion.FromRotationMatrixToRef(_oriMat, ref);
+    return true;
 };
 
 /**

--- a/tests/geoOverlayPlacement.unit.spec.ts
+++ b/tests/geoOverlayPlacement.unit.spec.ts
@@ -8,7 +8,7 @@
 
 import { describe, it, expect } from "@jest/globals";
 
-import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { Vector3, Quaternion, Matrix } from "@babylonjs/core/Maths/math.vector";
 
 import { geodeticToEcef } from "../src/terrain/geo/ecef";
 import {
@@ -18,6 +18,7 @@ import {
     computeOverlayLineHeight,
     buildDrapedPolygonPaths,
     generateGeodesicRing,
+    surfaceOrientationToRef,
     OVERLAY_REF_DISTANCE_M,
 } from "../src/terrain/geo/overlayPlacement";
 
@@ -170,5 +171,41 @@ describe("generateGeodesicRing", () => {
         expect(() => generateGeodesicRing(35, 139, -1, 8)).toThrow(/radiusMeters/);
         expect(() => generateGeodesicRing(35, 139, 5000, 2)).toThrow(/segments/);
         expect(() => generateGeodesicRing(35, 139, 5000, 8.5)).toThrow(/segments/);
+    });
+});
+
+describe("surfaceOrientationToRef", () => {
+    /** クォータニオン q でローカル軸 v を回した世界ベクトルを返す。 */
+    const rotate = (q: Quaternion, v: Vector3): Vector3 => {
+        const m = new Matrix();
+        q.toRotationMatrix(m);
+        return Vector3.TransformCoordinates(v, m);
+    };
+
+    it("ローカル +Y が地心 up（位置の正規化）へ向く", () => {
+        const pos = geodeticToEcef(35, 139, 1000);
+        const q = new Quaternion();
+        expect(surfaceOrientationToRef(pos, 0, q)).toBe(true);
+        const worldUp = rotate(q, new Vector3(0, 1, 0));
+        const up = pos.clone().normalize();
+        expect(Vector3.Dot(worldUp, up)).toBeCloseTo(1, 6);
+    });
+
+    it("heading=0 でローカル +Z が北向き（地心 up と直交・北成分正）", () => {
+        const pos = geodeticToEcef(35, 139, 0);
+        const q = new Quaternion();
+        surfaceOrientationToRef(pos, 0, q);
+        const fwd = rotate(q, new Vector3(0, 0, 1));
+        const up = pos.clone().normalize();
+        // 前方は接線（up と直交）。
+        expect(Vector3.Dot(fwd, up)).toBeCloseTo(0, 6);
+        // 北半球で「北向き」は +Z 成分が正（北極方向に近い）。
+        expect(fwd.z).toBeGreaterThan(0);
+    });
+
+    it("極では false（東が定義できない）", () => {
+        const pos = geodeticToEcef(90, 0, 0);
+        const q = new Quaternion();
+        expect(surfaceOrientationToRef(pos, 0, q)).toBe(false);
     });
 });

--- a/tests/globeModelManager.unit.spec.ts
+++ b/tests/globeModelManager.unit.spec.ts
@@ -41,11 +41,14 @@ jest.unstable_mockModule("@babylonjs/core/Meshes/transformNode", () => ({
 }));
 
 // ImportMeshAsync は解決を手動制御できる deferred にする。
-let resolveImport: ((meshes: { parent: unknown; dispose: () => void }[]) => void) | null = null;
+type StubAg = { stop: () => void; dispose: () => void };
+let resolveImport:
+    | ((meshes: { parent: unknown; dispose: () => void }[], ags?: StubAg[]) => void)
+    | null = null;
 const importMeshAsync = jest.fn(
     () =>
         new Promise((res) => {
-            resolveImport = (meshes) => res({ meshes, animationGroups: [] });
+            resolveImport = (meshes, ags = []) => res({ meshes, animationGroups: ags });
         }),
 );
 jest.unstable_mockModule("@babylonjs/core/Loading/sceneLoader", () => ({
@@ -101,6 +104,18 @@ describe("add / load", () => {
         mgr.add({ url: "x.glb", lat: 35, lon: 139 });
         mgr.update(); // まだ loaded=false
         expect(createdRoots[0].position.length()).toBe(0);
+    });
+
+    it("AnimationGroup はロード直後に stop+dispose される（リーク防止）", async () => {
+        const { mgr } = makeManager();
+        mgr.add({ url: "x.glb", lat: 35, lon: 139 });
+        await new Promise((r) => setTimeout(r, 0));
+        const ag = { stop: jest.fn(), dispose: jest.fn() };
+        const mesh = { parent: null as unknown, dispose: jest.fn() };
+        resolveImport?.([mesh], [ag]);
+        await new Promise((r) => setTimeout(r, 0));
+        expect(ag.stop).toHaveBeenCalled();
+        expect(ag.dispose).toHaveBeenCalled();
     });
 });
 

--- a/tests/globeModelManager.unit.spec.ts
+++ b/tests/globeModelManager.unit.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * GlobeModelManager の振る舞い (Issue #275 Phase 3)。
+ *
+ * Babylon の TransformNode / ImportMeshAsync と marker.ts のローダー登録（importLoaderForUrl）を
+ * スタブ化し、ロード完了→接地・起立、ロード前は配置しない、dispose 中のロード結果破棄、
+ * CRUD / dispose 後ガードを検証する（Vector3/Quaternion/overlayPlacement は実物）。
+ */
+import { jest } from "@jest/globals";
+
+import { Vector3, Quaternion } from "@babylonjs/core/Maths/math.vector";
+
+interface StubNode {
+    name: string;
+    position: Vector3;
+    rotationQuaternion: Quaternion | null;
+    scaling: Vector3;
+    enabled: boolean;
+    disposeCount: number;
+    setEnabled: (v: boolean) => void;
+    dispose: () => void;
+}
+const createdRoots: StubNode[] = [];
+
+jest.unstable_mockModule("@babylonjs/core/Meshes/transformNode", () => ({
+    TransformNode: class {
+        position = new Vector3();
+        rotationQuaternion: Quaternion | null = null;
+        scaling = new Vector3(1, 1, 1);
+        enabled = true;
+        disposeCount = 0;
+        constructor(public name: string) {
+            createdRoots.push(this as unknown as StubNode);
+        }
+        setEnabled(v: boolean): void {
+            this.enabled = v;
+        }
+        dispose(): void {
+            this.disposeCount++;
+        }
+    },
+}));
+
+// ImportMeshAsync は解決を手動制御できる deferred にする。
+let resolveImport: ((meshes: { parent: unknown; dispose: () => void }[]) => void) | null = null;
+const importMeshAsync = jest.fn(
+    () =>
+        new Promise((res) => {
+            resolveImport = (meshes) => res({ meshes, animationGroups: [] });
+        }),
+);
+jest.unstable_mockModule("@babylonjs/core/Loading/sceneLoader", () => ({
+    ImportMeshAsync: importMeshAsync,
+}));
+
+const importLoaderForUrl = jest.fn(async () => {});
+jest.unstable_mockModule("../src/terrain/modelManager", () => ({ importLoaderForUrl }));
+
+const { createGlobeModelManager } = await import("../src/terrain/geo/globeModelManager");
+const { describe, it, expect, beforeEach } = await import("@jest/globals");
+
+const makeManager = () => {
+    const terrainElevAt: (lat: number, lon: number) => number | null = jest.fn(() => 1000);
+    const mgr = createGlobeModelManager({ scene: {} as never, terrainElevAt });
+    return { mgr, terrainElevAt };
+};
+
+/** ロード完了をシミュレートする（親なしメッシュ 1 つ）。 */
+const completeLoad = async (): Promise<void> => {
+    // loadModel は先に await importLoaderForUrl → その後 ImportMeshAsync を呼ぶため、
+    // resolveImport がセットされるまで 1 ティック待ってから解決する。
+    await new Promise((r) => setTimeout(r, 0));
+    const mesh = { parent: null as unknown, dispose: jest.fn() };
+    resolveImport?.([mesh]);
+    await new Promise((r) => setTimeout(r, 0));
+};
+
+beforeEach(() => {
+    createdRoots.length = 0;
+    resolveImport = null;
+    importMeshAsync.mockClear();
+    importLoaderForUrl.mockClear();
+});
+
+describe("add / load", () => {
+    it("add で root を生成し、ロード完了後に接地・起立する", async () => {
+        const { mgr } = makeManager();
+        mgr.add({ url: "x.glb", lat: 35, lon: 139, scale: 10 });
+        expect(createdRoots.length).toBe(1);
+        await completeLoad();
+        const root = createdRoots[0];
+        // 接地: position が地表 ECEF（地心距離 > 6e6）。
+        expect(root.position.length()).toBeGreaterThan(6_000_000);
+        // 起立: rotationQuaternion が設定される。
+        expect(root.rotationQuaternion).not.toBeNull();
+        // スケール適用。
+        expect(root.scaling.x).toBe(10);
+    });
+
+    it("ロード完了前は update しても位置は原点のまま（loaded ガード）", () => {
+        const { mgr } = makeManager();
+        mgr.add({ url: "x.glb", lat: 35, lon: 139 });
+        mgr.update(); // まだ loaded=false
+        expect(createdRoots[0].position.length()).toBe(0);
+    });
+});
+
+describe("ライフサイクル", () => {
+    it("ロード前に remove するとロード結果は破棄される", async () => {
+        const { mgr } = makeManager();
+        const id = mgr.add({ url: "x.glb", lat: 35, lon: 139 });
+        mgr.remove(id); // cancelled
+        await new Promise((r) => setTimeout(r, 0)); // importLoaderForUrl 解決 → ImportMeshAsync 呼び出し待ち
+        const mesh = { parent: null as unknown, dispose: jest.fn() };
+        resolveImport?.([mesh]);
+        await new Promise((r) => setTimeout(r, 0));
+        expect(mesh.dispose).toHaveBeenCalled();
+        expect(createdRoots[0].disposeCount).toBe(1);
+    });
+
+    it("remove 未存在 id は warn + no-op、setEnabled 未存在は throw", () => {
+        const { mgr } = makeManager();
+        const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+        expect(() => mgr.remove("nope")).not.toThrow();
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('id "nope" not found'));
+        warn.mockRestore();
+        expect(() => mgr.setEnabled("nope", false)).toThrow(/not found/);
+    });
+
+    it("dispose 後の add/setEnabled/update は throw、二重 dispose は安全", () => {
+        const { mgr } = makeManager();
+        mgr.dispose();
+        expect(() => mgr.add({ url: "x.glb", lat: 35, lon: 139 })).toThrow(/after dispose/);
+        expect(() => mgr.setEnabled("x", true)).toThrow(/after dispose/);
+        expect(() => mgr.update()).toThrow(/after dispose/);
+        expect(() => mgr.dispose()).not.toThrow();
+    });
+});


### PR DESCRIPTION
## 概要

Issue #275 Phase 3（オーバーレイの ECEF 化）**最後の model スライス**。これで marker / polygon / circle / model が揃い **Phase 3 完了**。

glb/gltf モデルを lat/lon に接地し、**ローカル +Y を地心 up へ向けて「立たせる」**。平面版 `modelManager` は未改修で、ローダー登録（`importLoaderForUrl`）のみ座標系非依存のため再利用。

## 変更点

### `src/terrain/geo/overlayPlacement.ts`
- `surfaceOrientationToRef`（純関数）: 地表 ECEF 位置のモデル向きを計算。ローカル +Y→地心 up、+Z→方位（`headingDeg`、0=北/+東回り）へ向ける回転クォータニオン。極で false。

### `src/terrain/geo/globeModelManager.ts`（新規）
- `ImportMeshAsync` で glb を root `TransformNode` に読み込み、毎フレーム接地（`groundPlacementToRef`、標高 null は直前値フォールバック）＋起立（`surfaceOrientationToRef`）。`scale` 適用。
- dispose 中のロード結果破棄（`cancelled`）、dispose 後ガード（`add`/`setEnabled`/`update`=throw、`remove`=warn、`dispose` 冪等）。

### `src/scenes/globe.ts`
- `GlobeSceneController` に `modelManager` を追加。observer で `update()`、`dispose` で破棄。

### `demos/geospatial/index.ts`
- 富士山頂に `human.glb` を接地表示（`scale 400`、`?model=off` で無効化）。

### テスト
- `surfaceOrientationToRef`（up 整列/北向き/極）、`globeModelManager`（ロード→接地起立 / loaded ガード / ロード中 remove で破棄 / 未存在 warn・throw / dispose 後ガード。Babylon ローダーはモック）。

## 影響範囲
- 画面: `/geospatial` にグローブモデル（human.glb）が富士山頂に立つ
- API: `geo` に `surfaceOrientationToRef` / `globeModelManager` を追加、`GlobeSceneController.modelManager` を追加。既存平面モデルへの影響なし

## 検証（DoD）
- `npm run lint` / `typecheck` / `test:unit`（**1096 passed**）
- headless（webgl2）でモデルが富士山頂に接地（|pos|≈6.37e6）・ローカル +Y が地心 up と一致（dot≈1.0）・scale 反映・（タイル 404 以外の）エラーなしを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)