### PR TITLE
feat(globe): pick 非依存の地形クリック (terrain-click) を実装 (#275)

### DIFF
--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -30,6 +30,7 @@ import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
 import { PickingInfo } from "@babylonjs/core/Collisions/pickingInfo";
 
 import type { MapType } from "../terrain/gsiTile";
+import { TERRAIN_CLICK_DRAG_THRESHOLD_PX } from "../lib/types";
 import { DEG2RAD, geodeticToEcef, geodeticToEcefToRef, ecefToGeodetic, type Geodetic } from "../terrain/geo/ecef";
 import {
     cameraTangentBasisToRef,
@@ -127,12 +128,6 @@ const PAN_KEYS = new Set(["w", "a", "s", "d"]);
  * クランプし、ほぼ水平までは許しつつ完全水平の退化を抑止する。
  */
 const MAX_TILT_DEG = 89;
-
-/**
- * 地形クリック判定のドラッグしきい値 [CSS px]。pointerdown→pointerup の移動量がこれ以下なら
- * クリック、超えればパン/回転とみなしてクリック通知しない（平面版 default.ts と同方針）。
- */
-const GLOBE_TERRAIN_CLICK_DRAG_THRESHOLD_PX = 6;
 
 /**
  * 地球楕円体スフィア（背景＋地平線リファレンス, Issue #335）を海面より沈める量 [m]。
@@ -715,7 +710,7 @@ export class GlobeScene {
             recalculateCenterPublic();
         };
 
-        // ---- 地形クリック通知（pick 非依存・floating origin 対応, #275 P4-0 後続スライス） ----
+        // ---- 地形クリック通知（pick 非依存・floating origin 対応, #275 P4） ----
         // 平面版（default.ts）は scene.pick で地形メッシュをヒットするが、floating origin 下では
         // レンダリング座標と真の ECEF メッシュ位置がずれてピックがブレる。そこでズーム/パンと同じく
         // 真の ECEF カメラ位置からカーソル方向のレイを WGS84 楕円体（地形標高で 1 回反復）と交差させて
@@ -800,8 +795,8 @@ export class GlobeScene {
             const dx = e.clientX - start.x;
             const dy = e.clientY - start.y;
             if (
-                Math.abs(dx) > GLOBE_TERRAIN_CLICK_DRAG_THRESHOLD_PX ||
-                Math.abs(dy) > GLOBE_TERRAIN_CLICK_DRAG_THRESHOLD_PX
+                Math.abs(dx) > TERRAIN_CLICK_DRAG_THRESHOLD_PX ||
+                Math.abs(dy) > TERRAIN_CLICK_DRAG_THRESHOLD_PX
             ) {
                 return; // ドラッグ（パン/回転）はクリックとみなさない
             }

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -129,6 +129,12 @@ const PAN_KEYS = new Set(["w", "a", "s", "d"]);
 const MAX_TILT_DEG = 89;
 
 /**
+ * 地形クリック判定のドラッグしきい値 [CSS px]。pointerdown→pointerup の移動量がこれ以下なら
+ * クリック、超えればパン/回転とみなしてクリック通知しない（平面版 default.ts と同方針）。
+ */
+const GLOBE_TERRAIN_CLICK_DRAG_THRESHOLD_PX = 6;
+
+/**
  * 地球楕円体スフィア（背景＋地平線リファレンス, Issue #335）を海面より沈める量 [m]。
  * 地形（標高>=0）との z-fighting はスフィアの深度書き込み無効化（disableDepthWrite, 後述）で
  * 原理的に解消する。
@@ -185,6 +191,25 @@ export interface GlobeSceneSyncInfo extends GlobeTileSyncStats {
     pitch: number;
 }
 
+/**
+ * 地形クリックイベント（globe 版）。`scene.pick` 非依存で求めた緯度経度・標高・ECEF 交点を持つ。
+ * 公開 `TerrainClickEvent`（lib/types）と構造互換で、アダプタ（globeSceneController）が橋渡しする。
+ */
+export interface GlobeTerrainClickEvent {
+    /** クリック地点の緯度 [deg]。 */
+    lat: number;
+    /** クリック地点の経度 [deg]。 */
+    lon: number;
+    /** クリック地点の標高 [m]（地形標高。取得不可時は楕円体高）。 */
+    altitude: number;
+    /** 真の ECEF 交点 [m]（floating origin のレンダリング座標ではない）。 */
+    world: { x: number; y: number; z: number };
+    /** 元の `PointerEvent`。 */
+    pointerEvent: PointerEvent;
+}
+
+export type GlobeTerrainClickListener = (event: GlobeTerrainClickEvent) => void;
+
 export interface GlobeSceneController {
     scene: Scene;
     camera: GeospatialCamera;
@@ -197,6 +222,11 @@ export interface GlobeSceneController {
     circleManager: GlobeCircleManager;
     /** グローブ用モデル（Phase 3）。glb/gltf を接地し地心 up へ起立。 */
     modelManager: GlobeModelManager;
+    /**
+     * 地形クリック購読（pick 非依存・floating origin 対応）。クリック地点の緯度経度・標高を
+     * リスナーへ通知する。戻り値で購読解除する。
+     */
+    subscribeTerrainClick: (listener: GlobeTerrainClickListener) => () => void;
     dispose: () => void;
 }
 
@@ -530,7 +560,11 @@ export class GlobeScene {
         // フレーム毎に揺らぐ。これがズーム目標点をブレさせる精度要因。そこで行列を介さず、yaw/pitch
         // から forward を、camera.upVector から up/right を二重精度で求め、画素 NDC オフセットと
         // 垂直 FOV・アスペクトから解析的にレイ方向を構築する（中心画素は厳密に forward に一致）。
-        const computeCursorRayDirToRef = (ref: Vector3): Vector3 => {
+        const computeRayDirForPixelToRef = (
+            pxCss: number,
+            pyCss: number,
+            ref: Vector3,
+        ): Vector3 => {
             // 注意: computeCameraEcef は共有 lookAt バッファを radius 倍して破壊するため専用バッファに計算する。
             ComputeLookAtFromYawPitchToRef(
                 camera.yaw,
@@ -556,8 +590,8 @@ export class GlobeScene {
             const hsl = engine.getHardwareScalingLevel();
             const w = engine.getRenderWidth();
             const h = engine.getRenderHeight();
-            const ndcx = (scene.pointerX / hsl / w) * 2 - 1;
-            const ndcy = 1 - (scene.pointerY / hsl / h) * 2;
+            const ndcx = (pxCss / hsl / w) * 2 - 1;
+            const ndcy = 1 - (pyCss / hsl / h) * 2;
             const tanY = Math.tan(camera.fov / 2);
             const tanX = tanY * (w / h);
             ref.copyFrom(rayFwd)
@@ -566,6 +600,10 @@ export class GlobeScene {
                 .normalize();
             return ref;
         };
+
+        // ズーム（zoom-to-cursor）は現在のポインタ位置（scene.pointerX/Y）のレイを使う。
+        const computeCursorRayDirToRef = (ref: Vector3): Vector3 =>
+            computeRayDirForPixelToRef(scene.pointerX, scene.pointerY, ref);
 
         movement.handleZoom = (zoomDelta: number): void => {
             if (zoomDelta === 0) return;
@@ -675,6 +713,122 @@ export class GlobeScene {
         camera.zoomToPoint = (targetPoint, distance): void => {
             origZoomToPoint(targetPoint, distance);
             recalculateCenterPublic();
+        };
+
+        // ---- 地形クリック通知（pick 非依存・floating origin 対応, #275 P4-0 後続スライス） ----
+        // 平面版（default.ts）は scene.pick で地形メッシュをヒットするが、floating origin 下では
+        // レンダリング座標と真の ECEF メッシュ位置がずれてピックがブレる。そこでズーム/パンと同じく
+        // 真の ECEF カメラ位置からカーソル方向のレイを WGS84 楕円体（地形標高で 1 回反復）と交差させて
+        // 緯度経度・標高を求める。ドラッグ（パン/回転）はしきい値で除外する。
+        const terrainClickListeners: GlobeTerrainClickListener[] = [];
+        let clickStart: {
+            pointerId: number;
+            x: number;
+            y: number;
+            modifier: boolean;
+        } | null = null;
+        const clickRayDir = new Vector3();
+        const clickHit = new Vector3();
+
+        /** カーソル方向のレイ × 地形楕円体の交点から緯度経度・標高を求める。空（ミス）は null。 */
+        const computeTerrainClick = (e: PointerEvent): GlobeTerrainClickEvent | null => {
+            const rect = canvas.getBoundingClientRect();
+            const pxCss = e.clientX - rect.left;
+            const pyCss = e.clientY - rect.top;
+            computeRayDirForPixelToRef(pxCss, pyCss, clickRayDir);
+            const camEcef = computeCameraEcef();
+            // 1) 海面（h=0）の楕円体と交差させて概略の緯度経度を得る。
+            if (
+                !rayEllipsoidNearHitToRef(
+                    camEcef,
+                    clickRayDir,
+                    ellipsoidSemiMajor,
+                    ellipsoidSemiMajor,
+                    ellipsoidSemiMinor,
+                    clickHit,
+                )
+            ) {
+                return null; // 空（地球外）を指している
+            }
+            let geo = ecefToGeodetic(clickHit);
+            // 2) その地点の地形標高で楕円体面を持ち上げ、1 回だけ交点を補正する（斜面での誤差低減）。
+            const elev = tileManager.terrainElevAt(geo.latDeg, geo.lonDeg);
+            const hasElev = elev !== null && Number.isFinite(elev);
+            if (hasElev) {
+                if (
+                    rayEllipsoidNearHitToRef(
+                        camEcef,
+                        clickRayDir,
+                        ellipsoidSemiMajor + elev,
+                        ellipsoidSemiMajor + elev,
+                        ellipsoidSemiMinor + elev,
+                        clickHit,
+                    )
+                ) {
+                    geo = ecefToGeodetic(clickHit);
+                }
+            }
+            return {
+                lat: geo.latDeg,
+                lon: geo.lonDeg,
+                altitude: hasElev ? elev : geo.altMeters,
+                // world は真の ECEF 交点（floating origin のレンダリング座標ではない）。
+                world: { x: clickHit.x, y: clickHit.y, z: clickHit.z },
+                pointerEvent: e,
+            };
+        };
+
+        const onClickPointerDown = (e: PointerEvent): void => {
+            if (e.button !== 0) return;
+            clickStart = {
+                pointerId: e.pointerId,
+                x: e.clientX,
+                y: e.clientY,
+                modifier: e.ctrlKey || e.metaKey,
+            };
+        };
+        const cancelClick = (e: PointerEvent): void => {
+            if (clickStart && clickStart.pointerId === e.pointerId) clickStart = null;
+        };
+        const onClickPointerUp = (e: PointerEvent): void => {
+            const start = clickStart;
+            clickStart = null;
+            if (!start || start.pointerId !== e.pointerId) return;
+            // Ctrl/Cmd 併用はカメラ操作扱い（平面版と同じ）。pointerup 時点の修飾キーも確認する。
+            if (start.modifier || e.ctrlKey || e.metaKey) return;
+            if (terrainClickListeners.length === 0) return;
+            const dx = e.clientX - start.x;
+            const dy = e.clientY - start.y;
+            if (
+                Math.abs(dx) > GLOBE_TERRAIN_CLICK_DRAG_THRESHOLD_PX ||
+                Math.abs(dy) > GLOBE_TERRAIN_CLICK_DRAG_THRESHOLD_PX
+            ) {
+                return; // ドラッグ（パン/回転）はクリックとみなさない
+            }
+            const event = computeTerrainClick(e);
+            if (!event) return;
+            // iterate 中の add/remove 安全のため slice
+            for (const listener of terrainClickListeners.slice()) {
+                try {
+                    listener(event);
+                } catch (err) {
+                    console.error("[globe] terrain click listener threw:", err);
+                }
+            }
+        };
+        canvas.addEventListener("pointerdown", onClickPointerDown);
+        canvas.addEventListener("pointerup", onClickPointerUp);
+        canvas.addEventListener("pointercancel", cancelClick);
+        canvas.addEventListener("lostpointercapture", cancelClick);
+
+        const subscribeTerrainClick = (
+            listener: GlobeTerrainClickListener,
+        ): (() => void) => {
+            terrainClickListeners.push(listener);
+            return () => {
+                const i = terrainClickListeners.indexOf(listener);
+                if (i >= 0) terrainClickListeners.splice(i, 1);
+            };
         };
 
 
@@ -814,6 +968,11 @@ export class GlobeScene {
             canvas.removeEventListener("pointerup", onPointerUp);
             canvas.removeEventListener("pointercancel", endDrag);
             canvas.removeEventListener("pointermove", onPointerMove);
+            canvas.removeEventListener("pointerdown", onClickPointerDown);
+            canvas.removeEventListener("pointerup", onClickPointerUp);
+            canvas.removeEventListener("pointercancel", cancelClick);
+            canvas.removeEventListener("lostpointercapture", cancelClick);
+            terrainClickListeners.length = 0;
             markerManager.dispose();
             polygonManager.dispose();
             circleManager.dispose();
@@ -830,6 +989,7 @@ export class GlobeScene {
             polygonManager,
             circleManager,
             modelManager,
+            subscribeTerrainClick,
             dispose,
         };
     }

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -819,18 +819,37 @@ export class GlobeScene {
                 }
             }
         };
-        canvas.addEventListener("pointerdown", onClickPointerDown);
-        canvas.addEventListener("pointerup", onClickPointerUp);
-        canvas.addEventListener("pointercancel", cancelClick);
-        canvas.addEventListener("lostpointercapture", cancelClick);
+        // terrain-click のポインタハンドラは購読者がいる間だけ canvas に登録する
+        // （購読ゼロ時に余計なグローバルなポインタ処理を行わない・他のポインタ処理との
+        //   意図しない干渉を避ける）。
+        let clickHandlersAttached = false;
+        const attachClickHandlers = (): void => {
+            if (clickHandlersAttached) return;
+            canvas.addEventListener("pointerdown", onClickPointerDown);
+            canvas.addEventListener("pointerup", onClickPointerUp);
+            canvas.addEventListener("pointercancel", cancelClick);
+            canvas.addEventListener("lostpointercapture", cancelClick);
+            clickHandlersAttached = true;
+        };
+        const detachClickHandlers = (): void => {
+            if (!clickHandlersAttached) return;
+            canvas.removeEventListener("pointerdown", onClickPointerDown);
+            canvas.removeEventListener("pointerup", onClickPointerUp);
+            canvas.removeEventListener("pointercancel", cancelClick);
+            canvas.removeEventListener("lostpointercapture", cancelClick);
+            clickStart = null;
+            clickHandlersAttached = false;
+        };
 
         const subscribeTerrainClick = (
             listener: GlobeTerrainClickListener,
         ): (() => void) => {
             terrainClickListeners.push(listener);
+            attachClickHandlers();
             return () => {
                 const i = terrainClickListeners.indexOf(listener);
                 if (i >= 0) terrainClickListeners.splice(i, 1);
+                if (terrainClickListeners.length === 0) detachClickHandlers();
             };
         };
 
@@ -971,12 +990,8 @@ export class GlobeScene {
             canvas.removeEventListener("pointerup", onPointerUp);
             canvas.removeEventListener("pointercancel", endDrag);
             canvas.removeEventListener("pointermove", onPointerMove);
-            canvas.removeEventListener("pointerdown", onClickPointerDown);
-            canvas.removeEventListener("pointerup", onClickPointerUp);
-            canvas.removeEventListener("pointercancel", cancelClick);
-            canvas.removeEventListener("lostpointercapture", cancelClick);
+            detachClickHandlers();
             terrainClickListeners.length = 0;
-            clickStart = null;
             markerManager.dispose();
             polygonManager.dispose();
             circleManager.dispose();

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -724,6 +724,7 @@ export class GlobeScene {
         } | null = null;
         const clickRayDir = new Vector3();
         const clickHit = new Vector3();
+        const clickHitElev = new Vector3();
 
         /** カーソル方向のレイ × 地形楕円体の交点から緯度経度・標高を求める。空（ミス）は null。 */
         const computeTerrainClick = (e: PointerEvent): GlobeTerrainClickEvent | null => {
@@ -746,7 +747,12 @@ export class GlobeScene {
                 return null; // 空（地球外）を指している
             }
             let geo = ecefToGeodetic(clickHit);
+            // 採用する交点（既定は海面交点）と標高を、最終的に整合した1組として決める。
+            let adopted = clickHit;
+            let altitude = geo.altMeters;
             // 2) その地点の地形標高で楕円体面を持ち上げ、1 回だけ交点を補正する（斜面での誤差低減）。
+            //    再交差は別の一時ベクトルへ出力し、成功時のみ adopted/geo/altitude を差し替える
+            //    （失敗時に海面交点が破壊されず altitude/world/geo の整合が保たれる）。
             const elev = tileManager.terrainElevAt(geo.latDeg, geo.lonDeg);
             const hasElev = elev !== null && Number.isFinite(elev);
             if (hasElev) {
@@ -757,18 +763,20 @@ export class GlobeScene {
                         ellipsoidSemiMajor + elev,
                         ellipsoidSemiMajor + elev,
                         ellipsoidSemiMinor + elev,
-                        clickHit,
+                        clickHitElev,
                     )
                 ) {
-                    geo = ecefToGeodetic(clickHit);
+                    adopted = clickHitElev;
+                    geo = ecefToGeodetic(clickHitElev);
+                    altitude = elev;
                 }
             }
             return {
                 lat: geo.latDeg,
                 lon: geo.lonDeg,
-                altitude: hasElev ? elev : geo.altMeters,
-                // world は真の ECEF 交点（floating origin のレンダリング座標ではない）。
-                world: { x: clickHit.x, y: clickHit.y, z: clickHit.z },
+                altitude,
+                // world は採用した真の ECEF 交点（floating origin のレンダリング座標ではない）。
+                world: { x: adopted.x, y: adopted.y, z: adopted.z },
                 pointerEvent: e,
             };
         };
@@ -968,6 +976,7 @@ export class GlobeScene {
             canvas.removeEventListener("pointercancel", cancelClick);
             canvas.removeEventListener("lostpointercapture", cancelClick);
             terrainClickListeners.length = 0;
+            clickStart = null;
             markerManager.dispose();
             polygonManager.dispose();
             circleManager.dispose();

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -1361,7 +1361,7 @@ export const createGlobeSceneController = (
         getPolygonManager: () => polygonManager,
         getCircleManager: () => circleManager,
 
-        // ---- 地形クリック購読（pick 非依存・floating origin 対応, #275 P4-0 後続スライス） ----
+        // ---- 地形クリック購読（pick 非依存・floating origin 対応, #275 P4・実装済み） ----
         // globe シーン（globe.ts）が真の ECEF レイ × 地形楕円体で求めたクリック地点を、公開
         // TerrainClickEvent へ橋渡しする。GlobeTerrainClickEvent は構造互換だが、型を明示するため
         // ここで明示的にイベントを組み直す。

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -1030,7 +1030,6 @@ export const createGlobeSceneController = (
     const { camera } = gc;
     let currentMapType: MapType = initialMapType;
     let viewModeWarned = false;
-    let terrainClickWarned = false;
 
     // 公開 overlay manager 互換アダプタ（P4-0 Slice 2a / 2b-1）。
     const markerManager = createGlobeMarkerManagerAdapter(
@@ -1362,22 +1361,20 @@ export const createGlobeSceneController = (
         getPolygonManager: () => polygonManager,
         getCircleManager: () => circleManager,
 
-        // ---- イベント購読（floating-origin 対応の pick 非依存実装は P4-0 後続スライス） ----
-        // インターフェース通り listener を受け取るが globe では未対応のため無視する（no-op）。
-        // 引数を明示することで「未対応で listener を無視している」意図をコード上に残す。
-        subscribeTerrainClick: (listener) => {
-            // globe では未対応のため listener を無視する（no-op）。引数を明示的に受け取り
-            // `void` でデバッグ容易性のため「未対応で listener を無視している」意図を残す。
-            void listener;
-            // 他 no-op（setMapType/setViewMode）と同様、未対応をデバッグしやすいよう一度だけ warn する。
-            if (!terrainClickWarned) {
-                terrainClickWarned = true;
-                console.warn(
-                    "[globeSceneController] subscribeTerrainClick is not yet supported on the globe backend (pick-independent terrain click pending; P4-0 follow-up).",
-                );
-            }
-            return () => {};
-        },
+        // ---- 地形クリック購読（pick 非依存・floating origin 対応, #275 P4-0 後続スライス） ----
+        // globe シーン（globe.ts）が真の ECEF レイ × 地形楕円体で求めたクリック地点を、公開
+        // TerrainClickEvent へ橋渡しする。GlobeTerrainClickEvent は構造互換だが、型を明示するため
+        // ここで明示的にイベントを組み直す。
+        subscribeTerrainClick: (listener) =>
+            gc.subscribeTerrainClick((e) =>
+                listener({
+                    lat: e.lat,
+                    lon: e.lon,
+                    altitude: e.altitude,
+                    world: e.world,
+                    pointerEvent: e.pointerEvent,
+                }),
+            ),
         subscribePolygonPointHover: () => () => {},
         subscribePolygonPointClick: () => () => {},
         subscribePolygonPointDragStart: () => () => {},

--- a/tests/globeSceneController.unit.spec.ts
+++ b/tests/globeSceneController.unit.spec.ts
@@ -15,12 +15,12 @@ import {
     createGlobePolygonManagerAdapter,
     createGlobeCircleManagerAdapter,
 } from "../src/scenes/globeSceneController";
-import type { GlobeSceneController } from "../src/scenes/globe";
-import type { TerrainClickEvent } from "../src/lib/types";
 import type {
+    GlobeSceneController,
     GlobeTerrainClickEvent,
     GlobeTerrainClickListener,
 } from "../src/scenes/globe";
+import type { TerrainClickEvent } from "../src/lib/types";
 import type {
     GlobeMarkerManager,
     GlobeMarkerOptions,

--- a/tests/globeSceneController.unit.spec.ts
+++ b/tests/globeSceneController.unit.spec.ts
@@ -16,6 +16,7 @@ import {
     createGlobeCircleManagerAdapter,
 } from "../src/scenes/globeSceneController";
 import type { GlobeSceneController } from "../src/scenes/globe";
+import type { TerrainClickEvent } from "../src/lib/types";
 import type {
     GlobeTerrainClickEvent,
     GlobeTerrainClickListener,
@@ -181,20 +182,28 @@ describe("createGlobeSceneController (P4-0 globe backend adapter)", () => {
     it("subscribeTerrainClick は gc のクリックを公開 TerrainClickEvent へ橋渡しし、unsubscribe で解除する", () => {
         const stub = makeStub(35, 139, 1000, 0, 0);
         const c = createGlobeSceneController(stub.gc, "std");
-        const received: Array<{ lat: number; lon: number; altitude: number }> = [];
+        const received: TerrainClickEvent[] = [];
         const off = c.subscribeTerrainClick((e) => {
-            received.push({ lat: e.lat, lon: e.lon, altitude: e.altitude });
+            received.push(e);
         });
         expect(stub.clickListenerCount()).toBe(1);
         const pe = {} as PointerEvent;
+        const world = { x: 1, y: 2, z: 3 };
         stub.triggerTerrainClick({
             lat: 35.5,
             lon: 139.5,
             altitude: 120,
-            world: { x: 1, y: 2, z: 3 },
+            world,
             pointerEvent: pe,
         });
-        expect(received).toEqual([{ lat: 35.5, lon: 139.5, altitude: 120 }]);
+        expect(received).toHaveLength(1);
+        expect(received[0].lat).toBe(35.5);
+        expect(received[0].lon).toBe(139.5);
+        expect(received[0].altitude).toBe(120);
+        // world / pointerEvent も橋渡しされる（参照同一性も確認）。
+        expect(received[0].world).toEqual({ x: 1, y: 2, z: 3 });
+        expect(received[0].world).toBe(world);
+        expect(received[0].pointerEvent).toBe(pe);
         // unsubscribe 後はイベントが届かない。
         off();
         expect(stub.clickListenerCount()).toBe(0);

--- a/tests/globeSceneController.unit.spec.ts
+++ b/tests/globeSceneController.unit.spec.ts
@@ -168,7 +168,7 @@ describe("createGlobeSceneController (P4-0 globe backend adapter)", () => {
         expect(() => c.getMarkerContext()).toThrow(/not supported on the globe backend/);
     });
 
-    it("購読 API は no-op unsubscribe を返し、no-op メソッドは例外を投げない", () => {
+    it("subscribeTerrainClick は関数を返し、未実装の購読/設定メソッドは例外を投げない", () => {
         const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
         const { gc } = makeStub(35, 139, 1000, 0, 0);
         const c = createGlobeSceneController(gc, "std");

--- a/tests/globeSceneController.unit.spec.ts
+++ b/tests/globeSceneController.unit.spec.ts
@@ -17,6 +17,10 @@ import {
 } from "../src/scenes/globeSceneController";
 import type { GlobeSceneController } from "../src/scenes/globe";
 import type {
+    GlobeTerrainClickEvent,
+    GlobeTerrainClickListener,
+} from "../src/scenes/globe";
+import type {
     GlobeMarkerManager,
     GlobeMarkerOptions,
 } from "../src/terrain/geo/globeMarkerManager";
@@ -38,7 +42,12 @@ const makeStub = (
     yaw: number,
     pitch: number,
     idle = true,
-): { gc: GlobeSceneController; disposed: () => boolean } => {
+): {
+    gc: GlobeSceneController;
+    disposed: () => boolean;
+    triggerTerrainClick: (e: GlobeTerrainClickEvent) => void;
+    clickListenerCount: () => number;
+} => {
     let disposedFlag = false;
     const camera = {
         center: geodeticToEcef(lat, lon, 0),
@@ -46,6 +55,7 @@ const makeStub = (
         yaw,
         pitch,
     };
+    const clickListeners: GlobeTerrainClickListener[] = [];
     const gc = {
         camera,
         // isTerrainIdle / marker アダプタ / mapType 切替が参照する tileManager スタブ。
@@ -54,11 +64,25 @@ const makeStub = (
             terrainElevAt: () => null,
             setMapType: jest.fn(),
         },
+        subscribeTerrainClick: (listener: GlobeTerrainClickListener) => {
+            clickListeners.push(listener);
+            return () => {
+                const i = clickListeners.indexOf(listener);
+                if (i >= 0) clickListeners.splice(i, 1);
+            };
+        },
         dispose: () => {
             disposedFlag = true;
         },
     } as unknown as GlobeSceneController;
-    return { gc, disposed: () => disposedFlag };
+    return {
+        gc,
+        disposed: () => disposedFlag,
+        triggerTerrainClick: (e) => {
+            for (const l of clickListeners.slice()) l(e);
+        },
+        clickListenerCount: () => clickListeners.length,
+    };
 };
 
 describe("createGlobeSceneController (P4-0 globe backend adapter)", () => {
@@ -154,18 +178,34 @@ describe("createGlobeSceneController (P4-0 globe backend adapter)", () => {
         warn.mockRestore();
     });
 
-    it("subscribeTerrainClick は未対応を一度だけ warn し、unsubscribe を返す", () => {
-        const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
-        const { gc } = makeStub(35, 139, 1000, 0, 0);
-        const c = createGlobeSceneController(gc, "std");
-        const off1 = c.subscribeTerrainClick(() => {});
-        const off2 = c.subscribeTerrainClick(() => {});
-        expect(typeof off1).toBe("function");
-        expect(typeof off2).toBe("function");
-        expect(() => off1()).not.toThrow();
-        expect(warn).toHaveBeenCalledTimes(1);
-        expect(warn.mock.calls[0][0]).toMatch(/subscribeTerrainClick is not yet supported/);
-        warn.mockRestore();
+    it("subscribeTerrainClick は gc のクリックを公開 TerrainClickEvent へ橋渡しし、unsubscribe で解除する", () => {
+        const stub = makeStub(35, 139, 1000, 0, 0);
+        const c = createGlobeSceneController(stub.gc, "std");
+        const received: Array<{ lat: number; lon: number; altitude: number }> = [];
+        const off = c.subscribeTerrainClick((e) => {
+            received.push({ lat: e.lat, lon: e.lon, altitude: e.altitude });
+        });
+        expect(stub.clickListenerCount()).toBe(1);
+        const pe = {} as PointerEvent;
+        stub.triggerTerrainClick({
+            lat: 35.5,
+            lon: 139.5,
+            altitude: 120,
+            world: { x: 1, y: 2, z: 3 },
+            pointerEvent: pe,
+        });
+        expect(received).toEqual([{ lat: 35.5, lon: 139.5, altitude: 120 }]);
+        // unsubscribe 後はイベントが届かない。
+        off();
+        expect(stub.clickListenerCount()).toBe(0);
+        stub.triggerTerrainClick({
+            lat: 0,
+            lon: 0,
+            altitude: 0,
+            world: { x: 0, y: 0, z: 0 },
+            pointerEvent: pe,
+        });
+        expect(received).toHaveLength(1);
     });
 
     it("isTerrainIdle は tileManager.isIdle へ委譲する（true/false）", () => {


### PR DESCRIPTION
## 概要

globe バックエンドで未対応だった **地形クリック（terrain-click）** を実装します。`?terrainEngine=globe` で `onTerrainClick` が機能するようになり、distance / model など地面クリックに依存するデモを globe 配線するための前提が揃います。

## 背景・設計

平面版（`default.ts`）は `scene.pick` で地形メッシュをヒットしますが、globe は `useFloatingOrigin: true` のためレンダリング座標と真の ECEF メッシュ位置がずれ、ピックがブレます（zoom/pan も同じ理由で pick 非依存化済み）。そこで同方針で:

1. 真の ECEF カメラ位置からカーソル方向のレイを構築（`computeRayDirForPixelToRef`、zoom と共有）。
2. WGS84 楕円体（海面）と交差 → 概略の緯度経度。
3. その地点の地形標高で楕円体面を持ち上げ、1 回だけ交点を補正（斜面での誤差低減）。
4. ECEF→測地変換で `lat/lon/altitude` を確定し、`TerrainClickEvent` を発火。

ドラッグ（パン/回転）は移動量しきい値で除外し、Ctrl/Cmd 併用はカメラ操作扱いで通知しません（平面版と同方針）。

## 変更

- `src/scenes/globe.ts`: `GlobeTerrainClickEvent`/`GlobeTerrainClickListener` 型、クリックジェスチャ検出、`computeRayDirForPixelToRef` へのリファクタ（`computeCursorRayDirToRef` は薄いラッパに）、`subscribeTerrainClick`、`dispose` でのリスナ解除。
- `src/scenes/globeSceneController.ts`: 未対応 no-op+warn を `gc.subscribeTerrainClick` への委譲（公開 `TerrainClickEvent` へ橋渡し）へ置換。
- `tests/globeSceneController.unit.spec.ts`: 橋渡し・unsubscribe を検証（旧 warn テストを委譲テストへ更新）。

## 既知の差分・補足

- `event.world` は **真の ECEF 交点**（floating origin のレンダリング座標ではない）。デモは `lat/lon/altitude` のみ使用。
- 標高は `tileManager.terrainElevAt`（未取得時は楕円体高にフォールバック）。

## 検証

- typecheck / lint / test:unit（**1200 passed**）/ build すべて緑。
- **HITL 目視確認 待ち**: 3DCG 挙動のため、`?terrainEngine=globe` でクリック地点が地形上の意図した位置に対応するか目視確認が必要。

## 後続スライス（本PR前提）

- **distance** デモの globe 配線: polygon-point 編集（`onPolygonPoint*`）が別途必要。
- **model** デモの globe 配線: Model アダプタ（`GlobeModelManager`→公開 `ModelManager`）が別途必要。

関連: #275（Phase 4 / 親 #349）。本PRは Phase 4 の一部のため #275 はクローズしない。