### PR TITLE
feat(demos): avatar を terrainEngine=globe で起動可能に配線 (P4-2)

### DIFF
--- a/src/demos/avatar/index.ts
+++ b/src/demos/avatar/index.ts
@@ -12,12 +12,14 @@
  * - 地形追従（`altitudeMode: "terrain"`, `gravity: true`）
  * - 半径・速度のスライダー操作
  * - アニメーション開始/停止トグル
+ * - 地形バックエンド: `?terrainEngine=globe|planar`（既定 planar, #275 Phase 4 / P4-2）
  */
 import { JpmapTerrain } from "../../lib/jpmapTerrain";
 import type { JpmapTerrainOptions, TerrainClickEvent } from "../../lib/types";
 import {
     parseCameraStateFromUrl,
     parseMapTypeFromUrl,
+    resolveTerrainEngine,
 } from "../../terrain/urlState";
 import { circularOrbitPosition, circularOrbitHeading } from "./orbit";
 import humanWalkGlbUrl from "../../../assets/human_walk.glb";
@@ -50,9 +52,11 @@ const start = async (): Promise<void> => {
 
     const camera = parseCameraStateFromUrl(location.href);
     const mapType = parseMapTypeFromUrl(location.href);
+    const terrainEngine = resolveTerrainEngine(location.search);
 
     const opts: JpmapTerrainOptions = {
         engine: resolveEngine(location.search),
+        ...(terrainEngine ? { terrainEngine } : {}),
         lat: camera?.lat ?? TOKYO_STATION.lat,
         lon: camera?.lon ?? TOKYO_STATION.lon,
         altitude: camera?.altitude ?? 500,


### PR DESCRIPTION
## 概要
Issue #275 Phase 4 / **P4-2（avatar）**。avatar デモを `?terrainEngine=globe|planar` でグローブバックエンド（#350 / P4-0）へ切替え可能にします。既定は従来どおり planar。Closes #363 / Refs #275 #349

model（#362）で globe 対応済みの Model 公開 API（`addModel`/`updateModel`/`getModel`/`playModelAnimation`/`stopModelAnimation`）と pick 非依存標高を再利用し、デモ側の配線のみで対応しています。

## 変更内容
- **`demos/avatar`**: `resolveTerrainEngine` を opts に配線（model/viewer と同一パターン）。ヘッダ JSDoc に `?terrainEngine=globe|planar` を追記。

## 影響範囲
- 挙動: `terrainEngine` 未指定 / `planar` は従来どおり。`?terrainEngine=globe` で地球儀バックエンド上に human_walk を接地・起立し、円軌道移動・進行方向回転・歩行アニメ・スライダー・トグル・中心へ移動が動作。
- 公開 API のシグネチャ・契約は不変。

## 検証
- `npm run lint` ✓ / `npm run typecheck` ✓
- `npm run test:unit` ✓（1226 passed）
- `npm run test:visuals` 18 passed / 1 failed（`timelapseBackLink` は main でも失敗する既存 flake であり avatar 変更と無関係なことを確認済み）

## AIレビュー
- AGENTS.md Coding Rules 観点でレビュー実施。CRITICAL/HIGH なし。型/未使用import/デバッグログ/console 文字列いずれも問題なし。

## 目視確認（HITL）
- `npm start` → avatar を `?terrainEngine=globe` で開き、接地・起立 / 地面クリックで円軌道中心移動 / 進行方向回転 / 歩行アニメ / 半径・速度スライダー / 開始停止 / 中心へ移動を確認 → **承認済み**。
