### PR TITLE
fix(globe): パン中の seat 鉛直追従を停止しガタつきを解消 (#337)

### DIFF
--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -505,6 +505,12 @@ export class GlobeScene {
             const elev = tileManager.terrainElevAt(g.latDeg, g.lonDeg);
             if (elev === null) return;
             centerElevation = elev; // SSE 距離評価の基準標高（追従の有無に関わらず最新化）
+            // パン操作中（左ドラッグ / WASD）は鉛直追従を停止する（#337）。パンは
+            // panCenterOnSphereToRef で「旧標高の地心距離」を保って水平移動するため、毎フレーム
+            // seat が新地点の地形標高へ一気に引き戻すと離散的な鉛直補正＝画面のガタつきになる
+            // （山岳地帯ほど標高差が大きく顕著）。一定高度のまま滑らかにパンさせ、パン終了後に
+            // seat が滑らかに再着地する。地形衝突（enforceGroundClearance）は安全のため維持。
+            if (dragging || pressed.size > 0) return;
             // カメラの対地クリアランスで追従強度をフェード（FULL 以下で完全追従、ZERO 以上で停止）。
             const clearance = camAltMeters - elev;
             const seatFactor = Math.max(

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -505,12 +505,6 @@ export class GlobeScene {
             const elev = tileManager.terrainElevAt(g.latDeg, g.lonDeg);
             if (elev === null) return;
             centerElevation = elev; // SSE 距離評価の基準標高（追従の有無に関わらず最新化）
-            // パン操作中（左ドラッグ / WASD）は鉛直追従を停止する（#337）。パンは
-            // panCenterOnSphereToRef で「旧標高の地心距離」を保って水平移動するため、毎フレーム
-            // seat が新地点の地形標高へ一気に引き戻すと離散的な鉛直補正＝画面のガタつきになる
-            // （山岳地帯ほど標高差が大きく顕著）。一定高度のまま滑らかにパンさせ、パン終了後に
-            // seat が滑らかに再着地する。地形衝突（enforceGroundClearance）は安全のため維持。
-            if (dragging || pressed.size > 0) return;
             // カメラの対地クリアランスで追従強度をフェード（FULL 以下で完全追従、ZERO 以上で停止）。
             const clearance = camAltMeters - elev;
             const seatFactor = Math.max(

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -588,6 +588,10 @@ export const createGlobeTileManager = (
 
             const mesh = new Mesh(`tile-${k}`, scene);
             applyGeometry(mesh, data);
+            // 前景タイルも非ピッカブルにする（#337）。ピッカブルだと `GeospatialCamera` 内蔵パン
+            // の `scene.pick` がこのメッシュにヒットし、独自パン（scenes/globe.ts の onPointerMove）
+            // と二重にカメラを動かして水平方向にガタつく。基準タイル（base-tile）と挙動を揃える。
+            mesh.isPickable = false;
 
             // 地理院タイル画像を diffuseTexture として適用（同一 z/x/y）。タイルごとに専有し、
             // アンロード時に mesh.dispose(_, true) でテクスチャごと破棄する。

--- a/tests/globeTileManager.unit.spec.ts
+++ b/tests/globeTileManager.unit.spec.ts
@@ -279,6 +279,18 @@ describe("createGlobeTileManager", () => {
         expect(mesh.isEnabled()).toBe(true);
     });
 
+    it("前景タイルを非ピッカブルにする（内蔵パンとの二重操作=ガタつきを防ぐ, #337）", async () => {
+        const mgr = makeManager();
+        mgr.sync(syncParams());
+        await flush(); // 標高到着
+        mgr.sync(syncParams());
+        expect(MeshMock).toHaveBeenCalledTimes(1);
+        const mesh = MeshMock.mock.results[0].value as { isPickable?: boolean };
+        // ピッカブルだと GeospatialCamera 内蔵パンの scene.pick がヒットし、独自パンと二重に
+        // カメラを動かして水平方向にガタつく（#337）。基準タイル同様に非ピッカブルへ固定する。
+        expect(mesh.isPickable).toBe(false);
+    });
+
     it("不要になったタイルのメッシュを dispose する", async () => {
         const mgr = makeManager();
         selectedTiles = [tile(100, 100)];


### PR DESCRIPTION
Closes #337

## 概要
ドラッグ/WASD パン時の画面ガタつき（南北東西に水平方向へずれる）を解消する。

## 根本原因
前景タイルメッシュが pickable のままだったため、`GeospatialCamera` 内蔵パンの `scene.pick` が前景タイルにヒットして内蔵パンが作動し、独自パン（`scenes/globe.ts` onPointerMove）と二重にカメラ center を水平移動させていた。両者の差分が水平方向のガタつきになる。

- 海上でも発生（DEM no-data 時も FLAT_SEA_ELEV で前景タイルが生成され pickable）
- 山岳で顕著（hit point 半径が地形高で変動し内蔵 delta が不安定）
- 宇宙レベルで無し（高高度は非 pickable の base/低zoom タイルのみ → 内蔵 pick 失敗）
- 高度ではなく水平のズレ（内蔵・独自とも接線移動で地心距離を保持）

## 変更
- `src/terrain/geo/globeTileManager.ts`: 前景タイル `mesh.isPickable = false`（base-tile と統一）。
- `src/scenes/globe.ts`: 当初の seat 鉛直追従停止（水平ガタに無関係）を撤回。
- `tests/globeTileManager.unit.spec.ts`: 前景タイルが非 pickable である回帰テストを追加。

## 影響範囲
- 画面: グローブシーンのパン挙動のみ。タイルのピック無効化（既に他用途でピックは使用していない）。
- API/型: 変更なし。

## 検証
- `npm run typecheck` ✅ / `npm run lint` ✅ / `npm run test:unit` ✅（1128）
- 目視確認（HITL）: tilt 0.1°・海上で左ドラッグ→南北東西ガタつき解消を要確認。