### PR TITLE
feat(globe): distance デモの頂点編集を globe バックエンドへ対応

### DIFF
--- a/src/demos/distance/index.ts
+++ b/src/demos/distance/index.ts
@@ -27,6 +27,7 @@ import type {
 import {
     parseCameraStateFromUrl,
     parseMapTypeFromUrl,
+    resolveTerrainEngine,
 } from "../../terrain/urlState";
 import {
     DEFAULT_DISTANCE_DEMO_MODE,
@@ -221,6 +222,7 @@ const start = async (): Promise<void> => {
     }
 
     const engine = resolveEngine(location.search);
+    const terrainEngine = resolveTerrainEngine(location.search);
     const cameraState = parseCameraStateFromUrl(location.href) ?? undefined;
     const mapType = parseMapTypeFromUrl(location.href);
     // よみうりランド近傍を初期視点（URL 指定がない場合）。
@@ -234,6 +236,7 @@ const start = async (): Promise<void> => {
 
     const opts: JpmapTerrainOptions = {
         ...(engine ? { engine } : {}),
+        ...(terrainEngine ? { terrainEngine } : {}),
         ...(cameraState ?? defaultCamera),
         ...(mapType !== null ? { mapType } : {}),
         // ライブラリ内蔵の視点モード切替ボタンは非表示。デモ独自の UI を提供する (Issue #193)。
@@ -317,9 +320,12 @@ const start = async (): Promise<void> => {
     // 連続 pointermove 中に scene.pick が一瞬外れて hover が解除されると
     // cursor が `""` に戻ってしまう。そこで demo 側で pointermove ごとに
     // 自前でピックし直し、ライブラリ後段で cursor を再適用する。
-    viewer.onPolygonPointHover(() => {
-        /* no-op: cursor 制御は下記 pointermove 内で行う */
-    });
+    //
+    // ただし globe バックエンド（#275 P4）では floating origin のため demo 側の
+    // `scene.pick` は頂点メッシュをヒットできない。そこでライブラリの hover イベント
+    // （pick 非依存の幾何ピックで発火）も併用し、どちらかが hover を示せば hover 扱いに
+    // する。planar では従来どおり scene.pick が主、globe ではライブラリ hover が効く。
+    let libHoveringPoint = false;
     const scene = viewer.__debugScene;
     const renderCanvas =
         (scene?.getEngine().getRenderingCanvas() as HTMLCanvasElement | null) ??
@@ -329,6 +335,7 @@ const start = async (): Promise<void> => {
     let lastPointerCanvasX: number | null = null;
     let lastPointerCanvasY: number | null = null;
     const isHoveringPoint = (sx: number, sy: number): boolean => {
+        if (libHoveringPoint) return true;
         if (!scene) return false;
         const pick = scene.pick(sx, sy, (m) =>
             POLYGON_POINT_NAME_RE.test(m.name),
@@ -364,6 +371,14 @@ const start = async (): Promise<void> => {
             applyModeCursor(sx, sy);
         });
     }
+    // ライブラリ hover（#184, pick 非依存の幾何ピックで発火）を購読し、globe でも
+    // remove/edit のモード別カーソルが効くようにする。遷移時にカーソルを再適用する。
+    viewer.onPolygonPointHover((e) => {
+        libHoveringPoint = e !== null;
+        if (lastPointerCanvasX !== null && lastPointerCanvasY !== null) {
+            applyModeCursor(lastPointerCanvasX, lastPointerCanvasY);
+        }
+    });
     const onShiftKey = (down: boolean) => (ev: KeyboardEvent): void => {
         if (ev.key !== "Shift") return;
         shiftPressed = down;

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -977,7 +977,8 @@ export class GlobeScene {
         const pickPolygonPoint = (
             pxCss: number,
             pyCss: number,
-        ): { polygonId: string; index: number; world: Vector3 } | null => {
+            outWorld?: Vector3,
+        ): { polygonId: string; index: number } | null => {
             const count = polygonManager.getPickablePoints(ppPickBuffer);
             if (count === 0) return null;
             ppOrigin.copyFrom(computeCameraEcef());
@@ -1021,12 +1022,13 @@ export class GlobeScene {
                     bestZ = p.z;
                 }
             }
-            // Vector3 の生成はベスト確定後に 1 回だけ行い、毎候補の割り当て/GC を避ける。
+            // world 座標はドラッグ開始時のみ必要。hover/click では outWorld を渡さず
+            // 割り当てをゼロにする。要求時のみ呼び出し側の Vector3 へ書き込む。
             if (bestPolygonId === null) return null;
+            if (outWorld) outWorld.set(bestX, bestY, bestZ);
             return {
                 polygonId: bestPolygonId,
                 index: bestIndex,
-                world: new Vector3(bestX, bestY, bestZ),
             };
         };
 
@@ -1203,9 +1205,14 @@ export class GlobeScene {
             if (!hasPolygonPointGestureListeners()) return;
             if (e.ctrlKey || e.metaKey) return;
             const rect = canvas.getBoundingClientRect();
-            const hit = pickPolygonPoint(e.clientX - rect.left, e.clientY - rect.top);
+            const startWorld = new Vector3();
+            const hit = pickPolygonPoint(
+                e.clientX - rect.left,
+                e.clientY - rect.top,
+                startWorld,
+            );
             if (!hit) return;
-            const startGeo = ecefToGeodetic(hit.world);
+            const startGeo = ecefToGeodetic(startWorld);
             polygonPointGesture = {
                 pointerId: e.pointerId,
                 polygonId: hit.polygonId,
@@ -1213,7 +1220,7 @@ export class GlobeScene {
                 startClientX: e.clientX,
                 startClientY: e.clientY,
                 dragging: false,
-                startWorld: hit.world,
+                startWorld,
                 startAltMeters: startGeo.altMeters,
             };
             canvas.setPointerCapture?.(e.pointerId);

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -994,8 +994,11 @@ export class GlobeScene {
             ) {
                 tEllip = Vector3.Distance(ppOrigin, ppEllipHit);
             }
-            let best: { polygonId: string; index: number; world: Vector3 } | null =
-                null;
+            let bestPolygonId: string | null = null;
+            let bestIndex = -1;
+            let bestX = 0;
+            let bestY = 0;
+            let bestZ = 0;
             let bestT = Number.POSITIVE_INFINITY;
             for (const p of points) {
                 const vx = p.x - ppOrigin.x;
@@ -1008,14 +1011,20 @@ export class GlobeScene {
                 if (perp2 > p.radius * p.radius) continue; // レイがスフィアを外れている
                 if (t < bestT) {
                     bestT = t;
-                    best = {
-                        polygonId: p.polygonId,
-                        index: p.index,
-                        world: new Vector3(p.x, p.y, p.z),
-                    };
+                    bestPolygonId = p.polygonId;
+                    bestIndex = p.index;
+                    bestX = p.x;
+                    bestY = p.y;
+                    bestZ = p.z;
                 }
             }
-            return best;
+            // Vector3 の生成はベスト確定後に 1 回だけ行い、毎候補の割り当て/GC を避ける。
+            if (bestPolygonId === null) return null;
+            return {
+                polygonId: bestPolygonId,
+                index: bestIndex,
+                world: new Vector3(bestX, bestY, bestZ),
+            };
         };
 
         /** カーソルレイ × 地形楕円体の交点（terrain-click と同方針）。 */
@@ -1037,9 +1046,12 @@ export class GlobeScene {
             ) {
                 return { lat: null, lon: null, groundAltitude: null };
             }
-            let geo = ecefToGeodetic(ppEllipHit);
+            const geo = ecefToGeodetic(ppEllipHit);
             const elev = tileManager.terrainElevAt(geo.latDeg, geo.lonDeg);
             if (elev !== null && Number.isFinite(elev)) {
+                // 補正交点（地形標高ぶん持ち上げた楕円体面）が得られた場合のみ、
+                // その lat/lon と groundAltitude=elev を採用し両者を一貫させる。
+                // computeTerrainClick と同じく、補正に失敗したら海面交点へフォールバックする。
                 if (
                     rayEllipsoidNearHitToRef(
                         ppOrigin,
@@ -1050,9 +1062,13 @@ export class GlobeScene {
                         ppScratch,
                     )
                 ) {
-                    geo = ecefToGeodetic(ppScratch);
+                    const corrected = ecefToGeodetic(ppScratch);
+                    return {
+                        lat: corrected.latDeg,
+                        lon: corrected.lonDeg,
+                        groundAltitude: elev,
+                    };
                 }
-                return { lat: geo.latDeg, lon: geo.lonDeg, groundAltitude: elev };
             }
             return { lat: geo.latDeg, lon: geo.lonDeg, groundAltitude: geo.altMeters };
         };

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -40,7 +40,7 @@ import {
 } from "../terrain/geo/cameraMapping";
 import { createGlobeTileManager, type GlobeTileManager, type GlobeTileSyncStats } from "../terrain/geo/globeTileManager";
 import { createGlobeMarkerManager, type GlobeMarkerManager } from "../terrain/geo/globeMarkerManager";
-import { createGlobePolygonManager, type GlobePolygonManager } from "../terrain/geo/globePolygonManager";
+import { createGlobePolygonManager, type GlobePolygonManager, type GlobePolygonPickablePoint } from "../terrain/geo/globePolygonManager";
 import { createGlobeCircleManager, type GlobeCircleManager } from "../terrain/geo/globeCircleManager";
 import { createGlobeModelManager, type GlobeModelManager } from "../terrain/geo/globeModelManager";
 
@@ -967,6 +967,8 @@ export class GlobeScene {
         const ppUp = new Vector3();
         const ppScratch = new Vector3();
         const ppClosest = new Vector3();
+        // getPickablePoints の書き込み先（要素を再利用して毎 move の割り当てを避ける）。
+        const ppPickBuffer: GlobePolygonPickablePoint[] = [];
 
         /**
          * カーソル下の頂点を幾何ピックする（最も手前の点）。floating origin 非依存。
@@ -976,8 +978,8 @@ export class GlobeScene {
             pxCss: number,
             pyCss: number,
         ): { polygonId: string; index: number; world: Vector3 } | null => {
-            const points = polygonManager.getPickablePoints();
-            if (points.length === 0) return null;
+            const count = polygonManager.getPickablePoints(ppPickBuffer);
+            if (count === 0) return null;
             ppOrigin.copyFrom(computeCameraEcef());
             computeRayDirForPixelToRef(pxCss, pyCss, ppRayDir);
             // 楕円体（海面）近交点までの距離。これより十分奥の点は裏側として除外する。
@@ -1000,7 +1002,8 @@ export class GlobeScene {
             let bestY = 0;
             let bestZ = 0;
             let bestT = Number.POSITIVE_INFINITY;
-            for (const p of points) {
+            for (let i = 0; i < count; i++) {
+                const p = ppPickBuffer[i];
                 const vx = p.x - ppOrigin.x;
                 const vy = p.y - ppOrigin.y;
                 const vz = p.z - ppOrigin.z;
@@ -1314,11 +1317,19 @@ export class GlobeScene {
             }
         };
         const onPolygonPointerCancel = (e: PointerEvent): void => {
-            if (
-                polygonPointGesture &&
-                polygonPointGesture.pointerId === e.pointerId
-            ) {
-                polygonPointGesture = null;
+            const gesture = polygonPointGesture;
+            if (!gesture || gesture.pointerId !== e.pointerId) return;
+            polygonPointGesture = null;
+            canvas.releasePointerCapture?.(e.pointerId);
+            // planar (resetPointerState) と同契約: ドラッグ中に pointercancel /
+            // lostpointercapture で中断された場合も dragEnd を通知する。これにより
+            // デモ側の状態（altitudeDragStart クリア・rAF flush 等）が取りこぼされない。
+            if (gesture.dragging) {
+                dispatchPolygonDrag(
+                    polygonPointDragEndListeners,
+                    buildPolygonDragEvent(gesture, e),
+                    "onPolygonPointDragEnd",
+                );
             }
         };
 
@@ -1330,6 +1341,11 @@ export class GlobeScene {
             canvas.addEventListener("pointermove", onPolygonPointerMove);
             canvas.addEventListener("pointerup", onPolygonPointerUp);
             canvas.addEventListener("pointercancel", onPolygonPointerCancel);
+            // setPointerCapture を使うため、ブラウザ都合の capture 喪失でも確実に
+            // ジェスチャをリセットする（planar と同様に pointercancel と両方で reset）。
+            // pointerup は releasePointerCapture 前に gesture を null 化するため、
+            // ここでの lostpointercapture では二重に dragEnd が発火しない。
+            canvas.addEventListener("lostpointercapture", onPolygonPointerCancel);
             polygonPointHandlersAttached = true;
         };
         const detachPolygonPointHandlers = (): void => {
@@ -1338,6 +1354,7 @@ export class GlobeScene {
             canvas.removeEventListener("pointermove", onPolygonPointerMove);
             canvas.removeEventListener("pointerup", onPolygonPointerUp);
             canvas.removeEventListener("pointercancel", onPolygonPointerCancel);
+            canvas.removeEventListener("lostpointercapture", onPolygonPointerCancel);
             polygonPointGesture = null;
             if (polygonPointHoverState !== null) {
                 polygonPointHoverState = null;

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -1373,9 +1373,24 @@ export class GlobeScene {
                     if (!hasAnyPolygonPointListener()) detachPolygonPointHandlers();
                 };
             };
-        const subscribePolygonPointHover = makePolygonPointSubscribe(
-            polygonPointHoverListeners,
-        );
+        const subscribePolygonPointHover = (
+            listener: GlobePolygonPointListener,
+        ): (() => void) => {
+            polygonPointHoverListeners.push(listener);
+            attachPolygonPointHandlers();
+            return () => {
+                const i = polygonPointHoverListeners.indexOf(listener);
+                if (i >= 0) polygonPointHoverListeners.splice(i, 1);
+                // 最後の hover リスナー解除時は、click/drag リスナーが残って handler が
+                // 付いたままでも hover 検出が止まりカーソルが pointer のまま残り得る。
+                // planar (subscribePolygonPointHover) と同様に明示的にクリアする。
+                if (polygonPointHoverListeners.length === 0 && polygonPointHoverState !== null) {
+                    polygonPointHoverState = null;
+                    canvas.style.cursor = "";
+                }
+                if (!hasAnyPolygonPointListener()) detachPolygonPointHandlers();
+            };
+        };
         const subscribePolygonPointClick = makePolygonPointSubscribe(
             polygonPointClickListeners,
         );

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -30,7 +30,7 @@ import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
 import { PickingInfo } from "@babylonjs/core/Collisions/pickingInfo";
 
 import type { MapType } from "../terrain/gsiTile";
-import { TERRAIN_CLICK_DRAG_THRESHOLD_PX } from "../lib/types";
+import { TERRAIN_CLICK_DRAG_THRESHOLD_PX, POLYGON_POINT_DRAG_THRESHOLD_PX } from "../lib/types";
 import { DEG2RAD, geodeticToEcef, geodeticToEcefToRef, ecefToGeodetic, type Geodetic } from "../terrain/geo/ecef";
 import {
     cameraTangentBasisToRef,
@@ -205,6 +205,48 @@ export interface GlobeTerrainClickEvent {
 
 export type GlobeTerrainClickListener = (event: GlobeTerrainClickEvent) => void;
 
+/**
+ * ポリゴン頂点ポインタイベント（globe 版）。公開 `PolygonPointPointerEvent`（lib/types）と
+ * 構造互換で、アダプタ（globeSceneController）が橋渡しする。
+ */
+export interface GlobePolygonPointEvent {
+    /** 対象ポリゴンの id。 */
+    polygonId: string;
+    /** 対象頂点の index（0-based）。 */
+    index: number;
+    /** 元の `PointerEvent`。 */
+    pointerEvent: PointerEvent;
+}
+
+/**
+ * ポリゴン頂点ドラッグイベント（globe 版）。公開 `PolygonPointDragEvent` と構造互換。
+ * 各幾何量は floating origin 非依存に真の ECEF レイ × 楕円体/垂直線で求める。
+ */
+export interface GlobePolygonPointDragEvent extends GlobePolygonPointEvent {
+    /** カーソル位置の地形交点の緯度（ヒットなし null）。 */
+    lat: number | null;
+    /** カーソル位置の地形交点の経度（ヒットなし null）。 */
+    lon: number | null;
+    /** カーソル位置の地表標高 [m]（ヒットなし null）。 */
+    groundAltitude: number | null;
+    /** ドラッグ開始時の頂点高度を保つ面とカーソルレイの交点の緯度（得られない場合 null）。 */
+    planeLat: number | null;
+    /** 同経度（得られない場合 null）。 */
+    planeLon: number | null;
+    /** 頂点の鉛直線とカーソルレイ最近接点の標高 [m]（得られない場合 null）。 */
+    pointerAltitude: number | null;
+}
+
+export type GlobePolygonPointListener = (
+    event: GlobePolygonPointEvent | null,
+) => void;
+export type GlobePolygonPointClickListener = (
+    event: GlobePolygonPointEvent,
+) => void;
+export type GlobePolygonPointDragListener = (
+    event: GlobePolygonPointDragEvent,
+) => void;
+
 export interface GlobeSceneController {
     scene: Scene;
     camera: GeospatialCamera;
@@ -222,6 +264,26 @@ export interface GlobeSceneController {
      * リスナーへ通知する。戻り値で購読解除する。
      */
     subscribeTerrainClick: (listener: GlobeTerrainClickListener) => () => void;
+    /** ポリゴン頂点 hover 購読（pick 非依存）。hover 開始/切替でイベント、解除で null。 */
+    subscribePolygonPointHover: (
+        listener: GlobePolygonPointListener,
+    ) => () => void;
+    /** ポリゴン頂点 click 購読（pick 非依存）。 */
+    subscribePolygonPointClick: (
+        listener: GlobePolygonPointClickListener,
+    ) => () => void;
+    /** ポリゴン頂点ドラッグ開始購読（pick 非依存）。 */
+    subscribePolygonPointDragStart: (
+        listener: GlobePolygonPointDragListener,
+    ) => () => void;
+    /** ポリゴン頂点ドラッグ中購読（pick 非依存）。 */
+    subscribePolygonPointDrag: (
+        listener: GlobePolygonPointDragListener,
+    ) => () => void;
+    /** ポリゴン頂点ドラッグ終了購読（pick 非依存）。 */
+    subscribePolygonPointDragEnd: (
+        listener: GlobePolygonPointDragListener,
+    ) => () => void;
     dispose: () => void;
 }
 
@@ -344,6 +406,21 @@ export class GlobeScene {
         let dragging = false;
         let lastX = 0;
         let lastY = 0;
+        // ---- ポリゴン頂点インタラクション状態（#275 P4） ----
+        // パン handler（onPointerDown/Move）から参照するため早期に宣言する。実体の購読 API・
+        // 幾何ピック・ドラッグハンドラはカメラ/レイ補助関数（後述）の後で定義・遅延登録する。
+        let polygonPointGesture: {
+            pointerId: number;
+            polygonId: string;
+            index: number;
+            startClientX: number;
+            startClientY: number;
+            dragging: boolean;
+            /** ドラッグ開始時の頂点 ECEF 位置（複製。manager の top[] は毎フレーム更新されるため）。 */
+            startWorld: Vector3;
+            /** ドラッグ開始時の頂点測地高度 [m]（水平面交点の基準）。 */
+            startAltMeters: number;
+        } | null = null;
         const onPointerDown = (e: PointerEvent): void => {
             canvas.focus(); // WASD のためにフォーカスを確保（右/左/中ボタンいずれでも）
             if (e.button !== 0) return;
@@ -366,6 +443,13 @@ export class GlobeScene {
         const panned = new Vector3();
 
         const onPointerMove = (e: PointerEvent): void => {
+            // ポリゴン頂点ジェスチャ進行中はパンしない（#275 P4）。ドラッグ処理は専用 handler が行う。
+            if (
+                polygonPointGesture &&
+                polygonPointGesture.pointerId === e.pointerId
+            ) {
+                return;
+            }
             if (!dragging) return;
             const dx = e.clientX - lastX;
             const dy = e.clientY - lastY;
@@ -853,6 +937,423 @@ export class GlobeScene {
             };
         };
 
+        // ---- ポリゴン頂点インタラクション（pick 非依存・floating origin 対応, #275 P4） ----
+        // 平面版（default.ts）は scene.pick で頂点メッシュをヒットするが、floating origin 下では
+        // レンダリング座標がずれてピックがブレうる。そこで terrain-click と同じく、真の ECEF カメラ
+        // 位置からカーソル方向のレイを作り、各頂点 ECEF（globePolygonManager.getPickablePoints）との
+        // 幾何関係（レイ最近接距離 ≤ 点スフィア半径）でヒット判定する。ドラッグ中の幾何量も
+        // 真の ECEF レイ × 楕円体/鉛直線で求める。
+        const polygonPointHoverListeners: GlobePolygonPointListener[] = [];
+        const polygonPointClickListeners: GlobePolygonPointClickListener[] = [];
+        const polygonPointDragStartListeners: GlobePolygonPointDragListener[] = [];
+        const polygonPointDragListeners: GlobePolygonPointDragListener[] = [];
+        const polygonPointDragEndListeners: GlobePolygonPointDragListener[] = [];
+        let polygonPointHoverState: { polygonId: string; index: number } | null =
+            null;
+
+        const hasPolygonPointGestureListeners = (): boolean =>
+            polygonPointClickListeners.length > 0 ||
+            polygonPointDragStartListeners.length > 0 ||
+            polygonPointDragListeners.length > 0 ||
+            polygonPointDragEndListeners.length > 0;
+        const hasAnyPolygonPointListener = (): boolean =>
+            polygonPointHoverListeners.length > 0 ||
+            hasPolygonPointGestureListeners();
+
+        // ピック/幾何計算用の再利用バッファ（毎 move での割り当てを避ける）。
+        const ppOrigin = new Vector3();
+        const ppRayDir = new Vector3();
+        const ppEllipHit = new Vector3();
+        const ppUp = new Vector3();
+        const ppScratch = new Vector3();
+        const ppClosest = new Vector3();
+
+        /**
+         * カーソル下の頂点を幾何ピックする（最も手前の点）。floating origin 非依存。
+         * 地球の裏側に隠れた点は楕円体近交点距離との比較で除外する。
+         */
+        const pickPolygonPoint = (
+            pxCss: number,
+            pyCss: number,
+        ): { polygonId: string; index: number; world: Vector3 } | null => {
+            const points = polygonManager.getPickablePoints();
+            if (points.length === 0) return null;
+            ppOrigin.copyFrom(computeCameraEcef());
+            computeRayDirForPixelToRef(pxCss, pyCss, ppRayDir);
+            // 楕円体（海面）近交点までの距離。これより十分奥の点は裏側として除外する。
+            let tEllip = Number.POSITIVE_INFINITY;
+            if (
+                rayEllipsoidNearHitToRef(
+                    ppOrigin,
+                    ppRayDir,
+                    ellipsoidSemiMajor,
+                    ellipsoidSemiMajor,
+                    ellipsoidSemiMinor,
+                    ppEllipHit,
+                )
+            ) {
+                tEllip = Vector3.Distance(ppOrigin, ppEllipHit);
+            }
+            let best: { polygonId: string; index: number; world: Vector3 } | null =
+                null;
+            let bestT = Number.POSITIVE_INFINITY;
+            for (const p of points) {
+                const vx = p.x - ppOrigin.x;
+                const vy = p.y - ppOrigin.y;
+                const vz = p.z - ppOrigin.z;
+                const t = vx * ppRayDir.x + vy * ppRayDir.y + vz * ppRayDir.z;
+                if (t <= 0) continue; // カメラ背後
+                if (t > tEllip + p.radius) continue; // 地球裏側に隠れている
+                const perp2 = vx * vx + vy * vy + vz * vz - t * t;
+                if (perp2 > p.radius * p.radius) continue; // レイがスフィアを外れている
+                if (t < bestT) {
+                    bestT = t;
+                    best = {
+                        polygonId: p.polygonId,
+                        index: p.index,
+                        world: new Vector3(p.x, p.y, p.z),
+                    };
+                }
+            }
+            return best;
+        };
+
+        /** カーソルレイ × 地形楕円体の交点（terrain-click と同方針）。 */
+        const computeDragGroundHit = (
+            pxCss: number,
+            pyCss: number,
+        ): { lat: number | null; lon: number | null; groundAltitude: number | null } => {
+            ppOrigin.copyFrom(computeCameraEcef());
+            computeRayDirForPixelToRef(pxCss, pyCss, ppRayDir);
+            if (
+                !rayEllipsoidNearHitToRef(
+                    ppOrigin,
+                    ppRayDir,
+                    ellipsoidSemiMajor,
+                    ellipsoidSemiMajor,
+                    ellipsoidSemiMinor,
+                    ppEllipHit,
+                )
+            ) {
+                return { lat: null, lon: null, groundAltitude: null };
+            }
+            let geo = ecefToGeodetic(ppEllipHit);
+            const elev = tileManager.terrainElevAt(geo.latDeg, geo.lonDeg);
+            if (elev !== null && Number.isFinite(elev)) {
+                if (
+                    rayEllipsoidNearHitToRef(
+                        ppOrigin,
+                        ppRayDir,
+                        ellipsoidSemiMajor + elev,
+                        ellipsoidSemiMajor + elev,
+                        ellipsoidSemiMinor + elev,
+                        ppScratch,
+                    )
+                ) {
+                    geo = ecefToGeodetic(ppScratch);
+                }
+                return { lat: geo.latDeg, lon: geo.lonDeg, groundAltitude: elev };
+            }
+            return { lat: geo.latDeg, lon: geo.lonDeg, groundAltitude: geo.altMeters };
+        };
+
+        /**
+         * カーソルレイ × 「ドラッグ開始時の頂点高度を保つ楕円体面」の交点。平面版の水平面交点に相当。
+         */
+        const computeDragPlaneHit = (
+            pxCss: number,
+            pyCss: number,
+            startAltMeters: number,
+        ): { planeLat: number | null; planeLon: number | null } => {
+            ppOrigin.copyFrom(computeCameraEcef());
+            computeRayDirForPixelToRef(pxCss, pyCss, ppRayDir);
+            const eqr = ellipsoidSemiMajor + startAltMeters;
+            const pol = ellipsoidSemiMinor + startAltMeters;
+            if (
+                !rayEllipsoidNearHitToRef(ppOrigin, ppRayDir, eqr, eqr, pol, ppScratch)
+            ) {
+                return { planeLat: null, planeLon: null };
+            }
+            const geo = ecefToGeodetic(ppScratch);
+            return { planeLat: geo.latDeg, planeLon: geo.lonDeg };
+        };
+
+        /**
+         * 頂点の測地鉛直線（地心 up 方向）とカーソルレイの最近接点の測地高度。平面版の
+         * 鉛直線最近接に相当。カメラがほぼ鉛直線方向を向くと退化し null。
+         */
+        const computeDragVerticalHit = (
+            pxCss: number,
+            pyCss: number,
+            startWorld: Vector3,
+        ): number | null => {
+            ppOrigin.copyFrom(computeCameraEcef());
+            computeRayDirForPixelToRef(pxCss, pyCss, ppRayDir);
+            const startGeo = ecefToGeodetic(startWorld);
+            // 測地 up = ecef(alt+1) - ecef(alt) を正規化（楕円体法線。地心方向と微差）。
+            geodeticToEcefToRef(
+                startGeo.latDeg,
+                startGeo.lonDeg,
+                startGeo.altMeters + 1,
+                ppUp,
+            );
+            ppUp.subtractInPlace(startWorld);
+            const upLen = ppUp.length();
+            if (upLen < 1e-9) return null;
+            ppUp.scaleInPlace(1 / upLen);
+            // 二直線（鉛直線 d1=ppUp、レイ d2=ppRayDir、いずれも単位）の最近接点。
+            const b = Vector3.Dot(ppUp, ppRayDir);
+            const denom = 1 - b * b;
+            if (Math.abs(denom) < 1e-6) return null;
+            const wx = startWorld.x - ppOrigin.x;
+            const wy = startWorld.y - ppOrigin.y;
+            const wz = startWorld.z - ppOrigin.z;
+            const d = ppUp.x * wx + ppUp.y * wy + ppUp.z * wz; // d1·w0
+            const eDot = ppRayDir.x * wx + ppRayDir.y * wy + ppRayDir.z * wz; // d2·w0
+            const s = (b * eDot - d) / denom;
+            ppClosest
+                .copyFrom(startWorld)
+                .addInPlace(ppScratch.copyFrom(ppUp).scaleInPlace(s));
+            return ecefToGeodetic(ppClosest).altMeters;
+        };
+
+        const dispatchPolygonHover = (
+            event: GlobePolygonPointEvent | null,
+        ): void => {
+            for (const l of polygonPointHoverListeners.slice()) {
+                try {
+                    l(event);
+                } catch (err) {
+                    console.error("[globe] polygon point hover listener threw:", err);
+                }
+            }
+        };
+        const dispatchPolygonPoint = (
+            listeners: GlobePolygonPointClickListener[],
+            event: GlobePolygonPointEvent,
+            label: string,
+        ): void => {
+            for (const l of listeners.slice()) {
+                try {
+                    l(event);
+                } catch (err) {
+                    console.error(`[globe] ${label} listener threw:`, err);
+                }
+            }
+        };
+        const dispatchPolygonDrag = (
+            listeners: GlobePolygonPointDragListener[],
+            event: GlobePolygonPointDragEvent,
+            label: string,
+        ): void => {
+            for (const l of listeners.slice()) {
+                try {
+                    l(event);
+                } catch (err) {
+                    console.error(`[globe] ${label} listener threw:`, err);
+                }
+            }
+        };
+
+        const buildPolygonDragEvent = (
+            gesture: NonNullable<typeof polygonPointGesture>,
+            e: PointerEvent,
+        ): GlobePolygonPointDragEvent => {
+            const rect = canvas.getBoundingClientRect();
+            const sx = e.clientX - rect.left;
+            const sy = e.clientY - rect.top;
+            const ground = computeDragGroundHit(sx, sy);
+            const plane = computeDragPlaneHit(sx, sy, gesture.startAltMeters);
+            const pointerAltitude = computeDragVerticalHit(
+                sx,
+                sy,
+                gesture.startWorld,
+            );
+            return {
+                polygonId: gesture.polygonId,
+                index: gesture.index,
+                pointerEvent: e,
+                ...ground,
+                ...plane,
+                pointerAltitude,
+            };
+        };
+
+        const onPolygonPointerDown = (e: PointerEvent): void => {
+            if (e.button !== 0) return;
+            if (!hasPolygonPointGestureListeners()) return;
+            if (e.ctrlKey || e.metaKey) return;
+            const rect = canvas.getBoundingClientRect();
+            const hit = pickPolygonPoint(e.clientX - rect.left, e.clientY - rect.top);
+            if (!hit) return;
+            const startGeo = ecefToGeodetic(hit.world);
+            polygonPointGesture = {
+                pointerId: e.pointerId,
+                polygonId: hit.polygonId,
+                index: hit.index,
+                startClientX: e.clientX,
+                startClientY: e.clientY,
+                dragging: false,
+                startWorld: hit.world,
+                startAltMeters: startGeo.altMeters,
+            };
+            canvas.setPointerCapture?.(e.pointerId);
+            // terrain-click 抑制（登録順非依存）: 進行中の terrain クリック開始判定を破棄する。
+            clickStart = null;
+            // 後続リスナー（同一 canvas の terrain-click 等）への配送も止める。
+            e.stopImmediatePropagation();
+        };
+        const onPolygonPointerMove = (e: PointerEvent): void => {
+            const gesture = polygonPointGesture;
+            if (gesture && gesture.pointerId === e.pointerId) {
+                if (!gesture.dragging) {
+                    const dx = e.clientX - gesture.startClientX;
+                    const dy = e.clientY - gesture.startClientY;
+                    if (
+                        Math.abs(dx) >= POLYGON_POINT_DRAG_THRESHOLD_PX ||
+                        Math.abs(dy) >= POLYGON_POINT_DRAG_THRESHOLD_PX
+                    ) {
+                        gesture.dragging = true;
+                        dispatchPolygonDrag(
+                            polygonPointDragStartListeners,
+                            buildPolygonDragEvent(gesture, e),
+                            "onPolygonPointDragStart",
+                        );
+                    }
+                }
+                if (gesture.dragging) {
+                    dispatchPolygonDrag(
+                        polygonPointDragListeners,
+                        buildPolygonDragEvent(gesture, e),
+                        "onPolygonPointDrag",
+                    );
+                }
+                return;
+            }
+            // hover 検出（パン/ジェスチャ中でなく、hover リスナーがある場合）。
+            if (dragging || polygonPointHoverListeners.length === 0) return;
+            const rect = canvas.getBoundingClientRect();
+            const hit = pickPolygonPoint(e.clientX - rect.left, e.clientY - rect.top);
+            if (hit) {
+                if (
+                    !polygonPointHoverState ||
+                    polygonPointHoverState.polygonId !== hit.polygonId ||
+                    polygonPointHoverState.index !== hit.index
+                ) {
+                    polygonPointHoverState = {
+                        polygonId: hit.polygonId,
+                        index: hit.index,
+                    };
+                    canvas.style.cursor = "pointer";
+                    dispatchPolygonHover({
+                        polygonId: hit.polygonId,
+                        index: hit.index,
+                        pointerEvent: e,
+                    });
+                }
+            } else if (polygonPointHoverState !== null) {
+                polygonPointHoverState = null;
+                canvas.style.cursor = "";
+                dispatchPolygonHover(null);
+            }
+        };
+        const onPolygonPointerUp = (e: PointerEvent): void => {
+            const gesture = polygonPointGesture;
+            if (!gesture || gesture.pointerId !== e.pointerId) return;
+            polygonPointGesture = null;
+            canvas.releasePointerCapture?.(e.pointerId);
+            if (gesture.dragging) {
+                dispatchPolygonDrag(
+                    polygonPointDragEndListeners,
+                    buildPolygonDragEvent(gesture, e),
+                    "onPolygonPointDragEnd",
+                );
+                return;
+            }
+            // 未ドラッグ: 修飾キーはカメラ操作扱い。pointerup 位置が同一頂点上のときのみ click。
+            if (e.ctrlKey || e.metaKey) return;
+            const rect = canvas.getBoundingClientRect();
+            const picked = pickPolygonPoint(
+                e.clientX - rect.left,
+                e.clientY - rect.top,
+            );
+            if (
+                picked &&
+                picked.polygonId === gesture.polygonId &&
+                picked.index === gesture.index
+            ) {
+                dispatchPolygonPoint(
+                    polygonPointClickListeners,
+                    {
+                        polygonId: gesture.polygonId,
+                        index: gesture.index,
+                        pointerEvent: e,
+                    },
+                    "onPolygonPointClick",
+                );
+            }
+        };
+        const onPolygonPointerCancel = (e: PointerEvent): void => {
+            if (
+                polygonPointGesture &&
+                polygonPointGesture.pointerId === e.pointerId
+            ) {
+                polygonPointGesture = null;
+            }
+        };
+
+        // ポリゴン頂点 handler は購読者がいる間だけ canvas に登録する（terrain-click と同方針）。
+        let polygonPointHandlersAttached = false;
+        const attachPolygonPointHandlers = (): void => {
+            if (polygonPointHandlersAttached) return;
+            canvas.addEventListener("pointerdown", onPolygonPointerDown);
+            canvas.addEventListener("pointermove", onPolygonPointerMove);
+            canvas.addEventListener("pointerup", onPolygonPointerUp);
+            canvas.addEventListener("pointercancel", onPolygonPointerCancel);
+            canvas.addEventListener("lostpointercapture", onPolygonPointerCancel);
+            polygonPointHandlersAttached = true;
+        };
+        const detachPolygonPointHandlers = (): void => {
+            if (!polygonPointHandlersAttached) return;
+            canvas.removeEventListener("pointerdown", onPolygonPointerDown);
+            canvas.removeEventListener("pointermove", onPolygonPointerMove);
+            canvas.removeEventListener("pointerup", onPolygonPointerUp);
+            canvas.removeEventListener("pointercancel", onPolygonPointerCancel);
+            canvas.removeEventListener("lostpointercapture", onPolygonPointerCancel);
+            polygonPointGesture = null;
+            if (polygonPointHoverState !== null) {
+                polygonPointHoverState = null;
+                canvas.style.cursor = "";
+            }
+            polygonPointHandlersAttached = false;
+        };
+        const makePolygonPointSubscribe =
+            <T>(listeners: T[]) =>
+            (listener: T): (() => void) => {
+                listeners.push(listener);
+                attachPolygonPointHandlers();
+                return () => {
+                    const i = listeners.indexOf(listener);
+                    if (i >= 0) listeners.splice(i, 1);
+                    if (!hasAnyPolygonPointListener()) detachPolygonPointHandlers();
+                };
+            };
+        const subscribePolygonPointHover = makePolygonPointSubscribe(
+            polygonPointHoverListeners,
+        );
+        const subscribePolygonPointClick = makePolygonPointSubscribe(
+            polygonPointClickListeners,
+        );
+        const subscribePolygonPointDragStart = makePolygonPointSubscribe(
+            polygonPointDragStartListeners,
+        );
+        const subscribePolygonPointDrag = makePolygonPointSubscribe(
+            polygonPointDragListeners,
+        );
+        const subscribePolygonPointDragEnd = makePolygonPointSubscribe(
+            polygonPointDragEndListeners,
+        );
+
 
         // ズーム中（ホイール入力〜慣性減衰）か否かを判定する。ホイールが idle かつ radius が
         // フレーム間で settle したら「ズーム終了」とみなし seat を復帰させる（Issue #327）。
@@ -992,6 +1493,12 @@ export class GlobeScene {
             canvas.removeEventListener("pointermove", onPointerMove);
             detachClickHandlers();
             terrainClickListeners.length = 0;
+            detachPolygonPointHandlers();
+            polygonPointHoverListeners.length = 0;
+            polygonPointClickListeners.length = 0;
+            polygonPointDragStartListeners.length = 0;
+            polygonPointDragListeners.length = 0;
+            polygonPointDragEndListeners.length = 0;
             markerManager.dispose();
             polygonManager.dispose();
             circleManager.dispose();
@@ -1009,6 +1516,11 @@ export class GlobeScene {
             circleManager,
             modelManager,
             subscribeTerrainClick,
+            subscribePolygonPointHover,
+            subscribePolygonPointClick,
+            subscribePolygonPointDragStart,
+            subscribePolygonPointDrag,
+            subscribePolygonPointDragEnd,
             dispose,
         };
     }

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -1327,7 +1327,12 @@ export class GlobeScene {
             const gesture = polygonPointGesture;
             if (!gesture || gesture.pointerId !== e.pointerId) return;
             polygonPointGesture = null;
-            canvas.releasePointerCapture?.(e.pointerId);
+            // lostpointercapture は「既に capture を失った」通知でもあり、その場合に
+            // releasePointerCapture を呼ぶとブラウザによっては例外になる。capture 保持を
+            // 確認してから release する。
+            if (canvas.hasPointerCapture?.(e.pointerId)) {
+                canvas.releasePointerCapture?.(e.pointerId);
+            }
             // planar (resetPointerState) と同契約: ドラッグ中に pointercancel /
             // lostpointercapture で中断された場合も dragEnd を通知する。これにより
             // デモ側の状態（altitudeDragStart クリア・rAF flush 等）が取りこぼされない。

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -1198,6 +1198,10 @@ export class GlobeScene {
                 startAltMeters: startGeo.altMeters,
             };
             canvas.setPointerCapture?.(e.pointerId);
+            // パン handler はこの pointerdown で既に dragging=true / pointer capture を
+            // 設定済み（登録順が先）。頂点ジェスチャ中はパンを完全に無効化する。これにより
+            // 万一ジェスチャが途中で解除されてもカメラがパンしない（#275 P4 ドラッグ競合対策）。
+            dragging = false;
             // terrain-click 抑制（登録順非依存）: 進行中の terrain クリック開始判定を破棄する。
             clickStart = null;
             // 後続リスナー（同一 canvas の terrain-click 等）への配送も止める。
@@ -1310,7 +1314,6 @@ export class GlobeScene {
             canvas.addEventListener("pointermove", onPolygonPointerMove);
             canvas.addEventListener("pointerup", onPolygonPointerUp);
             canvas.addEventListener("pointercancel", onPolygonPointerCancel);
-            canvas.addEventListener("lostpointercapture", onPolygonPointerCancel);
             polygonPointHandlersAttached = true;
         };
         const detachPolygonPointHandlers = (): void => {
@@ -1319,7 +1322,6 @@ export class GlobeScene {
             canvas.removeEventListener("pointermove", onPolygonPointerMove);
             canvas.removeEventListener("pointerup", onPolygonPointerUp);
             canvas.removeEventListener("pointercancel", onPolygonPointerCancel);
-            canvas.removeEventListener("lostpointercapture", onPolygonPointerCancel);
             polygonPointGesture = null;
             if (polygonPointHoverState !== null) {
                 polygonPointHoverState = null;

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -1086,6 +1086,13 @@ export const createGlobeSceneController = (
     const resolvePolygonPublicId = (globeId: string): string =>
         polygonManager.resolvePublicPolygonId(globeId) ?? globeId;
 
+    // ドラッグ中に公開 id を固定する。distance デモは onPolygonPointDrag のたびに
+    // removePolygon→addPolygon でポリゴンを作り直すため、内部 globeId が毎フレーム
+    // 変わり、ジェスチャが dragstart 時に掴んだ内部 id は途中で失効する。dragstart 時点で
+    // 解決した公開 id を drag/dragEnd まで使い回し、id 失効でデモが更新を無視するのを防ぐ。
+    // 次の dragstart で必ず上書きされるため明示クリアは不要（複数リスナー時の取りこぼし回避）。
+    let activeDragPublicId: string | null = null;
+
     /** 現在の注視点（地表 lat/lon）。 */
     const currentGeodetic = (): { latDeg: number; lonDeg: number } => {
         const g = ecefToGeodetic(camera.center);
@@ -1440,16 +1447,27 @@ export const createGlobeSceneController = (
                 }),
             ),
         subscribePolygonPointDragStart: (listener: PolygonPointDragListener) =>
-            gc.subscribePolygonPointDragStart((e) =>
-                listener(toPublicDragEvent(e, resolvePolygonPublicId(e.polygonId))),
-            ),
+            gc.subscribePolygonPointDragStart((e) => {
+                activeDragPublicId = resolvePolygonPublicId(e.polygonId);
+                listener(toPublicDragEvent(e, activeDragPublicId));
+            }),
         subscribePolygonPointDrag: (listener: PolygonPointDragListener) =>
             gc.subscribePolygonPointDrag((e) =>
-                listener(toPublicDragEvent(e, resolvePolygonPublicId(e.polygonId))),
+                listener(
+                    toPublicDragEvent(
+                        e,
+                        activeDragPublicId ?? resolvePolygonPublicId(e.polygonId),
+                    ),
+                ),
             ),
         subscribePolygonPointDragEnd: (listener: PolygonPointDragListener) =>
             gc.subscribePolygonPointDragEnd((e) =>
-                listener(toPublicDragEvent(e, resolvePolygonPublicId(e.polygonId))),
+                listener(
+                    toPublicDragEvent(
+                        e,
+                        activeDragPublicId ?? resolvePolygonPublicId(e.polygonId),
+                    ),
+                ),
             ),
     };
 };

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -384,6 +384,9 @@ export const createGlobePolygonManagerAdapter = (
     terrainElevAt: (latDeg: number, lonDeg: number) => number | null,
 ): GlobePolygonManagerAdapter => {
     const entries = new Map<string, PolygonAdapterEntry>();
+    // 内部 globeId → 公開 id の逆引き（resolvePublicPolygonId を O(1) にする）。
+    // add/commitRebuild/remove/dispose で entries と同期する。
+    const globeIdToPublicId = new Map<string, string>();
     let disposed = false;
 
     const assertNotDisposed = (): void => {
@@ -431,7 +434,9 @@ export const createGlobePolygonManagerAdapter = (
     ): PolygonAdapterEntry => {
         const globeId = globeMgr.add(toGlobePolygonOptions(next));
         globeMgr.remove(prev.globeId);
+        globeIdToPublicId.delete(prev.globeId);
         next.globeId = globeId;
+        globeIdToPublicId.set(globeId, id);
         entries.set(id, next);
         return next;
     };
@@ -480,6 +485,7 @@ export const createGlobePolygonManagerAdapter = (
             const tmp = createEntry(options, "");
             const globeId = globeMgr.add(toGlobePolygonOptions(tmp));
             tmp.globeId = globeId;
+            globeIdToPublicId.set(globeId, id);
             entries.set(id, tmp);
             return buildHandle(id, tmp);
         },
@@ -538,6 +544,7 @@ export const createGlobePolygonManagerAdapter = (
                 return;
             }
             globeMgr.remove(e.globeId);
+            globeIdToPublicId.delete(e.globeId);
             entries.delete(id);
         },
         setEnabled(id: string, enabled: boolean): void {
@@ -667,10 +674,7 @@ export const createGlobePolygonManagerAdapter = (
             return Array.from(entries.keys());
         },
         resolvePublicPolygonId(globeId: string): string | null {
-            for (const [publicId, e] of entries) {
-                if (e.globeId === globeId) return publicId;
-            }
-            return null;
+            return globeIdToPublicId.get(globeId) ?? null;
         },
         dispose(): void {
             if (disposed) return;
@@ -684,6 +688,7 @@ export const createGlobePolygonManagerAdapter = (
                 globeMgr.remove(e.globeId);
             }
             entries.clear();
+            globeIdToPublicId.clear();
         },
     };
 };

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -1095,8 +1095,20 @@ export const createGlobeSceneController = (
     // removePolygon→addPolygon でポリゴンを作り直すため、内部 globeId が毎フレーム
     // 変わり、ジェスチャが dragstart 時に掴んだ内部 id は途中で失効する。dragstart 時点で
     // 解決した公開 id を drag/dragEnd まで使い回し、id 失効でデモが更新を無視するのを防ぐ。
-    // 次の dragstart で必ず上書きされるため明示クリアは不要（複数リスナー時の取りこぼし回避）。
+    //
+    // resolve は「内部イベント 1 件につき 1 度だけ」行う必要がある（複数リスナーが居ても
+    // activeDragPublicId を上書き/クリアする責務を 1 箇所に集約する）。そのため drag 系は
+    // public リスナーを配列で保持し、gc への購読は種別ごとに 1 本だけ張る。dragEnd では
+    // 全リスナーへ配送し終えてから activeDragPublicId をクリアし、stale id を次ジェスチャへ
+    // 持ち越さない。drag/dragEnd でも解決できた publicId で更新するため、dragStart を購読
+    // しない利用者が drag だけ購読しても publicId が安定する。
     let activeDragPublicId: string | null = null;
+    const dragStartListeners: PolygonPointDragListener[] = [];
+    const dragListeners: PolygonPointDragListener[] = [];
+    const dragEndListeners: PolygonPointDragListener[] = [];
+    let dragStartUnsub: (() => void) | null = null;
+    let dragUnsub: (() => void) | null = null;
+    let dragEndUnsub: (() => void) | null = null;
 
     /** 現在の注視点（地表 lat/lon）。 */
     const currentGeodetic = (): { latDeg: number; lonDeg: number } => {
@@ -1451,28 +1463,64 @@ export const createGlobeSceneController = (
                     pointerEvent: e.pointerEvent,
                 }),
             ),
-        subscribePolygonPointDragStart: (listener: PolygonPointDragListener) =>
-            gc.subscribePolygonPointDragStart((e) => {
-                activeDragPublicId = resolvePolygonPublicId(e.polygonId);
-                listener(toPublicDragEvent(e, activeDragPublicId));
-            }),
-        subscribePolygonPointDrag: (listener: PolygonPointDragListener) =>
-            gc.subscribePolygonPointDrag((e) =>
-                listener(
-                    toPublicDragEvent(
-                        e,
-                        activeDragPublicId ?? resolvePolygonPublicId(e.polygonId),
-                    ),
-                ),
-            ),
-        subscribePolygonPointDragEnd: (listener: PolygonPointDragListener) =>
-            gc.subscribePolygonPointDragEnd((e) =>
-                listener(
-                    toPublicDragEvent(
-                        e,
-                        activeDragPublicId ?? resolvePolygonPublicId(e.polygonId),
-                    ),
-                ),
-            ),
+        subscribePolygonPointDragStart: (listener: PolygonPointDragListener) => {
+            dragStartListeners.push(listener);
+            if (!dragStartUnsub) {
+                dragStartUnsub = gc.subscribePolygonPointDragStart((e) => {
+                    activeDragPublicId = resolvePolygonPublicId(e.polygonId);
+                    const ev = toPublicDragEvent(e, activeDragPublicId);
+                    for (const l of dragStartListeners.slice()) l(ev);
+                });
+            }
+            return () => {
+                const i = dragStartListeners.indexOf(listener);
+                if (i >= 0) dragStartListeners.splice(i, 1);
+                if (dragStartListeners.length === 0 && dragStartUnsub) {
+                    dragStartUnsub();
+                    dragStartUnsub = null;
+                }
+            };
+        },
+        subscribePolygonPointDrag: (listener: PolygonPointDragListener) => {
+            dragListeners.push(listener);
+            if (!dragUnsub) {
+                dragUnsub = gc.subscribePolygonPointDrag((e) => {
+                    const id =
+                        activeDragPublicId ?? resolvePolygonPublicId(e.polygonId);
+                    activeDragPublicId = id;
+                    const ev = toPublicDragEvent(e, id);
+                    for (const l of dragListeners.slice()) l(ev);
+                });
+            }
+            return () => {
+                const i = dragListeners.indexOf(listener);
+                if (i >= 0) dragListeners.splice(i, 1);
+                if (dragListeners.length === 0 && dragUnsub) {
+                    dragUnsub();
+                    dragUnsub = null;
+                }
+            };
+        },
+        subscribePolygonPointDragEnd: (listener: PolygonPointDragListener) => {
+            dragEndListeners.push(listener);
+            if (!dragEndUnsub) {
+                dragEndUnsub = gc.subscribePolygonPointDragEnd((e) => {
+                    const id =
+                        activeDragPublicId ?? resolvePolygonPublicId(e.polygonId);
+                    const ev = toPublicDragEvent(e, id);
+                    for (const l of dragEndListeners.slice()) l(ev);
+                    // 全リスナー配送後にクリアし、次ジェスチャへ stale id を持ち越さない。
+                    activeDragPublicId = null;
+                });
+            }
+            return () => {
+                const i = dragEndListeners.indexOf(listener);
+                if (i >= 0) dragEndListeners.splice(i, 1);
+                if (dragEndListeners.length === 0 && dragEndUnsub) {
+                    dragEndUnsub();
+                    dragEndUnsub = null;
+                }
+            };
+        },
     };
 };

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -49,6 +49,9 @@ import type {
     CircleCenterOptions,
     CircleStyleOptions,
     AltitudeMode,
+    PolygonPointHoverListener,
+    PolygonPointClickListener,
+    PolygonPointDragListener,
 } from "../lib/types";
 import {
     MARKER_DEFAULTS,
@@ -73,6 +76,23 @@ import type {
     MarkerContext,
 } from "./default";
 import { GlobeScene, type GlobeSceneController } from "./globe";
+import type { GlobePolygonPointDragEvent } from "./globe";
+import type { PolygonPointDragEvent } from "../lib/types";
+
+/** globe のドラッグイベントを公開 {@link PolygonPointDragEvent} へ変換する（#275 P4）。 */
+const toPublicDragEvent = (
+    e: GlobePolygonPointDragEvent,
+): PolygonPointDragEvent => ({
+    polygonId: e.polygonId,
+    index: e.index,
+    pointerEvent: e.pointerEvent,
+    lat: e.lat,
+    lon: e.lon,
+    groundAltitude: e.groundAltitude,
+    planeLat: e.planeLat,
+    planeLon: e.planeLon,
+    pointerAltitude: e.pointerAltitude,
+});
 
 /** lib の MapType（"standard"/"photo"）→ globe の MapType（"std"/"photo"）。 */
 const toGlobeMapType = (mapType: "standard" | "photo" | undefined): MapType =>
@@ -1375,10 +1395,34 @@ export const createGlobeSceneController = (
                     pointerEvent: e.pointerEvent,
                 }),
             ),
-        subscribePolygonPointHover: () => () => {},
-        subscribePolygonPointClick: () => () => {},
-        subscribePolygonPointDragStart: () => () => {},
-        subscribePolygonPointDrag: () => () => {},
-        subscribePolygonPointDragEnd: () => () => {},
+        // ---- ポリゴン頂点インタラクション購読（pick 非依存・floating origin 対応, #275 P4・実装済み） ----
+        // globe シーン（globe.ts）が真の ECEF レイ × 頂点 ECEF/楕円体/鉛直線で求めた hover/click/drag を、
+        // 公開 PolygonPointPointerEvent / PolygonPointDragEvent へ橋渡しする（構造互換だが型を明示する）。
+        subscribePolygonPointHover: (listener: PolygonPointHoverListener) =>
+            gc.subscribePolygonPointHover((e) =>
+                listener(
+                    e === null
+                        ? null
+                        : {
+                              polygonId: e.polygonId,
+                              index: e.index,
+                              pointerEvent: e.pointerEvent,
+                          },
+                ),
+            ),
+        subscribePolygonPointClick: (listener: PolygonPointClickListener) =>
+            gc.subscribePolygonPointClick((e) =>
+                listener({
+                    polygonId: e.polygonId,
+                    index: e.index,
+                    pointerEvent: e.pointerEvent,
+                }),
+            ),
+        subscribePolygonPointDragStart: (listener: PolygonPointDragListener) =>
+            gc.subscribePolygonPointDragStart((e) => listener(toPublicDragEvent(e))),
+        subscribePolygonPointDrag: (listener: PolygonPointDragListener) =>
+            gc.subscribePolygonPointDrag((e) => listener(toPublicDragEvent(e))),
+        subscribePolygonPointDragEnd: (listener: PolygonPointDragListener) =>
+            gc.subscribePolygonPointDragEnd((e) => listener(toPublicDragEvent(e))),
     };
 };

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -82,8 +82,9 @@ import type { PolygonPointDragEvent } from "../lib/types";
 /** globe のドラッグイベントを公開 {@link PolygonPointDragEvent} へ変換する（#275 P4）。 */
 const toPublicDragEvent = (
     e: GlobePolygonPointDragEvent,
+    polygonId: string,
 ): PolygonPointDragEvent => ({
-    polygonId: e.polygonId,
+    polygonId,
     index: e.index,
     pointerEvent: e.pointerEvent,
     lat: e.lat,
@@ -369,10 +370,19 @@ const toGlobePolygonOptions = (entry: PolygonAdapterEntry): GlobePolygonOptions 
     wallsEnabled: entry.wallsEnabled,
 });
 
+/**
+ * 公開 `PolygonManager` に globe 専用の逆引き（内部 globeId → 公開 id）を加えたアダプタ型。
+ * polygon-point イベントの polygonId を公開 id へ翻訳するために使う（#275 P4）。
+ */
+export interface GlobePolygonManagerAdapter extends PolygonManager {
+    /** 内部 globeId に対応する公開ポリゴン id を返す。未知なら null。 */
+    resolvePublicPolygonId(globeId: string): string | null;
+}
+
 export const createGlobePolygonManagerAdapter = (
     globeMgr: GlobePolygonManager,
     terrainElevAt: (latDeg: number, lonDeg: number) => number | null,
-): PolygonManager => {
+): GlobePolygonManagerAdapter => {
     const entries = new Map<string, PolygonAdapterEntry>();
     let disposed = false;
 
@@ -655,6 +665,12 @@ export const createGlobePolygonManagerAdapter = (
         },
         list(): readonly string[] {
             return Array.from(entries.keys());
+        },
+        resolvePublicPolygonId(globeId: string): string | null {
+            for (const [publicId, e] of entries) {
+                if (e.globeId === globeId) return publicId;
+            }
+            return null;
         },
         dispose(): void {
             if (disposed) return;
@@ -1065,6 +1081,11 @@ export const createGlobeSceneController = (
         (latDeg, lonDeg) => gc.tileManager.terrainElevAt(latDeg, lonDeg),
     );
 
+    // polygon-point イベントが運ぶ内部 globeId を公開ポリゴン id へ翻訳する。
+    // デモ側は公開 id（例: distance の POLYGON_ID）で照合するため必須（#275 P4）。
+    const resolvePolygonPublicId = (globeId: string): string =>
+        polygonManager.resolvePublicPolygonId(globeId) ?? globeId;
+
     /** 現在の注視点（地表 lat/lon）。 */
     const currentGeodetic = (): { latDeg: number; lonDeg: number } => {
         const g = ecefToGeodetic(camera.center);
@@ -1404,7 +1425,7 @@ export const createGlobeSceneController = (
                     e === null
                         ? null
                         : {
-                              polygonId: e.polygonId,
+                              polygonId: resolvePolygonPublicId(e.polygonId),
                               index: e.index,
                               pointerEvent: e.pointerEvent,
                           },
@@ -1413,16 +1434,22 @@ export const createGlobeSceneController = (
         subscribePolygonPointClick: (listener: PolygonPointClickListener) =>
             gc.subscribePolygonPointClick((e) =>
                 listener({
-                    polygonId: e.polygonId,
+                    polygonId: resolvePolygonPublicId(e.polygonId),
                     index: e.index,
                     pointerEvent: e.pointerEvent,
                 }),
             ),
         subscribePolygonPointDragStart: (listener: PolygonPointDragListener) =>
-            gc.subscribePolygonPointDragStart((e) => listener(toPublicDragEvent(e))),
+            gc.subscribePolygonPointDragStart((e) =>
+                listener(toPublicDragEvent(e, resolvePolygonPublicId(e.polygonId))),
+            ),
         subscribePolygonPointDrag: (listener: PolygonPointDragListener) =>
-            gc.subscribePolygonPointDrag((e) => listener(toPublicDragEvent(e))),
+            gc.subscribePolygonPointDrag((e) =>
+                listener(toPublicDragEvent(e, resolvePolygonPublicId(e.polygonId))),
+            ),
         subscribePolygonPointDragEnd: (listener: PolygonPointDragListener) =>
-            gc.subscribePolygonPointDragEnd((e) => listener(toPublicDragEvent(e))),
+            gc.subscribePolygonPointDragEnd((e) =>
+                listener(toPublicDragEvent(e, resolvePolygonPublicId(e.polygonId))),
+            ),
     };
 };

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -1102,6 +1102,11 @@ export const createGlobeSceneController = (
     // 全リスナーへ配送し終えてから activeDragPublicId をクリアし、stale id を次ジェスチャへ
     // 持ち越さない。drag/dragEnd でも解決できた publicId で更新するため、dragStart を購読
     // しない利用者が drag だけ購読しても publicId が安定する。
+    //
+    // activeDragPublicId のクリアは内部 gc dragEnd 購読の中で行う。利用者が dragEnd を購読
+    // しなくても（drag/dragStart のみでも）id が確実にクリアされるよう、drag 系のいずれかの
+    // public リスナーが存在する間は内部 dragEnd 購読を必ず張る（ensureDragEndBridge）。
+    // 解除は drag 系すべての public リスナーが居なくなったときのみ（releaseDragEndBridgeIfIdle）。
     let activeDragPublicId: string | null = null;
     const dragStartListeners: PolygonPointDragListener[] = [];
     const dragListeners: PolygonPointDragListener[] = [];
@@ -1109,6 +1114,32 @@ export const createGlobeSceneController = (
     let dragStartUnsub: (() => void) | null = null;
     let dragUnsub: (() => void) | null = null;
     let dragEndUnsub: (() => void) | null = null;
+
+    // drag 系のいずれかの public リスナーがある間は内部 gc dragEnd 購読を維持する。
+    // dragEnd を購読しない利用者（drag/dragStart のみ）でも activeDragPublicId が確実に
+    // クリアされるようにするため。
+    const ensureDragEndBridge = (): void => {
+        if (dragEndUnsub) return;
+        dragEndUnsub = gc.subscribePolygonPointDragEnd((e) => {
+            const id = activeDragPublicId ?? resolvePolygonPublicId(e.polygonId);
+            const ev = toPublicDragEvent(e, id);
+            for (const l of dragEndListeners.slice()) l(ev);
+            // 全リスナー配送後にクリアし、次ジェスチャへ stale id を持ち越さない。
+            activeDragPublicId = null;
+        });
+    };
+    // drag 系の public リスナーがすべて無くなったときのみ内部 dragEnd 購読を解除する。
+    const releaseDragEndBridgeIfIdle = (): void => {
+        if (
+            dragEndUnsub &&
+            dragStartListeners.length === 0 &&
+            dragListeners.length === 0 &&
+            dragEndListeners.length === 0
+        ) {
+            dragEndUnsub();
+            dragEndUnsub = null;
+        }
+    };
 
     /** 現在の注視点（地表 lat/lon）。 */
     const currentGeodetic = (): { latDeg: number; lonDeg: number } => {
@@ -1465,6 +1496,7 @@ export const createGlobeSceneController = (
             ),
         subscribePolygonPointDragStart: (listener: PolygonPointDragListener) => {
             dragStartListeners.push(listener);
+            ensureDragEndBridge();
             if (!dragStartUnsub) {
                 dragStartUnsub = gc.subscribePolygonPointDragStart((e) => {
                     activeDragPublicId = resolvePolygonPublicId(e.polygonId);
@@ -1479,10 +1511,12 @@ export const createGlobeSceneController = (
                     dragStartUnsub();
                     dragStartUnsub = null;
                 }
+                releaseDragEndBridgeIfIdle();
             };
         },
         subscribePolygonPointDrag: (listener: PolygonPointDragListener) => {
             dragListeners.push(listener);
+            ensureDragEndBridge();
             if (!dragUnsub) {
                 dragUnsub = gc.subscribePolygonPointDrag((e) => {
                     const id =
@@ -1499,27 +1533,16 @@ export const createGlobeSceneController = (
                     dragUnsub();
                     dragUnsub = null;
                 }
+                releaseDragEndBridgeIfIdle();
             };
         },
         subscribePolygonPointDragEnd: (listener: PolygonPointDragListener) => {
             dragEndListeners.push(listener);
-            if (!dragEndUnsub) {
-                dragEndUnsub = gc.subscribePolygonPointDragEnd((e) => {
-                    const id =
-                        activeDragPublicId ?? resolvePolygonPublicId(e.polygonId);
-                    const ev = toPublicDragEvent(e, id);
-                    for (const l of dragEndListeners.slice()) l(ev);
-                    // 全リスナー配送後にクリアし、次ジェスチャへ stale id を持ち越さない。
-                    activeDragPublicId = null;
-                });
-            }
+            ensureDragEndBridge();
             return () => {
                 const i = dragEndListeners.indexOf(listener);
                 if (i >= 0) dragEndListeners.splice(i, 1);
-                if (dragEndListeners.length === 0 && dragEndUnsub) {
-                    dragEndUnsub();
-                    dragEndUnsub = null;
-                }
+                releaseDragEndBridgeIfIdle();
             };
         },
     };

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -52,6 +52,7 @@ import type {
     PolygonPointHoverListener,
     PolygonPointClickListener,
     PolygonPointDragListener,
+    PolygonPointDragEvent,
 } from "../lib/types";
 import {
     MARKER_DEFAULTS,
@@ -75,9 +76,11 @@ import type {
     DefaultSceneInitOptions,
     MarkerContext,
 } from "./default";
-import { GlobeScene, type GlobeSceneController } from "./globe";
-import type { GlobePolygonPointDragEvent } from "./globe";
-import type { PolygonPointDragEvent } from "../lib/types";
+import {
+    GlobeScene,
+    type GlobeSceneController,
+    type GlobePolygonPointDragEvent,
+} from "./globe";
 
 /** globe のドラッグイベントを公開 {@link PolygonPointDragEvent} へ変換する（#275 P4）。 */
 const toPublicDragEvent = (

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -1141,6 +1141,9 @@ export const createGlobeSceneController = (
         ) {
             dragEndUnsub();
             dragEndUnsub = null;
+            // 購読ライフサイクル境界で stale id を残さない（解除→再購読で dragStart を
+            // 経由しない drag が来ても前ジェスチャの id を橋渡ししない）。
+            activeDragPublicId = null;
         }
     };
 

--- a/src/terrain/geo/globePolygonManager.ts
+++ b/src/terrain/geo/globePolygonManager.ts
@@ -169,10 +169,12 @@ export interface GlobePolygonManager {
     update(cameraEcef?: Vector3): void;
     /**
      * 現在表示中・ピック可能な頂点（点メッシュ）の真の ECEF 位置と当該フレームの
-     * ワールド半径を列挙する（floating origin 非依存の幾何ピック用, #275 P4）。
+     * ワールド半径を `out` に書き込み、件数を返す（floating origin 非依存の幾何ピック用, #275 P4）。
      * 非表示ノード・点無効ノード・標高未解決ノードは含めない。closed の重複末尾点は除外する。
+     * pointermove ごとに呼ばれるため、`out` の要素オブジェクトを再利用して割り当て/GC を抑える。
+     * 呼び出し側は返り値の件数ぶん（`out[0..count)`）のみ参照すること。
      */
-    getPickablePoints(): GlobePolygonPickablePoint[];
+    getPickablePoints(out: GlobePolygonPickablePoint[]): number;
     dispose(): void;
 }
 
@@ -697,9 +699,12 @@ export const createGlobePolygonManager = (
         }
     };
 
-    const getPickablePoints = (): GlobePolygonPickablePoint[] => {
-        if (disposed) return [];
-        const result: GlobePolygonPickablePoint[] = [];
+    const getPickablePoints = (out: GlobePolygonPickablePoint[]): number => {
+        let n = 0;
+        if (disposed) {
+            out.length = 0;
+            return 0;
+        }
         for (const node of nodes.values()) {
             if (!node.enabled || !node.elevationResolved || !node.pointsEnabled) {
                 continue;
@@ -709,17 +714,22 @@ export const createGlobePolygonManager = (
                 const entry = node.pointMeshes[i];
                 if (!entry) continue;
                 const top = node.top[i];
-                result.push({
-                    polygonId: node.id,
-                    index: i,
-                    x: top.x,
-                    y: top.y,
-                    z: top.z,
-                    radius: node.pointWorldRadius,
-                });
+                // 既存スロットを再利用し、無ければ 1 度だけ生成する（割り当て抑制）。
+                let slot = out[n];
+                if (!slot) {
+                    slot = { polygonId: "", index: 0, x: 0, y: 0, z: 0, radius: 0 };
+                    out[n] = slot;
+                }
+                slot.polygonId = node.id;
+                slot.index = i;
+                slot.x = top.x;
+                slot.y = top.y;
+                slot.z = top.z;
+                slot.radius = node.pointWorldRadius;
+                n++;
             }
         }
-        return result;
+        return n;
     };
 
     const dispose = (): void => {

--- a/src/terrain/geo/globePolygonManager.ts
+++ b/src/terrain/geo/globePolygonManager.ts
@@ -157,6 +157,8 @@ interface GlobePolygonNode {
     top: Vector3[];
     bottom: Vector3[];
     elevs: number[];
+    /** 直近 placeNode で算出した点スフィアのワールド半径 [m]（幾何ピック用, #275 P4）。 */
+    pointWorldRadius: number;
 }
 
 export interface GlobePolygonManager {
@@ -165,7 +167,27 @@ export interface GlobePolygonManager {
     setEnabled(id: string, enabled: boolean): void;
     /** 毎フレーム: 地形標高へ再ドレープし、距離スケールを更新する。 */
     update(cameraEcef?: Vector3): void;
+    /**
+     * 現在表示中・ピック可能な頂点（点メッシュ）の真の ECEF 位置と当該フレームの
+     * ワールド半径を列挙する（floating origin 非依存の幾何ピック用, #275 P4）。
+     * 非表示ノード・点無効ノード・標高未解決ノードは含めない。closed の重複末尾点は除外する。
+     */
+    getPickablePoints(): GlobePolygonPickablePoint[];
     dispose(): void;
+}
+
+/** {@link GlobePolygonManager.getPickablePoints} の戻り要素。 */
+export interface GlobePolygonPickablePoint {
+    /** ポリゴン id。 */
+    polygonId: string;
+    /** 頂点 index（0-based）。 */
+    index: number;
+    /** 頂点の真の ECEF 位置 [m]。 */
+    x: number;
+    y: number;
+    z: number;
+    /** 当該フレームの点スフィアのワールド半径 [m]（画面ほぼ定サイズ）。 */
+    radius: number;
 }
 
 const toColor3 = (color: string, fallbackHex: string): Color3 => {
@@ -384,6 +406,7 @@ export const createGlobePolygonManager = (
         }
         const pointDiameter = Math.max(node.style.pointDiameter, 0.001);
         const pointRadius = pointDiameter * distScale * 0.5;
+        node.pointWorldRadius = pointRadius;
         const labelGap = node.style.labelFontSize * distScale * LABEL_GAP_FONT_RATIO;
         for (let i = 0; i < node.points.length; i++) {
             const top = node.top[i];
@@ -616,6 +639,7 @@ export const createGlobePolygonManager = (
             top: Array.from({ length: pathLen }, () => new Vector3()),
             bottom: Array.from({ length: pathLen }, () => new Vector3()),
             elevs: opts.points.map(() => 0),
+            pointWorldRadius: Math.max(style.pointDiameter, 0.001) * 0.5,
         };
         nodes.set(id, node);
         placeNode(node);
@@ -673,11 +697,36 @@ export const createGlobePolygonManager = (
         }
     };
 
+    const getPickablePoints = (): GlobePolygonPickablePoint[] => {
+        if (disposed) return [];
+        const result: GlobePolygonPickablePoint[] = [];
+        for (const node of nodes.values()) {
+            if (!node.enabled || !node.elevationResolved || !node.pointsEnabled) {
+                continue;
+            }
+            // closed の重複末尾点（top[points.length]）は対象外。点メッシュ数ぶんのみ。
+            for (let i = 0; i < node.points.length; i++) {
+                const entry = node.pointMeshes[i];
+                if (!entry) continue;
+                const top = node.top[i];
+                result.push({
+                    polygonId: node.id,
+                    index: i,
+                    x: top.x,
+                    y: top.y,
+                    z: top.z,
+                    radius: node.pointWorldRadius,
+                });
+            }
+        }
+        return result;
+    };
+
     const dispose = (): void => {
         if (disposed) return;
         disposed = true;
         for (const id of [...nodes.keys()]) remove(id);
     };
 
-    return { add, remove, setEnabled, update, dispose };
+    return { add, remove, setEnabled, update, getPickablePoints, dispose };
 };

--- a/tests/globeSceneController.unit.spec.ts
+++ b/tests/globeSceneController.unit.spec.ts
@@ -382,6 +382,35 @@ describe("createGlobeSceneController (P4-0 globe backend adapter)", () => {
         expect(ends[0].polygonId).toBe("gpA");
     });
 
+    it("dragEnd 後は activeDragPublicId をクリアし、次ジェスチャへ stale id を持ち越さない", () => {
+        // 前ジェスチャの公開 id が次ジェスチャの drag に残留しないことを検証する。
+        const stub = makeStub(35, 139, 1000, 0, 0);
+        const c = createGlobeSceneController(stub.gc, "std");
+        const drags: PolygonPointDragEvent[] = [];
+        c.subscribePolygonPointDragStart(() => {});
+        c.subscribePolygonPointDrag((e) => drags.push(e));
+        c.subscribePolygonPointDragEnd(() => {});
+        const pe = {} as PointerEvent;
+        const base = {
+            index: 0,
+            pointerEvent: pe,
+            lat: 35.1,
+            lon: 139.2,
+            groundAltitude: 50,
+            planeLat: 35.11,
+            planeLon: 139.21,
+            pointerAltitude: 80,
+        };
+        // ジェスチャ1: dragStart "gpA" → drag → dragEnd。
+        stub.triggerPolygonDragStart({ ...base, polygonId: "gpA" });
+        stub.triggerPolygonDrag({ ...base, polygonId: "gpA" });
+        stub.triggerPolygonDragEnd({ ...base, polygonId: "gpA" });
+        // ジェスチャ2: dragStart せず drag のみ。entries 空のためフォールバックで
+        // 生 id "gpZ" を返すべき（クリアされていれば "gpA" は残らない）。
+        stub.triggerPolygonDrag({ ...base, polygonId: "gpZ" });
+        expect(drags.map((d) => d.polygonId)).toEqual(["gpA", "gpZ"]);
+    });
+
     it("subscribePolygonPointDrag は null 許容フィールドをそのまま橋渡しする", () => {
         const stub = makeStub(35, 139, 1000, 0, 0);
         const c = createGlobeSceneController(stub.gc, "std");

--- a/tests/globeSceneController.unit.spec.ts
+++ b/tests/globeSceneController.unit.spec.ts
@@ -19,8 +19,17 @@ import type {
     GlobeSceneController,
     GlobeTerrainClickEvent,
     GlobeTerrainClickListener,
+    GlobePolygonPointEvent,
+    GlobePolygonPointDragEvent,
+    GlobePolygonPointListener,
+    GlobePolygonPointClickListener,
+    GlobePolygonPointDragListener,
 } from "../src/scenes/globe";
-import type { TerrainClickEvent } from "../src/lib/types";
+import type {
+    TerrainClickEvent,
+    PolygonPointPointerEvent,
+    PolygonPointDragEvent,
+} from "../src/lib/types";
 import type {
     GlobeMarkerManager,
     GlobeMarkerOptions,
@@ -48,6 +57,12 @@ const makeStub = (
     disposed: () => boolean;
     triggerTerrainClick: (e: GlobeTerrainClickEvent) => void;
     clickListenerCount: () => number;
+    triggerPolygonHover: (e: GlobePolygonPointEvent | null) => void;
+    triggerPolygonClick: (e: GlobePolygonPointEvent) => void;
+    triggerPolygonDragStart: (e: GlobePolygonPointDragEvent) => void;
+    triggerPolygonDrag: (e: GlobePolygonPointDragEvent) => void;
+    triggerPolygonDragEnd: (e: GlobePolygonPointDragEvent) => void;
+    polygonHoverListenerCount: () => number;
 } => {
     let disposedFlag = false;
     const camera = {
@@ -57,6 +72,20 @@ const makeStub = (
         pitch,
     };
     const clickListeners: GlobeTerrainClickListener[] = [];
+    const hoverListeners: GlobePolygonPointListener[] = [];
+    const pointClickListeners: GlobePolygonPointClickListener[] = [];
+    const dragStartListeners: GlobePolygonPointDragListener[] = [];
+    const dragListeners: GlobePolygonPointDragListener[] = [];
+    const dragEndListeners: GlobePolygonPointDragListener[] = [];
+    const makeSub =
+        <T>(arr: T[]) =>
+        (listener: T) => {
+            arr.push(listener);
+            return () => {
+                const i = arr.indexOf(listener);
+                if (i >= 0) arr.splice(i, 1);
+            };
+        };
     const gc = {
         camera,
         // isTerrainIdle / marker アダプタ / mapType 切替が参照する tileManager スタブ。
@@ -72,6 +101,11 @@ const makeStub = (
                 if (i >= 0) clickListeners.splice(i, 1);
             };
         },
+        subscribePolygonPointHover: makeSub(hoverListeners),
+        subscribePolygonPointClick: makeSub(pointClickListeners),
+        subscribePolygonPointDragStart: makeSub(dragStartListeners),
+        subscribePolygonPointDrag: makeSub(dragListeners),
+        subscribePolygonPointDragEnd: makeSub(dragEndListeners),
         dispose: () => {
             disposedFlag = true;
         },
@@ -83,6 +117,22 @@ const makeStub = (
             for (const l of clickListeners.slice()) l(e);
         },
         clickListenerCount: () => clickListeners.length,
+        triggerPolygonHover: (e) => {
+            for (const l of hoverListeners.slice()) l(e);
+        },
+        triggerPolygonClick: (e) => {
+            for (const l of pointClickListeners.slice()) l(e);
+        },
+        triggerPolygonDragStart: (e) => {
+            for (const l of dragStartListeners.slice()) l(e);
+        },
+        triggerPolygonDrag: (e) => {
+            for (const l of dragListeners.slice()) l(e);
+        },
+        triggerPolygonDragEnd: (e) => {
+            for (const l of dragEndListeners.slice()) l(e);
+        },
+        polygonHoverListenerCount: () => hoverListeners.length,
     };
 };
 
@@ -215,6 +265,109 @@ describe("createGlobeSceneController (P4-0 globe backend adapter)", () => {
             pointerEvent: pe,
         });
         expect(received).toHaveLength(1);
+    });
+
+    it("subscribePolygonPointHover は gc の hover を公開 PolygonPointPointerEvent|null へ橋渡しする", () => {
+        const stub = makeStub(35, 139, 1000, 0, 0);
+        const c = createGlobeSceneController(stub.gc, "std");
+        const received: (PolygonPointPointerEvent | null)[] = [];
+        const off = c.subscribePolygonPointHover((e) => {
+            received.push(e);
+        });
+        expect(stub.polygonHoverListenerCount()).toBe(1);
+        const pe = {} as PointerEvent;
+        stub.triggerPolygonHover({ polygonId: "p1", index: 2, pointerEvent: pe });
+        stub.triggerPolygonHover(null);
+        expect(received).toHaveLength(2);
+        expect(received[0]).toEqual({ polygonId: "p1", index: 2, pointerEvent: pe });
+        expect(received[0]?.pointerEvent).toBe(pe);
+        expect(received[1]).toBeNull();
+        off();
+        expect(stub.polygonHoverListenerCount()).toBe(0);
+        stub.triggerPolygonHover({ polygonId: "p1", index: 0, pointerEvent: pe });
+        expect(received).toHaveLength(2);
+    });
+
+    it("subscribePolygonPointClick は gc のクリックを公開イベントへ橋渡しする", () => {
+        const stub = makeStub(35, 139, 1000, 0, 0);
+        const c = createGlobeSceneController(stub.gc, "std");
+        const received: PolygonPointPointerEvent[] = [];
+        c.subscribePolygonPointClick((e) => {
+            received.push(e);
+        });
+        const pe = {} as PointerEvent;
+        stub.triggerPolygonClick({ polygonId: "p2", index: 5, pointerEvent: pe });
+        expect(received).toHaveLength(1);
+        expect(received[0]).toEqual({ polygonId: "p2", index: 5, pointerEvent: pe });
+    });
+
+    it("subscribePolygonPointDrag* は lat/lon/groundAltitude/planeLat/planeLon/pointerAltitude を橋渡しする", () => {
+        const stub = makeStub(35, 139, 1000, 0, 0);
+        const c = createGlobeSceneController(stub.gc, "std");
+        const starts: PolygonPointDragEvent[] = [];
+        const drags: PolygonPointDragEvent[] = [];
+        const ends: PolygonPointDragEvent[] = [];
+        c.subscribePolygonPointDragStart((e) => {
+            starts.push(e);
+        });
+        c.subscribePolygonPointDrag((e) => {
+            drags.push(e);
+        });
+        c.subscribePolygonPointDragEnd((e) => {
+            ends.push(e);
+        });
+        const pe = {} as PointerEvent;
+        const ev: GlobePolygonPointDragEvent = {
+            polygonId: "p3",
+            index: 1,
+            pointerEvent: pe,
+            lat: 35.1,
+            lon: 139.2,
+            groundAltitude: 50,
+            planeLat: 35.11,
+            planeLon: 139.21,
+            pointerAltitude: 80,
+        };
+        stub.triggerPolygonDragStart(ev);
+        stub.triggerPolygonDrag(ev);
+        stub.triggerPolygonDragEnd(ev);
+        for (const arr of [starts, drags, ends]) {
+            expect(arr).toHaveLength(1);
+            expect(arr[0]).toEqual({
+                polygonId: "p3",
+                index: 1,
+                pointerEvent: pe,
+                lat: 35.1,
+                lon: 139.2,
+                groundAltitude: 50,
+                planeLat: 35.11,
+                planeLon: 139.21,
+                pointerAltitude: 80,
+            });
+        }
+    });
+
+    it("subscribePolygonPointDrag は null 許容フィールドをそのまま橋渡しする", () => {
+        const stub = makeStub(35, 139, 1000, 0, 0);
+        const c = createGlobeSceneController(stub.gc, "std");
+        const drags: PolygonPointDragEvent[] = [];
+        c.subscribePolygonPointDrag((e) => {
+            drags.push(e);
+        });
+        stub.triggerPolygonDrag({
+            polygonId: "p4",
+            index: 0,
+            pointerEvent: {} as PointerEvent,
+            lat: null,
+            lon: null,
+            groundAltitude: null,
+            planeLat: null,
+            planeLon: null,
+            pointerAltitude: null,
+        });
+        expect(drags).toHaveLength(1);
+        expect(drags[0].lat).toBeNull();
+        expect(drags[0].pointerAltitude).toBeNull();
     });
 
     it("isTerrainIdle は tileManager.isIdle へ委譲する（true/false）", () => {

--- a/tests/globeSceneController.unit.spec.ts
+++ b/tests/globeSceneController.unit.spec.ts
@@ -438,6 +438,36 @@ describe("createGlobeSceneController (P4-0 globe backend adapter)", () => {
         expect(drags.map((d) => d.polygonId)).toEqual(["gpA", "gpZ"]);
     });
 
+    it("drag 系を全解除すると activeDragPublicId がクリアされ、再購読後に stale id を残さない", () => {
+        // 購読ライフサイクル境界（全解除→再購読）で前ジェスチャの id が残らないことを検証する。
+        const stub = makeStub(35, 139, 1000, 0, 0);
+        const c = createGlobeSceneController(stub.gc, "std");
+        const pe = {} as PointerEvent;
+        const base = {
+            index: 0,
+            pointerEvent: pe,
+            lat: 35.1,
+            lon: 139.2,
+            groundAltitude: 50,
+            planeLat: 35.11,
+            planeLon: 139.21,
+            pointerAltitude: 80,
+        };
+        // ジェスチャ途中（dragStart→drag）で購読解除する（dragEnd を経ずに activeDragPublicId が残る状況）。
+        const drags1: PolygonPointDragEvent[] = [];
+        const unsubStart = c.subscribePolygonPointDragStart(() => {});
+        const unsubDrag = c.subscribePolygonPointDrag((e) => drags1.push(e));
+        stub.triggerPolygonDragStart({ ...base, polygonId: "gpA" });
+        stub.triggerPolygonDrag({ ...base, polygonId: "gpA" });
+        unsubStart();
+        unsubDrag();
+        // 再購読し、dragStart を経由しない drag が来ても stale "gpA" を橋渡ししない。
+        const drags2: PolygonPointDragEvent[] = [];
+        c.subscribePolygonPointDrag((e) => drags2.push(e));
+        stub.triggerPolygonDrag({ ...base, polygonId: "gpZ" });
+        expect(drags2.map((d) => d.polygonId)).toEqual(["gpZ"]);
+    });
+
     it("subscribePolygonPointDrag は null 許容フィールドをそのまま橋渡しする", () => {
         const stub = makeStub(35, 139, 1000, 0, 0);
         const c = createGlobeSceneController(stub.gc, "std");

--- a/tests/globeSceneController.unit.spec.ts
+++ b/tests/globeSceneController.unit.spec.ts
@@ -411,6 +411,33 @@ describe("createGlobeSceneController (P4-0 globe backend adapter)", () => {
         expect(drags.map((d) => d.polygonId)).toEqual(["gpA", "gpZ"]);
     });
 
+    it("dragEnd を購読しない（drag のみ）利用者でも次ジェスチャへ stale id を残さない", () => {
+        // 内部 dragEnd ブリッジが drag 購読時にも張られ、activeDragPublicId が
+        // クリアされることを検証する。
+        const stub = makeStub(35, 139, 1000, 0, 0);
+        const c = createGlobeSceneController(stub.gc, "std");
+        const drags: PolygonPointDragEvent[] = [];
+        // drag のみ購読（dragStart/dragEnd は購読しない）。
+        c.subscribePolygonPointDrag((e) => drags.push(e));
+        const pe = {} as PointerEvent;
+        const base = {
+            index: 0,
+            pointerEvent: pe,
+            lat: 35.1,
+            lon: 139.2,
+            groundAltitude: 50,
+            planeLat: 35.11,
+            planeLon: 139.21,
+            pointerAltitude: 80,
+        };
+        // ジェスチャ1: drag "gpA" → 内部 dragEnd（controller は購読していないが gc は発火）。
+        stub.triggerPolygonDrag({ ...base, polygonId: "gpA" });
+        stub.triggerPolygonDragEnd({ ...base, polygonId: "gpA" });
+        // ジェスチャ2: drag "gpZ"。クリアされていれば生 id "gpZ" になる。
+        stub.triggerPolygonDrag({ ...base, polygonId: "gpZ" });
+        expect(drags.map((d) => d.polygonId)).toEqual(["gpA", "gpZ"]);
+    });
+
     it("subscribePolygonPointDrag は null 許容フィールドをそのまま橋渡しする", () => {
         const stub = makeStub(35, 139, 1000, 0, 0);
         const c = createGlobeSceneController(stub.gc, "std");

--- a/tests/globeSceneController.unit.spec.ts
+++ b/tests/globeSceneController.unit.spec.ts
@@ -716,6 +716,18 @@ describe("createGlobeMarkerManagerAdapter (P4-0 Slice 2a marker overlay)", () =>
                 expect(() => m.add("x", { points: PTS })).toThrow(/disposed/);
                 warn.mockRestore();
             });
+
+            it("resolvePublicPolygonId は内部 globeId を公開 id へ逆引きする", () => {
+                const stub = makeGlobePolygonStub();
+                const m = createGlobePolygonManagerAdapter(stub.mgr, () => 1);
+                m.add("poly", { points: PTS });
+                const globeId = stub.added[stub.added.length - 1].id;
+                expect(m.resolvePublicPolygonId(globeId)).toBe("poly");
+                expect(m.resolvePublicPolygonId("unknown")).toBeNull();
+                // remove 後は逆引きできない。
+                m.remove("poly");
+                expect(m.resolvePublicPolygonId(globeId)).toBeNull();
+            });
         });
 
 const makeGlobeCircleStub = (): {

--- a/tests/globeSceneController.unit.spec.ts
+++ b/tests/globeSceneController.unit.spec.ts
@@ -347,6 +347,41 @@ describe("createGlobeSceneController (P4-0 globe backend adapter)", () => {
         }
     });
 
+    it("ドラッグ中は dragStart 時の公開 id を維持し、内部 globeId 失効後の drag も同一 id で橋渡しする", () => {
+        // distance デモはドラッグ中に removePolygon→addPolygon で内部 globeId を
+        // 毎フレーム作り直すため、ジェスチャが掴んだ内部 id は途中で失効する。
+        // dragStart 時に解決した公開 id を drag/dragEnd まで使い回すことを検証する。
+        const stub = makeStub(35, 139, 1000, 0, 0);
+        const c = createGlobeSceneController(stub.gc, "std");
+        const starts: PolygonPointDragEvent[] = [];
+        const drags: PolygonPointDragEvent[] = [];
+        const ends: PolygonPointDragEvent[] = [];
+        c.subscribePolygonPointDragStart((e) => starts.push(e));
+        c.subscribePolygonPointDrag((e) => drags.push(e));
+        c.subscribePolygonPointDragEnd((e) => ends.push(e));
+        const pe = {} as PointerEvent;
+        const base = {
+            index: 0,
+            pointerEvent: pe,
+            lat: 35.1,
+            lon: 139.2,
+            groundAltitude: 50,
+            planeLat: 35.11,
+            planeLon: 139.21,
+            pointerAltitude: 80,
+        };
+        // dragStart は内部 id "gpA"。以降の drag/dragEnd は失効後の別 id "gpB"/"gpC"。
+        stub.triggerPolygonDragStart({ ...base, polygonId: "gpA" });
+        stub.triggerPolygonDrag({ ...base, polygonId: "gpB" });
+        stub.triggerPolygonDrag({ ...base, polygonId: "gpC" });
+        stub.triggerPolygonDragEnd({ ...base, polygonId: "gpC" });
+        expect(starts[0].polygonId).toBe("gpA");
+        // entries が空のため resolve はフォールバックで生 id を返すが、dragStart で
+        // 固定された "gpA" が drag/dragEnd まで維持される（失効 id へすり替わらない）。
+        expect(drags.map((d) => d.polygonId)).toEqual(["gpA", "gpA"]);
+        expect(ends[0].polygonId).toBe("gpA");
+    });
+
     it("subscribePolygonPointDrag は null 許容フィールドをそのまま橋渡しする", () => {
         const stub = makeStub(35, 139, 1000, 0, 0);
         const c = createGlobeSceneController(stub.gc, "std");


### PR DESCRIPTION
関連: #275

## 概要
distance デモを `?terrainEngine=globe` で planar 同等の polygon-point 編集に対応させる。頂点の追加（地形クリック）/削除（頂点クリック）/ドラッグ（lat/lon 移動・Shift で高度変更）を floating-origin 安全な ECEF 幾何で実装。

## 変更点
- **globePolygonManager**: `getPickablePoints` を追加。各頂点の真 ECEF 座標とワールド半径を列挙（pick 非依存ピック用）。
- **globe.ts**: polygon-point のピック/ドラッグ状態機械を追加。
  - pick 非依存の幾何ピック（カメラ ECEF + カーソルレイ × 頂点スフィア、楕円体近交点で地球裏側を除外、最も手前を採用）。
  - ground/plane/vertical の各ドラッグ幾何（terrain-click と同じ標高クエリを共有）。
  - 遅延登録ハンドラと `subscribePolygonPoint*`。パン・terrain-click との競合を `polygonPointGesture` ガード + `clickStart=null` で抑止（登録順非依存）。
- **globeSceneController**: `subscribePolygonPoint*` を委譲し公開イベント型へ橋渡し。
- **distance デモ**: `resolveTerrainEngine` を配線。globe では `scene.pick` が頂点メッシュに当たらないため、ライブラリ hover イベントを併用して remove/edit カーソルを維持（planar は従来どおり `scene.pick` 主体）。
- **tests**: `subscribePolygonPoint*` の橋渡し（hover/click/drag・null 許容フィールド）を検証。

## 検証
- typecheck / lint / test:unit(**1204**) / build すべて緑。

## HITL 目視確認のお願い
`npm start` → distance を `?terrainEngine=globe` で開き、以下を確認してください。
- **add**: 地形クリックで頂点が追加される。
- **remove**: 頂点クリックで削除される。
- **edit**: 頂点ドラッグで lat/lon 移動、Shift+ドラッグで高度変更。
- 各モードのカーソル（+/-/move/ns-resize）が globe でも出る。