### PR TITLE
feat(lib): JpmapTerrain に globe バックエンドと marker overlay アダプタを追加 (P4-0)

### DIFF
--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -39,6 +39,7 @@ import {
     PolygonPointPartial,
     SUN_AUTO_UPDATE_INTERVAL_MS,
     TerrainClickListener,
+    TerrainEngine,
     PolygonPointHoverListener,
     PolygonPointClickListener,
     PolygonPointDragListener,
@@ -123,8 +124,13 @@ export class JpmapTerrain {
     /** 3Dモデル管理 (Issue #243)。`onReady` で初期化される */
     private _modelManager: ModelManager | null = null;
 
+    /** 地形描画バックエンド (Issue #349 / #275 Phase 4)。 */
+    private readonly _terrainEngine: TerrainEngine;
+
     private constructor(mountElement: HTMLElement, options: JpmapTerrainOptions) {
         this.mountElement = mountElement;
+        this._terrainEngine =
+            options.terrainEngine ?? JPMAP_TERRAIN_DEFAULTS.terrainEngine;
         this._lat = options.lat ?? JPMAP_TERRAIN_DEFAULTS.lat;
         this._lon = options.lon ?? JPMAP_TERRAIN_DEFAULTS.lon;
         this._altitude = options.altitude ?? JPMAP_TERRAIN_DEFAULTS.altitude;
@@ -211,7 +217,12 @@ export class JpmapTerrain {
             );
             this._engine = engine;
 
-            const sceneFactory = new DefaultScene();
+            // globe バックエンドは Babylon Geospatial 等の重い依存を伴うため、選択時のみ動的 import する
+            // （planar 既定のバンドル/テストへ globe 依存を持ち込まない）。
+            const sceneFactory =
+                this._terrainEngine === "globe"
+                    ? new (await import("../scenes/globeSceneController")).GlobeSceneAdapter()
+                    : new DefaultScene();
             const scene = await sceneFactory.createScene(engine, canvas, {
                 lat: this._lat,
                 lon: this._lon,
@@ -275,21 +286,29 @@ export class JpmapTerrain {
                         controller.setSunShadows(true);
                     }
                     // マーカー (Issue #167)。境界コンテキスト経由で manager を構築する。
-                    this._markerManager = createMarkerManager(
-                        controller.getMarkerContext(),
-                    );
-                    // ポリゴン (Issue #170)。MarkerContext と同一のコンテキストを共有する。
-                    this._polygonManager = createPolygonManager(
-                        controller.getMarkerContext(),
-                    );
-                    // 円 (Issue #201)。MarkerContext と同一のコンテキストを共有する。
-                    this._circleManager = createCircleManager(
-                        controller.getMarkerContext(),
-                    );
-                    // 3Dモデル (Issue #243)。MarkerContext と同一のコンテキストを共有する。
-                    this._modelManager = createModelManager(
-                        controller.getMarkerContext(),
-                    );
+                    // globe バックエンド（P4-0）では marker のみ専用アダプタ（getMarkerManager）
+                    // 経由で公開 interface に対応する。polygon/circle/model は globe マネージャの
+                    // 機能不足（ラベル/垂線/altitudeMode 等）で parity 未達のため後続スライス（未対応）。
+                    if (this._terrainEngine === "planar") {
+                        this._markerManager = createMarkerManager(
+                            controller.getMarkerContext(),
+                        );
+                        // ポリゴン (Issue #170)。MarkerContext と同一のコンテキストを共有する。
+                        this._polygonManager = createPolygonManager(
+                            controller.getMarkerContext(),
+                        );
+                        // 円 (Issue #201)。MarkerContext と同一のコンテキストを共有する。
+                        this._circleManager = createCircleManager(
+                            controller.getMarkerContext(),
+                        );
+                        // 3Dモデル (Issue #243)。MarkerContext と同一のコンテキストを共有する。
+                        this._modelManager = createModelManager(
+                            controller.getMarkerContext(),
+                        );
+                    } else {
+                        this._markerManager =
+                            controller.getMarkerManager?.() ?? null;
+                    }
                 },
             });
             this._scene = scene;
@@ -385,6 +404,11 @@ export class JpmapTerrain {
     }
 
     // ---- 位置・カメラ制御 (spec §3.3.1) ----
+
+    /** 地形描画バックエンド (Issue #349 / #275 Phase 4)。`"planar"` | `"globe"`。 */
+    public get terrainEngine(): TerrainEngine {
+        return this._terrainEngine;
+    }
 
     public get lat(): number {
         return this._controller?.getLat() ?? this._lat;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -20,12 +20,26 @@ export type MapType = "standard" | "photo";
 export type ViewMode = "3d" | "2d";
 
 /**
+ * 地形描画バックエンド (Issue #349 / #275 Phase 4)。
+ * - `"planar"` (既定): 従来の平面ワールド（`scenes/default.ts`）。
+ * - `"globe"`: ECEF 楕円体 + GeospatialCamera + floating origin（`scenes/globe.ts`）。
+ *   P4-0 段階では overlay / UI パネル / 2D / 太陽影 / external frustum は順次対応中。
+ */
+export type TerrainEngine = "planar" | "globe";
+
+/**
  * `JpmapTerrain.create` 初期化オプション。
  * すべて任意指定で、未指定時は spec/package.md §3.2 のデフォルト値が適用される。
  */
 export interface JpmapTerrainOptions {
     /** 描画エンジン。WebGPU 非対応時は自動で WebGL2 にフォールバックする */
     engine?: EngineType;
+    /**
+     * 地形描画バックエンド (Issue #349 / #275 Phase 4)。
+     * - `"planar"` (既定): 従来の平面ワールド。
+     * - `"globe"`: ECEF 楕円体 + GeospatialCamera（移行中。overlay/UI/2D 等は順次対応）。
+     */
+    terrainEngine?: TerrainEngine;
     /** 緯度（度） */
     lat?: number;
     /** 経度（度） */
@@ -106,6 +120,7 @@ export interface FlyToOptions {
  */
 export const JPMAP_TERRAIN_DEFAULTS = {
     engine: "webgpu" as EngineType,
+    terrainEngine: "planar" as TerrainEngine,
     lat: 35.681236,
     lon: 139.767125,
     altitude: 2000,

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -37,6 +37,7 @@ import {
     type PolygonPointDragListener,
     type ViewMode,
 } from "../lib/types";
+import type { MarkerManager } from "../terrain/markerManager";
 
 const TERRAIN_SUBDIVISIONS = 128;
 const MAX_ZOOM = TILE_MAX_ZOOM;
@@ -271,6 +272,12 @@ export interface DefaultSceneController {
 
     /** @internal MarkerManager 構築用コンテキスト (Issue #167) */
     getMarkerContext(): MarkerContext;
+    /**
+     * globe バックエンド（#275 Phase 4 / P4-0）専用フック。公開 `MarkerManager` 互換の
+     * アダプタを返す。planar 実装は `getMarkerContext()` 経由で manager を構築するため
+     * 本メソッドは実装せず（undefined）、`JpmapTerrain` は planar/globe を呼び分ける。
+     */
+    getMarkerManager?(): MarkerManager | null;
 
     /**
      * 地形タイルへのクリック通知を購読する (Issue #183)。

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -1,0 +1,397 @@
+/**
+ * グローブシーンを `DefaultSceneController` 互換にするアダプタ (Issue #349 / #275 Phase 4 P4-0)。
+ *
+ * `JpmapTerrain`（公開ライブラリ）は `DefaultSceneController` インターフェース越しに
+ * シーンを操作する。本アダプタは `scenes/globe.ts`（GeospatialCamera + ECEF + floating origin）の
+ * `GlobeSceneController` を同インターフェースへ橋渡しし、`JpmapTerrain` が `terrainEngine` で
+ * planar↔globe を切替えるだけで globe 描画へ移行できるようにする。
+ *
+ * 本スライス（Slice 1）はカメラ get/set/flyTo・mapType（生成時固定）・dispose を実装する。
+ * overlay マネージャ・UI コントロールパネル・2D(ortho)・太陽/影・external frustum・terrain click /
+ * polygon point drag は globe 側の未整備機能を伴うため後続スライスで対応し、ここでは安全な
+ * no-op もしくは明確な未対応エラーとする（design: files/p4-0_design.md）。
+ */
+import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
+import type { Scene } from "@babylonjs/core/scene";
+
+import type { MapType } from "../terrain/gsiTile";
+import { geodeticToEcef, ecefToGeodetic } from "../terrain/geo/ecef";
+import { uiToYawPitch, yawPitchToUi } from "../terrain/geo/cameraMapping";
+import { assertLatLonInBounds } from "../terrain/overlayCoords";
+import { resolveIcon, resolveText } from "../terrain/marker";
+import type { MarkerManager } from "../terrain/markerManager";
+import type {
+    MarkerHandle,
+    MarkerOptions,
+    MarkerUpdate,
+    MarkerIconOptions,
+    MarkerTextOptions,
+    MarkerLineOptions,
+} from "../lib/types";
+import { MARKER_DEFAULTS } from "../lib/types";
+import type { GlobeMarkerManager } from "../terrain/geo/globeMarkerManager";
+import type {
+    DefaultSceneController,
+    DefaultSceneInitOptions,
+    MarkerContext,
+} from "./default";
+import { GlobeScene, type GlobeSceneController } from "./globe";
+
+/** lib の MapType（"standard"/"photo"）→ globe の MapType（"std"/"photo"）。 */
+const toGlobeMapType = (mapType: "standard" | "photo" | undefined): MapType =>
+    mapType === "photo" ? "photo" : "std";
+
+/** globe の MapType（"std"/"photo"）→ lib の MapType（"standard"/"photo"）。 */
+const fromGlobeMapType = (mapType: MapType): "standard" | "photo" =>
+    mapType === "photo" ? "photo" : "standard";
+
+const ERROR_PREFIX = "marker";
+
+/** 公開 `MarkerLineOptions` を既定値で埋める（`marker.ts` の非公開 `resolveLine` 相当）。 */
+const resolveLine = (
+    line: MarkerLineOptions | undefined,
+): Required<MarkerLineOptions> => ({
+    color: line?.color ?? MARKER_DEFAULTS.line.color,
+    width: line?.width ?? MARKER_DEFAULTS.line.width,
+    height: line?.height ?? MARKER_DEFAULTS.line.height,
+});
+
+/** アダプタが保持する 1 マーカーの解決済み状態（公開ハンドル再構築用）。 */
+interface AdapterEntry {
+    /** `GlobeMarkerManager.add` が採番した内部 id。 */
+    globeId: string;
+    lat: number;
+    lon: number;
+    enabled: boolean;
+    icon: Required<MarkerIconOptions> | null;
+    text: Required<MarkerTextOptions> | null;
+    line: Required<MarkerLineOptions>;
+}
+
+/**
+ * `GlobeMarkerManager`（採番 id / handle・partial-update 非対応）を公開
+ * `MarkerManager`（明示 id / `MarkerHandle` 返却 / partial-update）へアダプトする
+ * （#275 Phase 4 / P4-0 Slice 2a）。
+ *
+ * - 公開 id ↔ globe 内部 id の対応と、ハンドル再構築に必要な解決済みオプションを保持する。
+ * - `GlobeMarkerManager` は in-place のプロパティ更新を持たないため、`update` は内部ノードを
+ *   作り直す（remove + add）。緯度経度・アイコン・テキスト・線・表示の各変更に対応する。
+ * - `elevationResolved` は globe マネージャが露出しないため、その lat/lon で地形標高が
+ *   取得できるか（`terrainElevAt !== null`）で best-effort に判定する（planar の初回解決と同趣旨）。
+ *
+ * @internal テスト用に export する。
+ */
+export const createGlobeMarkerManagerAdapter = (
+    globeMgr: GlobeMarkerManager,
+    terrainElevAt: (latDeg: number, lonDeg: number) => number | null,
+): MarkerManager => {
+    const entries = new Map<string, AdapterEntry>();
+    let disposed = false;
+
+    const assertNotDisposed = (): void => {
+        if (disposed) throw new Error("MarkerManager has been disposed");
+    };
+
+    const buildHandle = (id: string, e: AdapterEntry): MarkerHandle => ({
+        id,
+        lat: e.lat,
+        lon: e.lon,
+        enabled: e.enabled,
+        icon: e.icon,
+        text: e.text,
+        line: e.line,
+        elevationResolved: terrainElevAt(e.lat, e.lon) !== null,
+    });
+
+    const requireEntry = (id: string): AdapterEntry => {
+        const e = entries.get(id);
+        if (!e) throw new Error(`Marker id "${id}" not found`);
+        return e;
+    };
+
+    return {
+        add(id: string, options: MarkerOptions): MarkerHandle {
+            assertNotDisposed();
+            if (entries.has(id)) {
+                throw new Error(
+                    `JpmapTerrain.addMarker: id "${id}" already exists`,
+                );
+            }
+            assertLatLonInBounds(options.lat, options.lon, ERROR_PREFIX);
+            const icon = resolveIcon(options.icon);
+            const text = resolveText(options.text);
+            // planar(createMarkerNode) と同じ契約: icon/text の少なくとも一方が必須。
+            if (!icon && !text) {
+                throw new Error(
+                    `addMarker: at least one of icon/text is required (id="${id}")`,
+                );
+            }
+            const line = resolveLine(options.line);
+            const enabled = options.enabled ?? MARKER_DEFAULTS.enabled;
+            // 解決済みオプションを渡す（icon.url の危険スキームは globe 側で検証され throw する）。
+            const globeId = globeMgr.add({
+                lat: options.lat,
+                lon: options.lon,
+                icon: icon ?? undefined,
+                text: text ?? undefined,
+                line,
+                enabled,
+            });
+            const entry: AdapterEntry = {
+                globeId,
+                lat: options.lat,
+                lon: options.lon,
+                enabled,
+                icon,
+                text,
+                line,
+            };
+            entries.set(id, entry);
+            return buildHandle(id, entry);
+        },
+        get(id: string): MarkerHandle | null {
+            const e = entries.get(id);
+            return e ? buildHandle(id, e) : null;
+        },
+        update(id: string, partial: MarkerUpdate): MarkerHandle {
+            assertNotDisposed();
+            const prev = requireEntry(id);
+            const lat = partial.lat ?? prev.lat;
+            const lon = partial.lon ?? prev.lon;
+            if (partial.lat !== undefined || partial.lon !== undefined) {
+                assertLatLonInBounds(lat, lon, ERROR_PREFIX);
+            }
+            const icon =
+                partial.icon !== undefined ? resolveIcon(partial.icon) : prev.icon;
+            const text =
+                partial.text !== undefined ? resolveText(partial.text) : prev.text;
+            const line =
+                partial.line !== undefined ? resolveLine(partial.line) : prev.line;
+            const enabled = partial.enabled ?? prev.enabled;
+            // globe マネージャは in-place 更新を持たないため作り直す。再 add（icon.url 検証等で
+            // throw しうる）を先に行い、成功後に旧ノードを remove して内部状態の不整合を防ぐ
+            // （add-then-remove。planar は破壊操作前に検証するため parity を取る）。
+            const globeId = globeMgr.add({
+                lat,
+                lon,
+                icon: icon ?? undefined,
+                text: text ?? undefined,
+                line,
+                enabled,
+            });
+            globeMgr.remove(prev.globeId);
+            const entry: AdapterEntry = {
+                globeId,
+                lat,
+                lon,
+                enabled,
+                icon,
+                text,
+                line,
+            };
+            entries.set(id, entry);
+            return buildHandle(id, entry);
+        },
+        remove(id: string): void {
+            const e = entries.get(id);
+            if (!e) {
+                console.warn(
+                    `[jpmap-terrain] removeMarker: id "${id}" not found`,
+                );
+                return;
+            }
+            globeMgr.remove(e.globeId);
+            entries.delete(id);
+        },
+        setEnabled(id: string, enabled: boolean): void {
+            assertNotDisposed();
+            const e = requireEntry(id);
+            globeMgr.setEnabled(e.globeId, enabled);
+            e.enabled = enabled;
+        },
+        list(): readonly string[] {
+            return Array.from(entries.keys());
+        },
+        dispose(): void {
+            if (disposed) return;
+            disposed = true;
+            // globe マネージャの破棄はシーン破棄（gc.dispose）でも行われるが、公開 API の
+            // dispose 契約に合わせてここでも明示的に破棄する（GlobeMarkerManager は冪等）。
+            globeMgr.dispose();
+            entries.clear();
+        },
+    };
+};
+
+/**
+ * `DefaultScene` と同一シグネチャの `createScene` を提供する globe シーンファクトリ。
+ * `JpmapTerrain.initAsync` は `terrainEngine` に応じて `DefaultScene` か本クラスを選ぶ。
+ */
+export class GlobeSceneAdapter {
+    createScene = async (
+        engine: AbstractEngine,
+        canvas: HTMLCanvasElement,
+        options?: DefaultSceneInitOptions,
+    ): Promise<Scene> => {
+        const mapType = toGlobeMapType(options?.mapType);
+        const gc: GlobeSceneController = new GlobeScene().createSceneWithController(
+            engine,
+            canvas,
+            {
+                lat: options?.lat,
+                lon: options?.lon,
+                radius: options?.altitude,
+                azimuth: options?.azimuth,
+                tilt: options?.tilt,
+                mapType,
+            },
+        );
+
+        const controller = createGlobeSceneController(gc, mapType);
+        options?.onReady?.(controller);
+        return gc.scene;
+    };
+}
+
+/**
+ * `GlobeSceneController` を `DefaultSceneController` 互換へ橋渡しする。
+ *
+ * @internal テスト用に export する（カメラ get/set マッピングの単体検証）。
+ */
+export const createGlobeSceneController = (
+    gc: GlobeSceneController,
+    initialMapType: MapType,
+): DefaultSceneController => {
+    const { camera } = gc;
+    let currentMapType: MapType = initialMapType;
+    let mapTypeWarned = false;
+    let viewModeWarned = false;
+
+    // 公開 MarkerManager 互換アダプタ（P4-0 Slice 2a）。polygon/circle/model は globe
+    // マネージャの機能不足（ラベル/垂線/altitudeMode 等）で parity 未達のため後続スライス。
+    const markerManager = createGlobeMarkerManagerAdapter(
+        gc.markerManager,
+        (latDeg, lonDeg) => gc.tileManager.terrainElevAt(latDeg, lonDeg),
+    );
+
+    /** 現在の注視点（地表 lat/lon）。 */
+    const currentGeodetic = (): { latDeg: number; lonDeg: number } => {
+        const g = ecefToGeodetic(camera.center);
+        return { latDeg: g.latDeg, lonDeg: g.lonDeg };
+    };
+
+    /** lat/lon を中心へ反映する（高度は seat-on-terrain が地表へ再吸着）。 */
+    const setCenterLatLon = (latDeg: number, lonDeg: number): void => {
+        camera.center = geodeticToEcef(latDeg, lonDeg, 0);
+    };
+
+    return {
+        getLat: () => currentGeodetic().latDeg,
+        getLon: () => currentGeodetic().lonDeg,
+        getAltitude: () => camera.radius,
+        getAzimuth: () => yawPitchToUi(camera.yaw, camera.pitch).azimuthDeg,
+        getTilt: () => yawPitchToUi(camera.yaw, camera.pitch).tiltDeg,
+        // globe は 2D(ズームレベル)概念を持たないため undefined。
+        getZoomLevel: () => undefined,
+
+        setLat: (value: number) => {
+            const { lonDeg } = currentGeodetic();
+            setCenterLatLon(value, lonDeg);
+        },
+        setLon: (value: number) => {
+            const { latDeg } = currentGeodetic();
+            setCenterLatLon(latDeg, value);
+        },
+        setAltitude: (value: number) => {
+            camera.radius = value;
+        },
+        setAzimuth: (value: number) => {
+            camera.yaw = uiToYawPitch(value, 0).yaw;
+        },
+        setTilt: (value: number) => {
+            camera.pitch = uiToYawPitch(0, value).pitch;
+        },
+
+        setView: (values) => {
+            const cur = currentGeodetic();
+            const lat = values.lat ?? cur.latDeg;
+            const lon = values.lon ?? cur.lonDeg;
+            if (values.lat !== undefined || values.lon !== undefined) {
+                setCenterLatLon(lat, lon);
+            }
+            if (values.altitude !== undefined) camera.radius = values.altitude;
+            if (values.azimuth !== undefined) {
+                camera.yaw = uiToYawPitch(values.azimuth, 0).yaw;
+            }
+            if (values.tilt !== undefined) {
+                camera.pitch = uiToYawPitch(0, values.tilt).pitch;
+            }
+        },
+
+        // ---- mapType ----
+        getMapType: () => fromGlobeMapType(currentMapType),
+        setMapType: (value: "standard" | "photo") => {
+            const next = toGlobeMapType(value);
+            if (next === currentMapType) return;
+            // GlobeTileManager は生成時に mapType を固定しており実行時切替 API が無い（要シーン再構築）。
+            // P4-0 後続スライスで対応する。ここでは状態のみ保持し描画は変更しない。
+            currentMapType = next;
+            if (!mapTypeWarned) {
+                mapTypeWarned = true;
+                console.warn(
+                    "[globeSceneController] setMapType is not yet applied on the globe backend (runtime map switch pending; P4-0 follow-up).",
+                );
+            }
+        },
+
+        // ---- viewMode ----
+        // globe は GeospatialCamera ベースで 2D(ortho) を持たない。常に "3d" として扱う。
+        getViewMode: () => "3d",
+        setViewMode: (value) => {
+            if (value === "2d" && !viewModeWarned) {
+                viewModeWarned = true;
+                console.warn(
+                    "[globeSceneController] viewMode \"2d\" is not supported on the globe backend; staying in 3d.",
+                );
+            }
+        },
+
+        // ---- external frustum / tile camera（flight 用, P4-0 後続スライス） ----
+        refreshTerrainWithExternalFrustum: () => Promise.resolve(),
+        detachTileCamera: () => {},
+        attachTileCamera: () => {},
+        setExternalCompassDegrees: () => {},
+
+        // ---- UI コントロールパネル（globe 未実装, P4-0 後続スライス） ----
+        setUiVisibility: () => {},
+
+        // ---- 太陽 / 影（globe ライティング統合は P4-0 後続スライス） ----
+        setSunState: () => {},
+        setSunShadows: () => {},
+
+        // テスト用の idle 判定。globe は同期統計を本 API に露出していないため暫定 true。
+        isTerrainIdle: () => true,
+
+        dispose: () => gc.dispose(),
+
+        getMarkerContext: (): MarkerContext => {
+            // 平面版 MarkerContext（world XZ 前提）は globe（ECEF + 地心 up）に適合しない。
+            // marker は getMarkerManager（専用アダプタ）で対応する。polygon/circle/model の
+            // 公開 parity は globe マネージャ拡張を伴うため P4-0 後続スライスで対応する。
+            throw new Error(
+                "[globeSceneController] getMarkerContext is not supported on the globe backend; use getMarkerManager for markers (polygon/circle/model: P4-0 follow-up).",
+            );
+        },
+
+        // marker のみ globe 専用アダプタ経由で公開 MarkerManager 互換を提供する（P4-0 Slice 2a）。
+        getMarkerManager: () => markerManager,
+
+        // ---- イベント購読（floating-origin 対応の pick 非依存実装は P4-0 後続スライス） ----
+        subscribeTerrainClick: () => () => {},
+        subscribePolygonPointHover: () => () => {},
+        subscribePolygonPointClick: () => () => {},
+        subscribePolygonPointDragStart: () => () => {},
+        subscribePolygonPointDrag: () => () => {},
+        subscribePolygonPointDragEnd: () => () => {},
+    };
+};

--- a/tests/globeSceneController.unit.spec.ts
+++ b/tests/globeSceneController.unit.spec.ts
@@ -1,0 +1,309 @@
+/**
+ * `createGlobeSceneController` のカメラ get/set マッピング検証 (Issue #349 / #275 Phase 4 P4-0)。
+ *
+ * GeospatialCamera を実体ではなく軽量スタブ（center: 実 Vector3 / radius / yaw / pitch）に
+ * 差し替え、ECEF 変換（`geo/ecef`）と yaw/pitch ↔ azimuth/tilt（`geo/cameraMapping`）は実物で
+ * 往復精度を確認する。overlay 未対応・viewMode "3d" 固定・mapType 切替の暫定挙動もあわせて検証する。
+ */
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+
+import { jest } from "@jest/globals";
+
+import { createGlobeSceneController } from "../src/scenes/globeSceneController";
+import { createGlobeMarkerManagerAdapter } from "../src/scenes/globeSceneController";
+import type { GlobeSceneController } from "../src/scenes/globe";
+import type {
+    GlobeMarkerManager,
+    GlobeMarkerOptions,
+} from "../src/terrain/geo/globeMarkerManager";
+import { geodeticToEcef } from "../src/terrain/geo/ecef";
+
+/** camera のみ参照する軽量スタブ GlobeSceneController を作る。 */
+const makeStub = (
+    lat: number,
+    lon: number,
+    radius: number,
+    yaw: number,
+    pitch: number,
+): { gc: GlobeSceneController; disposed: () => boolean } => {
+    let disposedFlag = false;
+    const camera = {
+        center: geodeticToEcef(lat, lon, 0),
+        radius,
+        yaw,
+        pitch,
+    };
+    const gc = {
+        camera,
+        dispose: () => {
+            disposedFlag = true;
+        },
+    } as unknown as GlobeSceneController;
+    return { gc, disposed: () => disposedFlag };
+};
+
+describe("createGlobeSceneController (P4-0 globe backend adapter)", () => {
+    it("getLat/getLon は center(ECEF) を測地座標へ逆変換して返す", () => {
+        const { gc } = makeStub(35.36, 138.72, 60000, 0, Math.PI / 4);
+        const c = createGlobeSceneController(gc, "std");
+        expect(c.getLat()).toBeCloseTo(35.36, 4);
+        expect(c.getLon()).toBeCloseTo(138.72, 4);
+        expect(c.getAltitude()).toBe(60000);
+    });
+
+    it("setLat/setLon は中心を更新し getLat/getLon と往復一致する", () => {
+        const { gc } = makeStub(35, 139, 1000, 0, 0);
+        const c = createGlobeSceneController(gc, "std");
+        c.setLat(36.5);
+        c.setLon(140.25);
+        expect(c.getLat()).toBeCloseTo(36.5, 4);
+        expect(c.getLon()).toBeCloseTo(140.25, 4);
+    });
+
+    it("setAltitude は camera.radius に反映される", () => {
+        const { gc } = makeStub(35, 139, 1000, 0, 0);
+        const c = createGlobeSceneController(gc, "std");
+        c.setAltitude(2500);
+        expect(c.getAltitude()).toBe(2500);
+    });
+
+    it("azimuth/tilt は yaw/pitch と往復一致する（度↔rad）", () => {
+        const { gc } = makeStub(35, 139, 1000, 0, 0);
+        const c = createGlobeSceneController(gc, "std");
+        c.setAzimuth(90);
+        c.setTilt(30);
+        expect(c.getAzimuth()).toBeCloseTo(90, 4);
+        expect(c.getTilt()).toBeCloseTo(30, 4);
+    });
+
+    it("setView は複数パラメータをまとめて反映する", () => {
+        const { gc } = makeStub(35, 139, 1000, 0, 0);
+        const c = createGlobeSceneController(gc, "std");
+        c.setView({ lat: 34, lon: 135, altitude: 5000, azimuth: 45, tilt: 60 });
+        expect(c.getLat()).toBeCloseTo(34, 4);
+        expect(c.getLon()).toBeCloseTo(135, 4);
+        expect(c.getAltitude()).toBe(5000);
+        expect(c.getAzimuth()).toBeCloseTo(45, 4);
+        expect(c.getTilt()).toBeCloseTo(60, 4);
+    });
+
+    it("getViewMode は常に 3d、getZoomLevel は undefined", () => {
+        const { gc } = makeStub(35, 139, 1000, 0, 0);
+        const c = createGlobeSceneController(gc, "std");
+        expect(c.getViewMode()).toBe("3d");
+        expect(c.getZoomLevel()).toBeUndefined();
+    });
+
+    it("mapType は 'std'↔'standard' / 'photo' を相互変換する", () => {
+        const { gc } = makeStub(35, 139, 1000, 0, 0);
+        const c = createGlobeSceneController(gc, "photo");
+        expect(c.getMapType()).toBe("photo");
+        const c2 = createGlobeSceneController(makeStub(35, 139, 1000, 0, 0).gc, "std");
+        expect(c2.getMapType()).toBe("standard");
+    });
+
+    it("setMapType は状態のみ保持し warn は一度だけ（実描画は未適用）", () => {
+        const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+        const { gc } = makeStub(35, 139, 1000, 0, 0);
+        const c = createGlobeSceneController(gc, "std");
+        c.setMapType("photo");
+        c.setMapType("photo"); // 同値は no-op（warn しない）
+        expect(c.getMapType()).toBe("photo");
+        expect(warn).toHaveBeenCalledTimes(1);
+        warn.mockRestore();
+    });
+
+    it("getMarkerContext は globe 未対応のため throw する", () => {
+        const { gc } = makeStub(35, 139, 1000, 0, 0);
+        const c = createGlobeSceneController(gc, "std");
+        expect(() => c.getMarkerContext()).toThrow(/not supported on the globe backend/);
+    });
+
+    it("購読 API は no-op unsubscribe を返し、no-op メソッドは例外を投げない", () => {
+        const { gc } = makeStub(35, 139, 1000, 0, 0);
+        const c = createGlobeSceneController(gc, "std");
+        expect(typeof c.subscribeTerrainClick(() => {})).toBe("function");
+        expect(() => c.setUiVisibility("compass", false)).not.toThrow();
+        expect(() => c.setSunShadows(true)).not.toThrow();
+        expect(c.isTerrainIdle()).toBe(true);
+    });
+
+    it("dispose は GlobeSceneController.dispose へ委譲する", () => {
+        const { gc, disposed } = makeStub(35, 139, 1000, 0, 0);
+        const c = createGlobeSceneController(gc, "std");
+        c.dispose();
+        expect(disposed()).toBe(true);
+    });
+});
+
+/** Vector3 が実体であることの sanity（geodeticToEcef は非ゼロを返す）。 */
+it("geodeticToEcef は富士山付近で非ゼロ ECEF を返す（テスト基盤の sanity）", () => {
+    const v = geodeticToEcef(35.36, 138.72, 0);
+    expect(v).toBeInstanceOf(Vector3);
+    expect(v.length()).toBeGreaterThan(6_000_000);
+});
+
+/** add/remove/setEnabled/dispose を記録する軽量スタブ GlobeMarkerManager。 */
+const makeGlobeMarkerStub = (): {
+    mgr: GlobeMarkerManager;
+    added: { id: string; opts: GlobeMarkerOptions }[];
+    removed: string[];
+    enabledCalls: { id: string; enabled: boolean }[];
+    disposed: () => boolean;
+} => {
+    let seq = 0;
+    let disposedFlag = false;
+    const added: { id: string; opts: GlobeMarkerOptions }[] = [];
+    const removed: string[] = [];
+    const enabledCalls: { id: string; enabled: boolean }[] = [];
+    const mgr = {
+        add: (opts: GlobeMarkerOptions): string => {
+            const id = `g${seq++}`;
+            added.push({ id, opts });
+            return id;
+        },
+        remove: (id: string): void => {
+            removed.push(id);
+        },
+        setEnabled: (id: string, enabled: boolean): void => {
+            enabledCalls.push({ id, enabled });
+        },
+        update: (): void => {},
+        dispose: (): void => {
+            disposedFlag = true;
+        },
+    } as unknown as GlobeMarkerManager;
+    return { mgr, added, removed, enabledCalls, disposed: () => disposedFlag };
+};
+
+describe("createGlobeMarkerManagerAdapter (P4-0 Slice 2a marker overlay)", () => {
+    const VALID_LAT = 35.36;
+    const VALID_LON = 138.72;
+    /** 既定の有効オプション（icon/text の少なくとも一方が必須）。 */
+    const BASE = { lat: VALID_LAT, lon: VALID_LON, text: { value: "x" } };
+
+    it("add は globe マネージャへ委譲しハンドルを返す（標高解決済み）", () => {
+        const stub = makeGlobeMarkerStub();
+        const m = createGlobeMarkerManagerAdapter(stub.mgr, () => 100);
+        const h = m.add("p1", {
+            lat: VALID_LAT,
+            lon: VALID_LON,
+            icon: { url: "https://example.com/i.png" },
+            text: { value: "hello" },
+        });
+        expect(h.id).toBe("p1");
+        expect(h.lat).toBeCloseTo(VALID_LAT, 6);
+        expect(h.lon).toBeCloseTo(VALID_LON, 6);
+        expect(h.enabled).toBe(true);
+        expect(h.icon).toEqual({
+            url: "https://example.com/i.png",
+            width: 40,
+            height: 40,
+        });
+        expect(h.text?.value).toBe("hello");
+        expect(h.line).toEqual({ color: "#000000", width: 4, height: 500 });
+        expect(h.elevationResolved).toBe(true);
+        expect(stub.added).toHaveLength(1);
+        expect(stub.added[0].opts.lat).toBeCloseTo(VALID_LAT, 6);
+    });
+
+    it("elevationResolved は terrainElevAt が null のとき false", () => {
+        const stub = makeGlobeMarkerStub();
+        const m = createGlobeMarkerManagerAdapter(stub.mgr, () => null);
+        const h = m.add("p1", { lat: VALID_LAT, lon: VALID_LON, text: { value: "x" } });
+        expect(h.elevationResolved).toBe(false);
+        expect(h.icon).toBeNull();
+        expect(h.text?.value).toBe("x");
+    });
+
+    it("icon/text のいずれも無い add は throw する（planar parity）", () => {
+        const stub = makeGlobeMarkerStub();
+        const m = createGlobeMarkerManagerAdapter(stub.mgr, () => 0);
+        expect(() =>
+            m.add("p1", { lat: VALID_LAT, lon: VALID_LON }),
+        ).toThrow(/at least one of icon\/text is required/);
+    });
+
+    it("同一 id の add は throw する", () => {
+        const stub = makeGlobeMarkerStub();
+        const m = createGlobeMarkerManagerAdapter(stub.mgr, () => 0);
+        m.add("p1", { ...BASE });
+        expect(() => m.add("p1", { ...BASE })).toThrow(/already exists/);
+    });
+
+    it("JAPAN_BOUNDS 外の lat/lon は throw する", () => {
+        const stub = makeGlobeMarkerStub();
+        const m = createGlobeMarkerManagerAdapter(stub.mgr, () => 0);
+        expect(() => m.add("p1", { lat: 0, lon: 0, text: { value: "x" } })).toThrow(
+            /JAPAN_BOUNDS/,
+        );
+    });
+
+    it("get は未知 id で null、既知 id でハンドルを返す", () => {
+        const stub = makeGlobeMarkerStub();
+        const m = createGlobeMarkerManagerAdapter(stub.mgr, () => 0);
+        expect(m.get("none")).toBeNull();
+        m.add("p1", { ...BASE });
+        expect(m.get("p1")?.id).toBe("p1");
+    });
+
+    it("update は内部ノードを作り直し（add 後に旧 remove）更新後ハンドルを返す", () => {
+        const stub = makeGlobeMarkerStub();
+        const m = createGlobeMarkerManagerAdapter(stub.mgr, () => 50);
+        m.add("p1", { lat: VALID_LAT, lon: VALID_LON, text: { value: "a" } });
+        const h = m.update("p1", { lat: 34, lon: 135, text: { value: "b" }, enabled: false });
+        expect(stub.removed).toEqual(["g0"]);
+        expect(stub.added).toHaveLength(2);
+        expect(h.lat).toBeCloseTo(34, 6);
+        expect(h.lon).toBeCloseTo(135, 6);
+        expect(h.text?.value).toBe("b");
+        expect(h.enabled).toBe(false);
+    });
+
+    it("update は未知 id で throw、範囲外 lat で throw する", () => {
+        const stub = makeGlobeMarkerStub();
+        const m = createGlobeMarkerManagerAdapter(stub.mgr, () => 0);
+        expect(() => m.update("none", { enabled: false })).toThrow(/not found/);
+        m.add("p1", { ...BASE });
+        expect(() => m.update("p1", { lat: 0, lon: 0 })).toThrow(/JAPAN_BOUNDS/);
+    });
+
+    it("remove は委譲し、未知 id では warn のみで throw しない", () => {
+        const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+        const stub = makeGlobeMarkerStub();
+        const m = createGlobeMarkerManagerAdapter(stub.mgr, () => 0);
+        m.add("p1", { ...BASE });
+        m.remove("p1");
+        expect(stub.removed).toEqual(["g0"]);
+        expect(m.get("p1")).toBeNull();
+        m.remove("none");
+        expect(warn).toHaveBeenCalled();
+        warn.mockRestore();
+    });
+
+    it("setEnabled は委譲しハンドルへ反映する", () => {
+        const stub = makeGlobeMarkerStub();
+        const m = createGlobeMarkerManagerAdapter(stub.mgr, () => 0);
+        m.add("p1", { ...BASE });
+        m.setEnabled("p1", false);
+        expect(stub.enabledCalls).toEqual([{ id: "g0", enabled: false }]);
+        expect(m.get("p1")?.enabled).toBe(false);
+    });
+
+    it("list は登録 id を返す", () => {
+        const stub = makeGlobeMarkerStub();
+        const m = createGlobeMarkerManagerAdapter(stub.mgr, () => 0);
+        m.add("p1", { ...BASE });
+        m.add("p2", { ...BASE });
+        expect(m.list()).toEqual(["p1", "p2"]);
+    });
+
+    it("dispose は globe マネージャへ委譲し、以後の add は throw する", () => {
+        const stub = makeGlobeMarkerStub();
+        const m = createGlobeMarkerManagerAdapter(stub.mgr, () => 0);
+        m.add("p1", { ...BASE });
+        m.dispose();
+        expect(stub.disposed()).toBe(true);
+        expect(() => m.add("p2", { ...BASE })).toThrow(/disposed/);
+    });
+});


### PR DESCRIPTION
## 概要
Issue #275 Phase 4 / **P4-0**。公開ライブラリ `JpmapTerrain` を `terrainEngine` オプションで planar↔globe に切替え可能にする土台を追加します（planar の既存挙動は不変）。Refs #275 / #349

## 変更内容
### Slice 1: globe バックエンド選択 seam
- `types`: `TerrainEngine` 型 / `JpmapTerrainOptions.terrainEngine` / 既定 `"planar"`
- `GlobeSceneAdapter` + `createGlobeSceneController`（`DefaultSceneController` 互換）。camera get/set/setView・mapType（生成時固定）・dispose を実装。overlay/UI/2D/sun/external-frustum/terrain-click は no-op もしくは未対応エラー。
- globe 依存は `initAsync` 内の動的 import で planar バンドルに持ち込まない。

### Slice 2a: marker overlay アダプタ
- `createGlobeMarkerManagerAdapter`: globe `GlobeMarkerManager` を公開 `MarkerManager` interface へアダプト（明示id↔採番id 対応・`MarkerHandle` 再構築・partial update は add-then-remove・`elevationResolved` は `terrainElevAt!==null` で best-effort 判定）。icon/text 必須検証など planar 契約に合わせる。
- `DefaultSceneController` に optional `getMarkerManager?()` を追加。
- `JpmapTerrain` onReady: globe 時は marker のみアダプタ経由で配線。polygon/circle/model は未対応（後続 Slice 2b）。

## 影響範囲
- API/型: `JpmapTerrainOptions.terrainEngine` 追加（後方互換、既定 planar）。`DefaultSceneController` に optional `getMarkerManager?()`。
- 挙動: `planar` は従来どおり。`globe` は marker のみ overlay 対応。

## 検証
- lint ✓ / typecheck ✓ / test:unit ✓ **1167 passed**（globeSceneController.unit.spec.ts 24 ケース新規）
- AIコードレビュー実施・2件修正（icon/text 必須検証欠落・update 非アトミック）

## 残課題
- Slice 2b: polygon/circle/model アダプタ（globe マネージャ拡張・**実描画の目視確認(HITL)** 要）
- 実描画の目視確認はデモ配線（P4-1）で実施予定
