### PR TITLE
feat(globe): 標高タイルの穴埋めをグローブ表示に適用 (#339)

### DIFF
--- a/src/terrain/geo/elevSample.ts
+++ b/src/terrain/geo/elevSample.ts
@@ -6,12 +6,12 @@
  * 切り出す（両者が相互参照すると循環依存になるため）。両者が同じ式を使うことで、
  * 粗タイル表面の再構成がメッシュ生成と一致し、LOD 境界の陰影シームを防ぐ。
  */
-import { TILE_SIZE } from "../gsiTile";
+import { TILE_SIZE, isInvalidElev } from "../gsiTile";
 
 /**
  * 標高ラスタ（TILE_SIZE 角）をローカルピクセル座標で bilinear サンプルする。
  *
- * 無効値（NaN/Infinity）は重み計算から除外し、有効な隅だけで重みを正規化して加重平均する
+ * 無効値（NaN/Infinity/NO_DATA_SENTINEL）は重み計算から除外し、有効な隅だけで重みを正規化して加重平均する
  * （平面版 tileManager と同じ方式）。NaN を 0 として混ぜると、4 隅の一部だけ無効な
  * 湖面・欠測境界で結果が 0 側へ強く引っ張られ不自然に沈むため。4 隅すべて無効なら 0 を返す。
  */
@@ -33,7 +33,7 @@ export const sampleElevBilinear = (
     let valSum = 0;
     const addCorner = (x: number, y: number, w: number): void => {
         const v = elev[y * TILE_SIZE + x];
-        if (Number.isFinite(v)) {
+        if (!isInvalidElev(v) && Number.isFinite(v)) {
             wSum += w;
             valSum += w * v;
         }

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -316,7 +316,9 @@ export const createGlobeTileManager = (
                 // - 部分欠測（一部 NaN）: 自タイル内の有効ピクセルから BFS で内部の穴を即補間。
                 // - all-NaN（全面 no-data: 大きな湖など）: 自タイルにシードが無いため即補間できない。
                 //   `allNanGeom` に記録し、隣接の補間結果が揃い次第 `refineAllNaNTiles` で補間する。
-                //   それまでは生 NaN のまま格納し（globeMesh が海面 0m へ倒す＝従来挙動）暫定表示する。
+                //   それまでは生 NaN のまま格納するが、確定前に建築要求が来た場合は `buildReadyTiles`
+                //   が暫定代表標高（粗ズーム祖先 ?? 隣接接線 ?? 直近代表標高）で平坦建築するため、
+                //   0m クレーター（海面）には倒さない（確定後に署名差分で再建築）。
                 if (isAllNaN(elev)) {
                     allNanGeom.add(gk);
                 } else {

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -771,7 +771,7 @@ export const createGlobeTileManager = (
                 const coarse = coarseSeed.get(gk);
                 if (coarse !== undefined) {
                     // (2a) 粗ズーム祖先 DEM の代表標高（湖面標高近似）で平坦化。最優先。
-                    elevCache.set(gk, new Float32Array(TILE_SIZE * TILE_SIZE).fill(coarse));
+                    elevCache.set(gk, flatElevArray(coarse));
                     allNanGeom.delete(gk);
                     dirty.add(gk);
                     lastRepElev = coarse;
@@ -781,7 +781,7 @@ export const createGlobeTileManager = (
                     //      どちらも無い場合のみ生 NaN のまま（build で海面 0m＝外洋として妥当）。
                     const rep = inViewRep ?? lastRepElev;
                     if (rep !== undefined) {
-                        elevCache.set(gk, new Float32Array(TILE_SIZE * TILE_SIZE).fill(rep));
+                        elevCache.set(gk, flatElevArray(rep));
                     }
                     allNanGeom.delete(gk);
                     dirty.add(gk);

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -227,6 +227,7 @@ export const createGlobeTileManager = (
     // 湖岸（陸地）を含むため、その有効ピクセル平均を湖面標高として平坦化に用いる。
     const coarseSeed = new Map<string, number>(); // geomKey → 代表標高[m]
     const coarseSeedPending = new Set<string>(); // 粗ズーム取得中の geomKey
+    const coarseSeedDone = new Set<string>(); // 粗ズーム取得を試行完了した geomKey（成否問わず）
     // 粗ズームタイル取得結果のメモ（coarseKey `z/x/y` → 標高配列 or null）。
     // 同一湖の複数 all-NaN タイルが同じ粗タイルを参照するため取得を重複させない。
     const coarseTileMemo = new Map<string, Promise<Float32Array | null>>();
@@ -549,19 +550,23 @@ export const createGlobeTileManager = (
     /**
      * 元データが all-NaN（全面 no-data）だった geom タイルを穴埋めする（#339, 平面版 #221 相当）。
      *
-     * 大きな湖（本栖湖など）では、対象タイルだけでなく同 zoom 隣接タイルも all-NaN になり、
-     * 同 zoom 縫い合わせだけでは中心タイルにシードが届かず標高が 0m（海面）へ沈む。これを防ぐ:
+     * 大きな湖（本栖湖・諏訪湖など）では、対象タイルだけでなく同 zoom 隣接タイルも all-NaN になり、
+     * さらに LOD により隣接が粗 zoom で描画されると同 zoom 隣接自体が存在せず、同 zoom 縫い合わせ
+     * では中心タイルにシードが届かず標高が 0m（海面）へ沈む。これを防ぐ:
      *
      * 1. 波状反復: 同 zoom 隣接（`stitchTileEdges`）からシードが得られたタイルを `fillInvalidPixels`
      *    で補間し `elevCache` を更新する。解決済みタイルが次の反復で隣接のシード源になり、湖岸から
      *    中心へリング状に補間が前進する。1 sync 内で収束するよう内部反復する。
-     * 2. レスキュー（視界内代表標高）: 反復後も残った all-NaN タイル（周囲も all-NaN で到達不能）で、
-     *    かつ視界内に有効タイルがあれば、その代表標高で平坦化する（#221 Step4 同等）。誤って早期
-     *    平坦化しないよう、隣接が in-flight（`loading`）の間はそのタイルのレスキューを見送る。
-     * 2b. レスキュー（粗ズーム祖先）: 視界が全面水面で有効タイルが一切無い場合（大きな湖を z15 で
-     *    接写する等。本栖湖・諏訪湖で 0m へ沈む事象 #339）、粗ズーム祖先 DEM タイルの有効ピクセル
-     *    平均（＝湖岸・陸地を含むため湖面標高の近似）を非同期取得し、その代表標高で平坦化する。
+     * 2. レスキュー（粗ズーム祖先 DEM）: 反復後も残った all-NaN タイルは、粗ズーム祖先 DEM タイル
+     *    （湖岸＝陸地を含むため湖面標高の近似が得られる）の有効ピクセル平均を非同期取得し、その
+     *    代表標高で平坦化する（#339）。最優先。誤って早期確定しないよう、同 zoom 隣接が in-flight
+     *    （`loading`）の間はそのタイルの確定を見送る。
+     *    - 粗ズーム祖先にも有効標高が無い（真の no-data: 外洋等）場合は、視界内の有効タイルがあれば
+     *      その代表標高で、無ければ海面 0m（外洋として妥当）で確定する。
      * 3. 解決/レスキューしたタイルを共有する建築済み表示タイルの署名を無効化し再建築させる。
+     *
+     * なお、確定前（粗ズーム取得待ち）の all-NaN タイルは `buildReadyTiles` で建築を見送り、生 NaN を
+     * 0m（海面クレーター）として描画しない（解決後に正しい標高で初めて建築する）。
      */
     // 粗ズーム祖先タイルの取得デルタ候補（gz から何段階粗いタイルを試すか）。
     // 大きな湖ほど粗くしないと祖先タイルも全面水面（all-NaN）になるため複数段試す。
@@ -606,6 +611,7 @@ export const createGlobeTileManager = (
                 // 全粗ズームで有効標高無し（真の no-data: 外洋等）。0m(海面)のままが妥当。
             } finally {
                 coarseSeedPending.delete(gk);
+                coarseSeedDone.add(gk);
             }
         })();
     };
@@ -651,47 +657,44 @@ export const createGlobeTileManager = (
 
         // --- Step 2: レスキュー（到達不能な残存 all-NaN タイルを代表標高で平坦化） ---
         if (allNanGeom.size > 0) {
-            // 隣接が in-flight でないタイルのみ確定対象にする（早期平坦化を避ける）。
-            const ready: string[] = [];
-            for (const gk of allNanGeom) {
+            // 粗ズーム取得が真の no-data（外洋等）だった場合のフォールバック用に、視界内の
+            // 有効タイル代表標高（中央ピクセル平均）を一度だけ算出する（#221 同様の近似）。
+            const mid = (TILE_SIZE >> 1) * TILE_SIZE + (TILE_SIZE >> 1);
+            let inViewSum = 0;
+            let inViewCount = 0;
+            for (const [k, data] of elevCache) {
+                if (allNanGeom.has(k)) continue; // 未解決 all-NaN は除外
+                const v = data[mid];
+                if (!isInvalidElev(v)) { inViewSum += v; inViewCount++; }
+            }
+            const inViewRep = inViewCount > 0 ? inViewSum / inViewCount : undefined;
+
+            for (const gk of [...allNanGeom]) {
                 if (!elevCache.has(gk)) continue;
                 const { zoom: gz, x: gx, y: gy } = parseKey(gk);
+                // 同 zoom 隣接が in-flight の間は確定を見送る（揃えば波状反復で解決しうる）。
                 const neighborLoading = allNanNeighborOffsets.some(
                     ([dx, dy]) => loading.has(tileKey(gz, gx + dx, gy + dy)),
                 );
-                if (!neighborLoading) ready.push(gk);
-            }
-            if (ready.length > 0) {
-                // 解決済み（有効）タイルの中央ピクセルから代表標高を求める（#221 同様の近似）。
-                let sum = 0;
-                let count = 0;
-                const mid = (TILE_SIZE >> 1) * TILE_SIZE + (TILE_SIZE >> 1);
-                for (const [k, data] of elevCache) {
-                    if (allNanGeom.has(k)) continue; // 未解決 all-NaN は除外
-                    const v = data[mid];
-                    if (!isInvalidElev(v)) { sum += v; count++; }
-                }
-                if (count > 0) {
-                    // Step 2: 視界内に有効タイルあり → その代表標高で即時平坦化。
-                    const rep = sum / count;
-                    for (const gk of ready) {
-                        elevCache.set(gk, new Float32Array(TILE_SIZE * TILE_SIZE).fill(rep));
-                        allNanGeom.delete(gk);
-                        dirty.add(gk);
+                if (neighborLoading) continue;
+
+                const coarse = coarseSeed.get(gk);
+                if (coarse !== undefined) {
+                    // (2a) 粗ズーム祖先 DEM の代表標高（湖面標高近似）で平坦化。最優先。
+                    elevCache.set(gk, new Float32Array(TILE_SIZE * TILE_SIZE).fill(coarse));
+                    allNanGeom.delete(gk);
+                    dirty.add(gk);
+                } else if (coarseSeedDone.has(gk)) {
+                    // (2b) 粗ズーム祖先にも有効標高無し（真の no-data: 外洋等）。視界内に有効タイルが
+                    //      あればその代表標高で平坦化、無ければ生 NaN のまま（build で海面 0m＝外洋妥当）。
+                    if (inViewRep !== undefined) {
+                        elevCache.set(gk, new Float32Array(TILE_SIZE * TILE_SIZE).fill(inViewRep));
                     }
+                    allNanGeom.delete(gk);
+                    dirty.add(gk);
                 } else {
-                    // Step 2b: 視界が全面水面（有効タイル皆無）→ 粗ズーム祖先 DEM の代表標高で平坦化。
-                    // 取得済みなら即適用、未取得なら非同期取得を起動し次 sync で適用する（#339）。
-                    for (const gk of ready) {
-                        const rep = coarseSeed.get(gk);
-                        if (rep !== undefined) {
-                            elevCache.set(gk, new Float32Array(TILE_SIZE * TILE_SIZE).fill(rep));
-                            allNanGeom.delete(gk);
-                            dirty.add(gk);
-                        } else {
-                            requestCoarseSeed(gk);
-                        }
-                    }
+                    // (2c) 未取得 → 粗ズーム祖先取得を起動し、確定は次 sync へ見送る（build は遅延）。
+                    requestCoarseSeed(gk);
                 }
             }
         }
@@ -725,6 +728,13 @@ export const createGlobeTileManager = (
             // - failedRetryAt（取得失敗でバックオフ中）は「フラット確定」扱いで即建築（恒久欠けを防ぐ）。
             // - minZoom 未満（高高度グローバルビュー）は標高が視覚的に無意味なので即建築。
             if (isFlatFallback && !failedRetryAt.has(gk) && t.zoom >= minZoom) continue;
+
+            // 確定前（粗ズーム祖先 DEM の取得待ち等）の all-NaN タイルは建築を見送る。生 NaN を
+            // そのまま建築すると globeMesh が海面 0m へ倒し「湖中央の沈み込み（クレーター）」に
+            // なるため（本栖湖・諏訪湖 #339）。`refineAllNaNTiles` が代表標高で確定（allNanGeom
+            // から除外）し次第、正しい標高で初めて建築する。高高度（minZoom 未満）は標高が視覚的に
+            // 無意味なので従来どおり即建築する。
+            if (allNanGeom.has(gk) && t.zoom >= minZoom) continue;
 
             // クロスレベル「標高スナップ」は z<=geomMaxZoom の LOD 境界にのみ適用する。
             // crossLevel は細タイル zoom == その geom zoom を前提に、細グローバルピクセルを
@@ -958,6 +968,7 @@ export const createGlobeTileManager = (
                 allNanGeom.delete(key);
                 coarseSeed.delete(key);
                 coarseSeedPending.delete(key);
+                coarseSeedDone.delete(key);
             }
         }
         // 不要になった in-flight ロードを loading から外す。これにより、その後 resolve した
@@ -1108,6 +1119,7 @@ export const createGlobeTileManager = (
         allNanGeom.clear();
         coarseSeed.clear();
         coarseSeedPending.clear();
+        coarseSeedDone.clear();
         coarseTileMemo.clear();
         failedRetryAt.clear();
         newlyFailed.length = 0;

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -720,11 +720,19 @@ export const createGlobeTileManager = (
             }
             const { zoom: gz, x: gx, y: gy } = parseKey(gk);
             const neighbors: StitchNeighbors = {};
+            let hasNeighbor = false;
             for (const [dx, dy, dir] of allNanNeighborOffsets) {
-                const nElev = elevCache.get(tileKey(gz, gx + dx, gy + dy));
-                // 未解決 all-NaN 隣接（全 NaN）はシードにならず `nanMean` で自然に除外される。
-                if (nElev) neighbors[dir] = nElev;
+                const nKey = tileKey(gz, gx + dx, gy + dy);
+                const nElev = elevCache.get(nKey);
+                if (!nElev) continue;
+                neighbors[dir] = nElev;
+                // 未解決 all-NaN 隣接（全 NaN）はシードにならない（stitch では nanMean で
+                // 自然に除外される）ため、コピー要否の判定では有効隣接として数えない。
+                if (!allNanGeom.has(nKey)) hasNeighbor = true;
             }
+            // シード源となる隣接が一つも無ければ stitch しても all-NaN のまま。
+            // 大きな湖で all-NaN タイルが多い場合の無駄な 256x256 コピーを避ける（#339 レビュー指摘）。
+            if (!hasNeighbor) return false;
             const copy = Float32Array.from(target);
             stitchTileEdges(copy, neighbors, TILE_SIZE);
             if (isAllNaN(copy)) return false; // まだシード無し。

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -345,6 +345,61 @@ export const createGlobeTileManager = (
     const flatElevArray = (v: number): Float32Array =>
         new Float32Array(TILE_SIZE * TILE_SIZE).fill(Number.isFinite(v) ? v : 0);
 
+    /** 標高タイルの 1 辺（256px 列/行）の有効ピクセル平均[m]。全 NaN なら undefined。 */
+    const tileEdgeMean = (
+        e: Float32Array,
+        edge: "top" | "bottom" | "left" | "right",
+    ): number | undefined => {
+        let sum = 0;
+        let cnt = 0;
+        for (let i = 0; i < TILE_SIZE; i++) {
+            const idx =
+                edge === "top"
+                    ? i
+                    : edge === "bottom"
+                      ? (TILE_SIZE - 1) * TILE_SIZE + i
+                      : edge === "left"
+                        ? i * TILE_SIZE
+                        : i * TILE_SIZE + (TILE_SIZE - 1);
+            const v = e[idx];
+            if (!isInvalidElev(v)) {
+                sum += v;
+                cnt++;
+            }
+        }
+        return cnt > 0 ? sum / cnt : undefined;
+    };
+
+    /**
+     * geom タイル (gz,gx,gy) が「取得失敗(404)」「全面 no-data」等で実標高を持たない場合に、
+     * 上下左右の隣接タイルの「接する辺」の有効標高平均から代表標高[m] を推定する（#339）。
+     * これにより 0m 平坦（海面）に倒さず、隣接タイルの接線と段差なく連続した高さで平坦化できる。
+     * GSI は湖面など水域の z15 タイルを 404 で配信しないことがあり（本栖湖 15/28998/12927 等）、
+     * その場合この近傍代表標高（湖岸/湖面 ≒ 湖面標高）で穴を埋める。隣接が一切無効なら undefined。
+     */
+    const neighborRepElev = (gz: number, gx: number, gy: number): number | undefined => {
+        const facing: readonly [number, number, "top" | "bottom" | "left" | "right"][] = [
+            [0, -1, "bottom"], // 上隣の下辺がこのタイルの上辺に接する
+            [0, 1, "top"],
+            [-1, 0, "right"],
+            [1, 0, "left"],
+        ];
+        let sum = 0;
+        let cnt = 0;
+        for (const [dx, dy, edge] of facing) {
+            const nk = tileKey(gz, gx + dx, gy + dy);
+            if (allNanGeom.has(nk)) continue; // 未解決 all-NaN（水面）隣接は代表標高源にしない
+            const e = elevCache.get(nk);
+            if (!e) continue;
+            const m = tileEdgeMean(e, edge);
+            if (m !== undefined) {
+                sum += m;
+                cnt++;
+            }
+        }
+        return cnt > 0 ? sum / cnt : undefined;
+    };
+
     /** クロスレベル coarse-edge 集合の署名（順不同で同一なら同値）。 */
     const edgeSignature = (edges: readonly CoarseEdge[]): string =>
         edges
@@ -745,7 +800,6 @@ export const createGlobeTileManager = (
             // loadElevationTile は no-data(404) と一時的障害を区別できないため、失敗は一律バックオフ
             // 扱い。実標高が届いたら次 sync で実標高へ再構築（sig で検知）、失敗継続なら海面のまま残す。
             const isFlatFallback = !cachedElev;
-            // 確定前（粗ズーム祖先 DEM の取得待ち等）の all-NaN タイル（湖面・no-data 全面）。
             let geomElev = cachedElev ?? FLAT_SEA_ELEV;
 
             // 標高が視覚的に意味を持つ zoom レベル（minZoom 以上）では、標高ロード中は建築をスキップ。
@@ -754,16 +808,33 @@ export const createGlobeTileManager = (
             // - minZoom 未満（高高度グローバルビュー）は標高が視覚的に無意味なので即建築。
             if (isFlatFallback && !failedRetryAt.has(gk) && t.zoom >= minZoom) continue;
 
-            // 確定前（粗ズーム祖先 DEM の取得待ち等）の all-NaN タイル（本栖湖・諏訪湖 #339）。
-            // 生 NaN をそのまま建築すると globeMesh が海面 0m へ倒し「湖中央の沈み込み（クレーター）」、
-            // 逆に建築を見送ると下地の低解像度ベースレイヤ（陸地=橙系）が露出する。どちらも避けるため、
-            // 暫定代表標高（粗ズーム祖先 ?? 直近代表標高 ?? referenceAltitude）で平坦に建築する。
-            // 地図テクスチャは標高に依存せず読み込まれるため、湖面相当の高さに平坦な正しい地図が描かれる。
-            // `refineAllNaNTiles` が正確な湖面標高で確定（allNanGeom から除外）し次第、sig 差分で再建築する。
+            // 暫定平坦建築の代表標高[m]（sig へ反映し、隣接ロードで値が変われば再建築させる）。
+            let repElev: number | undefined;
+
+            // (A) 取得失敗(404/no-data)タイル（本栖湖の z15 湖面タイル 15/28998/12927 等は 404）。
+            //     GSI は水域の高 zoom タイルを 404 で配信しないため、従来は FLAT_SEA_ELEV(0m) で
+            //     平坦建築され「湖中央が 0m に沈む（≒900m クレーター）」原因になっていた（#339）。
+            //     隣接タイルの接線標高（湖岸/湖面 ≒ 湖面標高）で平坦化し、段差無く連続させる。
+            //     隣接も全て無効なら従来どおり 0m（外洋として妥当）。高高度(minZoom 未満)は標高無意味。
+            if (isFlatFallback && t.zoom >= minZoom) {
+                repElev = coarseSeed.get(gk) ?? neighborRepElev(gz, gx, gy) ?? lastRepElev;
+                if (repElev !== undefined) geomElev = flatElevArray(repElev);
+            }
+
+            // (B) 確定前（粗ズーム祖先 DEM の取得待ち等）の all-NaN タイル（湖面・no-data 全面）。
+            //     生 NaN をそのまま建築すると globeMesh が海面 0m へ倒し「湖中央の沈み込み（クレーター）」、
+            //     逆に建築を見送ると下地の低解像度ベースレイヤ（陸地=橙系）が露出する。どちらも避けるため、
+            //     暫定代表標高（粗ズーム祖先 ?? 隣接接線 ?? 直近代表標高 ?? referenceAltitude）で平坦建築。
+            //     地図テクスチャは標高非依存で読まれるため、湖面相当の高さに平坦な正しい地図が描かれる。
+            //     `refineAllNaNTiles` が正確な湖面標高で確定（allNanGeom から除外）し次第、sig 差分で再建築。
             const isAllNanPending = !!cachedElev && allNanGeom.has(gk) && t.zoom >= minZoom;
             if (isAllNanPending) {
-                const rep = coarseSeed.get(gk) ?? lastRepElev ?? lastReferenceAltitude;
-                geomElev = flatElevArray(rep);
+                repElev =
+                    coarseSeed.get(gk) ??
+                    neighborRepElev(gz, gx, gy) ??
+                    lastRepElev ??
+                    lastReferenceAltitude;
+                geomElev = flatElevArray(repElev);
             }
 
             // クロスレベル「標高スナップ」は z<=geomMaxZoom の LOD 境界にのみ適用する。
@@ -789,11 +860,13 @@ export const createGlobeTileManager = (
                 // シームは許容。欠けるよりは良い）。
                 edges = r.edges;
             }
-            // フラット建築・暫定 all-NaN 建築かどうかも署名に含める（実標高で確定したら、
-            // coarse-edge が同一でもジオメトリを再構築させるため）。
+            // フラット建築・暫定 all-NaN 建築かどうかと、暫定代表標高（10m 量子化）も署名に含める。
+            // 実標高で確定したら coarse-edge 同一でも再構築させ、隣接ロードで代表標高が変わったら
+            // （0m→湖面標高 等）追従して再構築させるため（#339）。
             const sig =
                 (isFlatFallback ? "flat|" : "") +
                 (isAllNanPending ? "allnan|" : "") +
+                (repElev !== undefined ? `r${Math.round(repElev / 10)}|` : "") +
                 edgeSignature(edges);
 
             // 既存メッシュは coarse-edge 集合が同一ならそのまま、変化していれば

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -637,13 +637,14 @@ export const createGlobeTileManager = (
      *      その代表標高で、無ければ海面 0m（外洋として妥当）で確定する。
      * 3. 解決/レスキューしたタイルを共有する建築済み表示タイルの署名を無効化し再建築させる。
      *
-     * なお、確定前（粗ズーム取得待ち）の all-NaN タイルは `buildReadyTiles` で建築を見送り、生 NaN を
-     * 0m（海面クレーター）として描画しない（解決後に正しい標高で初めて建築する）。
+     * なお、確定前（粗ズーム取得待ち）の all-NaN タイルは `buildReadyTiles` で生 NaN を 0m
+     * （海面クレーター）として描画せず、暫定代表標高（粗ズーム祖先 ?? 隣接接線 ?? 直近代表標高）で
+     * 平坦建築する。`refineAllNaNTiles` が正確な湖面標高で確定し次第、署名差分で再建築される。
      */
     // 粗ズーム祖先タイルの取得デルタ候補（gz から何段階粗いタイルを試すか）。
     // 大きな湖ほど粗くしないと祖先タイルも全面水面（all-NaN）になるため複数段試す。
     const COARSE_SEED_DELTAS: ReadonlyArray<number> = [4, 6, 8, 10];
-    /** 粗ズームタイルを取得（メモ化）。all-NaN や取得失敗は null。 */
+    /** 粗ズームタイルを取得（in-flight 重複排除のみメモ化）。all-NaN や取得失敗は null。 */
     const loadCoarseTile = (cz: number, cx: number, cy: number): Promise<Float32Array | null> => {
         const ck = tileKey(cz, cx, cy);
         let p = coarseTileMemo.get(ck);
@@ -652,6 +653,12 @@ export const createGlobeTileManager = (
                 .then((e) => (isAllNaN(e) ? null : e))
                 .catch(() => null);
             coarseTileMemo.set(ck, p);
+            // メモは「同一粗タイルへの同時並行取得の重複排除」が目的。確定後も Promise
+            // （256x256 の Float32Array を保持）を残すと、多数の湖/外洋を巡るとメモリが単調
+            // 増加する。settle 後にエントリを削除して上限を設けない（#339 レビュー指摘）。
+            void p.finally(() => {
+                if (coarseTileMemo.get(ck) === p) coarseTileMemo.delete(ck);
+            });
         }
         return p;
     };
@@ -678,12 +685,20 @@ export const createGlobeTileManager = (
                         const v = data[i];
                         if (!isInvalidElev(v)) { sum += v; n++; }
                     }
-                    if (n > 0) { coarseSeed.set(gk, sum / n); return; }
+                    // 取得完了までに当該 geom タイルが prune（eviction/dispose）または解決済み
+                    // （allNanGeom から除外）になっている場合は書き込まない。さもないと dispose/prune
+                    // 後に coarseSeed が再増加（リーク）・不要な seed が残る（#339 レビュー指摘）。
+                    if (n > 0) {
+                        if (allNanGeom.has(gk) && elevCache.has(gk)) coarseSeed.set(gk, sum / n);
+                        return;
+                    }
                 }
                 // 全粗ズームで有効標高無し（真の no-data: 外洋等）。0m(海面)のままが妥当。
             } finally {
                 coarseSeedPending.delete(gk);
-                coarseSeedDone.add(gk);
+                // done フラグも、まだ未解決(allNanGeom)かつキャッシュに在るタイルにのみ立てる。
+                // prune/解決済みのタイルで完了フラグだけ復活させない（#339 レビュー指摘）。
+                if (allNanGeom.has(gk) && elevCache.has(gk)) coarseSeedDone.add(gk);
             }
         })();
     };

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -231,6 +231,13 @@ export const createGlobeTileManager = (
     // 粗ズームタイル取得結果のメモ（coarseKey `z/x/y` → 標高配列 or null）。
     // 同一湖の複数 all-NaN タイルが同じ粗タイルを参照するため取得を重複させない。
     const coarseTileMemo = new Map<string, Promise<Float32Array | null>>();
+    // 直近に得られた有効な代表標高[m]（視界内有効タイル平均または粗ズーム祖先標高）。#339
+    // 大きな湖へ陸地から接近して全面水面になった瞬間でも、直前まで見えていた湖岸標高を
+    // 暫定代表として保持し、未解決 all-NaN タイルを生 NaN(=0m クレーター) ではなく湖面相当で
+    // 平坦化するために用いる（粗ズーム取得が完了するまでの同期フォールバック）。
+    let lastRepElev: number | undefined;
+    // 直近 sync の referenceAltitude（カメラ中心地表標高）。代表標高の最終フォールバック。
+    let lastReferenceAltitude = 0;
     // 取得失敗した geom タイルのバックオフ状態（キー → 再試行可能時刻[ms] と試行回数）。
     // `loadElevationTile` は no-data(404) と一時的なネットワーク障害の双方で throw し、
     // 投げられたエラーから両者を区別できない。失敗を永続化すると一時障害でも地形が恒久
@@ -275,7 +282,13 @@ export const createGlobeTileManager = (
         const lowerGz = Math.min(minZoom, geomMaxZoom);
         for (let gz = geomMaxZoom; gz >= lowerGz; gz--) {
             const { x, y } = toTileXY(latDeg, lonDeg, gz);
-            const e = elevCache.get(tileKey(gz, x, y));
+            const gk = tileKey(gz, x, y);
+            // 未解決 all-NaN（湖面・no-data）タイルは生 NaN を保持しており bilinear が 0m を返す。
+            // これを採用すると湖上で centerElevation→0→referenceAltitude→0 と循環して暫定代表標高
+            // まで 0m へ崩れる（湖中央 0m クレーターの一因）。未解決の間はこの zoom を飛ばし、
+            // より粗い zoom（無ければ null）へ委ねて直前の有効な centerElevation を維持させる。#339
+            if (allNanGeom.has(gk)) continue;
+            const e = elevCache.get(gk);
             if (!e) continue;
             const total = totalPixelsForZoom(gz);
             const { px, py } = latLonToPixel(latDeg, lonDeg, total);
@@ -327,6 +340,10 @@ export const createGlobeTileManager = (
                 newlyFailed.push(gk);
             });
     };
+
+    /** geom タイル全面を単一標高 v[m] で埋めた Float32Array を生成する（湖面平坦化用, #339）。 */
+    const flatElevArray = (v: number): Float32Array =>
+        new Float32Array(TILE_SIZE * TILE_SIZE).fill(Number.isFinite(v) ? v : 0);
 
     /** クロスレベル coarse-edge 集合の署名（順不同で同一なら同値）。 */
     const edgeSignature = (edges: readonly CoarseEdge[]): string =>
@@ -668,6 +685,9 @@ export const createGlobeTileManager = (
                 if (!isInvalidElev(v)) { inViewSum += v; inViewCount++; }
             }
             const inViewRep = inViewCount > 0 ? inViewSum / inViewCount : undefined;
+            // 視界内に有効タイルがあれば代表標高を更新して保持する（全面水面化後の同期
+            // フォールバックに使う）。湖へ陸地から接近する経路では湖岸標高が記録される。#339
+            if (inViewRep !== undefined) lastRepElev = inViewRep;
 
             for (const gk of [...allNanGeom]) {
                 if (!elevCache.has(gk)) continue;
@@ -684,16 +704,20 @@ export const createGlobeTileManager = (
                     elevCache.set(gk, new Float32Array(TILE_SIZE * TILE_SIZE).fill(coarse));
                     allNanGeom.delete(gk);
                     dirty.add(gk);
+                    lastRepElev = coarse;
                 } else if (coarseSeedDone.has(gk)) {
                     // (2b) 粗ズーム祖先にも有効標高無し（真の no-data: 外洋等）。視界内に有効タイルが
-                    //      あればその代表標高で平坦化、無ければ生 NaN のまま（build で海面 0m＝外洋妥当）。
-                    if (inViewRep !== undefined) {
-                        elevCache.set(gk, new Float32Array(TILE_SIZE * TILE_SIZE).fill(inViewRep));
+                    //      あればその代表標高、無ければ直近の代表標高（湖岸標高）で平坦化する。
+                    //      どちらも無い場合のみ生 NaN のまま（build で海面 0m＝外洋として妥当）。
+                    const rep = inViewRep ?? lastRepElev;
+                    if (rep !== undefined) {
+                        elevCache.set(gk, new Float32Array(TILE_SIZE * TILE_SIZE).fill(rep));
                     }
                     allNanGeom.delete(gk);
                     dirty.add(gk);
                 } else {
-                    // (2c) 未取得 → 粗ズーム祖先取得を起動し、確定は次 sync へ見送る（build は遅延）。
+                    // (2c) 未取得 → 粗ズーム祖先取得を起動し、確定は次 sync へ見送る。確定までは
+                    //      build が暫定代表標高で平坦化するため 0m クレーターも下地露出も生じない。
                     requestCoarseSeed(gk);
                 }
             }
@@ -721,7 +745,8 @@ export const createGlobeTileManager = (
             // loadElevationTile は no-data(404) と一時的障害を区別できないため、失敗は一律バックオフ
             // 扱い。実標高が届いたら次 sync で実標高へ再構築（sig で検知）、失敗継続なら海面のまま残す。
             const isFlatFallback = !cachedElev;
-            const geomElev = cachedElev ?? FLAT_SEA_ELEV;
+            // 確定前（粗ズーム祖先 DEM の取得待ち等）の all-NaN タイル（湖面・no-data 全面）。
+            let geomElev = cachedElev ?? FLAT_SEA_ELEV;
 
             // 標高が視覚的に意味を持つ zoom レベル（minZoom 以上）では、標高ロード中は建築をスキップ。
             // フラット(0m)で一度表示してから実標高で再構築するとカメラ近景でチラつくため (#330)。
@@ -729,12 +754,17 @@ export const createGlobeTileManager = (
             // - minZoom 未満（高高度グローバルビュー）は標高が視覚的に無意味なので即建築。
             if (isFlatFallback && !failedRetryAt.has(gk) && t.zoom >= minZoom) continue;
 
-            // 確定前（粗ズーム祖先 DEM の取得待ち等）の all-NaN タイルは建築を見送る。生 NaN を
-            // そのまま建築すると globeMesh が海面 0m へ倒し「湖中央の沈み込み（クレーター）」に
-            // なるため（本栖湖・諏訪湖 #339）。`refineAllNaNTiles` が代表標高で確定（allNanGeom
-            // から除外）し次第、正しい標高で初めて建築する。高高度（minZoom 未満）は標高が視覚的に
-            // 無意味なので従来どおり即建築する。
-            if (allNanGeom.has(gk) && t.zoom >= minZoom) continue;
+            // 確定前（粗ズーム祖先 DEM の取得待ち等）の all-NaN タイル（本栖湖・諏訪湖 #339）。
+            // 生 NaN をそのまま建築すると globeMesh が海面 0m へ倒し「湖中央の沈み込み（クレーター）」、
+            // 逆に建築を見送ると下地の低解像度ベースレイヤ（陸地=橙系）が露出する。どちらも避けるため、
+            // 暫定代表標高（粗ズーム祖先 ?? 直近代表標高 ?? referenceAltitude）で平坦に建築する。
+            // 地図テクスチャは標高に依存せず読み込まれるため、湖面相当の高さに平坦な正しい地図が描かれる。
+            // `refineAllNaNTiles` が正確な湖面標高で確定（allNanGeom から除外）し次第、sig 差分で再建築する。
+            const isAllNanPending = !!cachedElev && allNanGeom.has(gk) && t.zoom >= minZoom;
+            if (isAllNanPending) {
+                const rep = coarseSeed.get(gk) ?? lastRepElev ?? lastReferenceAltitude;
+                geomElev = flatElevArray(rep);
+            }
 
             // クロスレベル「標高スナップ」は z<=geomMaxZoom の LOD 境界にのみ適用する。
             // crossLevel は細タイル zoom == その geom zoom を前提に、細グローバルピクセルを
@@ -743,7 +773,7 @@ export const createGlobeTileManager = (
             // 残る z16-18×粗 境界の「陰影シーム」除去（geom 座標へ写像した粗表面評価）は
             // 後続フェーズの磨き込み対象（#275）。
             let edges: readonly CoarseEdge[] = [];
-            if (snapEnabled && t.zoom <= geomMaxZoom && !isFlatFallback) {
+            if (snapEnabled && t.zoom <= geomMaxZoom && !isFlatFallback && !isAllNanPending) {
                 const r = selectCoarseEdges(
                     t,
                     (kk) => desiredKeys.has(kk),
@@ -759,9 +789,12 @@ export const createGlobeTileManager = (
                 // シームは許容。欠けるよりは良い）。
                 edges = r.edges;
             }
-            // フラット建築かどうかも署名に含める（no-data 回復で flat→実標高に変わったら、
+            // フラット建築・暫定 all-NaN 建築かどうかも署名に含める（実標高で確定したら、
             // coarse-edge が同一でもジオメトリを再構築させるため）。
-            const sig = (isFlatFallback ? "flat|" : "") + edgeSignature(edges);
+            const sig =
+                (isFlatFallback ? "flat|" : "") +
+                (isAllNanPending ? "allnan|" : "") +
+                edgeSignature(edges);
 
             // 既存メッシュは coarse-edge 集合が同一ならそのまま、変化していれば
             // ジオメトリのみ差し替える（テクスチャ・マテリアルは再利用し再読込を避ける）。
@@ -868,6 +901,8 @@ export const createGlobeTileManager = (
     };
 
     const sync = (params: GlobeTileSyncParams): GlobeTileSyncStats => {
+        // 暫定代表標高の最終フォールバックとして referenceAltitude（カメラ中心地表標高）を保持。
+        if (Number.isFinite(params.referenceAltitude)) lastReferenceAltitude = params.referenceAltitude;
         // root 探索はカメラの現在の注視点(center)を追従する（パン後もカメラ直下を選択）。
         const camGeo = ecefToGeodetic(params.centerEcef);
         const tiles = selectGlobeTiles({

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -25,8 +25,11 @@ import {
     textureUrl,
     toTileXY,
     TILE_SIZE,
+    isAllNaN,
+    fillInvalidPixels,
     type MapType,
 } from "../gsiTile";
+import { stitchTileEdges, type StitchNeighbors } from "../tileStitching";
 import { ecefToGeodetic } from "./ecef";
 import { latLonToPixel, totalPixelsForZoom } from "./mapping";
 import { selectGlobeTiles, tileKey, type GlobeTile } from "./globeLod";
@@ -212,6 +215,10 @@ export const createGlobeTileManager = (
     const loading = new Set<string>();
     // クロスレベルスナップのため、ビルド後も標高配列を保持する（隣接細タイルが参照）。
     const elevCache = new Map<string, Float32Array>();
+    // 元データが all-NaN（湖面・no-data 領域全面）だった geom タイルキーの集合（#339）。
+    // 取得直後は隣接が未ロードでシードが無いため穴埋めできない。隣接の補間結果が揃い次第
+    // `refineAllNaNTiles` で同 zoom 隣接からシードして反復補間する。解決したらこの集合から外す。
+    const allNanGeom = new Set<string>();
     // 取得失敗した geom タイルのバックオフ状態（キー → 再試行可能時刻[ms] と試行回数）。
     // `loadElevationTile` は no-data(404) と一時的なネットワーク障害の双方で throw し、
     // 投げられたエラーから両者を区別できない。失敗を永続化すると一時障害でも地形が恒久
@@ -280,6 +287,17 @@ export const createGlobeTileManager = (
                 // （不要・dispose 済みマネージャの状態を書き戻さない）。
                 if (!loading.has(gk)) return;
                 loading.delete(gk);
+                // 穴埋め（#339, 平面版 #211/#221 相当）。
+                // - 部分欠測（一部 NaN）: 自タイル内の有効ピクセルから BFS で内部の穴を即補間。
+                // - all-NaN（全面 no-data: 大きな湖など）: 自タイルにシードが無いため即補間できない。
+                //   `allNanGeom` に記録し、隣接の補間結果が揃い次第 `refineAllNaNTiles` で補間する。
+                //   それまでは生 NaN のまま格納し（globeMesh が海面 0m へ倒す＝従来挙動）暫定表示する。
+                if (isAllNaN(elev)) {
+                    allNanGeom.add(gk);
+                } else {
+                    fillInvalidPixels(elev, TILE_SIZE, TILE_SIZE);
+                    allNanGeom.delete(gk);
+                }
                 elevCache.set(gk, elev);
                 failedRetryAt.delete(gk); // 回復したのでバックオフ状態を解消
             })
@@ -506,6 +524,58 @@ export const createGlobeTileManager = (
             // Case 3: 同 zoom の新タイルが同キーで ready なら不要。
             const same = loaded.get(key);
             if (same && isMeshTextureReady(same)) releasePendingTile(key);
+        }
+    };
+
+    /** 表示タイルキー `"z/x/y"` → 共有する geom 標高タイルキー（z16-18 は z15 祖先を共有）。 */
+    const geomKeyOfDisplay = (key: string): string => {
+        const { zoom, x, y } = parseKey(key);
+        const gz = Math.min(zoom, geomMaxZoom);
+        const d = zoom - gz;
+        return tileKey(gz, x >> d, y >> d);
+    };
+
+    /**
+     * 元データが all-NaN（全面 no-data）だった geom タイルを、同 zoom 隣接の補間結果を
+     * シードに穴埋めする（#339, 平面版 #221 相当）。
+     *
+     * - 隣接 8 タイル（同 geom zoom）を `stitchTileEdges` で境界辺に縫い合わせてシードを得る。
+     * - シードが入れば（縫い合わせ後に有効ピクセルが現れれば）`fillInvalidPixels` で内部へ伝播。
+     * - 解決したら `elevCache` を更新し `allNanGeom` から外し、該当表示タイルの建築署名を
+     *   無効化して次の `buildReadyTiles` で実標高へ再建築させる。
+     * - 隣接がまだ揃わずシードが得られないタイルは未解決のまま残し、次 sync で再試行する
+     *   （隣接が波状に解決するたびに 1 リング分ずつ前進し、最終的に収束する）。
+     */
+    const refineAllNaNTiles = (): void => {
+        if (allNanGeom.size === 0) return;
+        const neighborOffsets: ReadonlyArray<[number, number, keyof StitchNeighbors]> = [
+            [0, -1, "top"], [0, 1, "bottom"], [-1, 0, "left"], [1, 0, "right"],
+            [-1, -1, "topLeft"], [1, -1, "topRight"], [-1, 1, "bottomLeft"], [1, 1, "bottomRight"],
+        ];
+        for (const gk of [...allNanGeom]) {
+            const target = elevCache.get(gk);
+            if (!target) {
+                // 退避済み（視界外）。再ロード時に再評価されるのでここでは外すだけ。
+                allNanGeom.delete(gk);
+                continue;
+            }
+            const { zoom: gz, x: gx, y: gy } = parseKey(gk);
+            const neighbors: StitchNeighbors = {};
+            for (const [dx, dy, dir] of neighborOffsets) {
+                const nElev = elevCache.get(tileKey(gz, gx + dx, gy + dy));
+                // 未解決 all-NaN 隣接（全 NaN）はシードにならず `nanMean` で自然に除外される。
+                if (nElev) neighbors[dir] = nElev;
+            }
+            const copy = Float32Array.from(target);
+            stitchTileEdges(copy, neighbors, TILE_SIZE);
+            if (isAllNaN(copy)) continue; // まだシード無し。次 sync で再試行。
+            fillInvalidPixels(copy, TILE_SIZE, TILE_SIZE);
+            elevCache.set(gk, copy);
+            allNanGeom.delete(gk);
+            // この geom を共有する建築済み表示タイルを再建築対象にする（実標高へ差し替え）。
+            for (const key of [...builtEdgeSig.keys()]) {
+                if (geomKeyOfDisplay(key) === gk) builtEdgeSig.delete(key);
+            }
         }
     };
 
@@ -758,7 +828,10 @@ export const createGlobeTileManager = (
             }),
         );
         for (const key of elevCache.keys()) {
-            if (!neededGeom.has(key)) elevCache.delete(key);
+            if (!neededGeom.has(key)) {
+                elevCache.delete(key);
+                allNanGeom.delete(key);
+            }
         }
         // 不要になった in-flight ロードを loading から外す。これにより、その後 resolve した
         // 結果は loadTile の then/catch ゲート（loading.has）で無視され、不要な geom が
@@ -773,6 +846,8 @@ export const createGlobeTileManager = (
         }
         // 新規タイルをロードし、標高が揃ったものを（クロスレベルスナップ付きで）建築。
         for (const t of tiles) loadTile(t);
+        // 隣接が揃った all-NaN タイルを補間してから建築（#339）。
+        refineAllNaNTiles();
         buildReadyTiles(tiles);
 
         // 新規ロードが発生しない再 sync（同一可視集合での再評価など）では loadTile 経路の
@@ -903,6 +978,7 @@ export const createGlobeTileManager = (
         builtEdgeSig.clear();
         loading.clear();
         elevCache.clear();
+        allNanGeom.clear();
         failedRetryAt.clear();
         newlyFailed.length = 0;
         desiredKeys = new Set<string>();

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -24,6 +24,7 @@ import {
     loadElevationTile,
     textureUrl,
     toTileXY,
+    tileCenterLatLon,
     TILE_SIZE,
     isAllNaN,
     isInvalidElev,
@@ -220,6 +221,15 @@ export const createGlobeTileManager = (
     // 取得直後は隣接が未ロードでシードが無いため穴埋めできない。隣接の補間結果が揃い次第
     // `refineAllNaNTiles` で同 zoom 隣接からシードして反復補間する。解決したらこの集合から外す。
     const allNanGeom = new Set<string>();
+    // all-NaN タイルの粗ズーム祖先 DEM から得た代表標高（湖面標高近似）のキャッシュ（#339）。
+    // 視界が全面水面で同 zoom に有効タイルが一切無い場合（大きな湖を z15 で接写等）、
+    // 同 zoom 縫い合わせも視界内代表標高レスキューも効かない。粗ズーム祖先タイルは
+    // 湖岸（陸地）を含むため、その有効ピクセル平均を湖面標高として平坦化に用いる。
+    const coarseSeed = new Map<string, number>(); // geomKey → 代表標高[m]
+    const coarseSeedPending = new Set<string>(); // 粗ズーム取得中の geomKey
+    // 粗ズームタイル取得結果のメモ（coarseKey `z/x/y` → 標高配列 or null）。
+    // 同一湖の複数 all-NaN タイルが同じ粗タイルを参照するため取得を重複させない。
+    const coarseTileMemo = new Map<string, Promise<Float32Array | null>>();
     // 取得失敗した geom タイルのバックオフ状態（キー → 再試行可能時刻[ms] と試行回数）。
     // `loadElevationTile` は no-data(404) と一時的なネットワーク障害の双方で throw し、
     // 投げられたエラーから両者を区別できない。失敗を永続化すると一時障害でも地形が恒久
@@ -545,11 +555,60 @@ export const createGlobeTileManager = (
      * 1. 波状反復: 同 zoom 隣接（`stitchTileEdges`）からシードが得られたタイルを `fillInvalidPixels`
      *    で補間し `elevCache` を更新する。解決済みタイルが次の反復で隣接のシード源になり、湖岸から
      *    中心へリング状に補間が前進する。1 sync 内で収束するよう内部反復する。
-     * 2. レスキュー: 反復後も残った all-NaN タイル（周囲も all-NaN で到達不能）は、解決済みタイルの
-     *    代表標高で平坦化する（#221 Step4 同等）。誤って早期平坦化しないよう、隣接が in-flight
-     *    （`loading`）の間はそのタイルのレスキューを見送り、ロード完了後に確定させる。
+     * 2. レスキュー（視界内代表標高）: 反復後も残った all-NaN タイル（周囲も all-NaN で到達不能）で、
+     *    かつ視界内に有効タイルがあれば、その代表標高で平坦化する（#221 Step4 同等）。誤って早期
+     *    平坦化しないよう、隣接が in-flight（`loading`）の間はそのタイルのレスキューを見送る。
+     * 2b. レスキュー（粗ズーム祖先）: 視界が全面水面で有効タイルが一切無い場合（大きな湖を z15 で
+     *    接写する等。本栖湖・諏訪湖で 0m へ沈む事象 #339）、粗ズーム祖先 DEM タイルの有効ピクセル
+     *    平均（＝湖岸・陸地を含むため湖面標高の近似）を非同期取得し、その代表標高で平坦化する。
      * 3. 解決/レスキューしたタイルを共有する建築済み表示タイルの署名を無効化し再建築させる。
      */
+    // 粗ズーム祖先タイルの取得デルタ候補（gz から何段階粗いタイルを試すか）。
+    // 大きな湖ほど粗くしないと祖先タイルも全面水面（all-NaN）になるため複数段試す。
+    const COARSE_SEED_DELTAS: ReadonlyArray<number> = [4, 6, 8, 10];
+    /** 粗ズームタイルを取得（メモ化）。all-NaN や取得失敗は null。 */
+    const loadCoarseTile = (cz: number, cx: number, cy: number): Promise<Float32Array | null> => {
+        const ck = tileKey(cz, cx, cy);
+        let p = coarseTileMemo.get(ck);
+        if (!p) {
+            p = loadElevationTile(cz, cx, cy)
+                .then((e) => (isAllNaN(e) ? null : e))
+                .catch(() => null);
+            coarseTileMemo.set(ck, p);
+        }
+        return p;
+    };
+    /**
+     * all-NaN タイル `gk` の代表標高を粗ズーム祖先 DEM から非同期取得し `coarseSeed` に格納する。
+     * 取得後の適用（平坦化）は次 sync の `refineAllNaNTiles` が担う（連続 sync ループ前提）。
+     */
+    const requestCoarseSeed = (gk: string): void => {
+        if (coarseSeed.has(gk) || coarseSeedPending.has(gk)) return;
+        const { zoom: gz, x: gx, y: gy } = parseKey(gk);
+        const { lat, lon } = tileCenterLatLon(gx, gy, gz);
+        coarseSeedPending.add(gk);
+        void (async () => {
+            try {
+                for (const d of COARSE_SEED_DELTAS) {
+                    const cz = gz - d;
+                    if (cz < 0) continue;
+                    const { x: cx, y: cy } = toTileXY(lat, lon, cz);
+                    const data = await loadCoarseTile(cz, cx, cy);
+                    if (!data) continue;
+                    let sum = 0;
+                    let n = 0;
+                    for (let i = 0; i < data.length; i++) {
+                        const v = data[i];
+                        if (!isInvalidElev(v)) { sum += v; n++; }
+                    }
+                    if (n > 0) { coarseSeed.set(gk, sum / n); return; }
+                }
+                // 全粗ズームで有効標高無し（真の no-data: 外洋等）。0m(海面)のままが妥当。
+            } finally {
+                coarseSeedPending.delete(gk);
+            }
+        })();
+    };
     const ALL_NAN_REFINE_MAX_ITER = 8;
     const allNanNeighborOffsets: ReadonlyArray<[number, number, keyof StitchNeighbors]> = [
         [0, -1, "top"], [0, 1, "bottom"], [-1, 0, "left"], [1, 0, "right"],
@@ -613,11 +672,25 @@ export const createGlobeTileManager = (
                     if (!isInvalidElev(v)) { sum += v; count++; }
                 }
                 if (count > 0) {
+                    // Step 2: 視界内に有効タイルあり → その代表標高で即時平坦化。
                     const rep = sum / count;
                     for (const gk of ready) {
                         elevCache.set(gk, new Float32Array(TILE_SIZE * TILE_SIZE).fill(rep));
                         allNanGeom.delete(gk);
                         dirty.add(gk);
+                    }
+                } else {
+                    // Step 2b: 視界が全面水面（有効タイル皆無）→ 粗ズーム祖先 DEM の代表標高で平坦化。
+                    // 取得済みなら即適用、未取得なら非同期取得を起動し次 sync で適用する（#339）。
+                    for (const gk of ready) {
+                        const rep = coarseSeed.get(gk);
+                        if (rep !== undefined) {
+                            elevCache.set(gk, new Float32Array(TILE_SIZE * TILE_SIZE).fill(rep));
+                            allNanGeom.delete(gk);
+                            dirty.add(gk);
+                        } else {
+                            requestCoarseSeed(gk);
+                        }
                     }
                 }
             }
@@ -883,6 +956,8 @@ export const createGlobeTileManager = (
             if (!neededGeom.has(key)) {
                 elevCache.delete(key);
                 allNanGeom.delete(key);
+                coarseSeed.delete(key);
+                coarseSeedPending.delete(key);
             }
         }
         // 不要になった in-flight ロードを loading から外す。これにより、その後 resolve した
@@ -1031,6 +1106,9 @@ export const createGlobeTileManager = (
         loading.clear();
         elevCache.clear();
         allNanGeom.clear();
+        coarseSeed.clear();
+        coarseSeedPending.clear();
+        coarseTileMemo.clear();
         failedRetryAt.clear();
         newlyFailed.length = 0;
         desiredKeys = new Set<string>();

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -26,6 +26,7 @@ import {
     toTileXY,
     TILE_SIZE,
     isAllNaN,
+    isInvalidElev,
     fillInvalidPixels,
     type MapType,
 } from "../gsiTile";
@@ -536,45 +537,96 @@ export const createGlobeTileManager = (
     };
 
     /**
-     * 元データが all-NaN（全面 no-data）だった geom タイルを、同 zoom 隣接の補間結果を
-     * シードに穴埋めする（#339, 平面版 #221 相当）。
+     * 元データが all-NaN（全面 no-data）だった geom タイルを穴埋めする（#339, 平面版 #221 相当）。
      *
-     * - 隣接 8 タイル（同 geom zoom）を `stitchTileEdges` で境界辺に縫い合わせてシードを得る。
-     * - シードが入れば（縫い合わせ後に有効ピクセルが現れれば）`fillInvalidPixels` で内部へ伝播。
-     * - 解決したら `elevCache` を更新し `allNanGeom` から外し、該当表示タイルの建築署名を
-     *   無効化して次の `buildReadyTiles` で実標高へ再建築させる。
-     * - 隣接がまだ揃わずシードが得られないタイルは未解決のまま残し、次 sync で再試行する
-     *   （隣接が波状に解決するたびに 1 リング分ずつ前進し、最終的に収束する）。
+     * 大きな湖（本栖湖など）では、対象タイルだけでなく同 zoom 隣接タイルも all-NaN になり、
+     * 同 zoom 縫い合わせだけでは中心タイルにシードが届かず標高が 0m（海面）へ沈む。これを防ぐ:
+     *
+     * 1. 波状反復: 同 zoom 隣接（`stitchTileEdges`）からシードが得られたタイルを `fillInvalidPixels`
+     *    で補間し `elevCache` を更新する。解決済みタイルが次の反復で隣接のシード源になり、湖岸から
+     *    中心へリング状に補間が前進する。1 sync 内で収束するよう内部反復する。
+     * 2. レスキュー: 反復後も残った all-NaN タイル（周囲も all-NaN で到達不能）は、解決済みタイルの
+     *    代表標高で平坦化する（#221 Step4 同等）。誤って早期平坦化しないよう、隣接が in-flight
+     *    （`loading`）の間はそのタイルのレスキューを見送り、ロード完了後に確定させる。
+     * 3. 解決/レスキューしたタイルを共有する建築済み表示タイルの署名を無効化し再建築させる。
      */
+    const ALL_NAN_REFINE_MAX_ITER = 8;
+    const allNanNeighborOffsets: ReadonlyArray<[number, number, keyof StitchNeighbors]> = [
+        [0, -1, "top"], [0, 1, "bottom"], [-1, 0, "left"], [1, 0, "right"],
+        [-1, -1, "topLeft"], [1, -1, "topRight"], [-1, 1, "bottomLeft"], [1, 1, "bottomRight"],
+    ];
     const refineAllNaNTiles = (): void => {
         if (allNanGeom.size === 0) return;
-        const neighborOffsets: ReadonlyArray<[number, number, keyof StitchNeighbors]> = [
-            [0, -1, "top"], [0, 1, "bottom"], [-1, 0, "left"], [1, 0, "right"],
-            [-1, -1, "topLeft"], [1, -1, "topRight"], [-1, 1, "bottomLeft"], [1, 1, "bottomRight"],
-        ];
-        for (const gk of [...allNanGeom]) {
+        const dirty = new Set<string>(); // 再建築が必要になった geom キー
+
+        // --- Step 1: 同 zoom 隣接からのシード補間を波状に反復 ---
+        const tryStitch = (gk: string): boolean => {
             const target = elevCache.get(gk);
             if (!target) {
-                // 退避済み（視界外）。再ロード時に再評価されるのでここでは外すだけ。
-                allNanGeom.delete(gk);
-                continue;
+                allNanGeom.delete(gk); // 退避済み（視界外）。再ロード時に再評価。
+                return false;
             }
             const { zoom: gz, x: gx, y: gy } = parseKey(gk);
             const neighbors: StitchNeighbors = {};
-            for (const [dx, dy, dir] of neighborOffsets) {
+            for (const [dx, dy, dir] of allNanNeighborOffsets) {
                 const nElev = elevCache.get(tileKey(gz, gx + dx, gy + dy));
                 // 未解決 all-NaN 隣接（全 NaN）はシードにならず `nanMean` で自然に除外される。
                 if (nElev) neighbors[dir] = nElev;
             }
             const copy = Float32Array.from(target);
             stitchTileEdges(copy, neighbors, TILE_SIZE);
-            if (isAllNaN(copy)) continue; // まだシード無し。次 sync で再試行。
+            if (isAllNaN(copy)) return false; // まだシード無し。
             fillInvalidPixels(copy, TILE_SIZE, TILE_SIZE);
             elevCache.set(gk, copy);
             allNanGeom.delete(gk);
-            // この geom を共有する建築済み表示タイルを再建築対象にする（実標高へ差し替え）。
+            dirty.add(gk);
+            return true;
+        };
+        for (let iter = 0; iter < ALL_NAN_REFINE_MAX_ITER; iter++) {
+            let progressed = 0;
+            for (const gk of [...allNanGeom]) {
+                if (tryStitch(gk)) progressed++;
+            }
+            if (allNanGeom.size === 0 || progressed === 0) break;
+        }
+
+        // --- Step 2: レスキュー（到達不能な残存 all-NaN タイルを代表標高で平坦化） ---
+        if (allNanGeom.size > 0) {
+            // 隣接が in-flight でないタイルのみ確定対象にする（早期平坦化を避ける）。
+            const ready: string[] = [];
+            for (const gk of allNanGeom) {
+                if (!elevCache.has(gk)) continue;
+                const { zoom: gz, x: gx, y: gy } = parseKey(gk);
+                const neighborLoading = allNanNeighborOffsets.some(
+                    ([dx, dy]) => loading.has(tileKey(gz, gx + dx, gy + dy)),
+                );
+                if (!neighborLoading) ready.push(gk);
+            }
+            if (ready.length > 0) {
+                // 解決済み（有効）タイルの中央ピクセルから代表標高を求める（#221 同様の近似）。
+                let sum = 0;
+                let count = 0;
+                const mid = (TILE_SIZE >> 1) * TILE_SIZE + (TILE_SIZE >> 1);
+                for (const [k, data] of elevCache) {
+                    if (allNanGeom.has(k)) continue; // 未解決 all-NaN は除外
+                    const v = data[mid];
+                    if (!isInvalidElev(v)) { sum += v; count++; }
+                }
+                if (count > 0) {
+                    const rep = sum / count;
+                    for (const gk of ready) {
+                        elevCache.set(gk, new Float32Array(TILE_SIZE * TILE_SIZE).fill(rep));
+                        allNanGeom.delete(gk);
+                        dirty.add(gk);
+                    }
+                }
+            }
+        }
+
+        // --- Step 3: 解決/レスキュー済み geom を共有する建築済み表示タイルを再建築対象にする ---
+        if (dirty.size > 0) {
             for (const key of [...builtEdgeSig.keys()]) {
-                if (geomKeyOfDisplay(key) === gk) builtEdgeSig.delete(key);
+                if (dirty.has(geomKeyOfDisplay(key))) builtEdgeSig.delete(key);
             }
         }
     };

--- a/tests/globeMesh.unit.spec.ts
+++ b/tests/globeMesh.unit.spec.ts
@@ -8,7 +8,7 @@
 
 import { describe, it, expect } from "@jest/globals";
 
-import { TILE_SIZE } from "../src/terrain/gsiTile";
+import { TILE_SIZE, NO_DATA_SENTINEL } from "../src/terrain/gsiTile";
 import { geodeticToEcef } from "../src/terrain/geo/ecef";
 import { pixelToLatLon, totalPixelsForZoom } from "../src/terrain/geo/mapping";
 import { sampleElevBilinear } from "../src/terrain/geo/elevSample";
@@ -47,6 +47,17 @@ describe("sampleElevBilinear", () => {
         elev[1] = 200; // (x=1,y=0)
         // (px=0.5,py=0): 上辺の 2隅のみ有効、重み 0.5/0.5 → 150。
         expect(sampleElevBilinear(elev, 0.5, 0)).toBeCloseTo(150, 6);
+    });
+
+    it("番兵値 NO_DATA_SENTINEL(-100) を無効として除外する (#339)", () => {
+        // 穴埋め残しの番兵値が有効標高として混入すると、メッシュ/terrainElevAt が
+        // -100m へ引っ張られて沈む。NaN と同様に重み計算から除外する。
+        const elev = new Float32Array(TILE_SIZE * TILE_SIZE).fill(NO_DATA_SENTINEL);
+        elev[0] = 80; // (x=0,y=0) のみ有効
+        expect(sampleElevBilinear(elev, 0.5, 0.5)).toBeCloseTo(80, 6);
+        // 全隅が番兵なら 0 を返す（4隅すべて無効）。
+        const allSentinel = new Float32Array(TILE_SIZE * TILE_SIZE).fill(NO_DATA_SENTINEL);
+        expect(sampleElevBilinear(allSentinel, 3, 3)).toBe(0);
     });
 });
 

--- a/tests/globeTileManager.unit.spec.ts
+++ b/tests/globeTileManager.unit.spec.ts
@@ -89,15 +89,77 @@ jest.unstable_mockModule("@babylonjs/core/Maths/math.color", () => ({
 
 // ---- gsiTile モック（座標は単純な決定的実装、loadElevationTile は制御可能に） ----
 // 注: ecef / mapping / math.geospatial.functions / math.vector は実物のまま使う。
-jest.unstable_mockModule("../src/terrain/gsiTile", () => ({
-    TILE_SIZE: 256,
-    clamp: (v: number, min: number, max: number) => Math.min(Math.max(v, min), max),
-    toTileXY: jest.fn(() => ({ x: 100, y: 100 })),
-    tileCenterLatLon: jest.fn(() => ({ lat: 35, lon: 139 })),
-    tileEdgeMeters: jest.fn(() => 1000),
-    textureUrl: jest.fn(() => "https://example.com/tile.png"),
-    loadElevationTile: jest.fn(() => Promise.resolve(new Float32Array(256 * 256))),
-}));
+jest.unstable_mockModule("../src/terrain/gsiTile", () => {
+    const TILE_SIZE = 256;
+    const NO_DATA_SENTINEL = -100;
+    const isInvalidElev = (v: number): boolean =>
+        Number.isNaN(v) || v === NO_DATA_SENTINEL;
+    const isAllNaN = (data: Float32Array): boolean => {
+        for (let i = 0; i < data.length; i++) if (!isInvalidElev(data[i])) return false;
+        return true;
+    };
+    // 本物（gsiTile.fillInvalidPixels）と同じ BFS 穴埋め＋番兵フォールバック。
+    const fillInvalidPixels = (elev: Float32Array, width: number, height: number): void => {
+        const size = width * height;
+        const offsets: ReadonlyArray<[number, number]> = [
+            [-1, -1], [0, -1], [1, -1], [-1, 0], [1, 0], [-1, 1], [0, 1], [1, 1],
+        ];
+        let frontier: number[] = [];
+        for (let i = 0; i < size; i++) {
+            if (!isInvalidElev(elev[i])) continue;
+            const x = i % width;
+            const y = (i - x) / width;
+            for (const [dx, dy] of offsets) {
+                const nx = x + dx;
+                const ny = y + dy;
+                if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
+                if (!isInvalidElev(elev[ny * width + nx])) { frontier.push(i); break; }
+            }
+        }
+        while (frontier.length > 0) {
+            const next: number[] = [];
+            for (const idx of frontier) {
+                if (!isInvalidElev(elev[idx])) continue;
+                const x = idx % width;
+                const y = (idx - x) / width;
+                let sum = 0;
+                let count = 0;
+                for (const [dx, dy] of offsets) {
+                    const nx = x + dx;
+                    const ny = y + dy;
+                    if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
+                    const v = elev[ny * width + nx];
+                    if (!isInvalidElev(v)) { sum += v; count++; }
+                }
+                if (count > 0) {
+                    elev[idx] = sum / count;
+                    for (const [dx, dy] of offsets) {
+                        const nx = x + dx;
+                        const ny = y + dy;
+                        if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
+                        const ni = ny * width + nx;
+                        if (isInvalidElev(elev[ni])) next.push(ni);
+                    }
+                }
+            }
+            frontier = next;
+        }
+        for (let i = 0; i < size; i++) if (Number.isNaN(elev[i])) elev[i] = NO_DATA_SENTINEL;
+    };
+    return {
+        TILE_SIZE,
+        NO_DATA_SENTINEL,
+        isInvalidElev,
+        isAllNaN,
+        fillInvalidPixels,
+        clamp: (v: number, min: number, max: number) => Math.min(Math.max(v, min), max),
+        toTileXY: jest.fn(() => ({ x: 100, y: 100 })),
+        tileCenterLatLon: jest.fn(() => ({ lat: 35, lon: 139 })),
+        tileEdgeMeters: jest.fn(() => 1000),
+        textureUrl: jest.fn(() => "https://example.com/tile.png"),
+        loadElevationTile: jest.fn(() => Promise.resolve(new Float32Array(256 * 256))),
+    };
+});
 
 // ---- globeLod モック（タイル選択を決定的に制御） ----
 // マネージャはライフサイクル（ロード/ビルド/破棄）の責務を持つ。選択ロジック（高度/距離適応
@@ -569,5 +631,46 @@ describe("createGlobeTileManager", () => {
         selectedTiles = [tile(500, 500, 10)];
         mgr.sync(syncParams());
         expect(meshA.dispose).toHaveBeenCalledWith(false, true);
+    });
+
+    // ===== 標高タイルの穴埋め（Issue #339 / 平面版 #211・#221 相当） =====
+
+    it("部分欠測タイルの内部 NaN を周囲の有効標高で穴埋めする (#339)", async () => {
+        const mgr = makeManager();
+        // 1 ピクセルだけ有効(70m)で残りは全て NaN のタイル。fillInvalidPixels の BFS で
+        // タイル全体が 70m に伝播するため、どこをサンプルしても 70m になる（NaN→0 沈み無し）。
+        loadElevationTile.mockImplementation(() => {
+            const a = new Float32Array(256 * 256).fill(NaN);
+            a[0] = 70;
+            return Promise.resolve(a);
+        });
+        selectedTiles = [tile(100, 100, 10)];
+        mgr.sync(syncParams());
+        await flush(); // 標高到着 → loadTile で穴埋め
+        mgr.sync(syncParams());
+
+        const elev = mgr.terrainElevAt(35, 139);
+        expect(elev).not.toBeNull();
+        expect(elev as number).toBeCloseTo(70, 3);
+    });
+
+    it("all-NaN タイルを同 zoom 隣接の補間結果をシードに穴埋めする (#339, #221)", async () => {
+        const mgr = makeManager();
+        // 対象タイル(gx=100)は全面 no-data(all-NaN)、右隣(gx=101)は一様 60m。
+        loadElevationTile.mockImplementation((...args: unknown[]) => {
+            const gx = args[1] as number;
+            if (gx === 100) return Promise.resolve(new Float32Array(256 * 256).fill(NaN));
+            return Promise.resolve(new Float32Array(256 * 256).fill(60));
+        });
+        selectedTiles = [tile(100, 100, 10), tile(101, 100, 10)];
+        mgr.sync(syncParams());
+        await flush(); // 両タイル到着。100 は allNanGeom 入り、101 は穴埋め済み
+        // 1 回目: refineAllNaNTiles が隣接 60m をシードに 100 を補間する。
+        mgr.sync(syncParams());
+
+        // terrainElevAt は toTileXY モックで常に (100,100) を参照する。補間後は 60m。
+        const elev = mgr.terrainElevAt(35, 139);
+        expect(elev).not.toBeNull();
+        expect(elev as number).toBeCloseTo(60, 3);
     });
 });

--- a/tests/globeTileManager.unit.spec.ts
+++ b/tests/globeTileManager.unit.spec.ts
@@ -619,4 +619,25 @@ describe("createGlobeTileManager", () => {
         expect(elev).not.toBeNull();
         expect(elev as number).toBeCloseTo(60, 3);
     });
+
+    it("周囲も all-NaN で到達不能な水面のみタイルを代表標高でレスキューする (#339, #221)", async () => {
+        const mgr = makeManager();
+        // 対象タイル(gx=100)は全面 no-data(all-NaN)で同 zoom 隣接(99/101)は未ロード（視界外）。
+        // 別位置(gx=105)に有効標高 300m のタイルがあり、これが代表標高の供給源になる。
+        loadElevationTile.mockImplementation((...args: unknown[]) => {
+            const gx = args[1] as number;
+            if (gx === 100) return Promise.resolve(new Float32Array(256 * 256).fill(NaN));
+            return Promise.resolve(new Float32Array(256 * 256).fill(300));
+        });
+        selectedTiles = [tile(100, 100, 10), tile(105, 105, 10)];
+        mgr.sync(syncParams());
+        await flush(); // 両タイル到着。loading は空。100 は allNanGeom 入り
+        // refineAllNaNTiles: 100 は隣接シード無し → レスキューで代表標高 300m に平坦化。
+        mgr.sync(syncParams());
+
+        const elev = mgr.terrainElevAt(35, 139);
+        expect(elev).not.toBeNull();
+        // 海面 0m へ沈まず、代表標高 300m で平坦化されること（中心の沈み込み解消）。
+        expect(elev as number).toBeCloseTo(300, 3);
+    });
 });

--- a/tests/globeTileManager.unit.spec.ts
+++ b/tests/globeTileManager.unit.spec.ts
@@ -640,4 +640,32 @@ describe("createGlobeTileManager", () => {
         // 海面 0m へ沈まず、代表標高 300m で平坦化されること（中心の沈み込み解消）。
         expect(elev as number).toBeCloseTo(300, 3);
     });
+
+    it("視界が全面水面の all-NaN タイルを粗ズーム祖先 DEM の代表標高で平坦化する (#339)", async () => {
+        const mgr = makeManager();
+        // geom zoom(=10) は全タイル全面 no-data（all-NaN: 湖面のみ）。
+        // 粗ズーム祖先(<10)は湖岸（陸地）を含むため一様 900m を返す（湖面標高近似の供給源）。
+        loadElevationTile.mockImplementation((...args: unknown[]) => {
+            const z = args[0] as number;
+            if (z < 10) return Promise.resolve(new Float32Array(256 * 256).fill(900));
+            return Promise.resolve(new Float32Array(256 * 256).fill(NaN));
+        });
+        // 3x3 の全面水面ブロック（視界内に有効タイルが一切無い ＝ 大きな湖の接写）。
+        selectedTiles = [];
+        for (let dx = -1; dx <= 1; dx++) {
+            for (let dy = -1; dy <= 1; dy++) {
+                selectedTiles.push(tile(100 + dx, 100 + dy, 10));
+            }
+        }
+        mgr.sync(syncParams());
+        await flush(); // geom タイル到着（全 all-NaN）
+        mgr.sync(syncParams()); // Step2b: 粗ズーム祖先の取得を起動
+        await flush(); // 粗ズームタイル到着 → coarseSeed に 900m
+        mgr.sync(syncParams()); // 粗ズーム代表標高で平坦化
+
+        const elev = mgr.terrainElevAt(35, 139);
+        expect(elev).not.toBeNull();
+        // 海面 0m へ沈まず、粗ズーム祖先の代表標高 900m で平坦化されること。
+        expect(elev as number).toBeCloseTo(900, 3);
+    });
 });

--- a/tests/globeTileManager.unit.spec.ts
+++ b/tests/globeTileManager.unit.spec.ts
@@ -131,6 +131,26 @@ jest.unstable_mockModule("../src/terrain/geo/globeLod", () => ({
     tileKey: (z: number, x: number, y: number) => `${z}/${x}/${y}`,
 }));
 
+// ---- globeMesh スパイ（建築時に渡される geomElev を捕捉して建築標高を検証可能にする） ----
+// 実装（純粋関数）はそのまま動かしつつ、404/all-NaN タイルがどの代表標高で平坦建築されたかを
+// 観測する。terrainElevAt は elevCache を参照するため、elevCache に載らない 404 タイルの
+// 建築標高はメッシュ生成入力（geomElev）でしか検証できない（#339）。
+const capturedBuilds: { tx: number; ty: number; geomElev: Float32Array }[] = [];
+jest.unstable_mockModule("../src/terrain/geo/globeMesh", () => {
+    const actual = jest.requireActual(
+        "../src/terrain/geo/globeMesh",
+    ) as typeof import("../src/terrain/geo/globeMesh");
+    return {
+        ...actual,
+        buildGlobeTileMeshData: jest.fn(
+            (params: Parameters<typeof actual.buildGlobeTileMeshData>[0]) => {
+                capturedBuilds.push({ tx: params.tx, ty: params.ty, geomElev: params.geomElev });
+                return actual.buildGlobeTileMeshData(params);
+            },
+        ),
+    };
+});
+
 const { createGlobeTileManager } = await import("../src/terrain/geo/globeTileManager");
 const { geodeticToEcef } = await import("../src/terrain/geo/ecef");
 const gsiMock = await import("../src/terrain/gsiTile");
@@ -183,6 +203,7 @@ const makeManager = () => {
 
 beforeEach(() => {
     capturedTextures.length = 0;
+    capturedBuilds.length = 0;
     MeshMock.mockClear();
     loadElevationTile.mockReset();
     loadElevationTile.mockImplementation(() => Promise.resolve(new Float32Array(256 * 256)));
@@ -684,5 +705,36 @@ describe("createGlobeTileManager", () => {
         // referenceAltitude→0 と循環し暫定代表標高まで 0m に崩れる。これを防ぐため null を返す。
         const elev = mgr.terrainElevAt(35, 139);
         expect(elev).toBeNull();
+    });
+
+    it("取得失敗(404)の湖面タイルを 0m でなく隣接タイルの接線標高で平坦建築する (#339)", async () => {
+        const mgr = makeManager();
+        // 中央 geom タイル(gx=100,gy=100)は全レイヤ 404（reject）＝本栖湖 z15 湖面タイルの実挙動。
+        // 上下左右の隣接タイルは一様 900m（本栖湖の湖面標高 ≒ 湖岸標高）。
+        loadElevationTile.mockImplementation((...args: unknown[]) => {
+            const gx = args[1] as number;
+            const gy = args[2] as number;
+            if (gx === 100 && gy === 100) return Promise.reject(new Error("HTTP 404"));
+            return Promise.resolve(new Float32Array(256 * 256).fill(900));
+        });
+        selectedTiles = [
+            tile(100, 100, 10),
+            tile(100, 99, 10),
+            tile(100, 101, 10),
+            tile(99, 100, 10),
+            tile(101, 100, 10),
+        ];
+        mgr.sync(syncParams());
+        await flush(); // 中央 404→failedRetryAt、隣接 900m ロード完了
+        capturedBuilds.length = 0;
+        mgr.sync(syncParams()); // 隣接到着後、中央を隣接接線 900m で平坦建築
+
+        // 中央タイル(404)は FLAT_SEA_ELEV(0m) ではなく隣接接線標高 900m で平坦建築されること。
+        // これが「湖中央が 0m に沈む（≒900m クレーター）」(#339) の根本修正。
+        const centerBuilds = capturedBuilds.filter((b) => b.tx === 100 && b.ty === 100);
+        expect(centerBuilds.length).toBeGreaterThan(0);
+        const built = centerBuilds[centerBuilds.length - 1].geomElev;
+        const mean = built.reduce((a, b) => a + b, 0) / built.length;
+        expect(mean).toBeCloseTo(900, 0);
     });
 });

--- a/tests/globeTileManager.unit.spec.ts
+++ b/tests/globeTileManager.unit.spec.ts
@@ -89,70 +89,16 @@ jest.unstable_mockModule("@babylonjs/core/Maths/math.color", () => ({
 
 // ---- gsiTile モック（座標は単純な決定的実装、loadElevationTile は制御可能に） ----
 // 注: ecef / mapping / math.geospatial.functions / math.vector は実物のまま使う。
+// 穴埋め系の純関数（isAllNaN / fillInvalidPixels / isInvalidElev / NO_DATA_SENTINEL 等）や
+// 座標定数は本実装をそのまま再利用し（jest.requireActual）、テストで差し替えたい DOM 依存・
+// 制御対象（loadElevationTile / toTileXY など）だけを最小限モックする。本実装を再実装すると
+// 実装変更時にテスト側が取り残されて偽陽性/偽陰性になりやすいため（PR #344 レビュー指摘）。
 jest.unstable_mockModule("../src/terrain/gsiTile", () => {
-    const TILE_SIZE = 256;
-    const NO_DATA_SENTINEL = -100;
-    const isInvalidElev = (v: number): boolean =>
-        Number.isNaN(v) || v === NO_DATA_SENTINEL;
-    const isAllNaN = (data: Float32Array): boolean => {
-        for (let i = 0; i < data.length; i++) if (!isInvalidElev(data[i])) return false;
-        return true;
-    };
-    // 本物（gsiTile.fillInvalidPixels）と同じ BFS 穴埋め＋番兵フォールバック。
-    const fillInvalidPixels = (elev: Float32Array, width: number, height: number): void => {
-        const size = width * height;
-        const offsets: ReadonlyArray<[number, number]> = [
-            [-1, -1], [0, -1], [1, -1], [-1, 0], [1, 0], [-1, 1], [0, 1], [1, 1],
-        ];
-        let frontier: number[] = [];
-        for (let i = 0; i < size; i++) {
-            if (!isInvalidElev(elev[i])) continue;
-            const x = i % width;
-            const y = (i - x) / width;
-            for (const [dx, dy] of offsets) {
-                const nx = x + dx;
-                const ny = y + dy;
-                if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
-                if (!isInvalidElev(elev[ny * width + nx])) { frontier.push(i); break; }
-            }
-        }
-        while (frontier.length > 0) {
-            const next: number[] = [];
-            for (const idx of frontier) {
-                if (!isInvalidElev(elev[idx])) continue;
-                const x = idx % width;
-                const y = (idx - x) / width;
-                let sum = 0;
-                let count = 0;
-                for (const [dx, dy] of offsets) {
-                    const nx = x + dx;
-                    const ny = y + dy;
-                    if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
-                    const v = elev[ny * width + nx];
-                    if (!isInvalidElev(v)) { sum += v; count++; }
-                }
-                if (count > 0) {
-                    elev[idx] = sum / count;
-                    for (const [dx, dy] of offsets) {
-                        const nx = x + dx;
-                        const ny = y + dy;
-                        if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
-                        const ni = ny * width + nx;
-                        if (isInvalidElev(elev[ni])) next.push(ni);
-                    }
-                }
-            }
-            frontier = next;
-        }
-        for (let i = 0; i < size; i++) if (Number.isNaN(elev[i])) elev[i] = NO_DATA_SENTINEL;
-    };
+    const actual = jest.requireActual(
+        "../src/terrain/gsiTile",
+    ) as typeof import("../src/terrain/gsiTile");
     return {
-        TILE_SIZE,
-        NO_DATA_SENTINEL,
-        isInvalidElev,
-        isAllNaN,
-        fillInvalidPixels,
-        clamp: (v: number, min: number, max: number) => Math.min(Math.max(v, min), max),
+        ...actual,
         toTileXY: jest.fn(() => ({ x: 100, y: 100 })),
         tileCenterLatLon: jest.fn(() => ({ lat: 35, lon: 139 })),
         tileEdgeMeters: jest.fn(() => 1000),

--- a/tests/globeTileManager.unit.spec.ts
+++ b/tests/globeTileManager.unit.spec.ts
@@ -620,10 +620,10 @@ describe("createGlobeTileManager", () => {
         expect(elev as number).toBeCloseTo(60, 3);
     });
 
-    it("周囲も all-NaN で到達不能な水面のみタイルを代表標高でレスキューする (#339, #221)", async () => {
+    it("粗ズーム祖先が no-data でも視界内に有効タイルがあれば代表標高でレスキューする (#339, #221)", async () => {
         const mgr = makeManager();
-        // 対象タイル(gx=100)は全面 no-data(all-NaN)で同 zoom 隣接(99/101)は未ロード（視界外）。
-        // 別位置(gx=105)に有効標高 300m のタイルがあり、これが代表標高の供給源になる。
+        // 対象タイル(gx=100)は全面 no-data(all-NaN)で、粗ズーム祖先(toTileXY モックで gx=100)も
+        // no-data。別位置(gx=105)に有効標高 300m のタイルがあり、これが視界内代表標高の供給源になる。
         loadElevationTile.mockImplementation((...args: unknown[]) => {
             const gx = args[1] as number;
             if (gx === 100) return Promise.resolve(new Float32Array(256 * 256).fill(NaN));
@@ -632,12 +632,13 @@ describe("createGlobeTileManager", () => {
         selectedTiles = [tile(100, 100, 10), tile(105, 105, 10)];
         mgr.sync(syncParams());
         await flush(); // 両タイル到着。loading は空。100 は allNanGeom 入り
-        // refineAllNaNTiles: 100 は隣接シード無し → レスキューで代表標高 300m に平坦化。
-        mgr.sync(syncParams());
+        mgr.sync(syncParams()); // refine: 粗ズーム祖先の取得を起動（100 は確定見送り）
+        await flush(); // 粗ズーム祖先も no-data → coarseSeedDone（coarseSeed 無し）
+        mgr.sync(syncParams()); // 粗ズーム不可 → 視界内代表標高 300m でフォールバック平坦化
 
         const elev = mgr.terrainElevAt(35, 139);
         expect(elev).not.toBeNull();
-        // 海面 0m へ沈まず、代表標高 300m で平坦化されること（中心の沈み込み解消）。
+        // 海面 0m へ沈まず、視界内代表標高 300m で平坦化されること（中心の沈み込み解消）。
         expect(elev as number).toBeCloseTo(300, 3);
     });
 

--- a/tests/globeTileManager.unit.spec.ts
+++ b/tests/globeTileManager.unit.spec.ts
@@ -669,4 +669,20 @@ describe("createGlobeTileManager", () => {
         // 海面 0m へ沈まず、粗ズーム祖先の代表標高 900m で平坦化されること。
         expect(elev as number).toBeCloseTo(900, 3);
     });
+
+    it("未解決 all-NaN タイル上では terrainElevAt が 0m でなく null を返す（代表標高の循環崩壊防止, #339）", async () => {
+        const mgr = makeManager();
+        // 全タイル全面 no-data（all-NaN）。粗ズーム祖先取得が完了するまで未解決状態が続く。
+        loadElevationTile.mockImplementation(() =>
+            Promise.resolve(new Float32Array(256 * 256).fill(NaN)),
+        );
+        selectedTiles = [tile(100, 100, 10)];
+        mgr.sync(syncParams());
+        await flush(); // all-NaN 到着 → allNanGeom 入り（未解決）
+
+        // 未解決 all-NaN を生 NaN(bilinear=0m) として採用すると、湖上で centerElevation→0→
+        // referenceAltitude→0 と循環し暫定代表標高まで 0m に崩れる。これを防ぐため null を返す。
+        const elev = mgr.terrainElevAt(35, 139);
+        expect(elev).toBeNull();
+    });
 });


### PR DESCRIPTION
#221 で開発した標高タイルの穴埋め処理をグローブ表示でも実施する。湖・河川・no-data 領域が海面(0m)に沈む凹みを解消する。

変更: elevSample で番兵値(-100)を無効除外、globeTileManager.loadTile で部分欠測を fillInvalidPixels、all-NaN は refineAllNaNTiles で同 zoom 隣接からシードして反復補間。

検証: Unit 1131 passed / lint / typecheck / Visual 19 passed（差分なし）。

3DCG 描画変更のため、グローブ表示で湖・河川などの穴が周囲標高で連続補間されることの目視確認をお願いします（例: 奥多摩湖周辺）。

Closes #339

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>