### PR TITLE
fix(geo): グローブ地形タイル選択を視錐台被覆へ（水平チルト時の前景メッシュ欠落を解消） (#329)

### DIFF
--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -55,10 +55,12 @@ export const GLOBE_SCENE_DEFAULTS = {
     tilt: 60,
     /** SSE 採用しきい値 [px]。 */
     sseThreshold: 256 * 2.5,
-    /** 同時保持タイル数の上限。 */
-    maxTiles: 140,
-    /** root 探索半径（±N 格子）。 */
+    /** 同時保持タイル数の上限。水平チルト時の前景＋地平線被覆のため #329 で 140→200。 */
+    maxTiles: 200,
+    /** root 帯の横半幅／後方マージン（±N 格子）。 */
     rootSearchRadius: 2,
+    /** root 帯に張る minZoom タイル数の予算（上限）。#329 の nadir→center swath 用。 */
+    maxRootTiles: 96,
     /** 地平線カリングの内積しきい値。 */
     horizonDotThreshold: 0.1,
     /** タイルあたりの分割数（頂点は (seg+1)^2）。 */
@@ -399,6 +401,7 @@ export class GlobeScene {
                 sseThreshold: GLOBE_SCENE_DEFAULTS.sseThreshold,
                 maxTiles: GLOBE_SCENE_DEFAULTS.maxTiles,
                 rootSearchRadius: GLOBE_SCENE_DEFAULTS.rootSearchRadius,
+                maxRootTiles: GLOBE_SCENE_DEFAULTS.maxRootTiles,
                 horizonDotThreshold: GLOBE_SCENE_DEFAULTS.horizonDotThreshold,
                 referenceAltitude: centerElevation,
             });

--- a/src/terrain/geo/globeLod.ts
+++ b/src/terrain/geo/globeLod.ts
@@ -50,7 +50,9 @@ export interface GlobeLodOptions {
     maxTiles: number;
     /**
      * root タイル（minZoom）の帯の横半幅（lateral）かつ nadir 手前の後方マージン（±N 格子）。
-     * 直下視（nadir≒center）では nadir 中心の対称ボックス（一辺 2N+1）にフォールバックする。
+     * 直下視（nadir≒center）では nadir 中心の対称ボックス（一辺 2N+1）状に張る。ただし生成は
+     * 常に `maxRootTiles` の予算内に収まり、`maxRootTiles < (2N+1)^2` のときは前景優先で
+     * 打ち切られる（対称ボックスを満たし切らない）。
      */
     rootSearchRadius: number;
     /**

--- a/src/terrain/geo/globeLod.ts
+++ b/src/terrain/geo/globeLod.ts
@@ -16,7 +16,7 @@
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 
 import { tileCenterLatLon, tileEdgeMeters, toTileXY } from "../gsiTile";
-import { geodeticToEcefToRef } from "./ecef";
+import { ecefToGeodetic, geodeticToEcefToRef } from "./ecef";
 
 /** LOD 選択されたタイル。 */
 export interface GlobeTile {
@@ -48,8 +48,16 @@ export interface GlobeLodOptions {
     sseThreshold: number;
     /** 結果タイル数の上限。 */
     maxTiles: number;
-    /** root タイル（minZoom）の探索半径（±N 格子）。 */
+    /**
+     * root タイル（minZoom）の帯の横半幅（lateral）かつ nadir 手前の後方マージン（±N 格子）。
+     * 直下視（nadir≒center）では nadir 中心の対称ボックス（一辺 2N+1）にフォールバックする。
+     */
     rootSearchRadius: number;
+    /**
+     * root 帯に張る minZoom タイル数の予算（上限）。前景（nadir 側）から地平線側へ
+     * 帯を張り、予算を使い切ったら地平線側を捨てて前景を残す（水平チルト時の前景被覆を優先）。
+     */
+    maxRootTiles: number;
     /**
      * 地平線カリングの内積しきい値。
      * `dot(normalize(tileEcef), normalize(cameraEcef)) < threshold` のタイルを裏側として除外。
@@ -78,10 +86,97 @@ const tileCenterEcefToRef = (
     return { lat, lon };
 };
 
+/** `selectGlobeRootTiles` の入力（root 帯の選定に必要な最小集合）。 */
+export interface GlobeRootSeedOptions {
+    /** カメラの真の ECEF 位置。 */
+    cameraEcef: Vector3;
+    /** 注視点（look-at center）の緯度 [deg]。 */
+    centerLat: number;
+    /** 注視点の経度 [deg]。 */
+    centerLon: number;
+    /** root（最低）ズーム。 */
+    minZoom: number;
+    /** 帯の横半幅かつ nadir 手前の後方マージン（±N 格子）。 */
+    rootSearchRadius: number;
+    /** root タイル数の予算（上限）。 */
+    maxRootTiles: number;
+}
+/**
+ * 可視地表を覆う root（minZoom）タイル集合を選定する（Issue #329）。
+ *
+ * 旧実装は注視点（look-at center）中心の固定 ±N 格子のみを root にしていたため、水平
+ * チルト時にカメラ直下（nadir）の前景がこの領域の外へ出てタイルが生成されなかった。
+ * 本関数は **カメラ直下点（nadir）から注視点（center）を通り地平線方向へ伸びる帯**
+ * （ground track に沿う swath）に root を張る:
+ * - nadir と center の minZoom タイル座標を結ぶ方向を along-track、その直交を lateral とする。
+ * - along-track は nadir 手前 `rootSearchRadius` から、center を越え地平線側へ `2*dirLen`
+ *   ＋マージンまで（dirLen = nadir↔center のタイル距離）。lateral は ±`rootSearchRadius`。
+ * - 前景（nadir 側）から順に張り、`maxRootTiles` を使い切ったら地平線側を捨てる（前景優先）。
+ * - 直下視（nadir≒center で方向が定まらない）では nadir 中心の対称ボックスにフォールバックし、
+ *   旧来の中心アンカー挙動を保つ。
+ *
+ * 地平線側の被覆過多や裏側は後段の地平線カリング・SSE・maxTiles 打ち切りで間引かれる。
+ */
+export const selectGlobeRootTiles = (
+    opts: GlobeRootSeedOptions,
+): { x: number; y: number }[] => {
+    const { cameraEcef, centerLat, centerLon, minZoom, rootSearchRadius, maxRootTiles } =
+        opts;
+    const margin = Math.max(0, rootSearchRadius);
+    const budget = Math.max(1, maxRootTiles);
+
+    // カメラ直下点（nadir, 前景）と注視点（center）の minZoom タイル座標。
+    const nadir = ecefToGeodetic(cameraEcef);
+    const t0 = toTileXY(nadir.latDeg, nadir.lonDeg, minZoom);
+    const t1 = toTileXY(centerLat, centerLon, minZoom);
+
+    const dx = t1.x - t0.x;
+    const dy = t1.y - t0.y;
+    const dirLen = Math.hypot(dx, dy);
+
+    // along-track（帯の進行方向）と lateral（直交方向）の単位ベクトル。直下視で方向が
+    // 定まらない（dirLen≒0）ときは nadir 中心の対称ボックスへフォールバックする。
+    let ux = 1;
+    let uy = 0;
+    let px = 0;
+    let py = 1;
+    if (dirLen > 1e-6) {
+        ux = dx / dirLen;
+        uy = dy / dirLen;
+        px = -uy;
+        py = ux;
+    }
+
+    const seeds: { x: number; y: number }[] = [];
+    const seen = new Set<string>();
+    const add = (x: number, y: number): void => {
+        if (seeds.length >= budget) return;
+        const key = `${x},${y}`;
+        if (seen.has(key)) return;
+        seen.add(key);
+        seeds.push({ x, y });
+    };
+    /** along-track 位置 s の lateral 断面（±margin）を張る。 */
+    const addCrossSection = (s: number): void => {
+        const cx = t0.x + ux * s;
+        const cy = t0.y + uy * s;
+        for (let w = -margin; w <= margin; w++) {
+            add(Math.round(cx + px * w), Math.round(cy + py * w));
+        }
+    };
+
+    // nadir(s=0) を起点に、center を越え地平線側へ 2*dirLen + margin まで前進。前景を最優先で
+    // 張り、予算を使い切ったら地平線側を捨てる。最後に nadir 手前のマージン（s<0）を埋める。
+    const alongEnd = Math.round(2 * dirLen) + margin;
+    for (let s = 0; s <= alongEnd && seeds.length < budget; s++) addCrossSection(s);
+    for (let s = -1; s >= -margin && seeds.length < budget; s--) addCrossSection(s);
+    return seeds;
+};
+
 /**
  * グローブ向け Quadtree+SSE でカメラ近傍の可視タイルを選択する。
  *
- * root は中心 lat/lon の minZoom タイルを中心に ±rootSearchRadius 格子。
+ * root は `selectGlobeRootTiles` が選ぶ「nadir→center→地平線」の帯（Issue #329）。
  * 各ノードで「地平線カリング → SSE 判定」を行い、受容 or 4 子へ分割。
  * 最後にカメラ距離の昇順で maxTiles 件に打ち切る。
  */
@@ -97,6 +192,7 @@ export const selectGlobeTiles = (opts: GlobeLodOptions): GlobeTile[] => {
         sseThreshold,
         maxTiles,
         rootSearchRadius,
+        maxRootTiles,
         horizonDotThreshold,
         referenceAltitude = 0,
     } = opts;
@@ -153,12 +249,15 @@ export const selectGlobeTiles = (opts: GlobeLodOptions): GlobeTile[] => {
         }
     };
 
-    const root = toTileXY(centerLat, centerLon, minZoom);
-    for (let dy = -rootSearchRadius; dy <= rootSearchRadius; dy++) {
-        for (let dx = -rootSearchRadius; dx <= rootSearchRadius; dx++) {
-            traverse(minZoom, root.x + dx, root.y + dy);
-        }
-    }
+    const roots = selectGlobeRootTiles({
+        cameraEcef,
+        centerLat,
+        centerLon,
+        minZoom,
+        rootSearchRadius,
+        maxRootTiles,
+    });
+    for (const r of roots) traverse(minZoom, r.x, r.y);
 
     accepted.sort((a, b) => a.distance - b.distance);
     return accepted.slice(0, maxTiles);

--- a/src/terrain/geo/globeLod.ts
+++ b/src/terrain/geo/globeLod.ts
@@ -130,7 +130,12 @@ export const selectGlobeRootTiles = (
     const t0 = toTileXY(nadir.latDeg, nadir.lonDeg, minZoom);
     const t1 = toTileXY(centerLat, centerLon, minZoom);
 
-    const dx = t1.x - t0.x;
+    // x（経度方向）は日付変更線で巡回する（2^minZoom タイル周期）。単純差分だと境界を
+    // またいだとき t0.x=2047/t1.x=0 のように巨大な dx になり帯の方向・長さが壊れるため、
+    // 最短符号付き差分（[-n/2, n/2)）に正規化する。y（メルカトル緯度）は巡回しない。
+    const n = 2 ** minZoom;
+    let dx = ((((t1.x - t0.x) % n) + n) % n);
+    if (dx > n / 2) dx -= n;
     const dy = t1.y - t0.y;
     const dirLen = Math.hypot(dx, dy);
 
@@ -151,10 +156,14 @@ export const selectGlobeRootTiles = (
     const seen = new Set<string>();
     const add = (x: number, y: number): void => {
         if (seeds.length >= budget) return;
-        const key = `${x},${y}`;
+        // y（メルカトル緯度）は巡回しない。範囲外（極側のはみ出し）は無効タイルなので捨て、
+        // 予算を浪費しない。x（経度）は巡回するため範囲内へ正規化する。
+        if (y < 0 || y >= n) return;
+        const wx = ((x % n) + n) % n;
+        const key = `${wx},${y}`;
         if (seen.has(key)) return;
         seen.add(key);
-        seeds.push({ x, y });
+        seeds.push({ x: wx, y });
     };
     /** along-track 位置 s の lateral 断面（±margin）を張る。 */
     const addCrossSection = (s: number): void => {

--- a/src/terrain/geo/globeLod.ts
+++ b/src/terrain/geo/globeLod.ts
@@ -176,8 +176,16 @@ export const selectGlobeRootTiles = (
         }
     };
 
-    // nadir(s=0) を起点に、center を越え地平線側へ 2*dirLen + margin まで前進。前景を最優先で
-    // 張り、予算を使い切ったら地平線側を捨てる。最後に nadir 手前のマージン（s<0）を埋める。
+    // nadir と center の root タイルは予算内で最優先に確保する（前景=nadir を最優先、
+    // 次に視界中心=center）。これにより maxRootTiles が小さい／nadir↔center が遠いケースで
+    // 帯が center に届く前に予算切れになっても、視界中心が root 領域外にならない。
+    // budget=1 では nadir のみ確保される。
+    add(t0.x, t0.y);
+    add(t1.x, t1.y);
+
+    // 残り予算で nadir(s=0) を起点に、center を越え地平線側へ 2*dirLen + margin まで前進。
+    // 前景を優先して張り、予算を使い切ったら地平線側を捨てる。最後に nadir 手前のマージン
+    // （s<0）を埋める。既出タイル（nadir/center 等）は seen でデデュプされる。
     const alongEnd = Math.round(2 * dirLen) + margin;
     for (let s = 0; s <= alongEnd && seeds.length < budget; s++) addCrossSection(s);
     for (let s = -1; s >= -margin && seeds.length < budget; s--) addCrossSection(s);

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -77,8 +77,10 @@ export interface GlobeTileSyncParams {
     sseThreshold: number;
     /** 同時保持タイル数の上限。 */
     maxTiles: number;
-    /** root 探索半径（±N 格子）。 */
+    /** root 帯の横半幅／後方マージン（±N 格子）。 */
     rootSearchRadius: number;
+    /** root 帯に張る minZoom タイル数の予算（上限）。 */
+    maxRootTiles: number;
     /** 地平線カリングの内積しきい値。 */
     horizonDotThreshold: number;
     /** SSE 距離評価の基準標高 [m]（中心付近の地形標高）。 */
@@ -326,6 +328,7 @@ export const createGlobeTileManager = (
             sseThreshold: params.sseThreshold,
             maxTiles: params.maxTiles,
             rootSearchRadius: params.rootSearchRadius,
+            maxRootTiles: params.maxRootTiles,
             horizonDotThreshold: params.horizonDotThreshold,
             referenceAltitude: params.referenceAltitude,
         });

--- a/tests/globeLod.unit.spec.ts
+++ b/tests/globeLod.unit.spec.ts
@@ -10,8 +10,14 @@
 
 import { describe, it, expect } from "@jest/globals";
 
+import { tileCenterLatLon, toTileXY } from "../src/terrain/gsiTile";
 import { geodeticToEcef } from "../src/terrain/geo/ecef";
-import { selectGlobeTiles, tileKey, type GlobeLodOptions } from "../src/terrain/geo/globeLod";
+import {
+    selectGlobeRootTiles,
+    selectGlobeTiles,
+    tileKey,
+    type GlobeLodOptions,
+} from "../src/terrain/geo/globeLod";
 
 const CENTER_LAT = 35.3606;
 const CENTER_LON = 138.7274;
@@ -31,6 +37,7 @@ const baseOpts = (
     sseThreshold: 256 * 2.5,
     maxTiles: 200,
     rootSearchRadius: 2,
+    maxRootTiles: 256,
     horizonDotThreshold: 0.1,
     referenceAltitude: 0,
     ...overrides,
@@ -108,5 +115,73 @@ describe("selectGlobeTiles", () => {
         const tiles = selectGlobeTiles(baseOpts(60000));
         expect(tiles.length).toBeGreaterThan(0);
         for (const t of tiles) expect(t.tileSizeMeters).toBeGreaterThan(0);
+    });
+
+    it("水平チルトでカメラ直下（nadir）の前景タイルが選択される（#329）", () => {
+        // カメラ直下点を注視点の南 ~0.8°（≒88km）に置く＝水平気味のチルト。
+        const nadirLat = CENTER_LAT - 0.8;
+        const tiles = selectGlobeTiles(
+            baseOpts(60000, {
+                cameraEcef: geodeticToEcef(nadirLat, CENTER_LON, 60000),
+                centerLat: CENTER_LAT,
+                centerLon: CENTER_LON,
+                maxZoom: 15,
+            }),
+        );
+        // 前景（nadir 付近, 注視点より十分南）のタイルが少なくとも 1 枚含まれること。
+        // 旧来の注視点中心アンカーでは生成されず、欠落していた領域。
+        const hasForeground = tiles.some((t) => {
+            const { lat } = tileCenterLatLon(t.x, t.y, t.zoom);
+            return lat < CENTER_LAT - 0.5;
+        });
+        expect(hasForeground).toBe(true);
+    });
+});
+
+describe("selectGlobeRootTiles", () => {
+    const baseRoot = (
+        cameraEcef = geodeticToEcef(CENTER_LAT, CENTER_LON, 60000),
+        overrides: Partial<Parameters<typeof selectGlobeRootTiles>[0]> = {},
+    ) => ({
+        cameraEcef,
+        centerLat: CENTER_LAT,
+        centerLon: CENTER_LON,
+        minZoom: 11,
+        rootSearchRadius: 2,
+        maxRootTiles: 256,
+        ...overrides,
+    });
+
+    it("直下視（nadir≒center）は nadir 中心の対称ボックス（一辺 2r+1）", () => {
+        const r = 2;
+        const seeds = selectGlobeRootTiles(baseRoot(undefined, { rootSearchRadius: r }));
+        expect(seeds).toHaveLength((2 * r + 1) ** 2);
+        const center = toTileXY(CENTER_LAT, CENTER_LON, 11);
+        expect(seeds.some((s) => s.x === center.x && s.y === center.y)).toBe(true);
+    });
+
+    it("チルト時は nadir タイルと center タイルの両方を含む（#329 帯）", () => {
+        const nadirLat = CENTER_LAT - 0.8;
+        const seeds = selectGlobeRootTiles(
+            baseRoot(geodeticToEcef(nadirLat, CENTER_LON, 60000)),
+        );
+        const nadirTile = toTileXY(nadirLat, CENTER_LON, 11);
+        const centerTile = toTileXY(CENTER_LAT, CENTER_LON, 11);
+        expect(nadirTile.y).not.toBe(centerTile.y); // 前提: 別タイル
+        expect(seeds.some((s) => s.x === nadirTile.x && s.y === nadirTile.y)).toBe(true);
+        expect(seeds.some((s) => s.x === centerTile.x && s.y === centerTile.y)).toBe(true);
+    });
+
+    it("maxRootTiles 予算を超えず、前景（nadir）を残す", () => {
+        const nadirLat = CENTER_LAT - 0.8;
+        const budget = 5;
+        const seeds = selectGlobeRootTiles(
+            baseRoot(geodeticToEcef(nadirLat, CENTER_LON, 60000), {
+                maxRootTiles: budget,
+            }),
+        );
+        expect(seeds.length).toBeLessThanOrEqual(budget);
+        const nadirTile = toTileXY(nadirLat, CENTER_LON, 11);
+        expect(seeds.some((s) => s.x === nadirTile.x && s.y === nadirTile.y)).toBe(true);
     });
 });

--- a/tests/globeLod.unit.spec.ts
+++ b/tests/globeLod.unit.spec.ts
@@ -185,6 +185,30 @@ describe("selectGlobeRootTiles", () => {
         expect(seeds.some((s) => s.x === nadirTile.x && s.y === nadirTile.y)).toBe(true);
     });
 
+    it("予算が小さくても nadir と center の root を最優先で確保する", () => {
+        const nadirLat = CENTER_LAT - 0.8;
+        const seeds = selectGlobeRootTiles(
+            baseRoot(geodeticToEcef(nadirLat, CENTER_LON, 60000), { maxRootTiles: 2 }),
+        );
+        const nadirTile = toTileXY(nadirLat, CENTER_LON, 11);
+        const centerTile = toTileXY(CENTER_LAT, CENTER_LON, 11);
+        expect(nadirTile.y).not.toBe(centerTile.y); // 前提: 別タイル
+        expect(seeds.length).toBeLessThanOrEqual(2);
+        expect(seeds.some((s) => s.x === nadirTile.x && s.y === nadirTile.y)).toBe(true);
+        expect(seeds.some((s) => s.x === centerTile.x && s.y === centerTile.y)).toBe(true);
+    });
+
+    it("budget=1 では nadir を優先する", () => {
+        const nadirLat = CENTER_LAT - 0.8;
+        const seeds = selectGlobeRootTiles(
+            baseRoot(geodeticToEcef(nadirLat, CENTER_LON, 60000), { maxRootTiles: 1 }),
+        );
+        expect(seeds).toHaveLength(1);
+        const nadirTile = toTileXY(nadirLat, CENTER_LON, 11);
+        expect(seeds[0].x).toBe(nadirTile.x);
+        expect(seeds[0].y).toBe(nadirTile.y);
+    });
+
     it("日付変更線をまたいでも最短方向の帯になり center を含む（x は範囲内に正規化）", () => {
         const minZoom = 8;
         const n = 2 ** minZoom;

--- a/tests/globeLod.unit.spec.ts
+++ b/tests/globeLod.unit.spec.ts
@@ -184,4 +184,46 @@ describe("selectGlobeRootTiles", () => {
         const nadirTile = toTileXY(nadirLat, CENTER_LON, 11);
         expect(seeds.some((s) => s.x === nadirTile.x && s.y === nadirTile.y)).toBe(true);
     });
+
+    it("日付変更線をまたいでも最短方向の帯になり center を含む（x は範囲内に正規化）", () => {
+        const minZoom = 8;
+        const n = 2 ** minZoom;
+        // nadir lon=179.9 / center lon=-179.9: 地理的には近接だがタイル x は wrap する。
+        const seeds = selectGlobeRootTiles(
+            baseRoot(geodeticToEcef(CENTER_LAT, 179.9, 60000), {
+                minZoom,
+                centerLon: -179.9,
+            }),
+        );
+        const nadirTile = toTileXY(CENTER_LAT, 179.9, minZoom);
+        const centerTile = toTileXY(CENTER_LAT, -179.9, minZoom);
+        // 前提: 日付変更線をまたいで x が大きく離れている（wrap 発生）。
+        expect(Math.abs(nadirTile.x - centerTile.x)).toBeGreaterThan(n / 2);
+        // すべて範囲内に正規化され、最短方向の短い帯として nadir/center 両方を含む。
+        for (const s of seeds) {
+            expect(s.x).toBeGreaterThanOrEqual(0);
+            expect(s.x).toBeLessThan(n);
+            expect(s.y).toBeGreaterThanOrEqual(0);
+            expect(s.y).toBeLessThan(n);
+        }
+        expect(seeds.some((s) => s.x === nadirTile.x && s.y === nadirTile.y)).toBe(true);
+        expect(seeds.some((s) => s.x === centerTile.x && s.y === centerTile.y)).toBe(true);
+    });
+
+    it("極付近では範囲外 y の root を捨てる（予算を無効タイルに使わない）", () => {
+        const minZoom = 6;
+        const n = 2 ** minZoom;
+        const seeds = selectGlobeRootTiles(
+            baseRoot(geodeticToEcef(85.0, CENTER_LON, 200000), {
+                minZoom,
+                centerLat: 85.0,
+                rootSearchRadius: 3,
+            }),
+        );
+        expect(seeds.length).toBeGreaterThan(0);
+        for (const s of seeds) {
+            expect(s.y).toBeGreaterThanOrEqual(0);
+            expect(s.y).toBeLessThan(n);
+        }
+    });
 });

--- a/tests/globeTileManager.unit.spec.ts
+++ b/tests/globeTileManager.unit.spec.ts
@@ -120,6 +120,7 @@ const syncParams = () => ({
     sseThreshold: 1e9, // 必ず root で受容
     maxTiles: 10,
     rootSearchRadius: 0, // root 1 タイルのみ
+    maxRootTiles: 10,
     horizonDotThreshold: -1, // 地平線カリング無効
     referenceAltitude: 0,
 });


### PR DESCRIPTION
## 概要

`selectGlobeTiles` のルート選定が**注視点(center)中心の固定 ±N 格子**だったため、水平チルト時に**カメラ直下(nadir)の前景**がルート領域外へ出てタイルが生成されず、前景メッシュが欠落していた（#329）。ルート選定を **nadir→center→地平線方向の帯(swath)** へ変更して前景を被覆する。

## 変更点

- **`globeLod.ts`**: 純関数 `selectGlobeRootTiles` を新設。nadir↔center 方向に沿って帯を張り、前景(nadir 側)から前進して `maxRootTiles` 予算で打ち切る（前景優先）。直下視(nadir≒center)では従来どおり nadir 中心の対称ボックスにフォールバック。`maxRootTiles` を `GlobeLodOptions` に追加。
- **`globeTileManager.ts` / `scenes/globe.ts`**: `maxRootTiles` を sync 経路へ配線。既定 `maxRootTiles=96`、`maxTiles` 140→200（地平線側の被覆強化）。
- **テスト**: `globeLod.unit.spec.ts` に swath 系 4 ケース追加（前景被覆 / nadir・center 両含 / 予算上限）。

## 影響範囲

- グローブシーン（`/geospatial`）の LOD タイル選択挙動のみ。既存平面スタックは無変更。
- API: `GlobeLodOptions` / `GlobeTileSyncParams` に `maxRootTiles` を追加（内部型）。

## 検証

- `npm run lint` / `npm run typecheck` パス。
- `npm run test:unit` **1101 passed**（+4 新規）。
- headless(webgl2) 富士山・水平チルト: r60000/tilt86 で `selected 25→116` / `zoom 11–11→11–14`。前景が粗い平坦シートから 3D 起伏付き被覆へ改善を目視確認。

## 既知の残課題（別 issue）

- 高チルト(45°→90°)時の**遠景/地平線側**の被覆不足（`minZoom` フロア＝最粗タイルでも 16km のためタイル予算が地平線まで届かない）は本 PR のスコープ外。#335 に分離。

Closes #329