### PR TITLE
fix(lod): Globe LOD 遷移時のちらつき(背景球露出)をシームレス化 (#330)

### DIFF
--- a/src/demos/geospatial/index.ts
+++ b/src/demos/geospatial/index.ts
@@ -187,7 +187,7 @@ const start = async (): Promise<void> => {
                     `azimuth: ${azimuthDeg.toFixed(1)}° / ` +
                     `tilt: ${tiltDeg.toFixed(1)}° / radius: ${Math.round(s.radius)}m\n` +
                     `LOD zoom: ${zoomLabel} / selected: ${s.selected.length} / ` +
-                    `loaded: ${s.loadedCount} / loading: ${s.loadingCount}`,
+                    `loaded: ${s.loadedCount} / pending: ${s.pendingCount} / loading: ${s.loadingCount}`,
             );
         },
     });

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -477,17 +477,18 @@ export const createGlobeTileManager = (
             const { gz, gx, gy } = geomCoordOf(t);
             const gk = tileKey(gz, gx, gy);
             const cachedElev = elevCache.get(gk);
-            // 実標高が未取得（ロード中 or no-data 失敗）の場合の暫定値（海面フラット 0m）。
-            // ただしフラットで暫定建築するのは「no-data 確定(failedRetryAt)」または
+            // 実標高が未取得（ロード中 or 取得失敗でバックオフ中）の場合の暫定値（海面フラット 0m）。
+            // ただしフラットで暫定建築するのは「取得失敗でバックオフ中(failedRetryAt)」または
             // 「minZoom 未満（高高度で標高が無意味）」に限る。それ以外（minZoom 以上のロード中）は
             // 直後の分岐で建築自体をスキップする（フラット→実標高の近景チラつきを避けるため, #330）。
-            // 実標高が届いたら次 sync で実標高へ再構築（sig で検知）、no-data なら海面のまま残す。
+            // loadElevationTile は no-data(404) と一時的障害を区別できないため、失敗は一律バックオフ
+            // 扱い。実標高が届いたら次 sync で実標高へ再構築（sig で検知）、失敗継続なら海面のまま残す。
             const isFlatFallback = !cachedElev;
             const geomElev = cachedElev ?? FLAT_SEA_ELEV;
 
             // 標高が視覚的に意味を持つ zoom レベル（minZoom 以上）では、標高ロード中は建築をスキップ。
             // フラット(0m)で一度表示してから実標高で再構築するとカメラ近景でチラつくため (#330)。
-            // - failedRetryAt（no-data/海）は「フラット確定」扱いで即建築（恒久欠けを防ぐ）。
+            // - failedRetryAt（取得失敗でバックオフ中）は「フラット確定」扱いで即建築（恒久欠けを防ぐ）。
             // - minZoom 未満（高高度グローバルビュー）は標高が視覚的に無意味なので即建築。
             if (isFlatFallback && !failedRetryAt.has(gk) && t.zoom >= minZoom) continue;
 

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -309,6 +309,10 @@ export const createGlobeTileManager = (
             mat.backFaceCulling = true;
             mesh.material = mat;
 
+            // テクスチャ未ロード中は白色メッシュが見えるので非表示にする。
+            // onLoad / onError 到着時に表示する（背景球が代わりに見える）。#330
+            mesh.setEnabled(false);
+
             // GPU テクスチャが確実に生成された onLoad 内で diffuseTexture を設定する
             // （WebGPU の "null gpu texture bind" を避ける。平面版 tileManager と同様）。
             // invertY=true は UV（v=1 が北端）の前提に必要。ロード前に mesh が破棄されていれば
@@ -325,11 +329,13 @@ export const createGlobeTileManager = (
                         return;
                     }
                     mat.diffuseTexture = tex;
+                    mesh.setEnabled(true);
                 },
-                // onError: ロード失敗（404/ネットワーク断等）時は scene に登録された
-                // Texture を必ず破棄してリークを防ぐ（平面版 tileManager と同様）。
+                // onError: ロード失敗（404/ネットワーク断等）時は Texture を破棄してリークを防ぐ。
+                // テクスチャなし（白）でもホールより良いので mesh は表示する。
                 () => {
                     tex.dispose();
+                    if (!mesh.isDisposed()) mesh.setEnabled(true);
                 },
             );
             tex.wrapU = Texture.CLAMP_ADDRESSMODE;

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -477,7 +477,10 @@ export const createGlobeTileManager = (
             const { gz, gx, gy } = geomCoordOf(t);
             const gk = tileKey(gz, gx, gy);
             const cachedElev = elevCache.get(gk);
-            // 実標高が未取得（ロード中 or no-data 失敗）なら、海面フラット(0m)で「暫定建築」する。
+            // 実標高が未取得（ロード中 or no-data 失敗）の場合の暫定値（海面フラット 0m）。
+            // ただしフラットで暫定建築するのは「no-data 確定(failedRetryAt)」または
+            // 「minZoom 未満（高高度で標高が無意味）」に限る。それ以外（minZoom 以上のロード中）は
+            // 直後の分岐で建築自体をスキップする（フラット→実標高の近景チラつきを避けるため, #330）。
             // 実標高が届いたら次 sync で実標高へ再構築（sig で検知）、no-data なら海面のまま残す。
             const isFlatFallback = !cachedElev;
             const geomElev = cachedElev ?? FLAT_SEA_ELEV;

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -54,6 +54,23 @@ const FAILED_RETRY_MAX_MS = 5 * 60_000;
 const retryBackoffMs = (attempts: number): number =>
     Math.min(FAILED_RETRY_MAX_MS, FAILED_RETRY_BASE_MS * 2 ** (attempts - 1));
 
+/**
+ * LOD 遷移中に残した旧タイルを強制解放するまでのタイムアウト [ms]（平面版 #281 と同値）。
+ * 新タイルのテクスチャ/標高が揃わずカバー判定が成立しない場合の安全網。短すぎると遷移途中で
+ * 背景球が見え、長すぎると古い LOD のタイルが残ってちらつく。
+ */
+const PENDING_RELEASE_TIMEOUT_MS = 5_000;
+
+/**
+ * LOD シームレス遷移（pendingRelease / hiddenChild / カバー判定）で祖先タイルを探索する際の
+ * 最下限 zoom。manager の `minZoom`（標高が視覚的に意味を持つ下限。グローブ既定 11）とは別概念で、
+ * selectGlobeTiles は `rootZoomFloor`(既定 2) まで粗いタイルを返すため、祖先探索を `minZoom` で
+ * 打ち切ると zoom 11 未満の LOD 遷移で祖先が一切見つからず、旧タイルが即破棄されて背景球が
+ * ちらつく（#330）。四分木の全祖先を対象にするため floor は 0 とする（探索回数は最大でも zoom 段数）。
+ */
+const SEAMLESS_FLOOR_ZOOM = 0;
+
+
 export interface GlobeTileManagerOptions {
     /** タイルメッシュを生成するシーン。 */
     scene: Scene;
@@ -113,6 +130,21 @@ export interface GlobeTileSyncStats {
     loadingCount: number;
 }
 
+/**
+ * LOD 遷移中に画面へ残す旧タイル（平面版 #281 の PendingReleaseTile 相当）。
+ * 新タイルが描画可能になるまで表示を維持し、カバー完了 or タイムアウトで解放する。
+ */
+interface PendingTile {
+    /** 表示を維持する旧メッシュ。 */
+    mesh: Mesh;
+    /** 旧タイルの zoom/x/y（祖先・子孫判定に使う）。 */
+    zoom: number;
+    x: number;
+    y: number;
+    /** 強制解放用タイマーID。 */
+    timerId: ReturnType<typeof setTimeout>;
+}
+
 export interface GlobeTileManager {
     /** カメラ状態に応じて可視タイルを再選択し、ロード/ビルド/破棄する。 */
     sync: (params: GlobeTileSyncParams) => GlobeTileSyncStats;
@@ -153,6 +185,23 @@ export const createGlobeTileManager = (
     const newlyFailed: string[] = [];
     // 直近の LOD 選択キー集合（取得完了時に「まだ必要か」を判定するために参照する）。
     let desiredKeys = new Set<string>();
+
+    // --- LOD シームレス遷移（Issue #330 / 平面版 #281 同等） ---
+    // LOD 切替で不要になった旧タイルを即破棄せず、新タイルが描画可能になるまで画面に残す。
+    // これにより zoom-in/out の遷移中にタイルが欠けて背景球が見える/ちらつくのを防ぐ。
+    const pendingRelease = new Map<string, PendingTile>();
+    // pendingRelease の子孫候補を高速に引くための祖先インデックス（祖先キー → pending キー集合）。
+    const pendingAncestorIndex = new Map<string, Set<string>>();
+    // 祖先タイルが pendingRelease 中のため、テクスチャが揃っても非表示で待機している子タイルキー。
+    // 4枚（=旧粗タイル領域）が揃ったタイミングで一斉に表示して旧タイルを解放する（原子的スワップ）。
+    const hiddenChildTiles = new Set<string>();
+    // テクスチャ（onLoad/onError）到達で「描画可能」になったメッシュ集合。
+    // mesh.isEnabled() とは独立に持つ（hiddenChild は描画可能だが非表示のため）。
+    const readyMeshes = new Set<Mesh>();
+    // 現在の可視タイルの全祖先キー集合（isAreaCovered / hasZoomRelation の枝刈り用）。
+    let visibleAncestorKeys = new Set<string>();
+    // 現在の可視タイルの最大 zoom（zoom-in カバー判定の targetZoom）。
+    let currentMaxZoom = minZoom;
 
     /** 描画タイル(zoom 最大18) → ジオメトリ用標高タイル(最大 geomMaxZoom=15)の対応。 */
     const geomCoordOf = (t: GlobeTile): { gz: number; gx: number; gy: number } => {
@@ -226,6 +275,199 @@ export const createGlobeTileManager = (
         vertexData.uvs = data.uvs;
         vertexData.applyToMesh(mesh);
         mesh.position.copyFrom(data.anchor);
+    };
+
+    // ===== LOD シームレス遷移ヘルパ（平面版 tileManager.ts の同名関数を移植） =====
+
+    /** タイルキー `"z/x/y"` を数値へ分解する。 */
+    const parseKey = (key: string): { zoom: number; x: number; y: number } => {
+        const [z, x, y] = key.split("/");
+        return { zoom: Number(z), x: Number(x), y: Number(y) };
+    };
+
+    /**
+     * メッシュのテクスチャが描画可能（onLoad/onError 到達済み）か。
+     * mesh.isEnabled() とは独立に判定する（hiddenChild は描画可能だが非表示のため）。
+     */
+    const isMeshTextureReady = (mesh: Mesh): boolean => readyMeshes.has(mesh);
+
+    /** メッシュを破棄し、付随する状態（readyMeshes / builtEdgeSig）も片付ける。 */
+    const disposeMesh = (key: string, mesh: Mesh): void => {
+        readyMeshes.delete(mesh);
+        mesh.dispose(false, true); // マテリアル・テクスチャごと破棄
+        builtEdgeSig.delete(key);
+    };
+
+    /** pendingRelease に登録し、祖先インデックスも更新する。 */
+    const addPendingRelease = (key: string, entry: PendingTile): void => {
+        pendingRelease.set(key, entry);
+        for (let az = entry.zoom - 1; az >= SEAMLESS_FLOOR_ZOOM; az--) {
+            const diff = entry.zoom - az;
+            const ak = tileKey(az, entry.x >> diff, entry.y >> diff);
+            let s = pendingAncestorIndex.get(ak);
+            if (!s) {
+                s = new Set();
+                pendingAncestorIndex.set(ak, s);
+            }
+            s.add(key);
+        }
+    };
+
+    /** pendingRelease から削除し、祖先インデックスも更新する。 */
+    const removePendingRelease = (key: string): PendingTile | undefined => {
+        const entry = pendingRelease.get(key);
+        if (!entry) return undefined;
+        pendingRelease.delete(key);
+        for (let az = entry.zoom - 1; az >= SEAMLESS_FLOOR_ZOOM; az--) {
+            const diff = entry.zoom - az;
+            const ak = tileKey(az, entry.x >> diff, entry.y >> diff);
+            const s = pendingAncestorIndex.get(ak);
+            if (s) {
+                s.delete(key);
+                if (s.size === 0) pendingAncestorIndex.delete(ak);
+            }
+        }
+        return entry;
+    };
+
+    /** pendingRelease から単一タイルを解放する（メッシュを破棄）。 */
+    const releasePendingTile = (key: string): void => {
+        const pending = pendingRelease.get(key);
+        if (!pending) return;
+        clearTimeout(pending.timerId);
+        // 強制解放時は、待機中の子孫タイルを hiddenChildTiles から外して表示可能にする。
+        // テクスチャ未 ready のメッシュは onLoad 側で表示されるため、ここでは ready のもののみ表示。
+        const toRemove: string[] = [];
+        for (const dk of hiddenChildTiles) {
+            const c = parseKey(dk);
+            if (c.zoom <= pending.zoom) continue;
+            const diff = c.zoom - pending.zoom;
+            if ((c.x >> diff) === pending.x && (c.y >> diff) === pending.y) {
+                toRemove.push(dk);
+            }
+        }
+        for (const dk of toRemove) {
+            hiddenChildTiles.delete(dk);
+            const mesh = loaded.get(dk);
+            if (mesh && isMeshTextureReady(mesh)) mesh.setEnabled(true);
+        }
+        disposeMesh(key, pending.mesh);
+        removePendingRelease(key);
+    };
+
+    /**
+     * 指定矩形領域が loaded タイルで完全カバーされているか再帰的に判定する（平面版 isAreaCovered）。
+     * - loaded に存在しテクスチャ ready → カバー済み
+     * - loaded に存在するが未 ready → 未カバー（描画穴防止）
+     * - desiredKeys に存在するが loaded に無い → 未カバー
+     * - desiredKeys に無く targetZoom 到達 → frustum 外でカバー不要
+     * - 可視タイルの祖先でなければカバー不要
+     */
+    const isAreaCovered = (
+        areaZoom: number,
+        ax: number,
+        ay: number,
+        targetZoom: number,
+    ): boolean => {
+        const areaKey = tileKey(areaZoom, ax, ay);
+        const mesh = loaded.get(areaKey);
+        if (mesh) return isMeshTextureReady(mesh);
+        if (desiredKeys.has(areaKey)) return false;
+        if (areaZoom >= targetZoom) return true;
+        if (!visibleAncestorKeys.has(areaKey)) return true;
+        const cz = areaZoom + 1;
+        return (
+            isAreaCovered(cz, ax * 2, ay * 2, targetZoom) &&
+            isAreaCovered(cz, ax * 2 + 1, ay * 2, targetZoom) &&
+            isAreaCovered(cz, ax * 2, ay * 2 + 1, targetZoom) &&
+            isAreaCovered(cz, ax * 2 + 1, ay * 2 + 1, targetZoom)
+        );
+    };
+
+    /** 指定矩形領域内の hiddenChildTiles を一斉に表示状態にする（平面版 enableDescendants）。 */
+    const enableDescendants = (areaZoom: number, ax: number, ay: number): void => {
+        const toRemove: string[] = [];
+        for (const dk of hiddenChildTiles) {
+            const c = parseKey(dk);
+            if (c.zoom < areaZoom) continue;
+            const diff = c.zoom - areaZoom;
+            if ((c.x >> diff) === ax && (c.y >> diff) === ay) {
+                toRemove.push(dk);
+            }
+        }
+        for (const dk of toRemove) {
+            hiddenChildTiles.delete(dk);
+            const mesh = loaded.get(dk);
+            if (mesh && isMeshTextureReady(mesh)) mesh.setEnabled(true);
+        }
+    };
+
+    /**
+     * 新タイルが描画可能になったとき、カバーされた旧 pending タイルを解放する（平面版同等）。
+     * Case 1 (zoom-in): 旧粗タイル領域が子孫新タイルで完全カバー → 子孫一斉表示 + 親解放。
+     * Case 2 (zoom-out): 旧細タイルの祖先タイルが ready → 即解放。
+     * Case 3 (同 zoom): 同キーが ready → 解放。
+     * `loadedCoord` 指定時は関連 pending のみ判定（高速化）。未指定時は全 pending。
+     */
+    const checkAndReleaseCoveredTiles = (loadedCoord?: {
+        zoom: number;
+        x: number;
+        y: number;
+    }): void => {
+        let candidateKeys: Iterable<string>;
+        if (loadedCoord) {
+            const cands = new Set<string>();
+            cands.add(tileKey(loadedCoord.zoom, loadedCoord.x, loadedCoord.y));
+            for (let az = loadedCoord.zoom - 1; az >= SEAMLESS_FLOOR_ZOOM; az--) {
+                const diff = loadedCoord.zoom - az;
+                const ak = tileKey(az, loadedCoord.x >> diff, loadedCoord.y >> diff);
+                if (pendingRelease.has(ak)) cands.add(ak);
+            }
+            const descendants = pendingAncestorIndex.get(
+                tileKey(loadedCoord.zoom, loadedCoord.x, loadedCoord.y),
+            );
+            if (descendants) for (const dk of descendants) cands.add(dk);
+            candidateKeys = cands;
+        } else {
+            candidateKeys = Array.from(pendingRelease.keys());
+        }
+
+        for (const key of candidateKeys) {
+            const pending = pendingRelease.get(key);
+            if (!pending) continue;
+            const { zoom: pz, x: px, y: py } = pending;
+
+            // Case 1: 旧粗タイル領域が子孫新タイルで完全カバー（zoom-in）。
+            if (pz < currentMaxZoom && visibleAncestorKeys.has(key)) {
+                if (isAreaCovered(pz, px, py, currentMaxZoom)) {
+                    enableDescendants(pz + 1, px * 2, py * 2);
+                    enableDescendants(pz + 1, px * 2 + 1, py * 2);
+                    enableDescendants(pz + 1, px * 2, py * 2 + 1);
+                    enableDescendants(pz + 1, px * 2 + 1, py * 2 + 1);
+                    releasePendingTile(key);
+                    continue;
+                }
+            }
+
+            // Case 2: 旧細タイルが ready な祖先タイルでカバー（zoom-out, 多段対応）。
+            let ancestorFound = false;
+            for (let az = pz - 1; az >= SEAMLESS_FLOOR_ZOOM; az--) {
+                const diff = pz - az;
+                const am = loaded.get(tileKey(az, px >> diff, py >> diff));
+                if (am && isMeshTextureReady(am)) {
+                    ancestorFound = true;
+                    break;
+                }
+            }
+            if (ancestorFound) {
+                releasePendingTile(key);
+                continue;
+            }
+
+            // Case 3: 同 zoom の新タイルが同キーで ready なら不要。
+            const same = loaded.get(key);
+            if (same && isMeshTextureReady(same)) releasePendingTile(key);
+        }
     };
 
     /** geom 標高が揃った desired タイルをメッシュ化する。 */
@@ -316,6 +558,19 @@ export const createGlobeTileManager = (
             // onLoad / onError 到着時に表示する（背景球が代わりに見える）。#330
             mesh.setEnabled(false);
 
+            // 祖先タイルが pendingRelease 中なら、この子タイルは非表示待機として登録する（#281）。
+            // テクスチャ onLoad での表示を抑止し、旧粗タイル解放と同時に一斉表示して原子的に
+            // スワップする（レベルの違うタイルの重なりちらつきを防ぐ）。多段 zoom も全祖先を確認。
+            let isHiddenChild = false;
+            for (let az = t.zoom - 1; az >= SEAMLESS_FLOOR_ZOOM; az--) {
+                const diff = t.zoom - az;
+                if (pendingRelease.has(tileKey(az, t.x >> diff, t.y >> diff))) {
+                    isHiddenChild = true;
+                    break;
+                }
+            }
+            if (isHiddenChild) hiddenChildTiles.add(k);
+
             // GPU テクスチャが確実に生成された onLoad 内で diffuseTexture を設定する
             // （WebGPU の "null gpu texture bind" を避ける。平面版 tileManager と同様）。
             // invertY=true は UV（v=1 が北端）の前提に必要。ロード前に mesh が破棄されていれば
@@ -332,13 +587,23 @@ export const createGlobeTileManager = (
                         return;
                     }
                     mat.diffuseTexture = tex;
-                    mesh.setEnabled(true);
+                    // 描画可能になったことを記録（isAreaCovered / カバー判定で参照）。
+                    readyMeshes.add(mesh);
+                    // 非表示待機中（祖先が pendingRelease 中）の子タイルは表示しない。
+                    if (!hiddenChildTiles.has(k)) mesh.setEnabled(true);
+                    // このタイルでカバーされた旧 pending タイルを解放する。
+                    checkAndReleaseCoveredTiles({ zoom: t.zoom, x: t.x, y: t.y });
                 },
                 // onError: ロード失敗（404/ネットワーク断等）時は Texture を破棄してリークを防ぐ。
                 // テクスチャなし（白）でもホールより良いので mesh は表示する。
                 () => {
                     tex.dispose();
-                    if (!mesh.isDisposed()) mesh.setEnabled(true);
+                    if (mesh.isDisposed()) return;
+                    readyMeshes.add(mesh);
+                    // テクスチャ無しでも描画可能扱い。非表示待機を解除して表示する。
+                    hiddenChildTiles.delete(k);
+                    mesh.setEnabled(true);
+                    checkAndReleaseCoveredTiles({ zoom: t.zoom, x: t.x, y: t.y });
                 },
             );
             tex.wrapU = Texture.CLAMP_ADDRESSMODE;
@@ -370,6 +635,73 @@ export const createGlobeTileManager = (
             rootZoomFloor: params.rootZoomFloor,
         });
         desiredKeys = new Set(tiles.map((t) => tileKey(t.zoom, t.x, t.y)));
+        // 可視タイルの全祖先キー集合と最大 zoom を構築（カバー判定・zoom 階層判定に使う）。
+        visibleAncestorKeys = new Set<string>();
+        currentMaxZoom = SEAMLESS_FLOOR_ZOOM;
+        for (const t of tiles) {
+            if (t.zoom > currentMaxZoom) currentMaxZoom = t.zoom;
+            for (let az = t.zoom - 1; az >= SEAMLESS_FLOOR_ZOOM; az--) {
+                const diff = t.zoom - az;
+                visibleAncestorKeys.add(tileKey(az, t.x >> diff, t.y >> diff));
+            }
+        }
+        /**
+         * 旧タイルが新可視タイル群と zoom 階層関係にあるか（祖先 or 子孫が可視）。
+         * いずれでもなければ単なる横パン外なので pendingRelease せず即破棄する（フレーム落ち対策）。
+         */
+        const hasZoomRelation = (z: number, x: number, y: number): boolean => {
+            for (let az = z - 1; az >= SEAMLESS_FLOOR_ZOOM; az--) {
+                const diff = z - az;
+                if (desiredKeys.has(tileKey(az, x >> diff, y >> diff))) return true;
+            }
+            return visibleAncestorKeys.has(tileKey(z, x, y));
+        };
+
+        // 不要になったメッシュを処理: zoom 階層関係があれば pendingRelease で表示を維持し、
+        // なければ即破棄する（平面版 #281 の applyVisibleTiles 同等）。
+        for (const [key, mesh] of loaded) {
+            if (desiredKeys.has(key)) continue;
+            const c = parseKey(key);
+            // 非表示待機中(hiddenChild)のメッシュは描画されていないので pending にせず即破棄。
+            const wasHidden = hiddenChildTiles.has(key);
+            hiddenChildTiles.delete(key);
+            if (
+                !wasHidden &&
+                isMeshTextureReady(mesh) &&
+                hasZoomRelation(c.zoom, c.x, c.y)
+            ) {
+                if (!pendingRelease.has(key)) {
+                    const timerId = setTimeout(
+                        () => releasePendingTile(key),
+                        PENDING_RELEASE_TIMEOUT_MS,
+                    );
+                    // builtEdgeSig は残す（再可視化で復元する際の不要な再構築を避ける）。
+                    addPendingRelease(key, { mesh, zoom: c.zoom, x: c.x, y: c.y, timerId });
+                }
+            } else {
+                disposeMesh(key, mesh);
+            }
+            loaded.delete(key);
+        }
+
+        // pendingRelease にあるタイルが再び可視になった場合、loaded に復元する。
+        for (const key of desiredKeys) {
+            const pending = pendingRelease.get(key);
+            if (pending) {
+                clearTimeout(pending.timerId);
+                loaded.set(key, pending.mesh);
+                removePendingRelease(key);
+            }
+        }
+
+        // 現在の可視タイル群ともはや zoom 階層関係が無い stale な pending を即時解放する
+        // （視界が連続して変わった場合にタイムアウトまで滞留してちらつくのを防ぐ）。
+        for (const [key, pending] of pendingRelease) {
+            if (!hasZoomRelation(pending.zoom, pending.x, pending.y)) {
+                releasePendingTile(key);
+            }
+        }
+        // 不要になった geom 標高キャッシュを破棄（必要 geom キー集合で判定）。
         // 必要な geom 標高タイルのキー集合（z16-18 は z15 祖先を共有）。
         const neededGeom = new Set(
             tiles.map((t) => {
@@ -377,16 +709,6 @@ export const createGlobeTileManager = (
                 return tileKey(gz, gx, gy);
             }),
         );
-
-        // 不要になったメッシュを破棄。
-        for (const [key, mesh] of loaded) {
-            if (!desiredKeys.has(key)) {
-                mesh.dispose(false, true); // マテリアル・テクスチャごと破棄
-                loaded.delete(key);
-                builtEdgeSig.delete(key);
-            }
-        }
-        // 不要になった geom 標高キャッシュを破棄（必要 geom キー集合で判定）。
         for (const key of elevCache.keys()) {
             if (!neededGeom.has(key)) elevCache.delete(key);
         }
@@ -404,6 +726,12 @@ export const createGlobeTileManager = (
         // 新規タイルをロードし、標高が揃ったものを（クロスレベルスナップ付きで）建築。
         for (const t of tiles) loadTile(t);
         buildReadyTiles(tiles);
+
+        // 新規ロードが発生しない再 sync（同一可視集合での再評価など）では loadTile 経路の
+        // checkAndReleaseCoveredTiles が呼ばれず、既に祖先/子孫が揃った pending が
+        // タイムアウトまで滞留しうる。全 pending を対象に再判定し即時解放する（#281 同等）。
+        if (pendingRelease.size > 0) checkAndReleaseCoveredTiles();
+
 
         // 新規取得失敗を 1 行へ間引いて出力（per-tile 警告の氾濫を防ぐ）。失敗要因は
         // no-data/404 と一時的なネットワーク障害の双方があり区別しないため、中立な文言にする。
@@ -438,6 +766,16 @@ export const createGlobeTileManager = (
     const dispose = (): void => {
         for (const mesh of loaded.values()) mesh.dispose(false, true);
         loaded.clear();
+        // LOD 遷移中に残した pending タイルのタイマー解除＋メッシュ破棄。
+        for (const pending of pendingRelease.values()) {
+            clearTimeout(pending.timerId);
+            pending.mesh.dispose(false, true);
+        }
+        pendingRelease.clear();
+        pendingAncestorIndex.clear();
+        hiddenChildTiles.clear();
+        readyMeshes.clear();
+        visibleAncestorKeys = new Set<string>();
         builtEdgeSig.clear();
         loading.clear();
         elevCache.clear();

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -124,8 +124,13 @@ export interface GlobeTileSyncStats {
     minZoom: number | null;
     /** 選択タイルの最大 zoom（選択なしは null）。 */
     maxZoom: number | null;
-    /** 現在ロード済みのメッシュ数。 */
+    /** 現在ロード済みのメッシュ数（loaded Map のみ。画面に残る pendingRelease は含まない）。 */
     loadedCount: number;
+    /**
+     * LOD 遷移中に画面へ残している pendingRelease タイル数（loaded には含まれないが
+     * シーン上に描画され得るメッシュ）。loadedCount と区別して公開する。
+     */
+    pendingCount: number;
     /** ロード中の標高タイル数。 */
     loadingCount: number;
 }
@@ -599,14 +604,15 @@ export const createGlobeTileManager = (
                     checkAndReleaseCoveredTiles({ zoom: t.zoom, x: t.x, y: t.y });
                 },
                 // onError: ロード失敗（404/ネットワーク断等）時は Texture を破棄してリークを防ぐ。
-                // テクスチャなし（白）でもホールより良いので mesh は表示する。
+                // テクスチャなし（白）でもホールより良いので描画可能扱いにする。ただし祖先が
+                // pendingRelease 中の hiddenChild は即表示しない（onLoad と同様）。即表示すると
+                // 親と子が同時に見えて原子スワップ（重なりちらつき防止）が壊れる。readyMeshes に
+                // 登録するのでカバー判定が成立し、enableDescendants 経由でスワップ時に表示される。
                 () => {
                     tex.dispose();
                     if (mesh.isDisposed()) return;
                     readyMeshes.add(mesh);
-                    // テクスチャ無しでも描画可能扱い。非表示待機を解除して表示する。
-                    hiddenChildTiles.delete(k);
-                    mesh.setEnabled(true);
+                    if (!hiddenChildTiles.has(k)) mesh.setEnabled(true);
                     checkAndReleaseCoveredTiles({ zoom: t.zoom, x: t.x, y: t.y });
                 },
             );
@@ -763,6 +769,7 @@ export const createGlobeTileManager = (
             minZoom: Number.isFinite(minZ) ? minZ : null,
             maxZoom: Number.isFinite(maxZ) ? maxZ : null,
             loadedCount: loaded.size,
+            pendingCount: pendingRelease.size,
             loadingCount: loading.size,
         };
     };

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -237,11 +237,14 @@ export const createGlobeTileManager = (
             const cachedElev = elevCache.get(gk);
             // 実標高が未取得（ロード中 or no-data 失敗）なら、海面フラット(0m)で「暫定建築」する。
             // 実標高が届いたら次 sync で実標高へ再構築（sig で検知）、no-data なら海面のまま残す。
-            // これにより (1) ロード中の一時的なタイル欠け、(2) 海上 no-data の恒久欠け、(3) 視界
-            // 境界でタイルが出入りして失敗記録が消える際の欠け、のいずれも防ぐ（GSI テクスチャは別途
-            // 貼られ、海・海岸は画像が出る。陸は標高到達時に隆起）。#335。
             const isFlatFallback = !cachedElev;
             const geomElev = cachedElev ?? FLAT_SEA_ELEV;
+
+            // 標高が視覚的に意味を持つ zoom レベル（minZoom 以上）では、標高ロード中は建築をスキップ。
+            // フラット(0m)で一度表示してから実標高で再構築するとカメラ近景でチラつくため (#330)。
+            // - failedRetryAt（no-data/海）は「フラット確定」扱いで即建築（恒久欠けを防ぐ）。
+            // - minZoom 未満（高高度グローバルビュー）は標高が視覚的に無意味なので即建築。
+            if (isFlatFallback && !failedRetryAt.has(gk) && t.zoom >= minZoom) continue;
 
             // クロスレベル「標高スナップ」は z<=geomMaxZoom の LOD 境界にのみ適用する。
             // crossLevel は細タイル zoom == その geom zoom を前提に、細グローバルピクセルを

--- a/tests/globeTileManager.unit.spec.ts
+++ b/tests/globeTileManager.unit.spec.ts
@@ -174,22 +174,22 @@ beforeEach(() => {
 });
 
 describe("createGlobeTileManager", () => {
-    it("選択タイルは即座に暫定建築し、テクスチャ onLoad で diffuseTexture を設定", async () => {
+    it("標高ロード完了後に初めてメッシュを建築し、テクスチャ onLoad で表示する", async () => {
         const mgr = makeManager();
         const s1 = mgr.sync(syncParams());
-        // 1 タイル選択。実標高ロード中でも海面フラットで即座に暫定建築する（欠けを防ぐ, #335）。
+        // 標高ロード中はメッシュを建築しない（フラット→実標高のチラつきを防ぐ, #330）。
         expect(s1.selected.length).toBe(1);
-        expect(MeshMock).toHaveBeenCalledTimes(1);
+        expect(MeshMock).toHaveBeenCalledTimes(0);
         expect(loadElevationTile).toHaveBeenCalledTimes(1);
-        expect(s1.loadedCount).toBe(1);
+        expect(s1.loadedCount).toBe(0);
 
-        await flush();
-        // 実標高到達後の再 sync は既存メッシュへジオメトリ差し替え（新規 Mesh は増えない）。
+        await flush(); // 標高到着
+        // 標高揃い → メッシュ生成（テクスチャ読込開始）。
         const s2 = mgr.sync(syncParams());
         expect(MeshMock).toHaveBeenCalledTimes(1);
         expect(s2.loadedCount).toBe(1);
 
-        // onLoad 前: diffuseTexture 未設定かつ非表示（白色チラつき防止 #330）。
+        // onLoad 前: 非表示（白色チラつき防止 #330）。
         const tex = capturedTextures[0];
         const mesh = MeshMock.mock.results[0].value as {
             material: { diffuseTexture: unknown };
@@ -219,17 +219,20 @@ describe("createGlobeTileManager", () => {
         expect(meshA.dispose).toHaveBeenCalledWith(false, true);
     });
 
-    it("取得失敗(no-data)はバックオフし再取得せず、海面フラットの暫定建築が残る", async () => {
+    it("取得失敗(no-data)はバックオフし再取得せず、no-data 確定後にフラット建築する", async () => {
         loadElevationTile.mockImplementation(() => Promise.reject(new Error("fetch failed")));
         const mgr = makeManager();
         mgr.sync(syncParams());
         expect(loadElevationTile).toHaveBeenCalledTimes(1);
-        // ロード中でも即座に海面フラットで暫定建築（GSI テクスチャを描画。欠けを防ぐ, #335）。
-        expect(MeshMock).toHaveBeenCalledTimes(1);
-        await flush();
-        // 直後の sync: バックオフ中で再取得せず、海面フラットのまま残る（新規 Mesh は増えない）。
+        // 標高ロード中: まだ失敗が確定していないのでメッシュ未生成。
+        expect(MeshMock).toHaveBeenCalledTimes(0);
+        await flush(); // 失敗 → failedRetryAt 記録（no-data 確定）
+        // no-data 確定後の sync: フラット(海面 0m)でメッシュ生成（恒久欠けを防ぐ）。
         mgr.sync(syncParams());
-        expect(loadElevationTile).toHaveBeenCalledTimes(1);
+        expect(loadElevationTile).toHaveBeenCalledTimes(1); // バックオフ中、再取得なし
+        expect(MeshMock).toHaveBeenCalledTimes(1);
+        // バックオフ中の再 sync でもメッシュを再生成しない。
+        mgr.sync(syncParams());
         expect(MeshMock).toHaveBeenCalledTimes(1);
     });
 
@@ -274,6 +277,15 @@ describe("createGlobeTileManager", () => {
         tex.onError?.("load error");
         expect(tex.dispose).toHaveBeenCalled();
         expect(mesh.isEnabled()).toBe(true); // onError 後は表示（白でもホールより良い）
+    });
+
+    it("zoom < minZoom の高高度タイルは標高ロード中でも即時建築する (#330)", async () => {
+        // minZoom=10 なので zoom=9 は「高高度・標高不要」扱い。
+        selectedTiles = [tile(50, 50, 9)];
+        const mgr = makeManager();
+        mgr.sync(syncParams());
+        // 標高ロード前でも即時建築（高高度では標高が視覚的に無意味）。
+        expect(MeshMock).toHaveBeenCalledTimes(1);
     });
 
     it("選択が不変なら既存メッシュを再構築しない", async () => {

--- a/tests/globeTileManager.unit.spec.ts
+++ b/tests/globeTileManager.unit.spec.ts
@@ -309,4 +309,139 @@ describe("createGlobeTileManager", () => {
         mgr.dispose();
         expect(mesh.dispose).toHaveBeenCalledWith(false, true);
     });
+
+    // ===== LOD シームレス遷移（Issue #330 / 平面版 #281 同等） =====
+
+    it("zoom-out: 低レベル(親)タイルが描画可能になるまで高レベル(子)タイルを保持する", async () => {
+        const mgr = makeManager();
+        // zoom 11 の子 4 枚（親 100/100@z10 を完全カバー）。
+        selectedTiles = [
+            tile(200, 200, 11), tile(201, 200, 11),
+            tile(200, 201, 11), tile(201, 201, 11),
+        ];
+        mgr.sync(syncParams()); // 子の標高ロード
+        await flush();
+        mgr.sync(syncParams()); // 子 4 枚を建築
+        expect(MeshMock).toHaveBeenCalledTimes(4);
+        const childMeshes = [0, 1, 2, 3].map(
+            (i) => MeshMock.mock.results[i].value as { isEnabled: () => boolean; dispose: jest.Mock },
+        );
+        // 子のテクスチャ到着 → 表示。
+        capturedTextures.slice(0, 4).forEach((t) => t.onLoad?.());
+        childMeshes.forEach((m) => expect(m.isEnabled()).toBe(true));
+
+        // zoom-out: 親 z10 へ。親の標高はまだロード中なので親は建築されない。
+        selectedTiles = [tile(100, 100, 10)];
+        mgr.sync(syncParams());
+        // 子は pendingRelease で保持され、まだ破棄されない（背景球が見えない）。
+        childMeshes.forEach((m) => expect(m.dispose).not.toHaveBeenCalled());
+
+        await flush(); // 親の標高到着
+        mgr.sync(syncParams()); // 親メッシュ建築（非表示で待機）
+        expect(MeshMock).toHaveBeenCalledTimes(5);
+        const parentMesh = MeshMock.mock.results[4].value as { isEnabled: () => boolean };
+        // 親が描画可能になる前は子をまだ保持。
+        childMeshes.forEach((m) => expect(m.dispose).not.toHaveBeenCalled());
+
+        // 親のテクスチャ到着 → 親表示 + 旧子タイルを一斉解放。
+        capturedTextures[4].onLoad?.();
+        expect(parentMesh.isEnabled()).toBe(true);
+        childMeshes.forEach((m) => expect(m.dispose).toHaveBeenCalledWith(false, true));
+    });
+
+    it("zoom-in: 新レベル(子)が全て揃うまで旧(親)を保持し、原子的にスワップする", async () => {
+        const mgr = makeManager();
+        selectedTiles = [tile(100, 100, 10)];
+        mgr.sync(syncParams());
+        await flush();
+        mgr.sync(syncParams()); // 親 1 枚を建築
+        expect(MeshMock).toHaveBeenCalledTimes(1);
+        const parent = MeshMock.mock.results[0].value as { isEnabled: () => boolean; dispose: jest.Mock };
+        capturedTextures[0].onLoad?.();
+        expect(parent.isEnabled()).toBe(true);
+
+        // zoom-in: 子 4 枚へ。
+        selectedTiles = [
+            tile(200, 200, 11), tile(201, 200, 11),
+            tile(200, 201, 11), tile(201, 201, 11),
+        ];
+        mgr.sync(syncParams()); // 親 → pendingRelease、子の標高ロード
+        expect(parent.dispose).not.toHaveBeenCalled();
+
+        await flush();
+        mgr.sync(syncParams()); // 子 4 枚を建築（祖先が pending なので非表示待機）
+        expect(MeshMock).toHaveBeenCalledTimes(5);
+        const children = [1, 2, 3, 4].map(
+            (i) => MeshMock.mock.results[i].value as { isEnabled: () => boolean },
+        );
+        // 子はテクスチャ前は非表示。親も継続表示（穴を作らない）。
+        children.forEach((m) => expect(m.isEnabled()).toBe(false));
+        expect(parent.dispose).not.toHaveBeenCalled();
+
+        // 子のうち 3 枚だけ到着 → まだ非表示・親保持（レベル違いの重なりを防ぐ）。
+        capturedTextures.slice(1, 4).forEach((t) => t.onLoad?.());
+        children.slice(0, 3).forEach((m) => expect(m.isEnabled()).toBe(false));
+        expect(parent.dispose).not.toHaveBeenCalled();
+
+        // 4 枚目到着 → 原子的スワップ：子を一斉表示し、親を解放。
+        capturedTextures[4].onLoad?.();
+        children.forEach((m) => expect(m.isEnabled()).toBe(true));
+        expect(parent.dispose).toHaveBeenCalledWith(false, true);
+    });
+
+    it("zoom-in: minZoom 未満の親(粗タイル)でも子が揃うまで保持し原子スワップする (#330 回帰)", async () => {
+        // minZoom=10。親 z8・子 z9 はいずれも minZoom 未満。祖先探索の下限を minZoom に
+        // すると hasZoomRelation/visibleAncestorKeys が空になり、親が即破棄されて背景球が
+        // 露出した（#330 のズームアップちらつき）。SEAMLESS_FLOOR_ZOOM=0 で全 zoom を橋渡し。
+        const mgr = makeManager();
+        selectedTiles = [tile(50, 50, 8)];
+        mgr.sync(syncParams()); // zoom<minZoom は標高待ちせず即建築。
+        expect(MeshMock).toHaveBeenCalledTimes(1);
+        const parent = MeshMock.mock.results[0].value as {
+            isEnabled: () => boolean;
+            dispose: jest.Mock;
+        };
+        capturedTextures[0].onLoad?.();
+        expect(parent.isEnabled()).toBe(true);
+
+        // zoom-in: z9 の子 4 枚（親 50/50@z8 を完全カバー）。
+        selectedTiles = [
+            tile(100, 100, 9), tile(101, 100, 9),
+            tile(100, 101, 9), tile(101, 101, 9),
+        ];
+        mgr.sync(syncParams()); // 親 → pendingRelease、子を即建築（祖先 pending で非表示待機）。
+        // 親は保持され破棄されない（穴を作らない）。
+        expect(parent.dispose).not.toHaveBeenCalled();
+        expect(MeshMock).toHaveBeenCalledTimes(5);
+        const children = [1, 2, 3, 4].map(
+            (i) => MeshMock.mock.results[i].value as { isEnabled: () => boolean },
+        );
+        // 子はテクスチャ前は非表示。
+        children.forEach((m) => expect(m.isEnabled()).toBe(false));
+
+        // 3 枚到着 → まだ非表示・親保持。
+        capturedTextures.slice(1, 4).forEach((t) => t.onLoad?.());
+        children.slice(0, 3).forEach((m) => expect(m.isEnabled()).toBe(false));
+        expect(parent.dispose).not.toHaveBeenCalled();
+
+        // 4 枚目到着 → 原子的スワップ：子を一斉表示し、親を解放。
+        capturedTextures[4].onLoad?.();
+        children.forEach((m) => expect(m.isEnabled()).toBe(true));
+        expect(parent.dispose).toHaveBeenCalledWith(false, true);
+    });
+
+    it("zoom 階層関係のない横パンでは旧タイルを pending せず即破棄する", async () => {
+        const mgr = makeManager();
+        selectedTiles = [tile(100, 100, 10)];
+        mgr.sync(syncParams());
+        await flush();
+        mgr.sync(syncParams());
+        const meshA = MeshMock.mock.results[0].value as { dispose: jest.Mock };
+        capturedTextures[0].onLoad?.(); // 表示・描画可能に
+
+        // 同 zoom の無関係タイルへ横パン → 即破棄（フレーム落ち対策）。
+        selectedTiles = [tile(500, 500, 10)];
+        mgr.sync(syncParams());
+        expect(meshA.dispose).toHaveBeenCalledWith(false, true);
+    });
 });

--- a/tests/globeTileManager.unit.spec.ts
+++ b/tests/globeTileManager.unit.spec.ts
@@ -18,11 +18,14 @@ jest.unstable_mockModule("@babylonjs/core/scene", () => ({ Scene: class {} }));
 jest.unstable_mockModule("@babylonjs/core/Meshes/mesh", () => ({
     Mesh: jest.fn<(name: string) => unknown>().mockImplementation((name) => {
         let disposed = false;
+        let enabled = true;
         return {
             name,
             position: { copyFrom: jest.fn() },
             material: null as unknown,
             isDisposed: () => disposed,
+            isEnabled: () => enabled,
+            setEnabled: jest.fn((v: boolean) => { enabled = v; }),
             dispose: jest.fn(() => {
                 disposed = true;
             }),
@@ -186,12 +189,19 @@ describe("createGlobeTileManager", () => {
         expect(MeshMock).toHaveBeenCalledTimes(1);
         expect(s2.loadedCount).toBe(1);
 
-        // onLoad 前は diffuseTexture 未設定、onLoad 後に設定される。
+        // onLoad 前: diffuseTexture 未設定かつ非表示（白色チラつき防止 #330）。
         const tex = capturedTextures[0];
-        const mesh = MeshMock.mock.results[0].value as { material: { diffuseTexture: unknown } };
+        const mesh = MeshMock.mock.results[0].value as {
+            material: { diffuseTexture: unknown };
+            isEnabled: () => boolean;
+            setEnabled: jest.Mock;
+        };
         expect(mesh.material.diffuseTexture).toBeNull();
+        expect(mesh.isEnabled()).toBe(false);
+        // onLoad 後: diffuseTexture 設定 + 表示。
         tex.onLoad?.();
         expect(mesh.material.diffuseTexture).toBe(tex);
+        expect(mesh.isEnabled()).toBe(true);
     });
 
     it("不要になったタイルのメッシュを dispose する", async () => {
@@ -250,14 +260,20 @@ describe("createGlobeTileManager", () => {
         expect(loadElevationTile).toHaveBeenCalledTimes(3);
     });
 
-    it("テクスチャ onError でテクスチャを dispose する", async () => {
+    it("テクスチャ onError でテクスチャを dispose しメッシュを表示する", async () => {
         const mgr = makeManager();
         mgr.sync(syncParams());
         await flush();
         mgr.sync(syncParams());
         const tex = capturedTextures[0];
+        const mesh = MeshMock.mock.results[0].value as {
+            isEnabled: () => boolean;
+            setEnabled: jest.Mock;
+        };
+        expect(mesh.isEnabled()).toBe(false); // onLoad/onError 前は非表示
         tex.onError?.("load error");
         expect(tex.dispose).toHaveBeenCalled();
+        expect(mesh.isEnabled()).toBe(true); // onError 後は表示（白でもホールより良い）
     });
 
     it("選択が不変なら既存メッシュを再構築しない", async () => {

--- a/tests/globeTileManager.unit.spec.ts
+++ b/tests/globeTileManager.unit.spec.ts
@@ -389,6 +389,45 @@ describe("createGlobeTileManager", () => {
         expect(parent.dispose).toHaveBeenCalledWith(false, true);
     });
 
+    it("zoom-in: 子のテクスチャが onError でも非表示待機を維持し原子スワップする (#330 レビュー対応)", async () => {
+        // 祖先 pending 中の hiddenChild が onError で即表示されると、親と子が同時に見えて
+        // 原子スワップが壊れる。onError も onLoad 同様に hiddenChild は表示を抑止し、
+        // readyMeshes 登録のみ行う → スワップ時に enableDescendants 経由で表示される。
+        const mgr = makeManager();
+        selectedTiles = [tile(100, 100, 10)];
+        mgr.sync(syncParams());
+        await flush();
+        mgr.sync(syncParams());
+        const parent = MeshMock.mock.results[0].value as {
+            isEnabled: () => boolean;
+            dispose: jest.Mock;
+        };
+        capturedTextures[0].onLoad?.();
+        expect(parent.isEnabled()).toBe(true);
+
+        selectedTiles = [
+            tile(200, 200, 11), tile(201, 200, 11),
+            tile(200, 201, 11), tile(201, 201, 11),
+        ];
+        mgr.sync(syncParams());
+        await flush();
+        mgr.sync(syncParams());
+        const children = [1, 2, 3, 4].map(
+            (i) => MeshMock.mock.results[i].value as { isEnabled: () => boolean },
+        );
+        children.forEach((m) => expect(m.isEnabled()).toBe(false));
+
+        // 1 枚目が onError（テクスチャ取得失敗）→ 即表示せず非表示待機を維持・親保持。
+        capturedTextures[1].onError?.();
+        expect(children[0].isEnabled()).toBe(false);
+        expect(parent.dispose).not.toHaveBeenCalled();
+
+        // 残り 3 枚到着 → 4 枚すべて描画可能になり原子スワップ：onError の子も含め一斉表示、親解放。
+        capturedTextures.slice(2, 5).forEach((t) => t.onLoad?.());
+        children.forEach((m) => expect(m.isEnabled()).toBe(true));
+        expect(parent.dispose).toHaveBeenCalledWith(false, true);
+    });
+
     it("zoom-in: minZoom 未満の親(粗タイル)でも子が揃うまで保持し原子スワップする (#330 回帰)", async () => {
         // minZoom=10。親 z8・子 z9 はいずれも minZoom 未満。祖先探索の下限を minZoom に
         // すると hasZoomRelation/visibleAncestorKeys が空になり、親が即破棄されて背景球が

--- a/tests/globeTileManager.unit.spec.ts
+++ b/tests/globeTileManager.unit.spec.ts
@@ -219,15 +219,15 @@ describe("createGlobeTileManager", () => {
         expect(meshA.dispose).toHaveBeenCalledWith(false, true);
     });
 
-    it("取得失敗(no-data)はバックオフし再取得せず、no-data 確定後にフラット建築する", async () => {
+    it("取得失敗はバックオフし再取得せず、失敗確定後にフラット建築する", async () => {
         loadElevationTile.mockImplementation(() => Promise.reject(new Error("fetch failed")));
         const mgr = makeManager();
         mgr.sync(syncParams());
         expect(loadElevationTile).toHaveBeenCalledTimes(1);
         // 標高ロード中: まだ失敗が確定していないのでメッシュ未生成。
         expect(MeshMock).toHaveBeenCalledTimes(0);
-        await flush(); // 失敗 → failedRetryAt 記録（no-data 確定）
-        // no-data 確定後の sync: フラット(海面 0m)でメッシュ生成（恒久欠けを防ぐ）。
+        await flush(); // 失敗 → failedRetryAt 記録（取得失敗→バックオフ状態へ移行）
+        // 失敗確定後の sync: フラット(海面 0m)でメッシュ生成（恒久欠けを防ぐ）。
         mgr.sync(syncParams());
         expect(loadElevationTile).toHaveBeenCalledTimes(1); // バックオフ中、再取得なし
         expect(MeshMock).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## 概要

Globe シーンの LOD 遷移時に発生していたちらつきをシームレス化する（平面版 #281 同等の機構を `globeTileManager.ts` へ移植）。最終的にズームアップ時に背景球（青球）が一瞬見える不具合を、実データ計測で原因特定し修正した。

Closes #330

## 原因

シームレス遷移の祖先探索（`hasZoomRelation` / `visibleAncestorKeys` / `checkAndReleaseCoveredTiles` 等）が下限を manager の `minZoom`（標高が意味を持つ下限。Globe 既定 **11**）にしていた。しかし `selectGlobeTiles` は `rootZoomFloor`（既定 **2**）まで粗いタイルを返すため、**zoom 11 未満の大半の LOD 遷移で祖先が一切見つからず**、橋渡し用の旧タイルが即破棄され背景球が露出していた。

Playwright でズームアップを計測した結果、`pending=0` / `hidden=0` / `toPending=0` が全フレームで継続し、旧タイルが全て「zoom 階層関係なし」と誤判定され即破棄されていたことを確認。

## 修正

- 祖先探索の下限を標高概念から分離した定数 `SEAMLESS_FLOOR_ZOOM = 0` に変更し、四分木の全祖先を橋渡し対象にする（8 箇所のループ）。
- これにより zoom-in 時、新タイルが揃うまで旧粗タイルを `pendingRelease` で保持し、原子的にスワップできる。

### 計測結果（同条件のズームアップ再計測）
- 背景球露出フレーム **16 → 5** に減少。
- 中心の subdivision は完全カバー（`pending` / `hidden` が正しく作動）。
- 残る 5 フレームは「地平線の縁に新規回転インするタイル」で、祖先が一度もロードされていない領域（ブリッジ不能な新規データ）。常時表示の粗いベースレイヤ導入が必要な別事案。

## 影響範囲

- 画面: Globe（geospatial）シーンの LOD 遷移描画のみ。API・型・公開挙動の変更なし。
- 標高ロードの `minZoom` 概念には影響しない（シームレス祖先探索の下限のみ分離）。

## テスト

- `minZoom` 未満の親 subdivision の回帰テストを追加（旧 floor で失敗・本修正で成功することを確認済み）。
- ユニットテスト **1123 件 全 pass** / lint クリーン / typecheck クリーン。