### PR TITLE
feat(globe): Circle アダプタで circle/plan デモを globe 対応 (Slice 2b-2, #275)

### DIFF
--- a/src/demos/circle/index.ts
+++ b/src/demos/circle/index.ts
@@ -19,6 +19,7 @@ import type { CircleOptions, JpmapTerrainOptions } from "../../lib/types";
 import {
     parseCameraStateFromUrl,
     parseMapTypeFromUrl,
+    resolveTerrainEngine,
 } from "../../terrain/urlState";
 
 const DEMO_MOUNT_ID = "root";
@@ -259,6 +260,7 @@ const start = async (): Promise<void> => {
     }
 
     const engine = resolveEngine(location.search);
+    const terrainEngine = resolveTerrainEngine(location.search);
     const cameraState = parseCameraStateFromUrl(location.href) ?? undefined;
     const mapType = parseMapTypeFromUrl(location.href);
     const defaultCamera = {
@@ -271,6 +273,7 @@ const start = async (): Promise<void> => {
 
     const opts: JpmapTerrainOptions = {
         ...(engine ? { engine } : {}),
+        ...(terrainEngine ? { terrainEngine } : {}),
         ...(cameraState ?? defaultCamera),
         ...(mapType !== null ? { mapType } : {}),
         showViewModeButton: false,

--- a/src/demos/plan/index.ts
+++ b/src/demos/plan/index.ts
@@ -18,6 +18,7 @@ import { CIRCLE_RADIUS_MAX_M } from "../../lib/types";
 import {
     parseCameraStateFromUrl,
     parseMapTypeFromUrl,
+    resolveTerrainEngine,
 } from "../../terrain/urlState";
 import { parsePlan } from "./parsePlan";
 import type { ParsedPlan } from "./parsePlan";
@@ -276,6 +277,7 @@ const start = async (): Promise<void> => {
     }
 
     const engine = resolveEngine(location.search);
+    const terrainEngine = resolveTerrainEngine(location.search);
     const cameraState = parseCameraStateFromUrl(location.href) ?? undefined;
     const mapType = parseMapTypeFromUrl(location.href);
     const defaultCamera = {
@@ -288,6 +290,7 @@ const start = async (): Promise<void> => {
 
     const opts: JpmapTerrainOptions = {
         ...(engine ? { engine } : {}),
+        ...(terrainEngine ? { terrainEngine } : {}),
         ...(cameraState ?? defaultCamera),
         ...(mapType !== null ? { mapType } : {}),
         showViewModeButton: false,

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -286,9 +286,9 @@ export class JpmapTerrain {
                         controller.setSunShadows(true);
                     }
                     // マーカー (Issue #167)。境界コンテキスト経由で manager を構築する。
-                    // globe バックエンドでは marker（P4-0）/ polygon（P4-1 Slice 2b-1）が
-                    // 専用アダプタ（getMarkerManager / getPolygonManager）経由で公開 interface に
-                    // 対応する。circle/model は globe マネージャの機能不足で parity 未達のため
+                    // globe バックエンドでは marker（P4-0）/ polygon（Slice 2b-1）/ circle（Slice 2b-2）が
+                    // 専用アダプタ（getMarkerManager / getPolygonManager / getCircleManager）経由で
+                    // 公開 interface に対応する。model は globe マネージャの機能不足で parity 未達のため
                     // 後続スライス（未対応）。
                     if (this._terrainEngine === "planar") {
                         this._markerManager = createMarkerManager(
@@ -311,6 +311,8 @@ export class JpmapTerrain {
                             controller.getMarkerManager?.() ?? null;
                         this._polygonManager =
                             controller.getPolygonManager?.() ?? null;
+                        this._circleManager =
+                            controller.getCircleManager?.() ?? null;
                     }
                 },
             });

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -39,6 +39,7 @@ import {
 } from "../lib/types";
 import type { MarkerManager } from "../terrain/markerManager";
 import type { PolygonManager } from "../terrain/polygonManager";
+import type { CircleManager } from "../terrain/circleManager";
 
 const TERRAIN_SUBDIVISIONS = 128;
 const MAX_ZOOM = TILE_MAX_ZOOM;
@@ -284,6 +285,11 @@ export interface DefaultSceneController {
      * planar 実装は `getMarkerContext()` 経由で構築するため optional。
      */
     getPolygonManager?(): PolygonManager | null;
+    /**
+     * globe バックエンド専用フック。公開 `CircleManager` 互換のアダプタを返す。
+     * planar 実装は `getMarkerContext()` 経由で構築するため optional。
+     */
+    getCircleManager?(): CircleManager | null;
 
     /**
      * 地形タイルへのクリック通知を購読する (Issue #183)。

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -794,8 +794,8 @@ export class GlobeScene {
             markerManager.update(camEcef);
             // ポリゴンの地形再ドレープ（アウトライン・壁）と距離スケール更新（点/ラベル配置）。
             polygonManager.update(camEcef);
-            // サークルの地形再ドレープ。
-            circleManager.update();
+            // サークルの地形再ドレープと距離スケール更新（点/ラベル配置）。
+            circleManager.update(camEcef);
             // モデルの接地・起立更新。
             modelManager.update();
             if (frame % GLOBE_SCENE_DEFAULTS.syncIntervalFrames === 0) syncTiles();

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -29,6 +29,7 @@ import {
 import { createUiVisibilityController } from "../terrain/uiVisibility";
 import type { MarkerManager } from "../terrain/markerManager";
 import type { PolygonManager } from "../terrain/polygonManager";
+import type { CircleManager } from "../terrain/circleManager";
 import type {
     MarkerHandle,
     MarkerOptions,
@@ -42,14 +43,30 @@ import type {
     PolygonPointPartial,
     PolygonStyleOptions,
     PolygonUpdate,
+    CircleHandle,
+    CircleOptions,
+    CircleUpdate,
+    CircleCenterOptions,
+    CircleStyleOptions,
     AltitudeMode,
 } from "../lib/types";
-import { MARKER_DEFAULTS, POLYGON_DEFAULTS } from "../lib/types";
+import {
+    MARKER_DEFAULTS,
+    POLYGON_DEFAULTS,
+    CIRCLE_DEFAULTS,
+    CIRCLE_RADIUS_MAX_M,
+    CIRCLE_SEGMENTS_MIN,
+    CIRCLE_SEGMENTS_MAX,
+} from "../lib/types";
 import type { GlobeMarkerManager } from "../terrain/geo/globeMarkerManager";
 import type {
     GlobePolygonManager,
     GlobePolygonOptions,
 } from "../terrain/geo/globePolygonManager";
+import type {
+    GlobeCircleManager,
+    GlobeCircleOptions,
+} from "../terrain/geo/globeCircleManager";
 import type {
     DefaultSceneController,
     DefaultSceneInitOptions,
@@ -635,6 +652,330 @@ export const createGlobePolygonManagerAdapter = (
     };
 };
 
+const CIRCLE_ERROR_PREFIX = "JpmapTerrain.addCircle";
+
+/** 公開 `CircleStyleOptions` を `CIRCLE_DEFAULTS.style` で埋める。 */
+const resolveCircleStyle = (
+    style: CircleStyleOptions | undefined,
+): Required<CircleStyleOptions> => ({
+    pointColor: style?.pointColor ?? CIRCLE_DEFAULTS.style.pointColor,
+    pointDiameter: style?.pointDiameter ?? CIRCLE_DEFAULTS.style.pointDiameter,
+    pointOpacity: style?.pointOpacity ?? CIRCLE_DEFAULTS.style.pointOpacity,
+    lineColor: style?.lineColor ?? CIRCLE_DEFAULTS.style.lineColor,
+    lineWidth: style?.lineWidth ?? CIRCLE_DEFAULTS.style.lineWidth,
+    lineOpacity: style?.lineOpacity ?? CIRCLE_DEFAULTS.style.lineOpacity,
+    wallColor: style?.wallColor ?? CIRCLE_DEFAULTS.style.wallColor,
+    wallOpacity: style?.wallOpacity ?? CIRCLE_DEFAULTS.style.wallOpacity,
+    labelColor: style?.labelColor ?? CIRCLE_DEFAULTS.style.labelColor,
+    labelBackgroundColor:
+        style?.labelBackgroundColor ?? CIRCLE_DEFAULTS.style.labelBackgroundColor,
+    labelFontSize: style?.labelFontSize ?? CIRCLE_DEFAULTS.style.labelFontSize,
+});
+
+/**
+ * 中心ラベルの自動生成テキスト（lat / lon / alt / radius を 4 行）。planar `circle.ts` と一致させる。
+ */
+const formatCircleAutoLabel = (
+    center: CircleCenterOptions,
+    radius: number,
+): string => {
+    const altText = center.altitude !== undefined ? center.altitude.toFixed(1) : "0.0";
+    return [
+        `lat: ${center.lat.toFixed(6)}`,
+        `lon: ${center.lon.toFixed(6)}`,
+        `alt: ${altText} m`,
+        `radius: ${radius.toFixed(1)} m`,
+    ].join("\n");
+};
+
+/** アダプタが保持する 1 サークルの解決済み状態（公開ハンドル再構築用）。 */
+interface CircleAdapterEntry {
+    /** `GlobeCircleManager.add` が採番した内部 id。 */
+    globeId: string;
+    center: CircleCenterOptions;
+    radius: number;
+    segments: number;
+    altitudeMode: AltitudeMode;
+    /** label が undefined（自動生成）指定だったか。center/radius 変化時に再生成する。 */
+    labelAuto: boolean;
+    /** 現在のラベル文字列（null は非表示指定）。 */
+    labelText: string | null;
+    style: Required<CircleStyleOptions>;
+    enabled: boolean;
+    pointEnabled: boolean;
+    lineEnabled: boolean;
+    wallEnabled: boolean;
+    labelEnabled: boolean;
+}
+
+/**
+ * `GlobeCircleManager`（採番 id・閉ポリゴン委譲）を公開 `CircleManager`（明示 id・`CircleHandle`
+ * 返却・partial-update・各種トグル）へアダプトする（#275 Phase 4 / Slice 2b-2）。
+ *
+ * - `GlobeCircleManager` は in-place 更新を持たないため、`update` および各トグルは内部ノードを
+ *   作り直す（add-then-remove のトランザクション。Marker / Polygon アダプタと同契約）。
+ * - `elevationResolved` は planar 同様、中心の地形標高が取得できるか（`terrainElevAt !== null`）で
+ *   best-effort 判定する（`absolute` は常に true）。
+ *
+ * @internal テスト用に export する。
+ */
+export const createGlobeCircleManagerAdapter = (
+    globeMgr: GlobeCircleManager,
+    terrainElevAt: (latDeg: number, lonDeg: number) => number | null,
+): CircleManager => {
+    const entries = new Map<string, CircleAdapterEntry>();
+    let disposed = false;
+
+    const assertNotDisposed = (): void => {
+        if (disposed) throw new Error("CircleManager has been disposed");
+    };
+
+    const requireEntry = (id: string): CircleAdapterEntry => {
+        const e = entries.get(id);
+        if (!e) throw new Error(`Circle id "${id}" not found`);
+        return e;
+    };
+
+    const validateOptions = (
+        center: CircleCenterOptions,
+        radius: number,
+        segments: number | undefined,
+        altitudeMode: AltitudeMode,
+        prefix: string,
+    ): void => {
+        if (!center) throw new Error(`${prefix}: center is required`);
+        assertLatLonInBounds(center.lat, center.lon, prefix);
+        if (!Number.isFinite(radius) || radius <= 0 || radius > CIRCLE_RADIUS_MAX_M) {
+            throw new Error(
+                `${prefix}: radius must be in (0, ${CIRCLE_RADIUS_MAX_M}] m (got ${radius})`,
+            );
+        }
+        if (
+            segments !== undefined &&
+            (!Number.isInteger(segments) ||
+                segments < CIRCLE_SEGMENTS_MIN ||
+                segments > CIRCLE_SEGMENTS_MAX)
+        ) {
+            throw new Error(
+                `${prefix}: segments must be an integer in [${CIRCLE_SEGMENTS_MIN}, ${CIRCLE_SEGMENTS_MAX}] (got ${segments})`,
+            );
+        }
+        if (altitudeMode === "absolute" && center.altitude === undefined) {
+            throw new Error(`${prefix}: altitudeMode="absolute" requires center.altitude`);
+        }
+    };
+
+    const toGlobeOptions = (e: CircleAdapterEntry): GlobeCircleOptions => ({
+        centerLat: e.center.lat,
+        centerLon: e.center.lon,
+        radiusMeters: e.radius,
+        segments: e.segments,
+        altitudeMode: e.altitudeMode,
+        centerAltitudeMeters: e.center.altitude,
+        label: e.labelText,
+        style: e.style as PolygonStyleOptions,
+        enabled: e.enabled,
+        pointEnabled: e.pointEnabled,
+        lineEnabled: e.lineEnabled,
+        wallEnabled: e.wallEnabled,
+        labelEnabled: e.labelEnabled,
+    });
+
+    const buildHandle = (id: string, e: CircleAdapterEntry): CircleHandle => ({
+        id,
+        center: { ...e.center },
+        radius: e.radius,
+        segments: e.segments,
+        altitudeMode: e.altitudeMode,
+        label: e.labelText,
+        style: { ...e.style },
+        enabled: e.enabled,
+        pointEnabled: e.pointEnabled,
+        lineEnabled: e.lineEnabled,
+        wallEnabled: e.wallEnabled,
+        labelEnabled: e.labelEnabled,
+        elevationResolved:
+            e.altitudeMode === "absolute" ||
+            terrainElevAt(e.center.lat, e.center.lon) !== null,
+    });
+
+    // 先に新ノードを add し、成功時のみ旧ノードを remove する（Polygon アダプタと同契約）。
+    const commitRebuild = (
+        id: string,
+        prev: CircleAdapterEntry,
+        next: CircleAdapterEntry,
+    ): CircleAdapterEntry => {
+        const globeId = globeMgr.add(toGlobeOptions(next));
+        globeMgr.remove(prev.globeId);
+        next.globeId = globeId;
+        entries.set(id, next);
+        return next;
+    };
+
+    const cloneEntry = (e: CircleAdapterEntry): CircleAdapterEntry => ({
+        ...e,
+        center: { ...e.center },
+        style: { ...e.style },
+    });
+
+    return {
+        add(id: string, options: CircleOptions): CircleHandle {
+            assertNotDisposed();
+            if (entries.has(id)) {
+                throw new Error(`${CIRCLE_ERROR_PREFIX}: id "${id}" already exists`);
+            }
+            const altitudeMode = options.altitudeMode ?? CIRCLE_DEFAULTS.altitudeMode;
+            validateOptions(
+                options.center,
+                options.radius,
+                options.segments,
+                altitudeMode,
+                CIRCLE_ERROR_PREFIX,
+            );
+            const center = { ...options.center };
+            const radius = options.radius;
+            // label: undefined=自動生成 / null=非表示 / string=カスタム。
+            const labelAuto = options.label === undefined;
+            const labelText: string | null =
+                options.label === null
+                    ? null
+                    : labelAuto
+                      ? formatCircleAutoLabel(center, radius)
+                      : (options.label as string);
+            const entry: CircleAdapterEntry = {
+                globeId: "",
+                center,
+                radius,
+                segments: options.segments ?? CIRCLE_DEFAULTS.segments,
+                altitudeMode,
+                labelAuto,
+                labelText,
+                style: resolveCircleStyle(options.style),
+                enabled: options.enabled ?? CIRCLE_DEFAULTS.enabled,
+                pointEnabled: options.pointEnabled ?? CIRCLE_DEFAULTS.pointEnabled,
+                lineEnabled: options.lineEnabled ?? CIRCLE_DEFAULTS.lineEnabled,
+                wallEnabled: options.wallEnabled ?? CIRCLE_DEFAULTS.wallEnabled,
+                labelEnabled: options.labelEnabled ?? CIRCLE_DEFAULTS.labelEnabled,
+            };
+            entry.globeId = globeMgr.add(toGlobeOptions(entry));
+            entries.set(id, entry);
+            return buildHandle(id, entry);
+        },
+        update(id: string, partial: CircleUpdate): CircleHandle {
+            assertNotDisposed();
+            const prev = requireEntry(id);
+            const center =
+                partial.center !== undefined ? { ...partial.center } : { ...prev.center };
+            const radius = partial.radius ?? prev.radius;
+            const segments = partial.segments ?? prev.segments;
+            const altitudeMode = partial.altitudeMode ?? prev.altitudeMode;
+            validateOptions(
+                center,
+                radius,
+                segments,
+                altitudeMode,
+                `JpmapTerrain.updateCircle[${id}]`,
+            );
+            // label の再解決:
+            // - partial.label 指定あり: undefined=自動 / null=非表示 / string=カスタム
+            // - 未指定: 自動なら center/radius 変化に追従して再生成、それ以外は維持。
+            let labelAuto = prev.labelAuto;
+            let labelText = prev.labelText;
+            if (partial.label !== undefined) {
+                if (partial.label === null) {
+                    labelAuto = false;
+                    labelText = null;
+                } else {
+                    labelAuto = false;
+                    labelText = partial.label;
+                }
+            } else if (prev.labelAuto) {
+                labelText = formatCircleAutoLabel(center, radius);
+            }
+            const next: CircleAdapterEntry = {
+                ...prev,
+                center,
+                radius,
+                segments,
+                altitudeMode,
+                labelAuto,
+                labelText,
+                style:
+                    partial.style !== undefined
+                        ? resolveCircleStyle(partial.style)
+                        : { ...prev.style },
+                enabled: partial.enabled ?? prev.enabled,
+                pointEnabled: partial.pointEnabled ?? prev.pointEnabled,
+                lineEnabled: partial.lineEnabled ?? prev.lineEnabled,
+                wallEnabled: partial.wallEnabled ?? prev.wallEnabled,
+                labelEnabled: partial.labelEnabled ?? prev.labelEnabled,
+            };
+            return buildHandle(id, commitRebuild(id, prev, next));
+        },
+        get(id: string): CircleHandle | null {
+            const e = entries.get(id);
+            return e ? buildHandle(id, e) : null;
+        },
+        remove(id: string): void {
+            const e = entries.get(id);
+            if (!e) {
+                console.warn(`[jpmap-terrain] removeCircle: id "${id}" not found`);
+                return;
+            }
+            globeMgr.remove(e.globeId);
+            entries.delete(id);
+        },
+        setEnabled(id: string, enabled: boolean): void {
+            assertNotDisposed();
+            const e = requireEntry(id);
+            globeMgr.setEnabled(e.globeId, enabled);
+            e.enabled = enabled;
+        },
+        setPointEnabled(id: string, enabled: boolean): void {
+            assertNotDisposed();
+            const prev = requireEntry(id);
+            const next = cloneEntry(prev);
+            next.pointEnabled = enabled;
+            commitRebuild(id, prev, next);
+        },
+        setLineEnabled(id: string, enabled: boolean): void {
+            assertNotDisposed();
+            const prev = requireEntry(id);
+            const next = cloneEntry(prev);
+            next.lineEnabled = enabled;
+            commitRebuild(id, prev, next);
+        },
+        setWallEnabled(id: string, enabled: boolean): void {
+            assertNotDisposed();
+            const prev = requireEntry(id);
+            const next = cloneEntry(prev);
+            next.wallEnabled = enabled;
+            commitRebuild(id, prev, next);
+        },
+        setLabelEnabled(id: string, enabled: boolean): void {
+            assertNotDisposed();
+            const prev = requireEntry(id);
+            const next = cloneEntry(prev);
+            next.labelEnabled = enabled;
+            commitRebuild(id, prev, next);
+        },
+        list(): readonly string[] {
+            return Array.from(entries.keys());
+        },
+        dispose(): void {
+            if (disposed) return;
+            disposed = true;
+            // 内部 GlobeCircleManager はシーンが毎フレーム update(camEcef) で参照し
+            // GlobeScene.dispose() が破棄する所有者であるため、ここでは破棄しない。
+            // このアダプタが追加したサークルのみ削除し、以降の API 呼び出しを禁止する。
+            for (const e of entries.values()) {
+                globeMgr.remove(e.globeId);
+            }
+            entries.clear();
+        },
+    };
+};
+
 /**
  * `DefaultScene` と同一シグネチャの `createScene` を提供する globe シーンファクトリ。
  * `JpmapTerrain.initAsync` は `terrainEngine` に応じて `DefaultScene` か本クラスを選ぶ。
@@ -695,6 +1036,10 @@ export const createGlobeSceneController = (
     );
     const polygonManager = createGlobePolygonManagerAdapter(
         gc.polygonManager,
+        (latDeg, lonDeg) => gc.tileManager.terrainElevAt(latDeg, lonDeg),
+    );
+    const circleManager = createGlobeCircleManagerAdapter(
+        gc.circleManager,
         (latDeg, lonDeg) => gc.tileManager.terrainElevAt(latDeg, lonDeg),
     );
 
@@ -1012,6 +1357,7 @@ export const createGlobeSceneController = (
 
         getMarkerManager: () => markerManager,
         getPolygonManager: () => polygonManager,
+        getCircleManager: () => circleManager,
 
         // ---- イベント購読（floating-origin 対応の pick 非依存実装は P4-0 後続スライス） ----
         // インターフェース通り listener を受け取るが globe では未対応のため無視する（no-op）。

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -876,9 +876,12 @@ export const createGlobeCircleManagerAdapter = (
                 altitudeMode,
                 `JpmapTerrain.updateCircle[${id}]`,
             );
-            // label の再解決:
-            // - partial.label 指定あり: undefined=自動 / null=非表示 / string=カスタム
-            // - 未指定: 自動なら center/radius 変化に追従して再生成、それ以外は維持。
+            // label の再解決（CircleUpdate.label は string | null）:
+            // - partial.label === null: 非表示（auto 解除）
+            // - partial.label === string: カスタム文字列（auto 解除）
+            // - partial.label 未指定(undefined): 変更なし。元が自動生成なら center/radius の
+            //   変化に追従してテキストを再生成、それ以外は現状維持。
+            //   ※ undefined を渡して「自動生成へ戻す」操作は型上表現できない（= 維持扱い）。
             let labelAuto = prev.labelAuto;
             let labelText = prev.labelText;
             if (partial.label !== undefined) {

--- a/src/terrain/geo/globeCircleManager.ts
+++ b/src/terrain/geo/globeCircleManager.ts
@@ -1,16 +1,25 @@
 /**
- * グローブ用サークルマネージャ (Issue #275 Phase 3, circle スライス)。
+ * グローブ用サークルマネージャ (Issue #275 Phase 3 / Phase 4 Slice 2b-2)。
  *
  * 平面版（`circleManager` + `circle`）に対する **並行構築** のグローブ実装。中心 + 半径 + 分割数から
- * 円周上の lat/lon 点列を生成し、**閉じたポリゴン**として `globePolygonManager` に委譲して描画する
- * （アウトライン＋地心 up カーテン壁・地形ドレープ・深度交差は polygon と共通）。これにより
- * 円専用の描画コードを重複させず、polygon の堅牢化（dispose ガード等）をそのまま享受する。
+ * 円周上の lat/lon 点列を生成し、内部の `GlobePolygonManager` に委譲して描画する。
+ *
+ * 1 サークルは 2 つのポリゴンノードで構成する:
+ * - **ring ノード**: 円周（閉ポリゴン）。アウトライン（線）＋カーテン壁。頂点マーカー/垂線/ラベルは無効。
+ * - **center ノード**: 中心 1 点。中心点マーカー＋中心ラベル。線/壁/垂線は無効。
+ *
+ * これにより planar の「中心点・中心ラベル・円周線・壁」パリティを保ちつつ、polygon の堅牢化
+ * （dispose ガード・距離スケール・地形ドレープ）をそのまま享受する。
  */
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+
 import {
     createGlobePolygonManager,
+    type GlobePolygonManager,
     type GlobePolygonManagerDeps,
 } from "./globePolygonManager";
 import { generateGeodesicRing } from "./overlayPlacement";
+import type { AltitudeMode, PolygonStyleOptions } from "../../lib/types";
 
 /** サークルの分割数の既定・範囲。 */
 const DEFAULT_SEGMENTS = 64;
@@ -26,18 +35,34 @@ export interface GlobeCircleOptions {
     radiusMeters: number;
     /** 円周の分割数（既定 64、[3, 512]）。 */
     segments?: number;
-    /** アウトライン色（hex）。 */
+    /** 高度モード。default terrain。 */
+    altitudeMode?: AltitudeMode;
+    /** 中心高度 [m]。terrain では地表からのオフセット、absolute では楕円体高度。 */
+    centerAltitudeMeters?: number;
+    /** 中心ラベル文言。null/undefined はラベル無し。 */
+    label?: string | null;
+    /** スタイル（polygon と共通のキー）。 */
+    style?: PolygonStyleOptions;
+    /** 旧 API 互換。style.lineColor より優先度は低い（ring のアウトライン色）。 */
     outlineColor?: string;
-    /** 壁色（hex）。 */
+    /** 旧 API 互換。style.wallColor より優先度は低い。 */
     wallColor?: string;
-    /** 壁の不透明度 [0,1]。 */
+    /** 旧 API 互換。style.wallOpacity より優先度は低い。 */
     wallOpacity?: number;
-    /** 壁（カーテン）の表示。default true。 */
-    wallsEnabled?: boolean;
-    /** top を固定する楕円体高度[m]（未指定なら地形ドレープ）。 */
+    /** 旧 API 互換。top を固定する楕円体高度[m]（未指定なら地形ドレープ）。 */
     topAltitudeMeters?: number;
-    /** default true。 */
+    /** 円全体の表示。default true。 */
     enabled?: boolean;
+    /** 中心点マーカーの表示。default true。 */
+    pointEnabled?: boolean;
+    /** 円周線（アウトライン）の表示。default true。 */
+    lineEnabled?: boolean;
+    /** 壁（カーテン）の表示。default true。 */
+    wallEnabled?: boolean;
+    /** 旧 API 互換の壁表示フラグ（wallEnabled と同義、指定時は wallEnabled より優先）。 */
+    wallsEnabled?: boolean;
+    /** 中心ラベルの表示。default true。 */
+    labelEnabled?: boolean;
 }
 
 export type GlobeCircleManagerDeps = GlobePolygonManagerDeps;
@@ -47,12 +72,17 @@ export interface GlobeCircleManager {
     add(opts: GlobeCircleOptions): string;
     /** サークルを削除する。 */
     remove(id: string): void;
-    /** 表示/非表示を切り替える。 */
+    /** 表示/非表示を切り替える（中心点・円周線・壁・ラベルをまとめて）。 */
     setEnabled(id: string, enabled: boolean): void;
-    /** 毎フレーム: 地形へ再ドレープ。 */
-    update(): void;
+    /** 毎フレーム: 地形へ再ドレープし距離スケールを更新する。 */
+    update(cameraEcef?: Vector3): void;
     /** 全サークルを破棄する。 */
     dispose(): void;
+}
+
+interface CircleEntry {
+    ringId: string;
+    centerId: string;
 }
 
 /**
@@ -62,9 +92,13 @@ export const createGlobeCircleManager = (
     deps: GlobeCircleManagerDeps,
 ): GlobeCircleManager => {
     // サークル専用のポリゴンマネージャ（ユーザーポリゴンとは別インスタンス）。
-    const polygons = createGlobePolygonManager(deps);
+    const polygons: GlobePolygonManager = createGlobePolygonManager(deps);
+    const entries = new Map<string, CircleEntry>();
+    let seq = 0;
+    let disposed = false;
 
     const add = (opts: GlobeCircleOptions): string => {
+        if (disposed) throw new Error("GlobeCircleManager.add: called after dispose");
         if (!(opts.radiusMeters > 0)) {
             throw new Error(
                 `GlobeCircleManager.add: radiusMeters must be > 0 (got ${opts.radiusMeters})`,
@@ -76,33 +110,88 @@ export const createGlobeCircleManager = (
                 `GlobeCircleManager.add: segments must be an integer in [${MIN_SEGMENTS}, ${MAX_SEGMENTS}] (got ${segments})`,
             );
         }
-        const points = generateGeodesicRing(
+        const altitudeMode = opts.altitudeMode ?? "terrain";
+        const altitude = opts.centerAltitudeMeters;
+        const enabled = opts.enabled ?? true;
+        const wallEnabled = opts.wallsEnabled ?? opts.wallEnabled ?? true;
+        const ringPoints = generateGeodesicRing(
             opts.centerLat,
             opts.centerLon,
             opts.radiusMeters,
             segments,
-        );
-        // 閉じたポリゴンとして描画（始点・終点を結ぶ）。スタイルはそのまま委譲。
-        return polygons.add({
-            points,
+        ).map((p) => ({ lat: p.lat, lon: p.lon, altitude }));
+
+        // ring ノード: 円周線 + 壁。頂点マーカー/垂線/ラベルは無効。
+        const ringId = polygons.add({
+            points: ringPoints,
             closed: true,
+            altitudeMode,
+            topAltitudeMeters: opts.topAltitudeMeters,
+            style: opts.style,
             outlineColor: opts.outlineColor,
             wallColor: opts.wallColor,
             wallOpacity: opts.wallOpacity,
             pointsEnabled: false,
             verticalsEnabled: false,
             labelsEnabled: false,
-            wallsEnabled: opts.wallsEnabled,
-            topAltitudeMeters: opts.topAltitudeMeters,
-            enabled: opts.enabled,
+            lineEnabled: opts.lineEnabled ?? true,
+            wallsEnabled: wallEnabled,
+            enabled,
         });
+
+        // center ノード: 中心点マーカー + 中心ラベル。線/壁/垂線は無効。
+        const hasLabel = opts.label != null && (opts.labelEnabled ?? true);
+        const centerId = polygons.add({
+            points: [{ lat: opts.centerLat, lon: opts.centerLon, altitude }],
+            closed: false,
+            altitudeMode,
+            topAltitudeMeters: opts.topAltitudeMeters,
+            style: opts.style,
+            outlineColor: opts.outlineColor,
+            labels: hasLabel ? [opts.label as string] : undefined,
+            pointsEnabled: opts.pointEnabled ?? true,
+            verticalsEnabled: false,
+            labelsEnabled: hasLabel,
+            lineEnabled: false,
+            wallsEnabled: false,
+            enabled,
+        });
+
+        const id = `globe-circle-${seq++}`;
+        entries.set(id, { ringId, centerId });
+        return id;
+    };
+
+    const remove = (id: string): void => {
+        const e = entries.get(id);
+        if (!e) {
+            console.warn(`[globe-circle] remove: id "${id}" not found`);
+            return;
+        }
+        polygons.remove(e.ringId);
+        polygons.remove(e.centerId);
+        entries.delete(id);
+    };
+
+    const setEnabled = (id: string, enabled: boolean): void => {
+        const e = entries.get(id);
+        if (!e) {
+            console.warn(`[globe-circle] setEnabled: id "${id}" not found`);
+            return;
+        }
+        polygons.setEnabled(e.ringId, enabled);
+        polygons.setEnabled(e.centerId, enabled);
     };
 
     return {
         add,
-        remove: (id) => polygons.remove(id),
-        setEnabled: (id, enabled) => polygons.setEnabled(id, enabled),
-        update: () => polygons.update(),
-        dispose: () => polygons.dispose(),
+        remove,
+        setEnabled,
+        update: (cameraEcef) => polygons.update(cameraEcef),
+        dispose: () => {
+            disposed = true;
+            polygons.dispose();
+            entries.clear();
+        },
     };
 };

--- a/src/terrain/geo/globeCircleManager.ts
+++ b/src/terrain/geo/globeCircleManager.ts
@@ -11,7 +11,7 @@
  * これにより planar の「中心点・中心ラベル・円周線・壁」パリティを保ちつつ、polygon の堅牢化
  * （dispose ガード・距離スケール・地形ドレープ）をそのまま享受する。
  */
-import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import type { Vector3 } from "@babylonjs/core/Maths/math.vector";
 
 import {
     createGlobePolygonManager,
@@ -112,6 +112,18 @@ export const createGlobeCircleManager = (
         }
         const altitudeMode = opts.altitudeMode ?? "terrain";
         const altitude = opts.centerAltitudeMeters;
+        // absolute は高度を一意に決める必要がある。centerAltitudeMeters / topAltitudeMeters の
+        // いずれも無いと暗黙に 0m 扱いになり誤用を見逃すため、ここで早期 throw する
+        // （public CircleManager の absolute=center.altitude 必須と整合）。
+        if (
+            altitudeMode === "absolute" &&
+            altitude == null &&
+            opts.topAltitudeMeters == null
+        ) {
+            throw new Error(
+                'GlobeCircleManager.add: altitudeMode="absolute" requires centerAltitudeMeters (or topAltitudeMeters)',
+            );
+        }
         const enabled = opts.enabled ?? true;
         const wallEnabled = opts.wallsEnabled ?? opts.wallEnabled ?? true;
         const ringPoints = generateGeodesicRing(

--- a/src/terrain/geo/globePolygonManager.ts
+++ b/src/terrain/geo/globePolygonManager.ts
@@ -106,6 +106,8 @@ export interface GlobePolygonOptions {
     verticalsEnabled?: boolean;
     labelsEnabled?: boolean;
     wallsEnabled?: boolean;
+    /** アウトライン（輪郭線）の表示。default true。circle 委譲で線と壁を独立トグルするために使う。 */
+    lineEnabled?: boolean;
     /** 内部用途: circle 委譲時は頂点マーカーを非表示にして既存の円表示を保つ。 */
     pointsEnabled?: boolean;
     enabled?: boolean;
@@ -140,6 +142,7 @@ interface GlobePolygonNode {
     verticalsEnabled: boolean;
     labelsEnabled: boolean;
     wallsEnabled: boolean;
+    lineEnabled: boolean;
     pointsEnabled: boolean;
     elevationResolved: boolean;
     style: ResolvedStyle;
@@ -359,7 +362,7 @@ export const createGlobePolygonManager = (
         for (const entry of node.edgeLabels) {
             if (entry) entry.mesh.setEnabled(visible && node.labelsEnabled && hasEdges);
         }
-        node.lineMesh.setEnabled(visible && hasEdges);
+        node.lineMesh.setEnabled(visible && hasEdges && node.lineEnabled);
         node.wallMesh.setEnabled(visible && hasEdges && node.wallsEnabled);
     };
 
@@ -598,6 +601,7 @@ export const createGlobePolygonManager = (
             verticalsEnabled,
             labelsEnabled: opts.labelsEnabled ?? POLYGON_DEFAULTS.labelsEnabled,
             wallsEnabled: opts.wallsEnabled ?? POLYGON_DEFAULTS.wallsEnabled,
+            lineEnabled: opts.lineEnabled ?? true,
             pointsEnabled,
             elevationResolved: altitudeMode === "absolute",
             style,

--- a/tests/globeCircleManager.unit.spec.ts
+++ b/tests/globeCircleManager.unit.spec.ts
@@ -1,8 +1,9 @@
 /**
- * GlobeCircleManager の振る舞い (Issue #275 Phase 3)。
+ * GlobeCircleManager の振る舞い (Issue #275 Phase 3 / Phase 4 Slice 2b-2)。
  *
- * 内部の GlobePolygonManager をスタブに差し替え、サークルが「閉ポリゴン + 円周点列」へ委譲される
- * こと、半径/分割数の検証、CRUD/update/dispose の委譲を検証する。
+ * 内部の GlobePolygonManager をスタブに差し替え、1 サークルが ring（閉ポリゴン・線＋壁）と
+ * center（中心 1 点・点＋ラベル）の 2 ノードへ委譲されること、半径/分割数の検証、
+ * CRUD/update/dispose の委譲を検証する。
  */
 import { jest } from "@jest/globals";
 
@@ -10,6 +11,11 @@ interface AddCall {
     points: { lat: number; lon: number }[];
     closed?: boolean;
     outlineColor?: string;
+    pointsEnabled?: boolean;
+    lineEnabled?: boolean;
+    wallsEnabled?: boolean;
+    labelsEnabled?: boolean;
+    labels?: ReadonlyArray<string | undefined>;
 }
 const addCalls: AddCall[] = [];
 const removeCalls: string[] = [];
@@ -51,13 +57,19 @@ beforeEach(() => {
 });
 
 describe("add", () => {
-    it("円周点列を持つ閉ポリゴンとして委譲する", () => {
+    it("ring（閉ポリゴン）と center（中心 1 点）の 2 ノードへ委譲する", () => {
         const mgr = makeManager();
         const id = mgr.add({ centerLat: 35, centerLon: 139, radiusMeters: 5000, segments: 16 });
-        expect(addCalls.length).toBe(1);
+        expect(addCalls.length).toBe(2);
+        // ring ノード: 閉ポリゴン・円周点列・頂点マーカー無効。
         expect(addCalls[0].closed).toBe(true);
         expect(addCalls[0].points.length).toBe(16);
-        expect(id).toBe("globe-polygon-0");
+        expect(addCalls[0].pointsEnabled).toBe(false);
+        // center ノード: 中心 1 点・点マーカー有効・線無効。
+        expect(addCalls[1].points.length).toBe(1);
+        expect(addCalls[1].pointsEnabled).toBe(true);
+        expect(addCalls[1].lineEnabled).toBe(false);
+        expect(id).toBe("globe-circle-0");
     });
 
     it("segments 既定は 64", () => {
@@ -66,7 +78,14 @@ describe("add", () => {
         expect(addCalls[0].points.length).toBe(64);
     });
 
-    it("スタイル（色）を委譲する", () => {
+    it("ラベル指定時は center ノードにラベルを委譲する", () => {
+        const mgr = makeManager();
+        mgr.add({ centerLat: 35, centerLon: 139, radiusMeters: 5000, label: "中心" });
+        expect(addCalls[1].labelsEnabled).toBe(true);
+        expect(addCalls[1].labels?.[0]).toBe("中心");
+    });
+
+    it("旧 API のスタイル（色）を ring へ委譲する", () => {
         const mgr = makeManager();
         mgr.add({ centerLat: 35, centerLon: 139, radiusMeters: 5000, outlineColor: "#abcdef" });
         expect(addCalls[0].outlineColor).toBe("#abcdef");
@@ -91,16 +110,20 @@ describe("add", () => {
 });
 
 describe("委譲（remove/setEnabled/update/dispose）", () => {
-    it("各操作が内部ポリゴンマネージャへ委譲される", () => {
+    it("remove / setEnabled は ring・center 両ノードへ委譲する", () => {
         const mgr = makeManager();
         const id = mgr.add({ centerLat: 35, centerLon: 139, radiusMeters: 5000 });
         mgr.setEnabled(id, false);
         mgr.update();
         mgr.remove(id);
         mgr.dispose();
-        expect(setEnabledCalls).toEqual([[id, false]]);
+        // ring=globe-polygon-0 / center=globe-polygon-1 の 2 ノード。
+        expect(setEnabledCalls).toEqual([
+            ["globe-polygon-0", false],
+            ["globe-polygon-1", false],
+        ]);
         expect(updateCount).toBe(1);
-        expect(removeCalls).toEqual([id]);
+        expect(removeCalls).toEqual(["globe-polygon-0", "globe-polygon-1"]);
         expect(disposeCount).toBe(1);
     });
 });

--- a/tests/globeSceneController.unit.spec.ts
+++ b/tests/globeSceneController.unit.spec.ts
@@ -13,6 +13,7 @@ import { createGlobeSceneController } from "../src/scenes/globeSceneController";
 import {
     createGlobeMarkerManagerAdapter,
     createGlobePolygonManagerAdapter,
+    createGlobeCircleManagerAdapter,
 } from "../src/scenes/globeSceneController";
 import type { GlobeSceneController } from "../src/scenes/globe";
 import type {
@@ -23,6 +24,10 @@ import type {
     GlobePolygonManager,
     GlobePolygonOptions,
 } from "../src/terrain/geo/globePolygonManager";
+import type {
+    GlobeCircleManager,
+    GlobeCircleOptions,
+} from "../src/terrain/geo/globeCircleManager";
 import { geodeticToEcef } from "../src/terrain/geo/ecef";
 
 /** camera のみ参照する軽量スタブ GlobeSceneController を作る。 */
@@ -510,3 +515,152 @@ describe("createGlobeMarkerManagerAdapter (P4-0 Slice 2a marker overlay)", () =>
                 warn.mockRestore();
             });
         });
+
+const makeGlobeCircleStub = (): {
+    mgr: GlobeCircleManager;
+    added: { id: string; opts: GlobeCircleOptions }[];
+    removed: string[];
+    enabledCalls: { id: string; enabled: boolean }[];
+    disposed: () => boolean;
+} => {
+    let seq = 0;
+    let disposedFlag = false;
+    const added: { id: string; opts: GlobeCircleOptions }[] = [];
+    const removed: string[] = [];
+    const enabledCalls: { id: string; enabled: boolean }[] = [];
+    const mgr = {
+        add: (opts: GlobeCircleOptions): string => {
+            const id = `gc${seq++}`;
+            added.push({ id, opts });
+            return id;
+        },
+        remove: (id: string): void => {
+            removed.push(id);
+        },
+        setEnabled: (id: string, enabled: boolean): void => {
+            enabledCalls.push({ id, enabled });
+        },
+        update: (): void => {},
+        dispose: (): void => {
+            disposedFlag = true;
+        },
+    } as unknown as GlobeCircleManager;
+    return { mgr, added, removed, enabledCalls, disposed: () => disposedFlag };
+};
+
+describe("createGlobeCircleManagerAdapter (P4-0 Slice 2b-2 circle overlay)", () => {
+    const CENTER = { lat: 35.36, lon: 138.72 };
+
+    it("add/get/list は globe マネージャへ委譲し、既定補完済みハンドルを返す", () => {
+        const stub = makeGlobeCircleStub();
+        const m = createGlobeCircleManagerAdapter(stub.mgr, () => 10);
+        const h = m.add("c1", {
+            center: CENTER,
+            radius: 5000,
+            style: { pointColor: "#00ff00" },
+        });
+        expect(h.id).toBe("c1");
+        expect(h.radius).toBe(5000);
+        expect(h.segments).toBe(64);
+        expect(h.altitudeMode).toBe("terrain");
+        expect(h.pointEnabled).toBe(true);
+        expect(h.lineEnabled).toBe(true);
+        expect(h.wallEnabled).toBe(true);
+        expect(h.labelEnabled).toBe(true);
+        expect(h.style.pointColor).toBe("#00ff00");
+        expect(h.style.lineColor).toBe("#ff0000");
+        // label undefined は自動生成（lat/lon/alt/radius の 4 行）。
+        expect(h.label).toContain("radius: 5000.0 m");
+        expect(h.elevationResolved).toBe(true);
+        expect(m.get("c1")?.id).toBe("c1");
+        expect(m.list()).toEqual(["c1"]);
+        expect(stub.added[0].opts.radiusMeters).toBe(5000);
+    });
+
+    it("label=null は非表示、string はカスタム文字列を保持する", () => {
+        const stub = makeGlobeCircleStub();
+        const m = createGlobeCircleManagerAdapter(stub.mgr, () => 1);
+        expect(m.add("a", { center: CENTER, radius: 100, label: null }).label).toBeNull();
+        expect(
+            m.add("b", { center: CENTER, radius: 100, label: "custom" }).label,
+        ).toBe("custom");
+    });
+
+    it("terrain 未解決なら elevationResolved=false、absolute は altitude 必須かつ常に true", () => {
+        const terrainStub = makeGlobeCircleStub();
+        const terrain = createGlobeCircleManagerAdapter(terrainStub.mgr, () => null);
+        expect(terrain.add("t", { center: CENTER, radius: 100 }).elevationResolved).toBe(
+            false,
+        );
+        const absStub = makeGlobeCircleStub();
+        const abs = createGlobeCircleManagerAdapter(absStub.mgr, () => null);
+        expect(
+            abs.add("a", {
+                center: { ...CENTER, altitude: 50 },
+                radius: 100,
+                altitudeMode: "absolute",
+            }).elevationResolved,
+        ).toBe(true);
+        expect(() =>
+            abs.add("bad", { center: CENTER, radius: 100, altitudeMode: "absolute" }),
+        ).toThrow(/requires center.altitude/);
+    });
+
+    it("radius/segments の検証で throw する", () => {
+        const stub = makeGlobeCircleStub();
+        const m = createGlobeCircleManagerAdapter(stub.mgr, () => 1);
+        expect(() => m.add("x", { center: CENTER, radius: 0 })).toThrow(/radius/);
+        expect(() => m.add("y", { center: CENTER, radius: 100, segments: 2 })).toThrow(
+            /segments/,
+        );
+    });
+
+    it("update と各トグルは add-then-remove で内部ノードを作り直す", () => {
+        const stub = makeGlobeCircleStub();
+        const m = createGlobeCircleManagerAdapter(stub.mgr, () => 1);
+        m.add("c", { center: CENTER, radius: 100 });
+        const h = m.update("c", { radius: 200, labelEnabled: false });
+        expect(h.radius).toBe(200);
+        expect(h.labelEnabled).toBe(false);
+        expect(stub.removed).toEqual(["gc0"]);
+        m.setWallEnabled("c", false);
+        expect(stub.removed).toEqual(["gc0", "gc1"]);
+        expect(m.get("c")?.wallEnabled).toBe(false);
+        m.setPointEnabled("c", false);
+        m.setLineEnabled("c", false);
+        m.setLabelEnabled("c", true);
+        expect(m.get("c")?.pointEnabled).toBe(false);
+        expect(m.get("c")?.lineEnabled).toBe(false);
+        expect(m.get("c")?.labelEnabled).toBe(true);
+    });
+
+    it("自動ラベルは center/radius 変更に追従して再生成する", () => {
+        const stub = makeGlobeCircleStub();
+        const m = createGlobeCircleManagerAdapter(stub.mgr, () => 1);
+        m.add("c", { center: CENTER, radius: 100 });
+        const h = m.update("c", { radius: 300 });
+        expect(h.label).toContain("radius: 300.0 m");
+    });
+
+    it("setEnabled は委譲し、remove/dispose は内部マネージャを破棄しない", () => {
+        const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+        const stub = makeGlobeCircleStub();
+        const m = createGlobeCircleManagerAdapter(stub.mgr, () => 1);
+        m.add("c", { center: CENTER, radius: 100 });
+        m.setEnabled("c", false);
+        expect(stub.enabledCalls).toEqual([{ id: "gc0", enabled: false }]);
+        expect(m.get("c")?.enabled).toBe(false);
+        expect(() => m.add("c", { center: CENTER, radius: 100 })).toThrow(/already exists/);
+        m.remove("c");
+        expect(m.list()).toEqual([]);
+        m.remove("missing");
+        expect(warn).toHaveBeenCalled();
+        m.add("c2", { center: CENTER, radius: 100 });
+        const aliveId = stub.added[stub.added.length - 1].id;
+        m.dispose();
+        expect(stub.disposed()).toBe(false);
+        expect(stub.removed).toContain(aliveId);
+        expect(() => m.add("x", { center: CENTER, radius: 100 })).toThrow(/disposed/);
+        warn.mockRestore();
+    });
+});


### PR DESCRIPTION
## 概要
#275 Phase 4 Slice 2b-2。`GlobeCircleManager` をフルパリティ化し、公開 `CircleManager` 互換アダプタ経由で `?terrainEngine=globe` の **circle / plan** デモを解禁する。

## 変更
- **GlobePolygonManager**: `lineEnabled` オプション追加（アウトラインと壁を独立トグル）。
- **GlobeCircleManager**: ring（円周線+壁）と center（中心点+ラベル）の 2 ノードを合成。点/線/壁/ラベル各トグル・`altitudeMode`(terrain/absolute)・style・`update(camEcef)`（距離スケール）に対応。旧 API（`outlineColor`/`wallColor`/`topAltitudeMeters` 等）も互換維持。
- **createGlobeCircleManagerAdapter**: 公開 `CircleManager` 互換。`CircleHandle` 状態保持、`add`/`update`/`get`/`remove`/各 setter、自動ラベル（lat/lon/alt/radius）再生成、`elevationResolved` best-effort、add-then-remove トランザクションを planar parity。
- **配線**: `globe.ts` で `circleManager.update(camEcef)`、controller に `getCircleManager`、`default.ts` に optional `getCircleManager`、`jpmapTerrain` onReady で circle 配線。
- **demos**: circle/plan に `resolveTerrainEngine` で `?terrainEngine=globe` 対応。
- **tests**: globeCircleManager / globeSceneController に parity テスト追加。

## 影響範囲
- 画面: circle / plan デモの globe 描画（planar 既定は不変）。
- API: 公開 `CircleManager` の挙動は planar と同等（互換）。

## 検証
- typecheck / lint / test:unit(**1200** passed) / build すべて緑。

## 既知の差分
- 円周は planar の「中心標高での平面ディスク」ではなく、polygon 委譲のため地形ドレープ（3D 地形に沿う）。ラベルのオフセットは地心 up 基準で planar の screen-up 追従と微差。

## HITL（要目視確認）
`npm start` → circle / plan デモを `?terrainEngine=globe` で開き、中心点・中心ラベル・円周線・壁・各トグル・update（半径/中心/スタイル）・terrain/absolute を確認してください。

Closes #275 の一部（Slice 2b-2）