### PR TITLE
feat(demos): boids を terrainEngine=globe で起動可能に配線 (P4-2)

### DIFF
--- a/public/boids.html
+++ b/public/boids.html
@@ -125,10 +125,6 @@
         <span class="label">リージョン中心</span>
         <span class="value" id="region-center">-</span>
       </div>
-      <div class="info-row">
-        <span class="label">アバター数</span>
-        <span class="value" id="boid-count-display">20</span>
-      </div>
       <div>
         <div class="info-row">
           <label for="boid-count-slider" style="font-size: 11px; color: #e0e4ea;">アバター数</label>

--- a/src/demos/boids/index.ts
+++ b/src/demos/boids/index.ts
@@ -7,12 +7,14 @@
  * - Model API (`addModel` / `updateModel` / `playModelAnimation`) を使用
  * - Polygon API (`addPolygon`, `closed: true`) でリージョン境界を描画
  * - 地形追従 (`altitudeMode: "terrain"`, `gravity: true`)
+ * - 地形バックエンド: `?terrainEngine=globe|planar`（既定 planar, #275 Phase 4 / P4-2）
  */
 import { JpmapTerrain } from "../../lib/jpmapTerrain";
 import type { JpmapTerrainOptions } from "../../lib/types";
 import {
     parseCameraStateFromUrl,
     parseMapTypeFromUrl,
+    resolveTerrainEngine,
 } from "../../terrain/urlState";
 import {
     type BoidState,
@@ -52,10 +54,12 @@ const start = async (): Promise<void> => {
 
     const camera = parseCameraStateFromUrl(location.href);
     const mapType = parseMapTypeFromUrl(location.href);
+    const terrainEngine = resolveTerrainEngine(location.search);
     const region = DEFAULT_REGION;
 
     const opts: JpmapTerrainOptions = {
         engine: resolveEngine(location.search),
+        ...(terrainEngine ? { terrainEngine } : {}),
         lat: camera?.lat ?? region.centerLat,
         lon: camera?.lon ?? region.centerLon,
         altitude: camera?.altitude ?? 800,
@@ -188,7 +192,6 @@ const start = async (): Promise<void> => {
 
     // --- UI 要素の取得 ---
     const regionCenterDisplay = document.getElementById("region-center") as HTMLSpanElement | null;
-    const boidCountDisplay = document.getElementById("boid-count-display") as HTMLSpanElement | null;
     const boidCountValue = document.getElementById("boid-count-value") as HTMLSpanElement | null;
     const boidCountSlider = document.getElementById("boid-count-slider") as HTMLInputElement | null;
     const togglePauseBtn = document.getElementById("toggle-pause") as HTMLButtonElement | null;
@@ -200,7 +203,6 @@ const start = async (): Promise<void> => {
             regionCenterDisplay.textContent =
                 `${region.centerLat.toFixed(4)}, ${region.centerLon.toFixed(4)}`;
         }
-        if (boidCountDisplay) boidCountDisplay.textContent = `${boidCount}`;
         if (boidCountValue) boidCountValue.textContent = `${boidCount}`;
     };
     updateDisplay();


### PR DESCRIPTION
## 概要

Issue #275 Phase 4 / **P4-2（boids）**。Boids フロッキングデモ（`src/demos/boids/`）を `?terrainEngine=globe|planar` でグローブバックエンド（#350 / P4-0）へ切替え可能に配線。既定は従来どおり planar。

avatar(#363) / model(#361) と同型の `resolveTerrainEngine` 配線（最小差分）。

## 変更内容

- `src/demos/boids/index.ts`: `resolveTerrainEngine` を import し `opts` に条件付きで `terrainEngine` を渡す。doc コメント更新。
- `public/boids.html` + `index.ts`: パネルの「アバター数」表示が2つ重複していたため、スライダー側の表示に一本化（未使用になった `boid-count-display` 参照を除去）。

## 影響範囲

- 描画系デモのみ。公開 API・型の変更なし。
- `terrainEngine` 未指定 / `planar` は従来挙動を維持（回帰なし）。

## 確認

- `npm run lint` / `npm run typecheck` / `npm run test:unit`(1226 passed) 通過
- `npm run test:visuals`(19 passed) 通過（boids 配線変更前に実行）
- globe / planar の目視確認（HITL）通過

Closes #365
Refs #275 #349
