### PR TITLE
feat(demos): viewer を terrainEngine=globe で起動可能に配線 (P4-1)

### DIFF
--- a/src/demos/viewer/index.ts
+++ b/src/demos/viewer/index.ts
@@ -5,6 +5,7 @@
  * - URL 形式:
  *   - 3D: `/@lat,lon[,altitude,azimuth,tilt]?engine=webgpu|webgl|webgl2`
  *   - 2D: `/@lat,lon,Xz?viewMode=2d` （X はズームレベル, Issue #254）
+ *   - 地形バックエンド: `?terrainEngine=globe|planar`（既定 planar, #275 Phase 4 / P4-1）
  *   （`webgl`/`webgl2` は `webgl2` に正規化、既定: 自動。altitude/azimuth/tilt は省略可、Issue #64）
  * - `#root` 要素にビューアをマウントする。
  * - URL ↔ カメラ同期はパッケージ層から切り離し、デモ層 (本ファイル) で
@@ -15,7 +16,7 @@
  * `window.showToast` を露出する。これらは公開 API ではない。
  */
 import { JpmapTerrain } from "../../lib/jpmapTerrain";
-import type { EngineType, JpmapTerrainOptions } from "../../lib/types";
+import type { EngineType, JpmapTerrainOptions, TerrainEngine } from "../../lib/types";
 import { showToast } from "../../terrain/controlPanel";
 import {
     parseCameraStateFromUrl,
@@ -41,6 +42,23 @@ export const resolveEngine = (search: string): EngineType | undefined => {
     const value = new URLSearchParams(search).get("engine");
     if (value === "webgpu") return "webgpu";
     if (value === "webgl" || value === "webgl2") return "webgl2";
+    return undefined;
+};
+
+/**
+ * `?terrainEngine=` クエリ文字列から地形バックエンドを解決する (#275 Phase 4 / P4-1)。
+ * - `globe` → `"globe"`（GeospatialCamera + ECEF の地球儀バックエンド）
+ * - `planar` → `"planar"`（従来の平面シーン）
+ * - 上記以外 / 未指定 → `undefined`（lib 既定の `"planar"` にフォールバック）
+ *
+ * @param search `location.search` 等のクエリ文字列（先頭 `?` 任意）
+ */
+export const resolveTerrainEngine = (
+    search: string,
+): TerrainEngine | undefined => {
+    const value = new URLSearchParams(search).get("terrainEngine");
+    if (value === "globe") return "globe";
+    if (value === "planar") return "planar";
     return undefined;
 };
 
@@ -137,6 +155,7 @@ const start = async (): Promise<void> => {
         throw new Error(`#${DEMO_MOUNT_ID} mount element not found`);
     }
     const engine = resolveEngine(location.search);
+    const terrainEngine = resolveTerrainEngine(location.search);
     const cameraState = resolveCameraState(location.href);
     const dateTime = resolveDateTime(location.search);
     const autoSunPosition = resolveAutoSunPosition(location.search);
@@ -145,6 +164,7 @@ const start = async (): Promise<void> => {
     const viewMode = parseViewModeFromUrl(location.href);
     const opts: JpmapTerrainOptions = {
         ...(engine ? { engine } : {}),
+        ...(terrainEngine ? { terrainEngine } : {}),
         ...(cameraState ?? {}),
         ...(dateTime !== undefined ? { dateTime } : {}),
         ...(autoSunPosition !== undefined ? { autoSunPosition } : {}),

--- a/tests/index.unit.spec.ts
+++ b/tests/index.unit.spec.ts
@@ -15,11 +15,32 @@ import { describe, it, expect, jest } from "@jest/globals";
 
 import {
     resolveEngine,
+    resolveTerrainEngine,
     resolveLatLon,
     resolveDateTime,
     resolveAutoSunPosition,
     resolveShowSunShadows,
 } from "../src/demos/viewer/index";
+
+describe("resolveTerrainEngine", () => {
+    it("?terrainEngine=globe → 'globe'", () => {
+        expect(resolveTerrainEngine("?terrainEngine=globe")).toBe("globe");
+    });
+
+    it("?terrainEngine=planar → 'planar'", () => {
+        expect(resolveTerrainEngine("?terrainEngine=planar")).toBe("planar");
+    });
+
+    it("未指定 → undefined（lib 既定 planar にフォールバック）", () => {
+        expect(resolveTerrainEngine("")).toBeUndefined();
+        expect(resolveTerrainEngine("?engine=webgpu")).toBeUndefined();
+    });
+
+    it("不正値 → undefined", () => {
+        expect(resolveTerrainEngine("?terrainEngine=sphere")).toBeUndefined();
+        expect(resolveTerrainEngine("?terrainEngine=")).toBeUndefined();
+    });
+});
 
 describe("resolveEngine", () => {
     it("?engine=webgpu → 'webgpu'", () => {


### PR DESCRIPTION
## 概要
Issue #275 Phase 4 / **P4-1**。viewer デモを `?terrainEngine=globe|planar` で globe バックエンド（#350 / P4-0）へ切替え可能にします。Refs #275 / #349

> **スタックPR**: base は #350（`feature/349-p4-0-globe-backend`）。#350 マージ後に自動で `main` 向けへ切替わります。

## 変更内容
- `resolveTerrainEngine(search)` を追加（`globe`/`planar` のみ許容、未指定/不正は `undefined` で lib 既定 `planar` にフォールバック）。
- `start()` で URL から解決し `JpmapTerrain.create` の opts へ渡す。
- viewer は marker のみ使用（P4-0 Slice 2a で globe 対応済み）のため globe で動作可能。polygon/circle 系デモは globe overlay 拡張（Slice 2b）まで未配線。

## 影響範囲
- 挙動: `terrainEngine` 未指定/`planar` は従来どおり。`?terrainEngine=globe` で地球儀バックエンド。`viewMode=2d` は globe 非対応（3d 固定 + warn）。
- テスト: `tests/index.unit.spec.ts` に `resolveTerrainEngine` の 4 ケース追加。

## 検証
- lint ✓ / typecheck ✓ / test:unit ✓ / `vite build` ✓（globe は動的 import で別チャンク）

## 要・目視確認（HITL）
- `npm start` → viewer を `?terrainEngine=globe` で開き、地球儀地形＋3マーカー（東京駅/皇居/都庁）の接地・カメラ操作・mapType 切替を確認。
