### PR TITLE
feat(demos): model を terrainEngine=globe で起動可能に配線 (P4-2)

### DIFF
--- a/src/demos/geospatial/index.ts
+++ b/src/demos/geospatial/index.ts
@@ -254,7 +254,7 @@ const start = async (): Promise<void> => {
             url: humanGlbUrl,
             lat: 35.360625,
             lon: 138.727363,
-            scale: 400,
+            scaling: { x: 400, y: 400, z: 400 },
         });
     }
 

--- a/src/demos/model/index.ts
+++ b/src/demos/model/index.ts
@@ -18,6 +18,7 @@ import type { JpmapTerrainOptions, TerrainClickEvent } from "../../lib/types";
 import {
     parseCameraStateFromUrl,
     parseMapTypeFromUrl,
+    resolveTerrainEngine,
 } from "../../terrain/urlState";
 import humanGlbUrl from "../../../assets/human.glb";
 import humanObjUrl from "../../../assets/human.obj";
@@ -57,9 +58,11 @@ const start = async (): Promise<void> => {
 
     const camera = parseCameraStateFromUrl(location.href);
     const mapType = parseMapTypeFromUrl(location.href);
+    const terrainEngine = resolveTerrainEngine(location.search);
 
     const opts: JpmapTerrainOptions = {
         engine: resolveEngine(location.search),
+        ...(terrainEngine ? { terrainEngine } : {}),
         lat: camera?.lat ?? TOKYO_STATION.lat,
         lon: camera?.lon ?? TOKYO_STATION.lon,
         altitude: camera?.altitude ?? 500,

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -286,10 +286,9 @@ export class JpmapTerrain {
                         controller.setSunShadows(true);
                     }
                     // マーカー (Issue #167)。境界コンテキスト経由で manager を構築する。
-                    // globe バックエンドでは marker（P4-0）/ polygon（Slice 2b-1）/ circle（Slice 2b-2）が
-                    // 専用アダプタ（getMarkerManager / getPolygonManager / getCircleManager）経由で
-                    // 公開 interface に対応する。model は globe マネージャの機能不足で parity 未達のため
-                    // 後続スライス（未対応）。
+                    // globe バックエンドでは marker（P4-0）/ polygon（Slice 2b-1）/ circle（Slice 2b-2）/
+                    // model（P4-2）が専用アダプタ（getMarkerManager / getPolygonManager /
+                    // getCircleManager / getModelManager）経由で公開 interface に対応する。
                     if (this._terrainEngine === "planar") {
                         this._markerManager = createMarkerManager(
                             controller.getMarkerContext(),
@@ -313,6 +312,9 @@ export class JpmapTerrain {
                             controller.getPolygonManager?.() ?? null;
                         this._circleManager =
                             controller.getCircleManager?.() ?? null;
+                        // 3Dモデル (Issue #243 / #275 Phase 4 P4-2)。globe 専用アダプタ経由。
+                        this._modelManager =
+                            controller.getModelManager?.() ?? null;
                     }
                 },
             });

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -40,6 +40,7 @@ import {
 import type { MarkerManager } from "../terrain/markerManager";
 import type { PolygonManager } from "../terrain/polygonManager";
 import type { CircleManager } from "../terrain/circleManager";
+import type { ModelManager } from "../terrain/modelManager";
 
 const TERRAIN_SUBDIVISIONS = 128;
 const MAX_ZOOM = TILE_MAX_ZOOM;
@@ -290,6 +291,11 @@ export interface DefaultSceneController {
      * planar 実装は `getMarkerContext()` 経由で構築するため optional。
      */
     getCircleManager?(): CircleManager | null;
+    /**
+     * globe バックエンド専用フック。公開 `ModelManager` 互換のアダプタを返す。
+     * planar 実装は `getMarkerContext()` 経由で構築するため optional (#275 Phase 4 / P4-2)。
+     */
+    getModelManager?(): ModelManager | null;
 
     /**
      * 地形タイルへのクリック通知を購読する (Issue #183)。

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -1536,7 +1536,7 @@ export class GlobeScene {
             // サークルの地形再ドレープと距離スケール更新（点/ラベル配置）。
             circleManager.update(camEcef);
             // モデルの接地・起立更新。
-            modelManager.update();
+            modelManager.tick();
             if (frame % GLOBE_SCENE_DEFAULTS.syncIntervalFrames === 0) syncTiles();
             frame++;
         });

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -30,6 +30,7 @@ import { createUiVisibilityController } from "../terrain/uiVisibility";
 import type { MarkerManager } from "../terrain/markerManager";
 import type { PolygonManager } from "../terrain/polygonManager";
 import type { CircleManager } from "../terrain/circleManager";
+import type { ModelManager } from "../terrain/modelManager";
 import type {
     MarkerHandle,
     MarkerOptions,
@@ -49,6 +50,9 @@ import type {
     CircleCenterOptions,
     CircleStyleOptions,
     AltitudeMode,
+    ModelHandle,
+    ModelOptions,
+    ModelUpdate,
     PolygonPointHoverListener,
     PolygonPointClickListener,
     PolygonPointDragListener,
@@ -61,6 +65,7 @@ import {
     CIRCLE_RADIUS_MAX_M,
     CIRCLE_SEGMENTS_MIN,
     CIRCLE_SEGMENTS_MAX,
+    MODEL_DEFAULTS,
 } from "../lib/types";
 import type { GlobeMarkerManager } from "../terrain/geo/globeMarkerManager";
 import type {
@@ -71,6 +76,7 @@ import type {
     GlobeCircleManager,
     GlobeCircleOptions,
 } from "../terrain/geo/globeCircleManager";
+import type { GlobeModelManager } from "../terrain/geo/globeModelManager";
 import type {
     DefaultSceneController,
     DefaultSceneInitOptions,
@@ -1060,6 +1066,183 @@ export class GlobeSceneAdapter {
     };
 }
 
+const MODEL_ERROR_PREFIX = "JpmapTerrain.addModel";
+const MODEL_UPDATE_ERROR_PREFIX = "JpmapTerrain.updateModel";
+
+/**
+ * `GlobeModelManager`（採番 id・in-place 更新対応）を公開 `ModelManager`
+ * （明示 id / `ModelHandle` 返却）へアダプトする (#275 Phase 4 / P4-2)。
+ *
+ * - 公開 id ↔ globe 内部 id の対応を保持する。`GlobeModelManager` は in-place 更新・get・
+ *   animation を備えるため、marker/polygon/circle アダプタと異なりノード再構築（remove+add）は
+ *   不要で、メッシュ再ロードを避けられる。
+ * - planar(`modelManager`) と同契約: 重複 id throw・lat/lon 範囲検証・`absolute` 切替時の
+ *   altitude 必須・`MODEL_DEFAULTS` 適用。
+ * - `elevationResolved` は `GlobeModelManager.get()` の値を用いる（フォールバックとして
+ *   `terrainElevAt!==null` を併用）。
+ *
+ * @internal テスト用に export する。
+ */
+export const createGlobeModelManagerAdapter = (
+    globeMgr: GlobeModelManager,
+    terrainElevAt: (latDeg: number, lonDeg: number) => number | null,
+): ModelManager => {
+    const ids = new Map<string, string>(); // public id -> globe 内部 id
+    let disposed = false;
+
+    const assertNotDisposed = (): void => {
+        if (disposed) throw new Error("ModelManager has been disposed");
+    };
+
+    const requireGlobeId = (id: string, prefix: string): string => {
+        const gid = ids.get(id);
+        if (gid === undefined) throw new Error(`${prefix}: id "${id}" not found`);
+        return gid;
+    };
+
+    const buildHandle = (id: string, gid: string): ModelHandle => {
+        const s = globeMgr.get(gid);
+        if (!s) {
+            // ids に存在するのに globe 側に無いのは内部不整合。
+            throw new Error(`ModelManager: internal state lost for id "${id}"`);
+        }
+        return {
+            id,
+            url: s.url,
+            lat: s.lat,
+            lon: s.lon,
+            altitude: s.altitude,
+            altitudeMode: s.altitudeMode,
+            rotation: { ...s.rotation },
+            scaling: { ...s.scaling },
+            enabled: s.enabled,
+            gravity: s.gravity,
+            loaded: s.loaded,
+            elevationResolved:
+                s.elevationResolved ||
+                s.altitudeMode === "absolute" ||
+                terrainElevAt(s.lat, s.lon) !== null,
+            animationNames: s.animationNames,
+        };
+    };
+
+    return {
+        add(id: string, options: ModelOptions): ModelHandle {
+            assertNotDisposed();
+            if (ids.has(id)) {
+                throw new Error(`${MODEL_ERROR_PREFIX}: id "${id}" already exists`);
+            }
+            assertLatLonInBounds(options.lat, options.lon, MODEL_ERROR_PREFIX);
+            const altitudeMode = options.altitudeMode ?? MODEL_DEFAULTS.altitudeMode;
+            if (altitudeMode === "absolute" && options.altitude === undefined) {
+                throw new Error(
+                    `${MODEL_ERROR_PREFIX}: altitudeMode="absolute" requires altitude`,
+                );
+            }
+            const gid = globeMgr.add({
+                url: options.url,
+                lat: options.lat,
+                lon: options.lon,
+                altitude: options.altitude,
+                altitudeMode,
+                rotation: options.rotation,
+                scaling: options.scaling,
+                enabled: options.enabled,
+                gravity: options.gravity,
+            });
+            ids.set(id, gid);
+            return buildHandle(id, gid);
+        },
+
+        get(id: string): ModelHandle | null {
+            if (disposed) return null;
+            const gid = ids.get(id);
+            return gid === undefined ? null : buildHandle(id, gid);
+        },
+
+        update(id: string, partial: ModelUpdate): ModelHandle {
+            assertNotDisposed();
+            const gid = requireGlobeId(id, MODEL_UPDATE_ERROR_PREFIX);
+            const cur = globeMgr.get(gid);
+            // absolute へ切替える update では altitude の明示指定を要求する（planar 契約）。
+            if (
+                partial.altitudeMode === "absolute" &&
+                cur?.altitudeMode !== "absolute" &&
+                partial.altitude === undefined
+            ) {
+                throw new Error(
+                    `${MODEL_UPDATE_ERROR_PREFIX}: switching to altitudeMode="absolute" requires explicit altitude`,
+                );
+            }
+            if (partial.lat !== undefined || partial.lon !== undefined) {
+                const newLat = partial.lat ?? cur?.lat ?? 0;
+                const newLon = partial.lon ?? cur?.lon ?? 0;
+                assertLatLonInBounds(newLat, newLon, MODEL_UPDATE_ERROR_PREFIX);
+            }
+            globeMgr.update(gid, {
+                lat: partial.lat,
+                lon: partial.lon,
+                altitude: partial.altitude,
+                altitudeMode: partial.altitudeMode,
+                rotation: partial.rotation,
+                scaling: partial.scaling,
+                enabled: partial.enabled,
+                gravity: partial.gravity,
+            });
+            return buildHandle(id, gid);
+        },
+
+        remove(id: string): void {
+            const gid = ids.get(id);
+            if (gid === undefined) {
+                console.warn(`[jpmap-terrain] removeModel: id "${id}" not found`);
+                return;
+            }
+            globeMgr.remove(gid);
+            ids.delete(id);
+        },
+
+        setEnabled(id: string, enabled: boolean): void {
+            assertNotDisposed();
+            globeMgr.setEnabled(
+                requireGlobeId(id, "JpmapTerrain.setModelEnabled"),
+                enabled,
+            );
+        },
+
+        list(): readonly string[] {
+            return Array.from(ids.keys());
+        },
+
+        playAnimation(id: string, name?: string): void {
+            assertNotDisposed();
+            globeMgr.playAnimation(
+                requireGlobeId(id, "JpmapTerrain.playModelAnimation"),
+                name,
+            );
+        },
+
+        stopAnimation(id: string, name?: string): void {
+            assertNotDisposed();
+            globeMgr.stopAnimation(
+                requireGlobeId(id, "JpmapTerrain.stopModelAnimation"),
+                name,
+            );
+        },
+
+        dispose(): void {
+            if (disposed) return;
+            disposed = true;
+            // 内部 GlobeModelManager はシーンが毎フレーム tick() で参照し GlobeScene.dispose() が
+            // 破棄する所有者であるため、ここでは破棄しない。このアダプタが追加したモデルのみ削除する。
+            for (const gid of ids.values()) {
+                globeMgr.remove(gid);
+            }
+            ids.clear();
+        },
+    };
+};
+
 /**
  * `GlobeSceneController` を `DefaultSceneController` 互換へ橋渡しする。
  *
@@ -1086,6 +1269,10 @@ export const createGlobeSceneController = (
     );
     const circleManager = createGlobeCircleManagerAdapter(
         gc.circleManager,
+        (latDeg, lonDeg) => gc.tileManager.terrainElevAt(latDeg, lonDeg),
+    );
+    const modelManager = createGlobeModelManagerAdapter(
+        gc.modelManager,
         (latDeg, lonDeg) => gc.tileManager.terrainElevAt(latDeg, lonDeg),
     );
 
@@ -1462,6 +1649,7 @@ export const createGlobeSceneController = (
         getMarkerManager: () => markerManager,
         getPolygonManager: () => polygonManager,
         getCircleManager: () => circleManager,
+        getModelManager: () => modelManager,
 
         // ---- 地形クリック購読（pick 非依存・floating origin 対応, #275 P4・実装済み） ----
         // globe シーン（globe.ts）が真の ECEF レイ × 地形楕円体で求めたクリック地点を、公開

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -1132,6 +1132,9 @@ export const createGlobeModelManagerAdapter = (
             if (ids.has(id)) {
                 throw new Error(`${MODEL_ERROR_PREFIX}: id "${id}" already exists`);
             }
+            if (!options.url) {
+                throw new Error(`${MODEL_ERROR_PREFIX}: url is required`);
+            }
             assertLatLonInBounds(options.lat, options.lon, MODEL_ERROR_PREFIX);
             const altitudeMode = options.altitudeMode ?? MODEL_DEFAULTS.altitudeMode;
             if (altitudeMode === "absolute" && options.altitude === undefined) {

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -1219,18 +1219,33 @@ export const createGlobeModelManagerAdapter = (
 
         playAnimation(id: string, name?: string): void {
             assertNotDisposed();
-            globeMgr.playAnimation(
-                requireGlobeId(id, "JpmapTerrain.playModelAnimation"),
-                name,
-            );
+            const gid = requireGlobeId(id, "JpmapTerrain.playModelAnimation");
+            // planar(`ModelManager.playAnimation`) と同契約: 公開 id・`[jpmap-terrain]`
+            // prefix で warn し、未ロード/名前不一致では委譲しない。
+            const state = globeMgr.get(gid);
+            if (!state?.loaded) {
+                console.warn(
+                    `[jpmap-terrain] playModelAnimation: model "${id}" is not loaded yet`,
+                );
+                return;
+            }
+            if (name !== undefined && !state.animationNames.includes(name)) {
+                console.warn(
+                    `[jpmap-terrain] playModelAnimation: animation "${name}" not found in model "${id}"`,
+                );
+                return;
+            }
+            globeMgr.playAnimation(gid, name);
         },
 
         stopAnimation(id: string, name?: string): void {
             assertNotDisposed();
-            globeMgr.stopAnimation(
-                requireGlobeId(id, "JpmapTerrain.stopModelAnimation"),
-                name,
-            );
+            const gid = requireGlobeId(id, "JpmapTerrain.stopModelAnimation");
+            // planar と同契約: 未ロード時は警告せず no-op、名前不一致も静かに無視する。
+            const state = globeMgr.get(gid);
+            if (!state?.loaded) return;
+            if (name !== undefined && !state.animationNames.includes(name)) return;
+            globeMgr.stopAnimation(gid, name);
         },
 
         dispose(): void {

--- a/src/terrain/geo/globeModelManager.ts
+++ b/src/terrain/geo/globeModelManager.ts
@@ -1,35 +1,87 @@
 /**
- * グローブ用モデルマネージャ (Issue #275 Phase 3, model スライス)。
+ * グローブ用モデルマネージャ (Issue #275 Phase 3 / Phase 4 P4-2)。
  *
- * 平面版（`modelManager`）に対する **並行構築** のグローブ実装。glb/gltf モデルを lat/lon に接地し、
- * **ローカル +Y を地心 up へ向けて「立たせる」**（`overlayPlacement.surfaceOrientationToRef`）。
- * 配置は ECEF（`groundPlacementToRef`）で `scene.pick` 非依存。平面版 `modelManager` は未改修で、
+ * 平面版（`modelManager`）に対する **並行構築** のグローブ実装。glb/gltf/obj/stl モデルを
+ * lat/lon に接地し、**ローカル +Y を地心 up へ向けて「立たせる」**（`surfaceOrientationToRef`）。
+ * 配置は ECEF（`geodeticToEcefToRef`）で `scene.pick` 非依存。平面版 `modelManager` は未改修で、
  * ローダー登録（`importLoaderForUrl`）のみ座標系非依存のため再利用する。
+ *
+ * P4-2 で公開 `ModelManager`（`addModel`/`updateModel`/`getModel`/...）相当へ拡張:
+ * - in-place 更新（メッシュ再ロードなし）
+ * - altitudeMode `terrain`/`absolute` と gravity（地表追従）
+ * - per-axis scaling・フル Euler rotation（地心 up 起立に局所 pitch/roll を合成）
+ * - animation の保持と play/stop
  */
 import type { Scene } from "@babylonjs/core/scene";
-import { Vector3, Quaternion } from "@babylonjs/core/Maths/math.vector";
+import { Quaternion } from "@babylonjs/core/Maths/math.vector";
 import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import type { AbstractMesh } from "@babylonjs/core/Meshes/abstractMesh";
+import type { AnimationGroup } from "@babylonjs/core/Animations/animationGroup";
 import { ImportMeshAsync } from "@babylonjs/core/Loading/sceneLoader";
+import { GLTFLoaderAnimationStartMode } from "@babylonjs/loaders/glTF/glTFFileLoader";
 
 import { importLoaderForUrl } from "../modelManager";
-import { groundPlacementToRef, surfaceOrientationToRef } from "./overlayPlacement";
+import { surfaceOrientationToRef } from "./overlayPlacement";
+import { DEG2RAD, geodeticToEcefToRef } from "./ecef";
+
+/** 高度モード。`terrain`=地表からのオフセット / `absolute`=楕円体面からの絶対高度。 */
+export type GlobeAltitudeMode = "terrain" | "absolute";
+
+/** 3 軸ベクトル（各軸 optional）。 */
+export interface GlobeVec3 {
+    x?: number;
+    y?: number;
+    z?: number;
+}
 
 export interface GlobeModelOptions {
-    /** モデルファイルの URL（glb/gltf）。 */
+    /** モデルファイルの URL（glb/gltf/obj/stl）。 */
     url: string;
     /** 緯度 [deg]。 */
     lat: number;
     /** 経度 [deg]。 */
     lon: number;
-    /** 地表からの高さオフセット [m]（default 0）。 */
-    altitudeOffsetMeters?: number;
-    /** 方位 [deg]（0=北, +=東回り。モデルのローカル +Z が向く方向）。default 0。 */
-    headingDeg?: number;
-    /** 一様スケール（default 1）。 */
-    scale?: number;
+    /**
+     * 高度 [m]。
+     * - `altitudeMode==="absolute"`: 楕円体面からの絶対高度。
+     * - `altitudeMode==="terrain"`: 地表からのオフセット（default 0）。
+     */
+    altitude?: number;
+    /** 高度モード。default `"terrain"`。 */
+    altitudeMode?: GlobeAltitudeMode;
+    /**
+     * 回転 [deg]。`y` は方位（0=北, +=東回り）として地心 up 周りに適用し、
+     * `x`/`z` は起立姿勢に対する局所 pitch/roll として合成する。default `{0,0,0}`。
+     */
+    rotation?: GlobeVec3;
+    /** スケール倍率（per-axis）。default `{1,1,1}`。 */
+    scaling?: GlobeVec3;
     /** default true。 */
     enabled?: boolean;
+    /**
+     * 地表追従（重力）。default true。
+     * `altitudeMode==="terrain"` のときのみ有効（`absolute` 時は無視）。
+     */
+    gravity?: boolean;
+}
+
+/** `update` の部分更新型（`url` は変更不可）。 */
+export type GlobeModelUpdate = Partial<Omit<GlobeModelOptions, "url">>;
+
+/** `get` の戻り値（読み取り専用スナップショット）。アダプタが `ModelHandle` を組み立てる。 */
+export interface GlobeModelState {
+    url: string;
+    lat: number;
+    lon: number;
+    altitude: number;
+    altitudeMode: GlobeAltitudeMode;
+    rotation: Required<GlobeVec3>;
+    scaling: Required<GlobeVec3>;
+    enabled: boolean;
+    gravity: boolean;
+    loaded: boolean;
+    elevationResolved: boolean;
+    animationNames: string[];
 }
 
 export interface GlobeModelManagerDeps {
@@ -40,30 +92,52 @@ export interface GlobeModelManagerDeps {
 
 interface GlobeModelNode {
     id: string;
+    url: string;
     lat: number;
     lon: number;
-    altitudeOffsetMeters: number;
-    headingDeg: number;
-    scale: number;
+    altitude: number;
+    altitudeMode: GlobeAltitudeMode;
+    rotation: Required<GlobeVec3>;
+    scaling: Required<GlobeVec3>;
     enabled: boolean;
+    gravity: boolean;
     root: TransformNode;
     meshes: AbstractMesh[];
+    animationGroups: AnimationGroup[];
     /** ロード完了フラグ（完了まで placeNode しない）。 */
     loaded: boolean;
     /** dispose/remove 済みフラグ（非同期ロード結果の破棄判定）。 */
     cancelled: boolean;
-    /** 直近に取得できた地形標高[m]（null=未取得）。前景未ロード時のフォールバック。 */
+    /** 地表標高が解決済みなら true（absolute 時は常に true）。 */
+    elevationResolved: boolean;
+    /** 直近に取得できた地形標高[m]（null=未取得）。 */
     lastElev: number | null;
+    /** 前フレームの可視状態キャッシュ（冗長な setEnabled を削減）。 */
+    lastVisible: boolean | null;
 }
 
 export interface GlobeModelManager {
     add(opts: GlobeModelOptions): string;
+    get(id: string): GlobeModelState | null;
+    update(id: string, partial: GlobeModelUpdate): void;
     remove(id: string): void;
     setEnabled(id: string, enabled: boolean): void;
+    list(): readonly string[];
+    playAnimation(id: string, name?: string): void;
+    stopAnimation(id: string, name?: string): void;
     /** 毎フレーム: ロード済みモデルを地形へ接地し地心 up へ向ける。 */
-    update(): void;
+    tick(): void;
     dispose(): void;
 }
+
+const resolveVec3 = (
+    v: GlobeVec3 | undefined,
+    defaults: Required<GlobeVec3>,
+): Required<GlobeVec3> => ({
+    x: v?.x ?? defaults.x,
+    y: v?.y ?? defaults.y,
+    z: v?.z ?? defaults.z,
+});
 
 /**
  * グローブ用モデルマネージャを生成する。
@@ -75,43 +149,102 @@ export const createGlobeModelManager = (
     const nodes = new Map<string, GlobeModelNode>();
     let seq = 0;
     let disposed = false;
-    const quat = new Quaternion(); // 向き計算スクラッチ
-    const upScratch = new Vector3(); // groundPlacementToRef の up 受け（未使用だが要引数）
+    const quat = new Quaternion(); // 起立姿勢スクラッチ
+    const localQuat = new Quaternion(); // pitch/roll 合成スクラッチ
 
-    /** モデルを地形へ接地（標高 null は直前値→0）し、地心 up へ向ける。 */
-    const placeNode = (node: GlobeModelNode): void => {
-        const elevOrNull = terrainElevAt(node.lat, node.lon);
-        if (elevOrNull !== null) node.lastElev = elevOrNull;
-        const elev = (node.lastElev ?? 0) + node.altitudeOffsetMeters;
-        // root.position（真の ECEF）へ接地。向きは root.position から地心 up を算出して決める。
-        groundPlacementToRef(node.lat, node.lon, elev, node.root.position, upScratch);
-        if (surfaceOrientationToRef(node.root.position, node.headingDeg, quat)) {
-            if (!node.root.rotationQuaternion) node.root.rotationQuaternion = new Quaternion();
-            node.root.rotationQuaternion.copyFrom(quat);
+    /** ルートの可視状態を更新する（冗長な setEnabled を避ける）。 */
+    const setVisible = (node: GlobeModelNode, visible: boolean): void => {
+        if (node.lastVisible === visible) return;
+        node.lastVisible = visible;
+        node.root.setEnabled(visible);
+    };
+
+    /** 起立姿勢（地心 up + heading=rotation.y）に局所 pitch/roll(x,z) を合成して向きを与える。 */
+    const applyOrientation = (node: GlobeModelNode): void => {
+        if (!surfaceOrientationToRef(node.root.position, node.rotation.y, quat)) {
+            return; // 極などの特異点では向き更新をスキップ
         }
+        if (node.rotation.x !== 0 || node.rotation.z !== 0) {
+            Quaternion.FromEulerAnglesToRef(
+                node.rotation.x * DEG2RAD,
+                0,
+                node.rotation.z * DEG2RAD,
+                localQuat,
+            );
+            // surface * local: モデル局所軸で tilt してから地表へ起立させる。
+            quat.multiplyToRef(localQuat, quat);
+        }
+        if (!node.root.rotationQuaternion) {
+            node.root.rotationQuaternion = new Quaternion();
+        }
+        node.root.rotationQuaternion.copyFrom(quat);
+    };
+
+    /** モデルを ECEF へ接地し、可視状態と向きを更新する。 */
+    const placeNode = (node: GlobeModelNode): void => {
+        if (node.altitudeMode === "absolute") {
+            geodeticToEcefToRef(node.lat, node.lon, node.altitude, node.root.position);
+            node.elevationResolved = true;
+            setVisible(node, node.enabled);
+            applyOrientation(node);
+            return;
+        }
+        // terrain モード
+        if (node.gravity) {
+            const elev = terrainElevAt(node.lat, node.lon);
+            if (elev === null) {
+                // 平面版と同契約: 地表未解決のあいだは非表示にして原点/0m 表示のポップを防ぐ。
+                node.elevationResolved = false;
+                setVisible(node, false);
+                return;
+            }
+            node.lastElev = elev;
+            node.elevationResolved = true;
+            geodeticToEcefToRef(node.lat, node.lon, elev + node.altitude, node.root.position);
+        } else {
+            geodeticToEcefToRef(node.lat, node.lon, node.altitude, node.root.position);
+            node.elevationResolved = true;
+        }
+        setVisible(node, node.enabled);
+        applyOrientation(node);
+    };
+
+    /**
+     * 未ロード時の `elevationResolved` を planar(`modelManager`) と同契約で求める:
+     * absolute / 非gravity-terrain は地形非依存で true、gravity-terrain は標高取得可否で判定。
+     */
+    const resolveUnloadedElev = (node: GlobeModelNode): boolean => {
+        if (node.altitudeMode === "absolute") return true;
+        if (node.gravity) return terrainElevAt(node.lat, node.lon) !== null;
+        return true;
     };
 
     const loadModel = async (node: GlobeModelNode, url: string): Promise<void> => {
         try {
             await importLoaderForUrl(url);
-            const result = await ImportMeshAsync(url, scene);
-            // 本マネージャはアニメーション制御 API を持たないため、AnimationGroup はロード直後に
-            // 停止・破棄してリークを防ぐ（平面版 modelManager は remove/dispose 時に破棄）。
+            // animationStartMode: NONE でロードし自動再生を抑止する（planar と同方針）。
+            // 再生タイミングは playAnimation() で明示制御する。
+            const result = await ImportMeshAsync(url, scene, {
+                pluginOptions: {
+                    gltf: { animationStartMode: GLTFLoaderAnimationStartMode.NONE },
+                },
+            });
+            // glTF 以外（obj/stl）や既定変更に備え、ロード直後にも停止しておく。
             for (const ag of result.animationGroups) {
                 ag.stop();
-                ag.dispose();
             }
             if (node.cancelled) {
+                for (const ag of result.animationGroups) ag.dispose();
                 for (const m of result.meshes) m.dispose();
                 return;
             }
             node.meshes = result.meshes;
+            node.animationGroups = result.animationGroups;
             // 最上位ノードのみ root の子にする（スキン階層の内部親子は触らない）。
             for (const m of result.meshes) {
                 if (!m.parent) m.parent = node.root;
             }
-            node.root.scaling.setAll(node.scale);
-            node.root.setEnabled(node.enabled);
+            node.root.scaling.set(node.scaling.x, node.scaling.y, node.scaling.z);
             node.loaded = true;
             placeNode(node); // 初期配置（原点表示のチラつき防止）
         } catch (err) {
@@ -126,25 +259,82 @@ export const createGlobeModelManager = (
         const id = `globe-model-${seq++}`;
         const root = new TransformNode(`${id}-root`, scene);
         root.rotationQuaternion = new Quaternion();
-        const enabled = opts.enabled ?? true;
-        root.setEnabled(enabled);
         const node: GlobeModelNode = {
             id,
+            url: opts.url,
             lat: opts.lat,
             lon: opts.lon,
-            altitudeOffsetMeters: opts.altitudeOffsetMeters ?? 0,
-            headingDeg: opts.headingDeg ?? 0,
-            scale: opts.scale ?? 1,
-            enabled,
+            altitude: opts.altitude ?? 0,
+            altitudeMode: opts.altitudeMode ?? "terrain",
+            rotation: resolveVec3(opts.rotation, { x: 0, y: 0, z: 0 }),
+            scaling: resolveVec3(opts.scaling, { x: 1, y: 1, z: 1 }),
+            enabled: opts.enabled ?? true,
+            gravity: opts.gravity ?? true,
             root,
             meshes: [],
+            animationGroups: [],
             loaded: false,
             cancelled: false,
+            elevationResolved: false,
             lastElev: null,
+            lastVisible: null,
         };
+        // ロード完了までは非表示（原点表示のチラつき防止）。
+        root.setEnabled(false);
+        // 未ロード時点の elevationResolved を planar と同契約で初期化する。
+        node.elevationResolved = resolveUnloadedElev(node);
         nodes.set(id, node);
         void loadModel(node, opts.url);
         return id;
+    };
+
+    const buildState = (node: GlobeModelNode): GlobeModelState => ({
+        url: node.url,
+        lat: node.lat,
+        lon: node.lon,
+        altitude: node.altitude,
+        altitudeMode: node.altitudeMode,
+        rotation: { ...node.rotation },
+        scaling: { ...node.scaling },
+        enabled: node.enabled,
+        gravity: node.gravity,
+        loaded: node.loaded,
+        elevationResolved: node.elevationResolved,
+        animationNames: node.animationGroups.map((ag) => ag.name),
+    });
+
+    const get = (id: string): GlobeModelState | null => {
+        const node = nodes.get(id);
+        return node ? buildState(node) : null;
+    };
+
+    const update = (id: string, partial: GlobeModelUpdate): void => {
+        if (disposed) throw new Error("GlobeModelManager.update: called after dispose");
+        const node = nodes.get(id);
+        if (!node) throw new Error(`GlobeModelManager.update: id "${id}" not found`);
+
+        if (partial.lat !== undefined) node.lat = partial.lat;
+        if (partial.lon !== undefined) node.lon = partial.lon;
+        if (partial.altitude !== undefined) node.altitude = partial.altitude;
+        if (partial.altitudeMode !== undefined) node.altitudeMode = partial.altitudeMode;
+        if (partial.gravity !== undefined) node.gravity = partial.gravity;
+        if (partial.rotation !== undefined) {
+            node.rotation = resolveVec3(partial.rotation, node.rotation);
+        }
+        if (partial.scaling !== undefined) {
+            node.scaling = resolveVec3(partial.scaling, node.scaling);
+            if (node.loaded) {
+                node.root.scaling.set(node.scaling.x, node.scaling.y, node.scaling.z);
+            }
+        }
+        if (partial.enabled !== undefined) node.enabled = partial.enabled;
+
+        if (node.loaded) {
+            placeNode(node);
+        } else {
+            // 未ロード時も planar と同契約で elevationResolved を再計算する。
+            node.elevationResolved = resolveUnloadedElev(node);
+        }
     };
 
     const remove = (id: string): void => {
@@ -154,6 +344,10 @@ export const createGlobeModelManager = (
             return;
         }
         node.cancelled = true;
+        for (const ag of node.animationGroups) {
+            ag.stop();
+            ag.dispose();
+        }
         for (const m of node.meshes) m.dispose();
         node.root.dispose();
         nodes.delete(id);
@@ -164,14 +358,51 @@ export const createGlobeModelManager = (
         const node = nodes.get(id);
         if (!node) throw new Error(`GlobeModelManager.setEnabled: id "${id}" not found`);
         node.enabled = enabled;
-        node.root.setEnabled(enabled);
+        if (node.loaded) {
+            setVisible(node, enabled && node.elevationResolved);
+        }
     };
 
-    const update = (): void => {
-        if (disposed) throw new Error("GlobeModelManager.update: called after dispose");
+    const list = (): readonly string[] => Array.from(nodes.keys());
+
+    const playAnimation = (id: string, name?: string): void => {
+        if (disposed) throw new Error("GlobeModelManager.playAnimation: called after dispose");
+        const node = nodes.get(id);
+        if (!node) throw new Error(`GlobeModelManager.playAnimation: id "${id}" not found`);
+        if (!node.loaded) {
+            console.warn(`[globe-model] playAnimation: model "${id}" is not loaded yet`);
+            return;
+        }
+        if (name !== undefined) {
+            const ag = node.animationGroups.find((g) => g.name === name);
+            if (!ag) {
+                console.warn(`[globe-model] playAnimation: animation "${name}" not found in model "${id}"`);
+                return;
+            }
+            ag.play(true);
+        } else {
+            for (const ag of node.animationGroups) ag.play(true);
+        }
+    };
+
+    const stopAnimation = (id: string, name?: string): void => {
+        if (disposed) throw new Error("GlobeModelManager.stopAnimation: called after dispose");
+        const node = nodes.get(id);
+        if (!node) throw new Error(`GlobeModelManager.stopAnimation: id "${id}" not found`);
+        if (!node.loaded) return;
+        if (name !== undefined) {
+            const ag = node.animationGroups.find((g) => g.name === name);
+            if (ag) ag.stop();
+        } else {
+            for (const ag of node.animationGroups) ag.stop();
+        }
+    };
+
+    const tick = (): void => {
+        if (disposed) throw new Error("GlobeModelManager.tick: called after dispose");
         if (nodes.size === 0) return;
         for (const node of nodes.values()) {
-            if (!node.enabled || !node.loaded) continue;
+            if (!node.loaded) continue;
             placeNode(node);
         }
     };
@@ -182,5 +413,16 @@ export const createGlobeModelManager = (
         for (const id of [...nodes.keys()]) remove(id);
     };
 
-    return { add, remove, setEnabled, update, dispose };
+    return {
+        add,
+        get,
+        update,
+        remove,
+        setEnabled,
+        list,
+        playAnimation,
+        stopAnimation,
+        tick,
+        dispose,
+    };
 };

--- a/src/terrain/geo/globeModelManager.ts
+++ b/src/terrain/geo/globeModelManager.ts
@@ -110,8 +110,6 @@ interface GlobeModelNode {
     cancelled: boolean;
     /** 地表標高が解決済みなら true（absolute 時は常に true）。 */
     elevationResolved: boolean;
-    /** 直近に取得できた地形標高[m]（null=未取得）。 */
-    lastElev: number | null;
     /** 前フレームの可視状態キャッシュ（冗長な setEnabled を削減）。 */
     lastVisible: boolean | null;
 }
@@ -199,7 +197,6 @@ export const createGlobeModelManager = (
                 setVisible(node, false);
                 return;
             }
-            node.lastElev = elev;
             node.elevationResolved = true;
             geodeticToEcefToRef(node.lat, node.lon, elev + node.altitude, node.root.position);
         } else {
@@ -282,7 +279,6 @@ export const createGlobeModelManager = (
             loaded: false,
             cancelled: false,
             elevationResolved: false,
-            lastElev: null,
             lastVisible: null,
         };
         // ロード完了までは非表示（原点表示のチラつき防止）。

--- a/src/terrain/geo/globeModelManager.ts
+++ b/src/terrain/geo/globeModelManager.ts
@@ -171,7 +171,8 @@ export const createGlobeModelManager = (
                 node.rotation.z * DEG2RAD,
                 localQuat,
             );
-            // surface * local: モデル局所軸で tilt してから地表へ起立させる。
+            // surface * local（後置乗算 = intrinsic 合成）: 地表へ起立させた姿勢の
+            // 局所軸で pitch/roll を後から合成する。
             quat.multiplyToRef(localQuat, quat);
         }
         if (!node.root.rotationQuaternion) {
@@ -256,6 +257,11 @@ export const createGlobeModelManager = (
 
     const add = (opts: GlobeModelOptions): string => {
         if (disposed) throw new Error("GlobeModelManager.add: called after dispose");
+        const altitudeMode = opts.altitudeMode ?? "terrain";
+        // absolute モードは海抜高度を意図するため、暗黙の 0m を契約違反として弾く。
+        if (altitudeMode === "absolute" && opts.altitude === undefined) {
+            throw new Error('GlobeModelManager.add: altitudeMode="absolute" requires altitude');
+        }
         const id = `globe-model-${seq++}`;
         const root = new TransformNode(`${id}-root`, scene);
         root.rotationQuaternion = new Quaternion();
@@ -265,7 +271,7 @@ export const createGlobeModelManager = (
             lat: opts.lat,
             lon: opts.lon,
             altitude: opts.altitude ?? 0,
-            altitudeMode: opts.altitudeMode ?? "terrain",
+            altitudeMode,
             rotation: resolveVec3(opts.rotation, { x: 0, y: 0, z: 0 }),
             scaling: resolveVec3(opts.scaling, { x: 1, y: 1, z: 1 }),
             enabled: opts.enabled ?? true,
@@ -316,7 +322,20 @@ export const createGlobeModelManager = (
         if (partial.lat !== undefined) node.lat = partial.lat;
         if (partial.lon !== undefined) node.lon = partial.lon;
         if (partial.altitude !== undefined) node.altitude = partial.altitude;
-        if (partial.altitudeMode !== undefined) node.altitudeMode = partial.altitudeMode;
+        if (partial.altitudeMode !== undefined) {
+            // absolute への切替時は、同じ update 呼び出しで altitude の明示指定を要求する
+            // （node.altitude は常に数値のため、暗黙の 0m が海抜高度として通るのを防ぐ）。
+            if (
+                partial.altitudeMode === "absolute" &&
+                node.altitudeMode !== "absolute" &&
+                partial.altitude === undefined
+            ) {
+                throw new Error(
+                    'GlobeModelManager.update: switching to altitudeMode="absolute" requires explicit altitude',
+                );
+            }
+            node.altitudeMode = partial.altitudeMode;
+        }
         if (partial.gravity !== undefined) node.gravity = partial.gravity;
         if (partial.rotation !== undefined) {
             node.rotation = resolveVec3(partial.rotation, node.rotation);

--- a/tests/globeModelManager.unit.spec.ts
+++ b/tests/globeModelManager.unit.spec.ts
@@ -41,7 +41,7 @@ jest.unstable_mockModule("@babylonjs/core/Meshes/transformNode", () => ({
 }));
 
 // ImportMeshAsync は解決を手動制御できる deferred にする。
-type StubAg = { stop: () => void; dispose: () => void };
+type StubAg = { name?: string; stop: () => void; play?: (loop?: boolean) => void; dispose: () => void };
 let resolveImport:
     | ((meshes: { parent: unknown; dispose: () => void }[], ags?: StubAg[]) => void)
     | null = null;
@@ -53,6 +53,9 @@ const importMeshAsync = jest.fn(
 );
 jest.unstable_mockModule("@babylonjs/core/Loading/sceneLoader", () => ({
     ImportMeshAsync: importMeshAsync,
+}));
+jest.unstable_mockModule("@babylonjs/loaders/glTF/glTFFileLoader", () => ({
+    GLTFLoaderAnimationStartMode: { NONE: 0, FIRST: 1, ALL: 2 },
 }));
 
 const importLoaderForUrl = jest.fn(async () => {});
@@ -87,7 +90,7 @@ beforeEach(() => {
 describe("add / load", () => {
     it("add で root を生成し、ロード完了後に接地・起立する", async () => {
         const { mgr } = makeManager();
-        mgr.add({ url: "x.glb", lat: 35, lon: 139, scale: 10 });
+        mgr.add({ url: "x.glb", lat: 35, lon: 139, scaling: { x: 10, y: 10, z: 10 } });
         expect(createdRoots.length).toBe(1);
         await completeLoad();
         const root = createdRoots[0];
@@ -99,14 +102,14 @@ describe("add / load", () => {
         expect(root.scaling.x).toBe(10);
     });
 
-    it("ロード完了前は update しても位置は原点のまま（loaded ガード）", () => {
+    it("ロード完了前は tick しても位置は原点のまま（loaded ガード）", () => {
         const { mgr } = makeManager();
         mgr.add({ url: "x.glb", lat: 35, lon: 139 });
-        mgr.update(); // まだ loaded=false
+        mgr.tick(); // まだ loaded=false
         expect(createdRoots[0].position.length()).toBe(0);
     });
 
-    it("AnimationGroup はロード直後に stop+dispose される（リーク防止）", async () => {
+    it("AnimationGroup はロード直後に stop されるが保持される（dispose しない）", async () => {
         const { mgr } = makeManager();
         mgr.add({ url: "x.glb", lat: 35, lon: 139 });
         await new Promise((r) => setTimeout(r, 0));
@@ -115,7 +118,8 @@ describe("add / load", () => {
         resolveImport?.([mesh], [ag]);
         await new Promise((r) => setTimeout(r, 0));
         expect(ag.stop).toHaveBeenCalled();
-        expect(ag.dispose).toHaveBeenCalled();
+        // P4-2: play/stop 制御のため保持する（リーク防止は remove/dispose で行う）。
+        expect(ag.dispose).not.toHaveBeenCalled();
     });
 });
 
@@ -146,7 +150,84 @@ describe("ライフサイクル", () => {
         mgr.dispose();
         expect(() => mgr.add({ url: "x.glb", lat: 35, lon: 139 })).toThrow(/after dispose/);
         expect(() => mgr.setEnabled("x", true)).toThrow(/after dispose/);
-        expect(() => mgr.update()).toThrow(/after dispose/);
+        expect(() => mgr.tick()).toThrow(/after dispose/);
         expect(() => mgr.dispose()).not.toThrow();
+    });
+});
+
+describe("in-place update / get / list", () => {
+    it("get は解決済み状態を返し、update は lat/lon/altitude/scaling を反映する", async () => {
+        const { mgr } = makeManager();
+        const id = mgr.add({ url: "x.glb", lat: 35, lon: 139 });
+        await completeLoad();
+        mgr.update(id, { lat: 36, lon: 140, altitude: 5, scaling: { x: 2, y: 2, z: 2 } });
+        const s = mgr.get(id);
+        expect(s).not.toBeNull();
+        expect(s?.lat).toBe(36);
+        expect(s?.lon).toBe(140);
+        expect(s?.altitude).toBe(5);
+        expect(s?.scaling.x).toBe(2);
+        expect(s?.loaded).toBe(true);
+        expect(createdRoots[0].scaling.x).toBe(2);
+        // 内部 id を 1 件保持する。
+        expect(mgr.list()).toHaveLength(1);
+    });
+
+    it("update は import を再実行しない（メッシュ再ロードなし）", async () => {
+        const { mgr } = makeManager();
+        const id = mgr.add({ url: "x.glb", lat: 35, lon: 139 });
+        await completeLoad();
+        importMeshAsync.mockClear();
+        mgr.update(id, { lat: 36 });
+        expect(importMeshAsync).not.toHaveBeenCalled();
+    });
+
+    it("get は未存在 id で null、update は未存在 id で throw", () => {
+        const { mgr } = makeManager();
+        expect(mgr.get("nope")).toBeNull();
+        expect(() => mgr.update("nope", { lat: 1 })).toThrow(/not found/);
+    });
+});
+
+describe("altitude / 接地", () => {
+    it("absolute モードは地形標高に依らず配置し elevationResolved=true", async () => {
+        const terrainElevAt = jest.fn(() => null as number | null);
+        const mgr = createGlobeModelManager({ scene: {} as never, terrainElevAt });
+        const id = mgr.add({
+            url: "x.glb",
+            lat: 35,
+            lon: 139,
+            altitudeMode: "absolute",
+            altitude: 100,
+        });
+        await completeLoad();
+        expect(mgr.get(id)?.elevationResolved).toBe(true);
+        expect(createdRoots[0].position.length()).toBeGreaterThan(6_000_000);
+    });
+
+    it("terrain+gravity で標高未解決のあいだは非表示（elevationResolved=false）", async () => {
+        const terrainElevAt = jest.fn(() => null as number | null);
+        const mgr = createGlobeModelManager({ scene: {} as never, terrainElevAt });
+        const id = mgr.add({ url: "x.glb", lat: 35, lon: 139 });
+        await completeLoad();
+        expect(mgr.get(id)?.elevationResolved).toBe(false);
+        expect(createdRoots[0].enabled).toBe(false);
+    });
+});
+
+describe("animation", () => {
+    it("playAnimation/stopAnimation は保持した AnimationGroup を制御する", async () => {
+        const { mgr } = makeManager();
+        const id = mgr.add({ url: "x.glb", lat: 35, lon: 139 });
+        await new Promise((r) => setTimeout(r, 0));
+        const ag = { name: "walk", stop: jest.fn(), play: jest.fn(), dispose: jest.fn() };
+        const mesh = { parent: null as unknown, dispose: jest.fn() };
+        resolveImport?.([mesh], [ag as unknown as StubAg]);
+        await new Promise((r) => setTimeout(r, 0));
+        expect(mgr.get(id)?.animationNames).toEqual(["walk"]);
+        mgr.playAnimation(id, "walk");
+        expect(ag.play).toHaveBeenCalledWith(true);
+        mgr.stopAnimation(id, "walk");
+        expect(ag.stop).toHaveBeenCalled();
     });
 });

--- a/tests/globeModelManager.unit.spec.ts
+++ b/tests/globeModelManager.unit.spec.ts
@@ -213,6 +213,25 @@ describe("altitude / 接地", () => {
         expect(mgr.get(id)?.elevationResolved).toBe(false);
         expect(createdRoots[0].enabled).toBe(false);
     });
+
+    it('add で altitudeMode="absolute" かつ altitude 未指定は throw する', () => {
+        const { mgr } = makeManager();
+        expect(() =>
+            mgr.add({ url: "x.glb", lat: 35, lon: 139, altitudeMode: "absolute" }),
+        ).toThrow(/requires altitude/);
+    });
+
+    it('update で absolute へ切替時に altitude 未指定は throw する', async () => {
+        const { mgr } = makeManager();
+        const id = mgr.add({ url: "x.glb", lat: 35, lon: 139 });
+        await completeLoad();
+        expect(() => mgr.update(id, { altitudeMode: "absolute" })).toThrow(
+            /requires explicit altitude/,
+        );
+        // altitude を同時に指定すれば切替できる。
+        expect(() => mgr.update(id, { altitudeMode: "absolute", altitude: 50 })).not.toThrow();
+        expect(mgr.get(id)?.altitudeMode).toBe("absolute");
+    });
 });
 
 describe("animation", () => {

--- a/tests/globeSceneController.unit.spec.ts
+++ b/tests/globeSceneController.unit.spec.ts
@@ -14,6 +14,7 @@ import {
     createGlobeMarkerManagerAdapter,
     createGlobePolygonManagerAdapter,
     createGlobeCircleManagerAdapter,
+    createGlobeModelManagerAdapter,
 } from "../src/scenes/globeSceneController";
 import type {
     GlobeSceneController,
@@ -42,6 +43,12 @@ import type {
     GlobeCircleManager,
     GlobeCircleOptions,
 } from "../src/terrain/geo/globeCircleManager";
+import type {
+    GlobeModelManager,
+    GlobeModelOptions,
+    GlobeModelUpdate,
+    GlobeModelState,
+} from "../src/terrain/geo/globeModelManager";
 import { geodeticToEcef } from "../src/terrain/geo/ecef";
 
 /** camera のみ参照する軽量スタブ GlobeSceneController を作る。 */
@@ -996,6 +1003,177 @@ describe("createGlobeCircleManagerAdapter (P4-0 Slice 2b-2 circle overlay)", () 
         expect(stub.disposed()).toBe(false);
         expect(stub.removed).toContain(aliveId);
         expect(() => m.add("x", { center: CENTER, radius: 100 })).toThrow(/disposed/);
+        warn.mockRestore();
+    });
+});
+/** GlobeModelManager の軽量スタブ。in-place 更新・get・animation を備える。 */
+const makeGlobeModelStub = (): {
+    mgr: GlobeModelManager;
+    added: { id: string; opts: GlobeModelOptions }[];
+    removed: string[];
+    importCount: () => number;
+    disposed: () => boolean;
+} => {
+    let seq = 0;
+    let disposedFlag = false;
+    let imports = 0;
+    const added: { id: string; opts: GlobeModelOptions }[] = [];
+    const removed: string[] = [];
+    const states = new Map<string, GlobeModelState>();
+    const mgr = {
+        add: (opts: GlobeModelOptions): string => {
+            const id = `gm${seq++}`;
+            imports++;
+            added.push({ id, opts });
+            states.set(id, {
+                url: opts.url,
+                lat: opts.lat,
+                lon: opts.lon,
+                altitude: opts.altitude ?? 0,
+                altitudeMode: opts.altitudeMode ?? "terrain",
+                rotation: {
+                    x: opts.rotation?.x ?? 0,
+                    y: opts.rotation?.y ?? 0,
+                    z: opts.rotation?.z ?? 0,
+                },
+                scaling: {
+                    x: opts.scaling?.x ?? 1,
+                    y: opts.scaling?.y ?? 1,
+                    z: opts.scaling?.z ?? 1,
+                },
+                enabled: opts.enabled ?? true,
+                gravity: opts.gravity ?? true,
+                loaded: true,
+                elevationResolved: (opts.altitudeMode ?? "terrain") === "absolute",
+                animationNames: ["walk"],
+            });
+            return id;
+        },
+        get: (id: string): GlobeModelState | null => states.get(id) ?? null,
+        update: (id: string, partial: GlobeModelUpdate): void => {
+            const s = states.get(id);
+            if (!s) return;
+            if (partial.lat !== undefined) s.lat = partial.lat;
+            if (partial.lon !== undefined) s.lon = partial.lon;
+            if (partial.altitude !== undefined) s.altitude = partial.altitude;
+            if (partial.altitudeMode !== undefined) s.altitudeMode = partial.altitudeMode;
+            if (partial.scaling !== undefined) {
+                s.scaling = {
+                    x: partial.scaling.x ?? s.scaling.x,
+                    y: partial.scaling.y ?? s.scaling.y,
+                    z: partial.scaling.z ?? s.scaling.z,
+                };
+            }
+            if (partial.enabled !== undefined) s.enabled = partial.enabled;
+        },
+        remove: (id: string): void => {
+            removed.push(id);
+            states.delete(id);
+        },
+        setEnabled: (id: string, enabled: boolean): void => {
+            const s = states.get(id);
+            if (s) s.enabled = enabled;
+        },
+        list: (): readonly string[] => Array.from(states.keys()),
+        playAnimation: (): void => {},
+        stopAnimation: (): void => {},
+        tick: (): void => {},
+        dispose: (): void => {
+            disposedFlag = true;
+        },
+    } as unknown as GlobeModelManager;
+    return {
+        mgr,
+        added,
+        removed,
+        importCount: () => imports,
+        disposed: () => disposedFlag,
+    };
+};
+
+describe("createGlobeModelManagerAdapter (P4-2 model overlay)", () => {
+    const POS = { lat: 35.681236, lon: 139.767125 };
+
+    it("add/get/list は globe マネージャへ委譲し、既定補完済みハンドルを返す", () => {
+        const stub = makeGlobeModelStub();
+        const m = createGlobeModelManagerAdapter(stub.mgr, () => 100);
+        const h = m.add("human", { url: "a.glb", lat: POS.lat, lon: POS.lon });
+        expect(h.id).toBe("human");
+        expect(h.altitudeMode).toBe("terrain");
+        expect(h.gravity).toBe(true);
+        expect(h.scaling).toEqual({ x: 1, y: 1, z: 1 });
+        expect(h.rotation).toEqual({ x: 0, y: 0, z: 0 });
+        expect(h.elevationResolved).toBe(true);
+        expect(h.animationNames).toEqual(["walk"]);
+        expect(m.get("human")?.id).toBe("human");
+        expect(m.list()).toEqual(["human"]);
+    });
+
+    it("重複 id は throw、lat/lon 範囲外は throw", () => {
+        const stub = makeGlobeModelStub();
+        const m = createGlobeModelManagerAdapter(stub.mgr, () => 1);
+        m.add("a", { url: "a.glb", lat: POS.lat, lon: POS.lon });
+        expect(() => m.add("a", { url: "a.glb", lat: POS.lat, lon: POS.lon })).toThrow(
+            /already exists/,
+        );
+        expect(() => m.add("b", { url: "a.glb", lat: 999, lon: POS.lon })).toThrow();
+    });
+
+    it("absolute は altitude 必須、terrain 未解決なら elevationResolved=false", () => {
+        const stub = makeGlobeModelStub();
+        const m = createGlobeModelManagerAdapter(stub.mgr, () => null);
+        expect(() =>
+            m.add("a", { url: "a.glb", lat: POS.lat, lon: POS.lon, altitudeMode: "absolute" }),
+        ).toThrow(/requires altitude/);
+        const h = m.add("t", { url: "a.glb", lat: POS.lat, lon: POS.lon });
+        expect(h.elevationResolved).toBe(false);
+    });
+
+    it("update は in-place（import 再実行なし）で反映し、ハンドルを返す", () => {
+        const stub = makeGlobeModelStub();
+        const m = createGlobeModelManagerAdapter(stub.mgr, () => 100);
+        m.add("a", { url: "a.glb", lat: POS.lat, lon: POS.lon });
+        const before = stub.importCount();
+        const h = m.update("a", {
+            lat: 36,
+            altitude: 5,
+            scaling: { x: 2, y: 2, z: 2 },
+        });
+        expect(h.lat).toBe(36);
+        expect(h.altitude).toBe(5);
+        expect(h.scaling.x).toBe(2);
+        expect(stub.importCount()).toBe(before); // 再ロードなし
+    });
+
+    it("absolute へ切替える update は altitude 明示が必要", () => {
+        const stub = makeGlobeModelStub();
+        const m = createGlobeModelManagerAdapter(stub.mgr, () => 100);
+        m.add("a", { url: "a.glb", lat: POS.lat, lon: POS.lon });
+        expect(() => m.update("a", { altitudeMode: "absolute" })).toThrow(
+            /requires explicit altitude/,
+        );
+        expect(() =>
+            m.update("a", { altitudeMode: "absolute", altitude: 50 }),
+        ).not.toThrow();
+    });
+
+    it("setEnabled は委譲し、remove/dispose は内部マネージャを破棄しない", () => {
+        const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+        const stub = makeGlobeModelStub();
+        const m = createGlobeModelManagerAdapter(stub.mgr, () => 1);
+        m.add("a", { url: "a.glb", lat: POS.lat, lon: POS.lon });
+        m.setEnabled("a", false);
+        expect(m.get("a")?.enabled).toBe(false);
+        m.remove("a");
+        expect(m.list()).toEqual([]);
+        m.remove("missing");
+        expect(warn).toHaveBeenCalled();
+        m.add("b", { url: "a.glb", lat: POS.lat, lon: POS.lon });
+        m.dispose();
+        expect(stub.disposed()).toBe(false);
+        expect(() => m.add("c", { url: "a.glb", lat: POS.lat, lon: POS.lon })).toThrow(
+            /disposed/,
+        );
         warn.mockRestore();
     });
 });

--- a/tests/globeSceneController.unit.spec.ts
+++ b/tests/globeSceneController.unit.spec.ts
@@ -1119,6 +1119,14 @@ describe("createGlobeModelManagerAdapter (P4-2 model overlay)", () => {
         expect(() => m.add("b", { url: "a.glb", lat: 999, lon: POS.lon })).toThrow();
     });
 
+    it("url 未指定/空文字は throw（planar 契約と整合）", () => {
+        const stub = makeGlobeModelStub();
+        const m = createGlobeModelManagerAdapter(stub.mgr, () => 1);
+        expect(() => m.add("a", { url: "", lat: POS.lat, lon: POS.lon })).toThrow(
+            /url is required/,
+        );
+    });
+
     it("absolute は altitude 必須、terrain 未解決なら elevationResolved=false", () => {
         const stub = makeGlobeModelStub();
         const m = createGlobeModelManagerAdapter(stub.mgr, () => null);

--- a/tests/globeSceneController.unit.spec.ts
+++ b/tests/globeSceneController.unit.spec.ts
@@ -1013,12 +1013,17 @@ const makeGlobeModelStub = (): {
     removed: string[];
     importCount: () => number;
     disposed: () => boolean;
+    playCalls: { id: string; name?: string }[];
+    stopCalls: { id: string; name?: string }[];
+    setLoaded: (id: string, loaded: boolean) => void;
 } => {
     let seq = 0;
     let disposedFlag = false;
     let imports = 0;
     const added: { id: string; opts: GlobeModelOptions }[] = [];
     const removed: string[] = [];
+    const playCalls: { id: string; name?: string }[] = [];
+    const stopCalls: { id: string; name?: string }[] = [];
     const states = new Map<string, GlobeModelState>();
     const mgr = {
         add: (opts: GlobeModelOptions): string => {
@@ -1075,8 +1080,12 @@ const makeGlobeModelStub = (): {
             if (s) s.enabled = enabled;
         },
         list: (): readonly string[] => Array.from(states.keys()),
-        playAnimation: (): void => {},
-        stopAnimation: (): void => {},
+        playAnimation: (id: string, name?: string): void => {
+            playCalls.push({ id, name });
+        },
+        stopAnimation: (id: string, name?: string): void => {
+            stopCalls.push({ id, name });
+        },
         tick: (): void => {},
         dispose: (): void => {
             disposedFlag = true;
@@ -1088,6 +1097,12 @@ const makeGlobeModelStub = (): {
         removed,
         importCount: () => imports,
         disposed: () => disposedFlag,
+        playCalls,
+        stopCalls,
+        setLoaded: (id: string, loaded: boolean): void => {
+            const s = states.get(id);
+            if (s) s.loaded = loaded;
+        },
     };
 };
 
@@ -1182,6 +1197,56 @@ describe("createGlobeModelManagerAdapter (P4-2 model overlay)", () => {
         expect(() => m.add("c", { url: "a.glb", lat: POS.lat, lon: POS.lon })).toThrow(
             /disposed/,
         );
+        warn.mockRestore();
+    });
+
+    it("playAnimation は公開 id・[jpmap-terrain] prefix で warn し、条件を満たすときのみ委譲する", () => {
+        const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+        const stub = makeGlobeModelStub();
+        const m = createGlobeModelManagerAdapter(stub.mgr, () => 1);
+        m.add("human", { url: "a.glb", lat: POS.lat, lon: POS.lon });
+        const gid = stub.added[0].id;
+
+        // 未ロード時は warn して委譲しない（公開 id を含む）。
+        stub.setLoaded(gid, false);
+        m.playAnimation("human", "walk");
+        expect(warn).toHaveBeenCalledWith(
+            '[jpmap-terrain] playModelAnimation: model "human" is not loaded yet',
+        );
+        expect(stub.playCalls).toHaveLength(0);
+
+        // 名前不一致は warn して委譲しない。
+        stub.setLoaded(gid, true);
+        m.playAnimation("human", "missing");
+        expect(warn).toHaveBeenCalledWith(
+            '[jpmap-terrain] playModelAnimation: animation "missing" not found in model "human"',
+        );
+        expect(stub.playCalls).toHaveLength(0);
+
+        // 条件を満たせば内部 gid で委譲する。
+        m.playAnimation("human", "walk");
+        expect(stub.playCalls).toEqual([{ id: gid, name: "walk" }]);
+        warn.mockRestore();
+    });
+
+    it("stopAnimation は未ロード/名前不一致では委譲せず warn もしない", () => {
+        const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+        const stub = makeGlobeModelStub();
+        const m = createGlobeModelManagerAdapter(stub.mgr, () => 1);
+        m.add("human", { url: "a.glb", lat: POS.lat, lon: POS.lon });
+        const gid = stub.added[0].id;
+
+        stub.setLoaded(gid, false);
+        m.stopAnimation("human");
+        expect(stub.stopCalls).toHaveLength(0);
+
+        stub.setLoaded(gid, true);
+        m.stopAnimation("human", "missing");
+        expect(stub.stopCalls).toHaveLength(0);
+
+        m.stopAnimation("human", "walk");
+        expect(stub.stopCalls).toEqual([{ id: gid, name: "walk" }]);
+        expect(warn).not.toHaveBeenCalled();
         warn.mockRestore();
     });
 });


### PR DESCRIPTION
## 概要
Issue #275 Phase 4 / **P4-2（model）**。model デモを `?terrainEngine=globe|planar` でグローブバックエンド（#350 / P4-0）へ切替え可能にします。Closes #361 / Refs #275 #349

グローブでは 3D モデルを lat/lon に接地し、ローカル +Y を地心 up へ向けて起立させ、terrain-follow を pick 非依存標高クエリ（`globeTileManager.terrainElevAt`）で行います。

## 変更内容
- **`globeModelManager`**: 公開 `ModelManager` 相当へ parity 拡張。
  - in-place `update` / `get` / `list`（メッシュ再ロードなし）
  - `altitudeMode`（`terrain` / `absolute`）と `gravity`（地表追従）
  - per-axis `scaling` / フル Euler `rotation`（地心 up 起立に局所 pitch/roll を合成）
  - animation の保持と `playAnimation` / `stopAnimation`、`animationStartMode: NONE` 抑止
  - 毎フレーム駆動を `update()` → `tick()` にリネーム
- **`globeSceneController`**: `createGlobeModelManagerAdapter`（public id ↔ 内部 id、`ModelHandle` 組立、planar 契約のバリデーション）を追加し `getModelManager()` を公開。
- **`default`**: `DefaultSceneController` に `getModelManager?()` を追加。
- **`jpmapTerrain`**: globe 分岐で `_modelManager` を配線。
- **`demos/model`**: `resolveTerrainEngine` を opts に配線。
- **`demos/geospatial`**: 旧 `scale` → `scaling` へ移行。

## 影響範囲
- 挙動: `terrainEngine` 未指定 / `planar` は従来どおり。`?terrainEngine=globe` で地球儀バックエンド上に human モデルを接地。地面クリック移動・方位/スケールスライダー・フォーマット切替・モデル位置へ移動が globe で動作。
- 公開 API（`addModel`/`updateModel`/...）のシグネチャ・契約は不変。

## 検証
- `npm run lint` ✓ / `npm run typecheck` ✓
- `npm run test:unit` ✓（1221 passed、model 関連テスト追加）
- `npm run test:visuals` ✓（19 passed、回帰なし）
- `npm run build:dev` ✓（globe は動的 import で別チャンク）

## AIレビュー
- code-review エージェントで AGENTS.md Coding Rules 観点でレビュー実施。CRITICAL/HIGH なし。
- LOW 2 件（planar parity 乖離: 未ロード時 `elevationResolved` / `animationStartMode`）は本 PR で対応済み。

## 目視確認（HITL）
- `npm start` → model を `?terrainEngine=globe` で開き、接地・起立 / 地面クリック移動 / 方位・スケール変更 / フォーマット切替（glb/obj/stl）/ モデル位置へ移動を確認 → **承認済み**。
