### PR TITLE
feat(globe): terrainEngine=globe に UI コントロールパネルを配線 (#349 P4-1)

### DIFF
--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -337,6 +337,9 @@ export const createGlobeSceneController = (
 
     if (canvas && typeof document !== "undefined") {
         const ui = createControlPanel();
+        // UI 破棄後にアニメーション（requestAnimationFrame）が camera を更新し続けないための
+        // ガードフラグ。uiDispose で true にし、各 rAF ループは次フレームをスケジュールしない。
+        let uiDisposed = false;
         // globe は 2D(ortho) を持たないため視点切替ボタンは常時非表示にする（#275 P4-1）。
         // createUiVisibilityController は生成時の display を初期値として捕捉するため、
         // 先に "none" にしておけば setUiVisibility("viewModeButton", true) でも再表示されない。
@@ -356,10 +359,13 @@ export const createGlobeSceneController = (
         const SCALE_BAR_BASE_PX = 100;
         let prevCompassDeg = Number.NaN;
         let prevScaleText = "";
+        let prevBarPx = Number.NaN;
         const updateOverlayUi = (): void => {
             // コンパス: 北矢印が実際の北を指すよう azimuth の逆回転を適用する。
+            // azimuthDeg は浮動小数のためほぼ毎フレーム変化しうる。0.1 度に丸めて比較し、
+            // 視覚的に意味のある変化があるときだけ DOM(style.transform) を書く。
             const az = yawPitchToUi(camera.yaw, camera.pitch).azimuthDeg;
-            const deg = -az;
+            const deg = Math.round(-az * 10) / 10;
             if (deg !== prevCompassDeg) {
                 ui.compass.style.transform = `rotate(${deg}deg)`;
                 prevCompassDeg = deg;
@@ -378,7 +384,11 @@ export const createGlobeSceneController = (
                         ui.scaleBar.label.textContent = text;
                         prevScaleText = text;
                     }
-                    ui.scaleBar.bar.style.width = `${barPx}px`;
+                    // ラベル同様、幅も変化時のみ更新して不要なレイアウトを避ける。
+                    if (barPx !== prevBarPx) {
+                        ui.scaleBar.bar.style.width = `${barPx}px`;
+                        prevBarPx = barPx;
+                    }
                 }
             }
         };
@@ -399,6 +409,8 @@ export const createGlobeSceneController = (
             const duration = 400;
             const startTime = performance.now();
             const animate = (now: number): void => {
+                // UI 破棄後はカメラを更新せず再スケジュールも止める。
+                if (uiDisposed) return;
                 const t = Math.min((now - startTime) / duration, 1);
                 const ease = 1 - Math.pow(1 - t, 3);
                 camera.yaw = startYaw + dYaw * ease;
@@ -422,6 +434,8 @@ export const createGlobeSceneController = (
             const duration = 250;
             const startTime = performance.now();
             const animate = (now: number): void => {
+                // UI 破棄後は camera.radius を更新せず再スケジュールも止める。
+                if (uiDisposed) return;
                 const t = Math.min((now - startTime) / duration, 1);
                 const ease = 1 - Math.pow(1 - t, 3);
                 camera.radius = startR + (targetR - startR) * ease;
@@ -487,6 +501,7 @@ export const createGlobeSceneController = (
             el?.parentElement?.removeChild(el);
         };
         uiDispose = (): void => {
+            uiDisposed = true;
             gc.scene.onBeforeRenderObservable.remove(overlayObserver);
             removeFromParent(ui.compass);
             removeFromParent(ui.mapToggle);

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -15,10 +15,18 @@ import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
 import type { Scene } from "@babylonjs/core/scene";
 
 import type { MapType } from "../terrain/gsiTile";
+import { JAPAN_BOUNDS } from "../terrain/gsiTile";
 import { geodeticToEcef, ecefToGeodetic } from "../terrain/geo/ecef";
 import { uiToYawPitch, yawPitchToUi } from "../terrain/geo/cameraMapping";
 import { assertLatLonInBounds } from "../terrain/overlayCoords";
 import { resolveIcon, resolveText } from "../terrain/marker";
+import {
+    createControlPanel,
+    snapScale,
+    formatScale,
+    showToast,
+} from "../terrain/controlPanel";
+import { createUiVisibilityController } from "../terrain/uiVisibility";
 import type { MarkerManager } from "../terrain/markerManager";
 import type {
     MarkerHandle,
@@ -258,7 +266,7 @@ export class GlobeSceneAdapter {
             },
         );
 
-        const controller = createGlobeSceneController(gc, mapType);
+        const controller = createGlobeSceneController(gc, mapType, options, canvas);
         options?.onReady?.(controller);
 
         // JpmapTerrain.initAsync は初期フラッシュ防止のため canvas を visibility:hidden で
@@ -279,10 +287,11 @@ export class GlobeSceneAdapter {
 export const createGlobeSceneController = (
     gc: GlobeSceneController,
     initialMapType: MapType,
+    options?: DefaultSceneInitOptions,
+    canvas?: HTMLCanvasElement,
 ): DefaultSceneController => {
     const { camera } = gc;
-    const currentMapType: MapType = initialMapType;
-    let mapTypeWarned = false;
+    let currentMapType: MapType = initialMapType;
     let viewModeWarned = false;
     let terrainClickWarned = false;
 
@@ -303,6 +312,197 @@ export const createGlobeSceneController = (
     const setCenterLatLon = (latDeg: number, lonDeg: number): void => {
         camera.center = geodeticToEcef(latDeg, lonDeg, 0);
     };
+
+    // ---- UI コントロールパネル配線（#275 Phase 4 / P4-1） ----
+    // canvas が渡された実行時のみ DOM コントロールパネルを生成・配線する（単体テストの
+    // 軽量スタブ呼び出しでは canvas 未指定で no-op）。
+    let uiSetVisibility: (
+        target: Parameters<DefaultSceneController["setUiVisibility"]>[0],
+        visible: boolean,
+    ) => void = () => {};
+    let uiDispose: () => void = () => {};
+    let updateMapToggleLabel: ((m: MapType) => void) | undefined;
+
+    /**
+     * 地図種別を切り替える共通処理（UI ボタン / `controller.setMapType` の双方から呼ぶ）。
+     * 同値なら no-op。タイルマネージャを実行時切替し、ラベル更新と onMapTypeChange 通知を行う。
+     */
+    const applyMapType = (next: MapType, fireChange: boolean): void => {
+        if (next === currentMapType) return;
+        currentMapType = next;
+        gc.tileManager.setMapType(next);
+        updateMapToggleLabel?.(next);
+        if (fireChange) options?.onMapTypeChange?.(fromGlobeMapType(next));
+    };
+
+    if (canvas && typeof document !== "undefined") {
+        const ui = createControlPanel();
+        // globe は 2D(ortho) を持たないため視点切替ボタンは常時非表示にする（#275 P4-1）。
+        // createUiVisibilityController は生成時の display を初期値として捕捉するため、
+        // 先に "none" にしておけば setUiVisibility("viewModeButton", true) でも再表示されない。
+        ui.viewModeButton.style.display = "none";
+
+        // 地図切替ボタンのラベル/aria を現在の mapType に合わせて更新する。
+        updateMapToggleLabel = (m: MapType): void => {
+            ui.mapToggle.textContent = m === "std" ? "写真" : "標準";
+            ui.mapToggle.setAttribute(
+                "aria-label",
+                m === "std" ? "地図切替: 写真地図に変更" : "地図切替: 標準地図に変更",
+            );
+        };
+        updateMapToggleLabel(currentMapType);
+
+        // コンパス回転 + スケールバーをフレーム毎に更新する（変化時のみ DOM を書く）。
+        const SCALE_BAR_BASE_PX = 100;
+        let prevCompassDeg = Number.NaN;
+        let prevScaleText = "";
+        const updateOverlayUi = (): void => {
+            // コンパス: 北矢印が実際の北を指すよう azimuth の逆回転を適用する。
+            const az = yawPitchToUi(camera.yaw, camera.pitch).azimuthDeg;
+            const deg = -az;
+            if (deg !== prevCompassDeg) {
+                ui.compass.style.transform = `rotate(${deg}deg)`;
+                prevCompassDeg = deg;
+            }
+            // スケールバー: 視野中心の地表サンプリング（fov 高 / ビュー高さ[px]）から m/px を概算する。
+            const h = canvas.clientHeight || canvas.height;
+            if (h > 0) {
+                const metersPerPx =
+                    (2 * camera.radius * Math.tan(camera.fov / 2)) / h;
+                const rawMeters = metersPerPx * SCALE_BAR_BASE_PX;
+                if (Number.isFinite(rawMeters) && rawMeters > 0) {
+                    const snapped = snapScale(rawMeters);
+                    const barPx = Math.round(snapped / metersPerPx);
+                    const text = formatScale(snapped);
+                    if (text !== prevScaleText) {
+                        ui.scaleBar.label.textContent = text;
+                        prevScaleText = text;
+                    }
+                    ui.scaleBar.bar.style.width = `${barPx}px`;
+                }
+            }
+        };
+        const overlayObserver =
+            gc.scene.onBeforeRenderObservable.add(updateOverlayUi);
+        updateOverlayUi();
+
+        // コンパスクリック: 北向き・真下（azimuth=0 / tilt=0）へスムーズに戻す。
+        ui.compass.style.cursor = "pointer";
+        const resetCompassView = (): void => {
+            const startYaw = camera.yaw;
+            const startPitch = camera.pitch;
+            const targetYaw = uiToYawPitch(0, 0).yaw;
+            const targetPitch = uiToYawPitch(0, 0).pitch;
+            // yaw は最短経路（±π に正規化）で回す。
+            let dYaw = targetYaw - startYaw;
+            dYaw = Math.atan2(Math.sin(dYaw), Math.cos(dYaw));
+            const duration = 400;
+            const startTime = performance.now();
+            const animate = (now: number): void => {
+                const t = Math.min((now - startTime) / duration, 1);
+                const ease = 1 - Math.pow(1 - t, 3);
+                camera.yaw = startYaw + dYaw * ease;
+                camera.pitch = startPitch + (targetPitch - startPitch) * ease;
+                if (t < 1) requestAnimationFrame(animate);
+            };
+            requestAnimationFrame(animate);
+        };
+        ui.compass.addEventListener("click", resetCompassView);
+        ui.compass.addEventListener("keydown", (e: KeyboardEvent) => {
+            if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                resetCompassView();
+            }
+        });
+
+        // ズームボタン: camera.radius（高度相当）を係数で滑らかに増減する。
+        const zoomByFactor = (factor: number): void => {
+            const startR = camera.radius;
+            const targetR = startR * factor;
+            const duration = 250;
+            const startTime = performance.now();
+            const animate = (now: number): void => {
+                const t = Math.min((now - startTime) / duration, 1);
+                const ease = 1 - Math.pow(1 - t, 3);
+                camera.radius = startR + (targetR - startR) * ease;
+                if (t < 1) requestAnimationFrame(animate);
+            };
+            requestAnimationFrame(animate);
+        };
+        ui.zoomIn.addEventListener("click", () => zoomByFactor(0.7));
+        ui.zoomOut.addEventListener("click", () => zoomByFactor(1 / 0.7));
+
+        // 現在地ボタン: Geolocation で取得した地点へ注視点を移す。
+        ui.locateMe.addEventListener("click", () => {
+            if (!navigator.geolocation) {
+                console.warn(
+                    "[globeSceneController] Geolocation API is not supported by this browser.",
+                );
+                return;
+            }
+            navigator.geolocation.getCurrentPosition(
+                (position) => {
+                    const lat = position.coords.latitude;
+                    const lon = position.coords.longitude;
+                    // GSI 地形タイルは日本域のみ。域外は背景球のみ表示になる旨を通知する。
+                    if (
+                        lat < JAPAN_BOUNDS.minLat ||
+                        lat > JAPAN_BOUNDS.maxLat ||
+                        lon < JAPAN_BOUNDS.minLon ||
+                        lon > JAPAN_BOUNDS.maxLon
+                    ) {
+                        showToast(
+                            "現在地は対応エリア外のため、地形が表示されない場合があります",
+                        );
+                    }
+                    setCenterLatLon(lat, lon);
+                },
+                (error) => {
+                    console.warn(
+                        `[globeSceneController] Geolocation error: ${error.message}`,
+                    );
+                },
+            );
+        });
+
+        // 地図切替ボタン: std ↔ photo を実行時に切り替える（#275 P4-1）。
+        ui.mapToggle.addEventListener("click", () => {
+            applyMapType(currentMapType === "std" ? "photo" : "std", true);
+        });
+
+        uiSetVisibility = createUiVisibilityController({
+            compass: ui.compass,
+            locateMe: ui.locateMe,
+            zoomIn: ui.zoomIn,
+            zoomOut: ui.zoomOut,
+            scaleBarBar: ui.scaleBar.bar,
+            scaleBarLabel: ui.scaleBar.label,
+            mapToggle: ui.mapToggle,
+            viewModeButton: ui.viewModeButton,
+            attribution: ui.scaleBar.attribution,
+        });
+
+        // dispose: フレーム購読を解除し、controlPanel が body に追加した UI 要素を除去する。
+        const removeFromParent = (el: HTMLElement | null): void => {
+            el?.parentElement?.removeChild(el);
+        };
+        uiDispose = (): void => {
+            gc.scene.onBeforeRenderObservable.remove(overlayObserver);
+            removeFromParent(ui.compass);
+            removeFromParent(ui.mapToggle);
+            removeFromParent(ui.viewModeButton);
+            // locateMe / zoomIn / zoomOut / scaleBar.* は共通の親コンテナ配下。
+            const zoomContainer = ui.zoomIn.parentElement;
+            if (zoomContainer) {
+                removeFromParent(zoomContainer);
+            } else {
+                removeFromParent(ui.locateMe);
+                removeFromParent(ui.zoomIn);
+                removeFromParent(ui.zoomOut);
+                removeFromParent(ui.scaleBar.container);
+            }
+        };
+    }
 
     return {
         getLat: () => currentGeodetic().latDeg,
@@ -350,17 +550,8 @@ export const createGlobeSceneController = (
         // ---- mapType ----
         getMapType: () => fromGlobeMapType(currentMapType),
         setMapType: (value: "standard" | "photo") => {
-            const next = toGlobeMapType(value);
-            if (next === currentMapType) return;
-            // GlobeTileManager は生成時に mapType を固定しており実行時切替 API が無い（要シーン再構築）。
-            // P4-0 後続スライスで対応する。実行時切替が未対応の間は currentMapType を更新せず
-            // （getMapType が実描画＝生成時固定値と乖離しないように）、warn のみに留める。
-            if (!mapTypeWarned) {
-                mapTypeWarned = true;
-                console.warn(
-                    "[globeSceneController] setMapType is not yet applied on the globe backend (runtime map switch pending; P4-0 follow-up).",
-                );
-            }
+            // UI ボタンと同じ共通処理で実行時切替する（#275 P4-1）。onMapTypeChange も発火する。
+            applyMapType(toGlobeMapType(value), true);
         },
 
         // ---- viewMode ----
@@ -381,8 +572,8 @@ export const createGlobeSceneController = (
         attachTileCamera: () => {},
         setExternalCompassDegrees: () => {},
 
-        // ---- UI コントロールパネル（globe 未実装, P4-0 後続スライス） ----
-        setUiVisibility: () => {},
+        // ---- UI コントロールパネル（#275 P4-1 で配線。canvas 未指定時は no-op） ----
+        setUiVisibility: (target, visible) => uiSetVisibility(target, visible),
 
         // ---- 太陽 / 影（globe ライティング統合は P4-0 後続スライス） ----
         setSunState: () => {},
@@ -393,7 +584,10 @@ export const createGlobeSceneController = (
         //  希望タイル desiredKeys がすべて loaded かつテクスチャ適用済み readyMeshes）を返す。
         isTerrainIdle: () => gc.tileManager.isIdle(),
 
-        dispose: () => gc.dispose(),
+        dispose: () => {
+            uiDispose();
+            gc.dispose();
+        },
 
         getMarkerContext: (): MarkerContext => {
             // 平面版 MarkerContext（world XZ 前提）は globe（ECEF + 地心 up）に適合しない。

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -456,6 +456,7 @@ export const createGlobeSceneController = (
             }
             navigator.geolocation.getCurrentPosition(
                 (position) => {
+                    if (uiDisposed) return;
                     const lat = position.coords.latitude;
                     const lon = position.coords.longitude;
                     // GSI 地形タイルは日本域のみ。域外は背景球のみ表示になる旨を通知する。
@@ -472,6 +473,7 @@ export const createGlobeSceneController = (
                     setCenterLatLon(lat, lon);
                 },
                 (error) => {
+                    if (uiDisposed) return;
                     console.warn(
                         `[globeSceneController] Geolocation error: ${error.message}`,
                     );

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -980,7 +980,11 @@ export const createGlobeTileManager = (
             // GPU テクスチャが確実に生成された onLoad 内で diffuseTexture を設定する
             // （WebGPU の "null gpu texture bind" を避ける。平面版 tileManager と同様）。
             // invertY=true は UV（v=1 が北端）の前提に必要。ロード前に mesh が破棄されていれば
-            // 孤立テクスチャを破棄する。
+            // 孤立テクスチャを破棄する。ロードは非同期なので、ロード中に setMapType で地図種別が
+            // 変わった場合は、この（旧種別の）テクスチャを適用すると誤表示になる。生成時の種別を
+            // 捕捉し、完了時に currentMapType と一致する場合のみ適用する（不一致なら破棄。描画可能化は
+            // setMapType が起動した再テクスチャ側 onLoad/onError が担う）。
+            const builtFor = currentMapType;
             const tex = new Texture(
                 textureUrl(currentMapType, t.zoom, t.x, t.y),
                 scene,
@@ -988,7 +992,7 @@ export const createGlobeTileManager = (
                 true,
                 Texture.TRILINEAR_SAMPLINGMODE,
                 () => {
-                    if (mesh.isDisposed()) {
+                    if (mesh.isDisposed() || currentMapType !== builtFor) {
                         tex.dispose();
                         return;
                     }
@@ -1005,9 +1009,10 @@ export const createGlobeTileManager = (
                 // pendingRelease 中の hiddenChild は即表示しない（onLoad と同様）。即表示すると
                 // 親と子が同時に見えて原子スワップ（重なりちらつき防止）が壊れる。readyMeshes に
                 // 登録するのでカバー判定が成立し、enableDescendants 経由でスワップ時に表示される。
+                // 種別不一致（ロード中に setMapType）の場合は再テクスチャ側に委ねる。
                 () => {
                     tex.dispose();
-                    if (mesh.isDisposed()) return;
+                    if (mesh.isDisposed() || currentMapType !== builtFor) return;
                     readyMeshes.add(mesh);
                     if (!hiddenChildTiles.has(k)) mesh.setEnabled(true);
                     checkAndReleaseCoveredTiles({ zoom: t.zoom, x: t.x, y: t.y });
@@ -1226,7 +1231,10 @@ export const createGlobeTileManager = (
 
                 // GPU テクスチャ生成完了（onLoad）で diffuseTexture を設定する（WebGPU の
                 // "null gpu texture bind" 回避。LOD タイルと同様）。ベースは常時表示なので
-                // setEnabled の出し入れはしない。
+                // setEnabled の出し入れはしない。ロード中に setMapType で地図種別が変わった場合は
+                // 旧種別の適用を避けるため、生成時の種別を捕捉して一致時のみ適用する（不一致なら
+                // 破棄。新種別の適用は setMapType の再テクスチャ側が担う）。
+                const builtFor = currentMapType;
                 const tex = new Texture(
                     textureUrl(currentMapType, BASE_LAYER_ZOOM, x, y),
                     scene,
@@ -1234,7 +1242,7 @@ export const createGlobeTileManager = (
                     true,
                     Texture.TRILINEAR_SAMPLINGMODE,
                     () => {
-                        if (mesh.isDisposed()) {
+                        if (mesh.isDisposed() || currentMapType !== builtFor) {
                             tex.dispose();
                             return;
                         }
@@ -1290,6 +1298,9 @@ export const createGlobeTileManager = (
      * 新テクスチャの onLoad で diffuseTexture を張り替え、旧テクスチャを破棄する
      * （張替え前にちらつかないよう、新テクスチャ準備完了まで旧テクスチャを保持）。
      * base レイヤはテクスチャ適用時に海色ティントを白へ戻す（buildBaseLayer と同様）。
+     * 初回テクスチャ未到着（setEnabled(false)・readyMeshes 未登録）の LOD メッシュに対して
+     * setMapType された場合も、ここで描画可能化（readyMeshes 登録・表示・カバー判定）を行う。
+     * これがないとタイルが永続的に非表示になり isIdle も false のままになる。
      */
     const retextureMesh = (
         mesh: Mesh,
@@ -1301,10 +1312,18 @@ export const createGlobeTileManager = (
         const mat = mesh.material as StandardMaterial | null;
         if (!mat) return;
         const oldTex = mat.diffuseTexture;
+        const k = tileKey(zoom, x, y);
         // ロードは非同期。setMapType を短時間に複数回呼ぶと（例: 地図切替の連打）
         // 旧種別のテクスチャが後から完了して選択と不一致になりうるため、
         // 生成時の種別を捕捉し、完了時に currentMapType と一致する場合のみ適用する。
         const builtFor = currentMapType;
+        // base 以外（LOD/pendingRelease）は未 ready のメッシュを描画可能化する。
+        const markReady = (): void => {
+            if (isBase) return;
+            readyMeshes.add(mesh);
+            if (!hiddenChildTiles.has(k)) mesh.setEnabled(true);
+            checkAndReleaseCoveredTiles({ zoom, x, y });
+        };
         const tex = new Texture(
             textureUrl(currentMapType, zoom, x, y),
             scene,
@@ -1318,11 +1337,17 @@ export const createGlobeTileManager = (
                 }
                 mat.diffuseTexture = tex;
                 if (isBase) mat.diffuseColor = BASE_LAYER_TEXTURE_TINT;
+                else markReady();
                 // 新テクスチャ適用後に旧テクスチャを破棄（GPU リソースリーク防止）。
                 oldTex?.dispose();
             },
             // onError: 取得失敗時は新テクスチャを破棄し、旧テクスチャ（現状表示）を保持する。
-            () => tex.dispose(),
+            // ただし未 ready の LOD メッシュは白のままでも描画可能化する（ホールより良い）。
+            () => {
+                tex.dispose();
+                if (mesh.isDisposed() || currentMapType !== builtFor) return;
+                if (!isBase && !readyMeshes.has(mesh)) markReady();
+            },
         );
         tex.wrapU = Texture.CLAMP_ADDRESSMODE;
         tex.wrapV = Texture.CLAMP_ADDRESSMODE;

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -202,6 +202,16 @@ export interface GlobeTileManager {
      * 平面版 `tileManager.isIdle` 相当の安定判定を globe で提供する。
      */
     isIdle: () => boolean;
+    /** 現在の地図種別（"std"/"photo"）。 */
+    getMapType: () => MapType;
+    /**
+     * 地図種別を実行時に切り替える (#275 Phase 4 / P4-1)。
+     * 現在ロード済みの LOD タイル・LOD 遷移中の pendingRelease タイル・常時表示ベースレイヤの
+     * 各メッシュのテクスチャを新しい mapType の URL で差し替える（新テクスチャ onLoad で適用し
+     * 旧テクスチャを破棄）。以降に sync が新規生成するタイルも新 mapType の URL を参照する。
+     * 同値なら no-op。
+     */
+    setMapType: (mapType: MapType) => void;
     /** 全メッシュ・キャッシュを破棄する。 */
     dispose: () => void;
 }
@@ -212,7 +222,10 @@ export interface GlobeTileManager {
 export const createGlobeTileManager = (
     opts: GlobeTileManagerOptions,
 ): GlobeTileManager => {
-    const { scene, mapType, minZoom, geomMaxZoom, segments, snapEnabled } = opts;
+    const { scene, minZoom, geomMaxZoom, segments, snapEnabled } = opts;
+    // 地図種別は実行時に切替可能（#275 P4-1）。buildTile / buildBaseLayer のテクスチャ URL は
+    // この可変値を参照するため、以降の新規タイルは切替後の mapType を使う。
+    let currentMapType: MapType = opts.mapType;
 
     const loaded = new Map<string, Mesh>();
     // 常時表示の粗いベースレイヤのメッシュ（Issue #341, key="z/x/y"）。LOD の loaded とは別管理で
@@ -969,7 +982,7 @@ export const createGlobeTileManager = (
             // invertY=true は UV（v=1 が北端）の前提に必要。ロード前に mesh が破棄されていれば
             // 孤立テクスチャを破棄する。
             const tex = new Texture(
-                textureUrl(mapType, t.zoom, t.x, t.y),
+                textureUrl(currentMapType, t.zoom, t.x, t.y),
                 scene,
                 false,
                 true,
@@ -1215,7 +1228,7 @@ export const createGlobeTileManager = (
                 // "null gpu texture bind" 回避。LOD タイルと同様）。ベースは常時表示なので
                 // setEnabled の出し入れはしない。
                 const tex = new Texture(
-                    textureUrl(mapType, BASE_LAYER_ZOOM, x, y),
+                    textureUrl(currentMapType, BASE_LAYER_ZOOM, x, y),
                     scene,
                     false,
                     true,
@@ -1270,6 +1283,73 @@ export const createGlobeTileManager = (
         desiredKeys = new Set<string>();
     };
 
+    const getMapType = (): MapType => currentMapType;
+
+    /**
+     * 指定メッシュのテクスチャを現在の currentMapType の URL で差し替える。
+     * 新テクスチャの onLoad で diffuseTexture を張り替え、旧テクスチャを破棄する
+     * （張替え前にちらつかないよう、新テクスチャ準備完了まで旧テクスチャを保持）。
+     * base レイヤはテクスチャ適用時に海色ティントを白へ戻す（buildBaseLayer と同様）。
+     */
+    const retextureMesh = (
+        mesh: Mesh,
+        zoom: number,
+        x: number,
+        y: number,
+        isBase: boolean,
+    ): void => {
+        const mat = mesh.material as StandardMaterial | null;
+        if (!mat) return;
+        const oldTex = mat.diffuseTexture;
+        // ロードは非同期。setMapType を短時間に複数回呼ぶと（例: 地図切替の連打）
+        // 旧種別のテクスチャが後から完了して選択と不一致になりうるため、
+        // 生成時の種別を捕捉し、完了時に currentMapType と一致する場合のみ適用する。
+        const builtFor = currentMapType;
+        const tex = new Texture(
+            textureUrl(currentMapType, zoom, x, y),
+            scene,
+            false,
+            true,
+            Texture.TRILINEAR_SAMPLINGMODE,
+            () => {
+                if (mesh.isDisposed() || currentMapType !== builtFor) {
+                    tex.dispose();
+                    return;
+                }
+                mat.diffuseTexture = tex;
+                if (isBase) mat.diffuseColor = BASE_LAYER_TEXTURE_TINT;
+                // 新テクスチャ適用後に旧テクスチャを破棄（GPU リソースリーク防止）。
+                oldTex?.dispose();
+            },
+            // onError: 取得失敗時は新テクスチャを破棄し、旧テクスチャ（現状表示）を保持する。
+            () => tex.dispose(),
+        );
+        tex.wrapU = Texture.CLAMP_ADDRESSMODE;
+        tex.wrapV = Texture.CLAMP_ADDRESSMODE;
+    };
+
+    const setMapType = (next: MapType): void => {
+        if (next === currentMapType) return;
+        currentMapType = next;
+        // key="z/x/y"。ロード済み LOD・LOD 遷移中の pendingRelease・常時表示ベースレイヤを再テクスチャする。
+        const parseKey = (k: string): [number, number, number] => {
+            const [z, x, y] = k.split("/").map(Number);
+            return [z, x, y];
+        };
+        for (const [k, mesh] of loaded) {
+            const [z, x, y] = parseKey(k);
+            retextureMesh(mesh, z, x, y, false);
+        }
+        for (const [k, pending] of pendingRelease) {
+            const [z, x, y] = parseKey(k);
+            retextureMesh(pending.mesh, z, x, y, false);
+        }
+        for (const [k, mesh] of baseLoaded) {
+            const [z, x, y] = parseKey(k);
+            retextureMesh(mesh, z, x, y, true);
+        }
+    };
+
     const isIdle = (): boolean => {
         if (!syncedAtLeastOnce) return false;
         // 標高ロード中・LOD 遷移の残置タイルがある間は安定とみなさない。
@@ -1288,5 +1368,5 @@ export const createGlobeTileManager = (
     // 常時表示の粗いベースレイヤを一度だけ構築する（Issue #341）。
     buildBaseLayer();
 
-    return { sync, terrainElevAt, isIdle, dispose };
+    return { sync, terrainElevAt, isIdle, getMapType, setMapType, dispose };
 };

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -1357,21 +1357,17 @@ export const createGlobeTileManager = (
         if (next === currentMapType) return;
         currentMapType = next;
         // key="z/x/y"。ロード済み LOD・LOD 遷移中の pendingRelease・常時表示ベースレイヤを再テクスチャする。
-        const parseKey = (k: string): [number, number, number] => {
-            const [z, x, y] = k.split("/").map(Number);
-            return [z, x, y];
-        };
         for (const [k, mesh] of loaded) {
-            const [z, x, y] = parseKey(k);
-            retextureMesh(mesh, z, x, y, false);
+            const { zoom, x, y } = parseKey(k);
+            retextureMesh(mesh, zoom, x, y, false);
         }
         for (const [k, pending] of pendingRelease) {
-            const [z, x, y] = parseKey(k);
-            retextureMesh(pending.mesh, z, x, y, false);
+            const { zoom, x, y } = parseKey(k);
+            retextureMesh(pending.mesh, zoom, x, y, false);
         }
         for (const [k, mesh] of baseLoaded) {
-            const [z, x, y] = parseKey(k);
-            retextureMesh(mesh, z, x, y, true);
+            const { zoom, x, y } = parseKey(k);
+            retextureMesh(mesh, zoom, x, y, true);
         }
     };
 

--- a/tests/globeSceneController.unit.spec.ts
+++ b/tests/globeSceneController.unit.spec.ts
@@ -36,10 +36,11 @@ const makeStub = (
     };
     const gc = {
         camera,
-        // isTerrainIdle / marker アダプタが参照する tileManager スタブ。
+        // isTerrainIdle / marker アダプタ / mapType 切替が参照する tileManager スタブ。
         tileManager: {
             isIdle: () => idle,
             terrainElevAt: () => null,
+            setMapType: jest.fn(),
         },
         dispose: () => {
             disposedFlag = true;
@@ -108,16 +109,21 @@ describe("createGlobeSceneController (P4-0 globe backend adapter)", () => {
         expect(c2.getMapType()).toBe("standard");
     });
 
-    it("setMapType は実描画未適用のため getMapType は生成時固定値のまま、warn は一度だけ", () => {
-        const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    it("setMapType は実行時切替を tileManager に委譲し getMapType に反映、onMapTypeChange を発火する (#275 P4-1)", () => {
         const { gc } = makeStub(35, 139, 1000, 0, 0);
-        const c = createGlobeSceneController(gc, "std");
+        const setMapTypeSpy = (
+            gc.tileManager as unknown as { setMapType: jest.Mock }
+        ).setMapType;
+        const onMapTypeChange = jest.fn();
+        const c = createGlobeSceneController(gc, "std", { onMapTypeChange });
         c.setMapType("photo");
-        c.setMapType("photo"); // 実行時切替未対応のため状態は変えず、warn も増やさない
-        // 実描画と乖離させないため currentMapType は生成時固定値("std"→"standard")のまま。
-        expect(c.getMapType()).toBe("standard");
-        expect(warn).toHaveBeenCalledTimes(1);
-        warn.mockRestore();
+        expect(setMapTypeSpy).toHaveBeenCalledWith("photo");
+        expect(c.getMapType()).toBe("photo");
+        expect(onMapTypeChange).toHaveBeenCalledWith("photo");
+        // 同値再 set は no-op（委譲も通知もしない）。
+        c.setMapType("photo");
+        expect(setMapTypeSpy).toHaveBeenCalledTimes(1);
+        expect(onMapTypeChange).toHaveBeenCalledTimes(1);
     });
 
     it("getMarkerContext は globe 未対応のため throw する", () => {

--- a/tests/globeSceneControllerUi.unit.spec.ts
+++ b/tests/globeSceneControllerUi.unit.spec.ts
@@ -36,6 +36,7 @@ const makeObservable = <T extends () => void>(): ObservableStub<T> => {
 };
 
 let rafCallbacks: FrameRequestCallback[] = [];
+let originalRaf: typeof requestAnimationFrame;
 
 const makeCamera = () => ({
     center: geodeticToEcef(35, 139, 0),
@@ -82,10 +83,15 @@ const makeCanvas = (): HTMLCanvasElement => {
 beforeEach(() => {
     document.body.innerHTML = "";
     rafCallbacks = [];
+    originalRaf = global.requestAnimationFrame;
     global.requestAnimationFrame = ((cb: FrameRequestCallback) => {
         rafCallbacks.push(cb);
         return rafCallbacks.length;
     }) as typeof requestAnimationFrame;
+});
+
+afterEach(() => {
+    global.requestAnimationFrame = originalRaf;
 });
 
 describe("globe UI コントロールパネル配線 (#275 P4-1)", () => {

--- a/tests/globeSceneControllerUi.unit.spec.ts
+++ b/tests/globeSceneControllerUi.unit.spec.ts
@@ -1,0 +1,204 @@
+/**
+ * @jest-environment jsdom
+ *
+ * `createGlobeSceneController` の UI コントロールパネル配線（#275 Phase 4 / P4-1）の
+ * 挙動検証。Copilot レビュー指摘（PR #355）への回帰テスト:
+ * - コンパス回転角は丸めて DOM へ書く（浮動小数で毎フレーム書かない）
+ * - スケールバー幅は変化時のみ更新する
+ * - dispose 後はズーム/コンパスのアニメーション（rAF）が camera を更新せず再スケジュールしない
+ */
+import { jest } from "@jest/globals";
+
+import { createGlobeSceneController } from "../src/scenes/globeSceneController";
+import type { GlobeSceneController } from "../src/scenes/globe";
+import { geodeticToEcef } from "../src/terrain/geo/ecef";
+
+interface ObservableStub<T> {
+    add: (cb: T) => T;
+    remove: (cb: T) => boolean;
+    addOnce: (cb: T) => T;
+    fire: () => void;
+}
+const makeObservable = <T extends () => void>(): ObservableStub<T> => {
+    const cbs = new Set<T>();
+    return {
+        add: (cb: T) => {
+            cbs.add(cb);
+            return cb;
+        },
+        remove: (cb: T) => cbs.delete(cb),
+        addOnce: (cb: T) => {
+            cbs.add(cb);
+            return cb;
+        },
+        fire: () => cbs.forEach((cb) => cb()),
+    };
+};
+
+let rafCallbacks: FrameRequestCallback[] = [];
+
+const makeCamera = () => ({
+    center: geodeticToEcef(35, 139, 0),
+    radius: 100000,
+    yaw: 0,
+    pitch: 0,
+    fov: 0.8,
+});
+
+const makeGcWithScene = (
+    camera: ReturnType<typeof makeCamera>,
+): {
+    gc: GlobeSceneController;
+    onBeforeRender: ObservableStub<() => void>;
+    disposed: () => boolean;
+} => {
+    const onBeforeRender = makeObservable<() => void>();
+    let disposedFlag = false;
+    const gc = {
+        camera,
+        scene: {
+            onBeforeRenderObservable: onBeforeRender,
+            onAfterRenderObservable: makeObservable<() => void>(),
+        },
+        tileManager: {
+            isIdle: () => true,
+            terrainElevAt: () => null,
+            setMapType: jest.fn(),
+        },
+        dispose: () => {
+            disposedFlag = true;
+        },
+    } as unknown as GlobeSceneController;
+    return { gc, onBeforeRender, disposed: () => disposedFlag };
+};
+
+const makeCanvas = (): HTMLCanvasElement => {
+    const canvas = document.createElement("canvas");
+    // jsdom は clientHeight=0 のため height をフォールバックに使う。
+    canvas.height = 600;
+    return canvas;
+};
+
+beforeEach(() => {
+    document.body.innerHTML = "";
+    rafCallbacks = [];
+    global.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+        rafCallbacks.push(cb);
+        return rafCallbacks.length;
+    }) as typeof requestAnimationFrame;
+});
+
+describe("globe UI コントロールパネル配線 (#275 P4-1)", () => {
+    it("コンパス回転角は 0.1 度に丸めて transform へ書く", () => {
+        const camera = makeCamera();
+        // ほぼゼロでない方位を作る（丸めの効果を観察する）。
+        camera.yaw = 0.123456789;
+        const { gc } = makeGcWithScene(camera);
+        createGlobeSceneController(gc, "std", undefined, makeCanvas());
+
+        const compass = document.querySelector(".cp-compass") as HTMLElement;
+        expect(compass).not.toBeNull();
+        const m = /rotate\((-?\d+(?:\.\d+)?)deg\)/.exec(
+            compass.style.transform,
+        );
+        expect(m).not.toBeNull();
+        const deg = Number(m![1]);
+        // 0.1 度刻みに丸められている（deg*10 が整数）。
+        expect(Number.isInteger(Math.round(deg * 10))).toBe(true);
+        expect(deg * 10).toBeCloseTo(Math.round(deg * 10), 9);
+    });
+
+    it("スケールバー幅は値が変わらないフレームでは書き換えない", () => {
+        const camera = makeCamera();
+        const { gc, onBeforeRender } = makeGcWithScene(camera);
+        createGlobeSceneController(gc, "std", undefined, makeCanvas());
+
+        // scaleContainer = 地理院タイル attribution の親。その中の div が幅更新対象の bar。
+        const attribution = document.querySelector(
+            'a[href*="maps.gsi.go.jp"]',
+        ) as HTMLElement;
+        expect(attribution).not.toBeNull();
+        const scaleContainer = attribution.parentElement as HTMLElement;
+        const bar = scaleContainer.querySelector("div") as HTMLElement;
+        expect(bar).not.toBeNull();
+
+        // 生成時に一度 width が設定済み。以降の width 書き込み回数をスパイする。
+        let widthWrites = 0;
+        let widthVal = bar.style.width;
+        Object.defineProperty(bar.style, "width", {
+            get: () => widthVal,
+            set: (v: string) => {
+                widthVal = v;
+                widthWrites++;
+            },
+            configurable: true,
+        });
+
+        // 同条件で再 fire しても width は書き換えない。
+        onBeforeRender.fire();
+        expect(widthWrites).toBe(0);
+
+        // 距離が大きく変わると（barPx が変化）width を 1 回だけ更新する。
+        camera.radius = 100000 * 4;
+        onBeforeRender.fire();
+        expect(widthWrites).toBe(1);
+        // 再度同条件なら書き換えない。
+        onBeforeRender.fire();
+        expect(widthWrites).toBe(1);
+    });
+
+    it("dispose 後はズームアニメーションが camera.radius を更新せず再スケジュールしない", () => {
+        const camera = makeCamera();
+        const { gc } = makeGcWithScene(camera);
+        const c = createGlobeSceneController(gc, "std", undefined, makeCanvas());
+        rafCallbacks = []; // 生成時 fire 由来をクリア
+
+        const zoomIn = document.querySelector(
+            '[aria-label="ズームイン"]',
+        ) as HTMLElement;
+        expect(zoomIn).not.toBeNull();
+        zoomIn.dispatchEvent(new Event("click"));
+        expect(rafCallbacks.length).toBe(1); // animate がスケジュールされた
+
+        const start = performance.now();
+        rafCallbacks[0](start + 10); // 1 フレーム進める
+        const radiusAfterOneFrame = camera.radius;
+        expect(radiusAfterOneFrame).toBeLessThan(100000); // 縮小した
+        expect(rafCallbacks.length).toBe(2); // 次フレームを予約
+
+        // dispose 後は次フレームを実行しても radius を更新せず、再スケジュールしない。
+        c.dispose();
+        const pending = rafCallbacks[1];
+        rafCallbacks = [];
+        pending(start + 100000);
+        expect(camera.radius).toBe(radiusAfterOneFrame); // 変化なし
+        expect(rafCallbacks.length).toBe(0); // 再スケジュールなし
+    });
+
+    it("dispose 後はコンパスリセットアニメーションが camera を更新せず再スケジュールしない", () => {
+        const camera = makeCamera();
+        camera.yaw = 1.0;
+        camera.pitch = 0.5;
+        const { gc } = makeGcWithScene(camera);
+        const c = createGlobeSceneController(gc, "std", undefined, makeCanvas());
+        rafCallbacks = [];
+
+        const compass = document.querySelector(".cp-compass") as HTMLElement;
+        compass.dispatchEvent(new Event("click"));
+        expect(rafCallbacks.length).toBe(1);
+
+        const start = performance.now();
+        rafCallbacks[0](start + 10);
+        const yawAfter = camera.yaw;
+        const pitchAfter = camera.pitch;
+        expect(rafCallbacks.length).toBe(2);
+
+        c.dispose();
+        const pending = rafCallbacks[1];
+        rafCallbacks = [];
+        pending(start + 100000);
+        expect(camera.yaw).toBe(yawAfter);
+        expect(camera.pitch).toBe(pitchAfter);
+        expect(rafCallbacks.length).toBe(0);
+    });
+});

--- a/tests/globeSceneControllerUi.unit.spec.ts
+++ b/tests/globeSceneControllerUi.unit.spec.ts
@@ -207,4 +207,35 @@ describe("globe UI コントロールパネル配線 (#275 P4-1)", () => {
         expect(camera.pitch).toBe(pitchAfter);
         expect(rafCallbacks.length).toBe(0);
     });
+
+    it("dispose 後は現在地取得のコールバックが camera を更新しない", () => {
+        const camera = makeCamera();
+        const { gc } = makeGcWithScene(camera);
+
+        let successCb: ((p: unknown) => void) | null = null;
+        let errorCb: ((e: unknown) => void) | null = null;
+        // @ts-expect-error jsdom には geolocation が無いため最小スタブを差し込む。
+        navigator.geolocation = {
+            getCurrentPosition: (s: (p: unknown) => void, e: (e: unknown) => void) => {
+                successCb = s;
+                errorCb = e;
+            },
+        };
+
+        const c = createGlobeSceneController(gc, "std", undefined, makeCanvas());
+        const locateMe = document.querySelector(
+            '[aria-label="現在地を表示"]',
+        ) as HTMLElement;
+        expect(locateMe).not.toBeNull();
+        locateMe.dispatchEvent(new Event("click"));
+        expect(successCb).not.toBeNull();
+
+        const centerBefore = { ...camera.center };
+        c.dispose();
+        // dispose 後に成功コールバックが返っても camera.center を更新しない。
+        successCb!({ coords: { latitude: 36, longitude: 140 } });
+        expect(camera.center).toEqual(centerBefore);
+        // error コールバックも例外なく早期 return する。
+        expect(() => errorCb!({ message: "denied" })).not.toThrow();
+    });
 });

--- a/tests/globeTileManager.unit.spec.ts
+++ b/tests/globeTileManager.unit.spec.ts
@@ -328,6 +328,68 @@ describe("createGlobeTileManager", () => {
         expect(mgr.isIdle()).toBe(true);
     });
 
+    it("setMapType は実行時にロード済み LOD・ベースレイヤを新 mapType で再テクスチャする (#275 P4-1)", async () => {
+        const textureUrlMock = gsiMock.textureUrl as jest.Mock;
+        const mgr = makeManager();
+        expect(mgr.getMapType()).toBe("std");
+
+        mgr.sync(syncParams());
+        await flush(); // 標高到着
+        mgr.sync(syncParams()); // LOD メッシュ 1 枚生成
+        expect(MeshMock).toHaveBeenCalledTimes(1);
+
+        textureUrlMock.mockClear();
+        const before = capturedTextures.length;
+        mgr.setMapType("photo");
+
+        expect(mgr.getMapType()).toBe("photo");
+        // 再テクスチャの URL はすべて新 mapType("photo")。
+        expect(textureUrlMock).toHaveBeenCalled();
+        expect(textureUrlMock.mock.calls.every((c) => c[0] === "photo")).toBe(
+            true,
+        );
+        // ロード済み LOD(1) + 常時表示ベースレイヤ(z2=16) = 17 枚を再テクスチャする。
+        expect(capturedTextures.length - before).toBe(17);
+        // 新テクスチャ onLoad で旧テクスチャを破棄しても例外を投げない。
+        expect(() => capturedTextures[before].onLoad?.()).not.toThrow();
+
+        // 同値再 set は no-op（再テクスチャしない）。
+        textureUrlMock.mockClear();
+        mgr.setMapType("photo");
+        expect(textureUrlMock).not.toHaveBeenCalled();
+    });
+
+    it("setMapType 連打時、追い越された旧種別テクスチャは適用せず破棄し最後の選択を保つ (#275 P4-1)", async () => {
+        const mgr = makeManager();
+        mgr.sync(syncParams());
+        await flush(); // 標高到着
+        mgr.sync(syncParams()); // LOD メッシュ 1 枚生成
+        expect(MeshMock).toHaveBeenCalledTimes(1);
+
+        const lodMesh = MeshMock.mock.results[0].value as {
+            material: { diffuseTexture: unknown };
+        };
+        // 初回テクスチャ（std）を適用しておく。
+        capturedTextures[0].onLoad?.();
+
+        // std → photo → std を素早く切り替える（テクスチャは非同期ロードで未適用）。
+        const beforePhoto = capturedTextures.length;
+        mgr.setMapType("photo"); // T_photo 生成（builtFor=photo）
+        const lodPhotoTex = capturedTextures[beforePhoto];
+        const beforeStd = capturedTextures.length;
+        mgr.setMapType("std"); // T_std 生成（builtFor=std）
+        const lodStdTex = capturedTextures[beforeStd];
+
+        // 到着順が逆転しても（photo が後着）、現在選択(std)と不一致なら適用せず破棄する。
+        lodStdTex.onLoad?.();
+        expect(lodMesh.material.diffuseTexture).toBe(lodStdTex);
+        lodPhotoTex.onLoad?.();
+        expect(lodPhotoTex.dispose).toHaveBeenCalled();
+        // 追い越された photo テクスチャは適用されない（誤表示しない）。
+        expect(lodMesh.material.diffuseTexture).toBe(lodStdTex);
+        expect(mgr.getMapType()).toBe("std");
+    });
+
     it("前景タイルを非ピッカブルにする（内蔵パンとの二重操作=ガタつきを防ぐ, #337）", async () => {
         const mgr = makeManager();
         mgr.sync(syncParams());

--- a/tests/globeTileManager.unit.spec.ts
+++ b/tests/globeTileManager.unit.spec.ts
@@ -390,6 +390,67 @@ describe("createGlobeTileManager", () => {
         expect(mgr.getMapType()).toBe("std");
     });
 
+    it("初回テクスチャ in-flight 中の setMapType: 旧種別 onLoad は無視し再テクスチャ側が描画可能化する (#275 P4-1)", async () => {
+        const mgr = makeManager();
+        mgr.sync(syncParams());
+        await flush(); // 標高到着
+        mgr.sync(syncParams()); // LOD メッシュ生成、初回テクスチャ in-flight
+        expect(MeshMock).toHaveBeenCalledTimes(1);
+        const lodMesh = MeshMock.mock.results[0].value as {
+            material: { diffuseTexture: unknown };
+            isEnabled: () => boolean;
+        };
+        // 初回テクスチャ未到着: 非表示・未 idle。
+        expect(lodMesh.isEnabled()).toBe(false);
+        expect(mgr.isIdle()).toBe(false);
+
+        const initialTex = capturedTextures[0]; // std, in-flight
+        const before = capturedTextures.length;
+        mgr.setMapType("photo"); // loaded を最初に再テクスチャ
+        const retexTex = capturedTextures[before]; // LOD photo
+
+        // 旧種別(std)の初回 onLoad が遅れて発火 → currentMapType(photo) と不一致で破棄・非適用。
+        initialTex.onLoad?.();
+        expect(initialTex.dispose).toHaveBeenCalled();
+        expect(lodMesh.isEnabled()).toBe(false);
+        expect(mgr.isIdle()).toBe(false);
+
+        // 再テクスチャ(photo) onLoad で未 ready メッシュを描画可能化（タイル欠け・idle 永続 false 防止）。
+        retexTex.onLoad?.();
+        expect(lodMesh.material.diffuseTexture).toBe(retexTex);
+        expect(lodMesh.isEnabled()).toBe(true);
+        expect(mgr.isIdle()).toBe(true);
+    });
+
+    it("ベースレイヤ初回テクスチャ in-flight 中の setMapType: 旧種別 onLoad は適用しない (#275 P4-1)", () => {
+        // ベースレイヤはコンストラクタで生成されるため、makeManager のクリアを通さず直接構築する。
+        MeshMock.mockClear();
+        MaterialMock.mockClear();
+        capturedTextures.length = 0;
+        const mgr = createGlobeTileManager({
+            scene: {} as never,
+            mapType: "std",
+            minZoom: 10,
+            geomMaxZoom: 15,
+            segments: 2,
+            snapEnabled: false,
+        });
+        // 全球 z2 = 16 枚のベース初回テクスチャが in-flight。
+        expect(capturedTextures.length).toBe(16);
+        const baseInitial = capturedTextures[0]; // std, in-flight
+        const baseMat = MaterialMock.mock.results[0].value as {
+            diffuseTexture: unknown;
+        };
+        expect(baseMat.diffuseTexture).toBeNull();
+
+        mgr.setMapType("photo"); // 16 枚を photo で再テクスチャ
+
+        // 旧種別(std)のベース初回 onLoad が遅れて発火 → 不一致で破棄・非適用（切り戻り防止）。
+        baseInitial.onLoad?.();
+        expect(baseInitial.dispose).toHaveBeenCalled();
+        expect(baseMat.diffuseTexture).toBeNull();
+    });
+
     it("前景タイルを非ピッカブルにする（内蔵パンとの二重操作=ガタつきを防ぐ, #337）", async () => {
         const mgr = makeManager();
         mgr.sync(syncParams());


### PR DESCRIPTION
## 概要

#275 Phase 4 / **P4-1**。`?terrainEngine=globe` で planar 側にあるボタン・スケールバーが表示されない問題に対応し、動作可能な UI を globe バックエンドへ配線する。

Parent: #349 / #275

## 変更内容

### `src/scenes/globeSceneController.ts`
- `createControlPanel()` を生成し、各 UI を globe カメラ（GeospatialCamera）へ配線:
  - **コンパス**: カメラ方位に追従して回転、クリックで北・真下（top-down）へリセット
  - **ズーム +/-**: `camera.radius` をアニメーション
  - **現在地**: `navigator.geolocation` → `setCenterLatLon`（地理院域外は toast）
  - **スケールバー**: `(2*radius*tan(fov/2))/clientHeight` で m/px を概算
  - **地図切替**: 標準/写真を実行時に切り替え（`onMapTypeChange` 発火）
  - **2D(視点切替)ボタン**: globe は ortho 非対応のため常時非表示
  - `setUiVisibility` / `dispose` を実装
- `controller.setMapType` を warn no-op から実行時切替へ変更

### `src/terrain/geo/globeTileManager.ts`
- `mapType` を実行時切替可能化（`getMapType` / `setMapType`）
- 既存メッシュ（LOD / pendingRelease / ベースレイヤ）を新 `mapType` の URL で再テクスチャ（新テクスチャ onLoad で張替え・旧破棄、onError は新破棄）
- **地図切替連打時のレース対策**: 生成時の種別(`builtFor`)を捕捉し、完了時に現在選択と一致する場合のみ適用（追い越したテクスチャは破棄）→ 誤表示・テクスチャリーク防止

## 影響範囲
- 画面: `?terrainEngine=globe`（viewer 等）の UI 表示・操作。planar は不変。
- API: `GlobeTileManager` に `getMapType`/`setMapType` 追加（後方互換）。

## 検証
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test:unit`（1177 passed）
- [x] `npm run build`
- [x] ユーザー目視確認（HITL）: コンパス/ズーム/現在地/スケール/地図切替/2D非表示

## レビュー観点
- スケールバーの m/px 概算（tilt による foreshortening は無視）
- コンパス回転符号・北/真下リセットの挙動
- 地図切替連打時のレース対策の妥当性