### PR TITLE
feat(globe): timelapse の太陽ライティング統合と地球による画素単位の遮蔽 (#368)

### DIFF
--- a/src/demos/timelapse/clockOverlay.ts
+++ b/src/demos/timelapse/clockOverlay.ts
@@ -23,7 +23,8 @@ export interface ClockAngles {
  */
 export const longitudeToOffsetMs = (lonDeg: number): number => {
     if (!Number.isFinite(lonDeg)) return 0;
-    const normalized = (((lonDeg + 180) % 360) + 360) % 360 - 180;
+    // (-180, 180] へ正規化する（経度 180° は -180° へ折り返さず +180° = UTC+12 とする）。
+    const normalized = 180 - ((((180 - lonDeg) % 360) + 360) % 360);
     // 1° = 24h/360 = 240000 ms。
     return normalized * 240000;
 };

--- a/src/demos/timelapse/clockOverlay.ts
+++ b/src/demos/timelapse/clockOverlay.ts
@@ -31,10 +31,12 @@ export const longitudeToOffsetMs = (lonDeg: number): number => {
 
 /** UTC オフセット (ms) を `UTC±H[:MM]` 形式のラベルへ整形する。 */
 export const formatUtcOffsetLabel = (offsetMs: number): string => {
-    const sign = offsetMs < 0 ? "-" : "+";
-    const totalMin = Math.round(Math.abs(offsetMs) / 60000);
-    const h = Math.floor(totalMin / 60);
-    const m = totalMin % 60;
+    // 符号は丸め後の分で判定する。-1ms のような「ほぼ 0 の負値」でも totalMin=0 なら UTC+0 に正規化する。
+    const totalMin = Math.round(offsetMs / 60000);
+    const sign = totalMin < 0 ? "-" : "+";
+    const absMin = Math.abs(totalMin);
+    const h = Math.floor(absMin / 60);
+    const m = absMin % 60;
     return m === 0
         ? `UTC${sign}${h}`
         : `UTC${sign}${h}:${String(m).padStart(2, "0")}`;

--- a/src/demos/timelapse/clockOverlay.ts
+++ b/src/demos/timelapse/clockOverlay.ts
@@ -16,8 +16,28 @@ export interface ClockAngles {
     minuteDeg: number;
 }
 
-/** JST (UTC+9) のオフセット (ms) */
-const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+/**
+ * 経度 [deg] から地方平均太陽時のUTCオフセット (ms) を導出する。
+ * 経度 15° ごとに 1 時間（= 経度 1° あたり 4 分）。これにより太陽の南中（経線通過）が
+ * おおよそ地方時の正午に一致する。経度は (-180, 180] に正規化する。
+ */
+export const longitudeToOffsetMs = (lonDeg: number): number => {
+    if (!Number.isFinite(lonDeg)) return 0;
+    const normalized = (((lonDeg + 180) % 360) + 360) % 360 - 180;
+    // 1° = 24h/360 = 240000 ms。
+    return normalized * 240000;
+};
+
+/** UTC オフセット (ms) を `UTC±H[:MM]` 形式のラベルへ整形する。 */
+export const formatUtcOffsetLabel = (offsetMs: number): string => {
+    const sign = offsetMs < 0 ? "-" : "+";
+    const totalMin = Math.round(Math.abs(offsetMs) / 60000);
+    const h = Math.floor(totalMin / 60);
+    const m = totalMin % 60;
+    return m === 0
+        ? `UTC${sign}${h}`
+        : `UTC${sign}${h}:${String(m).padStart(2, "0")}`;
+};
 
 /**
  * `Date` から各針の角度を算出する純粋関数。
@@ -25,20 +45,23 @@ const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
  * - 時針は分に応じて連続的に回転する（12 時間で 360°）。
  * - 分針は秒に応じて連続的に回転する（60 分で 360°）。
  *
- * 表示は日本標準時 (JST = UTC+9) 基準。シミュレーション時刻は UTC で保持されるため、
- * ここで +9h オフセットを加えてから UTC ゲッタで分解する。
+ * `offsetMs` は表示先タイムゾーンのUTCオフセット (ms)。シミュレーション時刻は UTC で保持される
+ * ため、ここで `offsetMs` を加えてから UTC ゲッタで分解する（既定 0 = UTC）。
  *
  * `Invalid Date` が渡された場合は 0° を返す（呼び出し側でフォールバック値を期待しないよう注意）。
  */
-export const computeClockAngles = (date: Date): ClockAngles => {
+export const computeClockAngles = (
+    date: Date,
+    offsetMs = 0,
+): ClockAngles => {
     if (Number.isNaN(date.getTime())) {
         return { hourDeg: 0, minuteDeg: 0 };
     }
-    const jst = new Date(date.getTime() + JST_OFFSET_MS);
-    const ms = jst.getUTCMilliseconds();
-    const s = jst.getUTCSeconds() + ms / 1000;
-    const m = jst.getUTCMinutes() + s / 60;
-    const h = (jst.getUTCHours() % 12) + m / 60;
+    const local = new Date(date.getTime() + offsetMs);
+    const ms = local.getUTCMilliseconds();
+    const s = local.getUTCSeconds() + ms / 1000;
+    const m = local.getUTCMinutes() + s / 60;
+    const h = (local.getUTCHours() % 12) + m / 60;
     return {
         hourDeg: h * 30, // 360 / 12
         minuteDeg: m * 6, // 360 / 60
@@ -46,14 +69,16 @@ export const computeClockAngles = (date: Date): ClockAngles => {
 };
 
 /**
- * シミュレーション時刻の表示用ラベル（HH:MM JST）を整形する。
+ * シミュレーション時刻の表示用ラベル（`HH:MM UTC±H`）を整形する。
+ * `offsetMs` は表示先タイムゾーンのUTCオフセット (ms、既定 0 = UTC)。
  */
-export const formatClockLabel = (date: Date): string => {
-    if (Number.isNaN(date.getTime())) return "--:-- JST";
-    const jst = new Date(date.getTime() + JST_OFFSET_MS);
-    const hh = String(jst.getUTCHours()).padStart(2, "0");
-    const mm = String(jst.getUTCMinutes()).padStart(2, "0");
-    return `${hh}:${mm} JST`;
+export const formatClockLabel = (date: Date, offsetMs = 0): string => {
+    const offsetLabel = formatUtcOffsetLabel(offsetMs);
+    if (Number.isNaN(date.getTime())) return `--:-- ${offsetLabel}`;
+    const local = new Date(date.getTime() + offsetMs);
+    const hh = String(local.getUTCHours()).padStart(2, "0");
+    const mm = String(local.getUTCMinutes()).padStart(2, "0");
+    return `${hh}:${mm} ${offsetLabel}`;
 };
 
 const SVG_NS = "http://www.w3.org/2000/svg";
@@ -101,8 +126,8 @@ export const renderClockSvg = (angles: ClockAngles): string =>
 
 /** マウント済みクロックを更新するためのハンドル。 */
 export interface ClockHandle {
-    /** シミュレーション時刻に基づき針位置を更新する */
-    update(date: Date): void;
+    /** シミュレーション時刻と表示先UTCオフセット (ms) に基づき針位置・ラベルを更新する */
+    update(date: Date, offsetMs?: number): void;
 }
 
 /**
@@ -155,8 +180,8 @@ export const mountClock = (
     svg.appendChild(center);
 
     return {
-        update(date: Date): void {
-            const angles = computeClockAngles(date);
+        update(date: Date, offsetMs = 0): void {
+            const angles = computeClockAngles(date, offsetMs);
             hourHand.setAttribute(
                 "transform",
                 `rotate(${angles.hourDeg} 50 50)`,
@@ -165,7 +190,7 @@ export const mountClock = (
                 "transform",
                 `rotate(${angles.minuteDeg} 50 50)`,
             );
-            if (labelEl) labelEl.textContent = formatClockLabel(date);
+            if (labelEl) labelEl.textContent = formatClockLabel(date, offsetMs);
         },
     };
 };

--- a/src/demos/timelapse/index.ts
+++ b/src/demos/timelapse/index.ts
@@ -9,7 +9,8 @@
  * - `?engine=webgpu|webgl|webgl2`（既存と互換）
  * - `?terrainEngine=globe|planar`（既定 planar, #275 Phase 4 / P4-1。globe では太陽方向が時刻追従する）
  * - `?lat=`, `?lon=` 等のカメラ初期値（viewer デモと共通の `parseCameraStateFromUrl`）
- * - `?start=<ISO8601>`: シミュレーション開始時刻（UTC として解釈）
+ * - `?start=<ISO8601>`: シミュレーション開始時刻（タイムゾーン無指定は UTC として解釈。`+09:00` の
+ *   ような正オフセットは URL では `%2B09:00` とエンコードするか、`Z` 付き UTC を推奨）
  * - `?speed=<秒>`: 24h を何秒に圧縮するか（0 以下は 60s にフォールバック）
  * - `?paused` または `?paused=true`: 一時停止（テスト用）
  *
@@ -27,7 +28,7 @@ import {
     createUrlUpdater,
     resolveTerrainEngine,
 } from "../../terrain/urlState";
-import { mountClock } from "./clockOverlay";
+import { longitudeToOffsetMs, mountClock } from "./clockOverlay";
 import {
     computeSimulatedDate,
     parseTimelapseQuery,
@@ -156,11 +157,35 @@ const start = async (): Promise<void> => {
 
     const viewer = await JpmapTerrain.create(mount, opts);
 
+    // 時計表示は「表示中の地点の地方平均太陽時」を反映する（経度から導出。太陽の南中≒正午）。
+    // カメラの注視点経度に追従させるため、現在経度と最後に表示した時刻を保持する。
+    let currentLon = viewer.lon;
+    let lastDisplayedDate = timelapse.startUtc;
+
+    // 時計オーバーレイをマウント。
+    const clockSvg = document.getElementById(CLOCK_ELEMENT_ID);
+    const clockLabel = document.getElementById(CLOCK_LABEL_ID);
+    let clockHandle: ReturnType<typeof mountClock> | null = null;
+    const refreshClock = (date: Date): void => {
+        lastDisplayedDate = date;
+        clockHandle?.update(date, longitudeToOffsetMs(currentLon));
+    };
+    if (clockSvg instanceof SVGSVGElement) {
+        clockHandle = mountClock(
+            clockSvg,
+            clockLabel instanceof HTMLElement ? clockLabel : null,
+        );
+        refreshClock(timelapse.startUtc);
+    }
+
     // URL 同期: カメラ変化のたびに URL を更新する (Issue #155)。
     // 2D モードでは `@lat,lon,Xz`、3D では `@lat,lon,altitude,azimuth,tilt` (#254)。
     // 既存クエリ（?engine=, ?start=, ?speed= など）は `createUrlUpdater` 内で保持される。
+    // あわせて注視点経度を更新し、時計の地方時表示を追従させる（停止中のパンでも反映）。
     const urlUpdater = createUrlUpdater(200);
-    viewer.onCameraChange((event) =>
+    viewer.onCameraChange((event) => {
+        currentLon = event.lon;
+        refreshClock(lastDisplayedDate);
         urlUpdater({
             lat: event.lat,
             lon: event.lon,
@@ -168,20 +193,8 @@ const start = async (): Promise<void> => {
             azimuth: event.azimuth,
             tilt: event.tilt,
             zoomLevel: event.zoomLevel,
-        }),
-    );
-
-    // 時計オーバーレイをマウント。
-    const clockSvg = document.getElementById(CLOCK_ELEMENT_ID);
-    const clockLabel = document.getElementById(CLOCK_LABEL_ID);
-    let clockHandle: ReturnType<typeof mountClock> | null = null;
-    if (clockSvg instanceof SVGSVGElement) {
-        clockHandle = mountClock(
-            clockSvg,
-            clockLabel instanceof HTMLElement ? clockLabel : null,
-        );
-        clockHandle.update(timelapse.startUtc);
-    }
+        });
+    });
 
     // タイムラプスループ。
     const startedAt = performance.now();
@@ -196,7 +209,7 @@ const start = async (): Promise<void> => {
         // setter 連打を避けるため UPDATE_INTERVAL_MS 周期に間引く。
         if (nowMs - lastApplied >= UPDATE_INTERVAL_MS) {
             viewer.dateTime = simulated;
-            clockHandle?.update(simulated);
+            refreshClock(simulated);
             lastApplied = nowMs;
         }
         window.requestAnimationFrame(tick);

--- a/src/demos/timelapse/index.ts
+++ b/src/demos/timelapse/index.ts
@@ -7,6 +7,7 @@
  *
  * URL 規約:
  * - `?engine=webgpu|webgl|webgl2`（既存と互換）
+ * - `?terrainEngine=globe|planar`（既定 planar, #275 Phase 4 / P4-1。globe では太陽方向が時刻追従する）
  * - `?lat=`, `?lon=` 等のカメラ初期値（viewer デモと共通の `parseCameraStateFromUrl`）
  * - `?start=<ISO8601>`: シミュレーション開始時刻（UTC として解釈）
  * - `?speed=<秒>`: 24h を何秒に圧縮するか（0 以下は 60s にフォールバック）
@@ -24,6 +25,7 @@ import {
     parseCameraStateFromUrl,
     parseMapTypeFromUrl,
     createUrlUpdater,
+    resolveTerrainEngine,
 } from "../../terrain/urlState";
 import { mountClock } from "./clockOverlay";
 import {
@@ -43,6 +45,16 @@ const UPDATE_INTERVAL_MS = 200;
  */
 const TIMELAPSE_CAMERA_DEFAULTS = {
     azimuth: 270,
+    tilt: 75,
+} as const;
+
+/**
+ * globe バックエンド用のカメラ初期値。globe（GeospatialCamera）は平面版と方位の符号規約が逆で、
+ * 同じ azimuth では反対方向（西）を向くため、平面版の意図（日の出が正面に見える）を再現するには
+ * 日の出方位（東京の夏至前後で概ね ENE ≒ 65°）を向ける必要がある。tilt は平面版と同じ。
+ */
+const TIMELAPSE_GLOBE_CAMERA_DEFAULTS = {
+    azimuth: 65,
     tilt: 75,
 } as const;
 
@@ -102,6 +114,12 @@ export const resolveEngine = (search: string): EngineType | undefined => {
     return undefined;
 };
 
+/**
+ * `?terrainEngine=` クエリから地形バックエンドを解決する（viewer #352 / model #361 に倣う）。
+ * 実装は `terrain/urlState` に集約し、既存 import 互換のため再 export する（#368 / P4-1）。
+ */
+export { resolveTerrainEngine };
+
 /** `?showSunShadows=false` のときのみ false を返す。それ以外は既定 true。 */
 export const resolveShowSunShadows = (search: string): boolean => {
     const raw = new URLSearchParams(search).get("showSunShadows");
@@ -115,6 +133,7 @@ const start = async (): Promise<void> => {
     }
 
     const engine = resolveEngine(location.search);
+    const terrainEngine = resolveTerrainEngine(location.search);
     const cameraInit = resolveCameraInit(location.href);
     const mapType = parseMapTypeFromUrl(location.href);
     const showSunShadows = resolveShowSunShadows(location.search);
@@ -123,7 +142,10 @@ const start = async (): Promise<void> => {
     const opts: JpmapTerrainOptions = {
         // タイムラプス固有のカメラデフォルト（URLで明示指定された値のみ上書きされる）。
         ...TIMELAPSE_CAMERA_DEFAULTS,
+        // globe では方位規約が逆のため、日の出が正面に見えるよう globe 専用デフォルトで上書きする。
+        ...(terrainEngine === "globe" ? TIMELAPSE_GLOBE_CAMERA_DEFAULTS : {}),
         ...(engine ? { engine } : {}),
+        ...(terrainEngine ? { terrainEngine } : {}),
         ...cameraInit,
         ...(mapType !== null ? { mapType } : {}),
         // タイムラプスでは autoSunPosition は必ず OFF（dateTime を毎フレーム駆動するため）。

--- a/src/demos/timelapse/timelapseClock.ts
+++ b/src/demos/timelapse/timelapseClock.ts
@@ -68,9 +68,36 @@ export const computeSimulatedDate = (
     return new Date(options.startUtc.getTime() + offsetMs);
 };
 
+// 日時部分（`T` 以降に時刻を含む）にタイムゾーン指定（`Z` または `±hh:mm` / `±hhmm`）が
+// 付いているか判定する。
+const HAS_TZ_DESIGNATOR = /T\d{2}:\d{2}.*(Z|[+-]\d{2}:?\d{2})$/;
+// `URLSearchParams` が `+hh:mm` の `+` を空白へデコードした形（`...T09:30:00 09:00`）を捉える。
+const PLUS_OFFSET_AS_SPACE =
+    /^(.*T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?) (\d{2}:?\d{2})$/;
+
+/**
+ * `?start=` の生文字列を `Date` に解釈する。`start` は仕様上 UTC として解釈する（決定的表示）。
+ * - `URLSearchParams` は `application/x-www-form-urlencoded` 規約で `+` を空白へデコードするため、
+ *   `+09:00` のような正のタイムゾーンオフセットが空白に化けて `Invalid Date` になる。日時の後ろに
+ *   ` hh:mm` が続く形を検出し、`+hh:mm` へ復元する（`%2B` で明示エンコードされた場合は既に `+`）。
+ * - タイムゾーン指定（`Z` / `±hh:mm`）が無いベア日時は、ECMAScript では実行環境のローカル時刻として
+ *   解釈され非決定的になる。仕様（UTC 解釈）に合わせて末尾に `Z` を補う。日付のみ（時刻なし）は
+ *   ES 仕様で既に UTC 扱いのため変更しない。
+ * @returns 解釈できた `Date`。空文字や解釈不能なら `undefined`。
+ */
+export const parseStartDate = (raw: string): Date | undefined => {
+    let s = raw.trim();
+    if (s === "") return undefined;
+    const spaceOffset = PLUS_OFFSET_AS_SPACE.exec(s);
+    if (spaceOffset) s = `${spaceOffset[1]}+${spaceOffset[2]}`;
+    if (s.includes("T") && !HAS_TZ_DESIGNATOR.test(s)) s = `${s}Z`;
+    const d = new Date(s);
+    return Number.isNaN(d.getTime()) ? undefined : d;
+};
+
 /**
  * URL クエリ文字列からタイムラプス設定を解決する。
- * - `?start=` ISO 8601。失敗時は本日 0 時 (UTC)
+ * - `?start=` ISO 8601（タイムゾーン無指定は UTC として解釈）。失敗時は本日 0 時 (UTC)
  * - `?speed=` 数値秒（24h を何秒で再生するか）。0 以下や NaN は 60s にフォールバック
  * - `?paused`（値なし）または `?paused=true` で停止
  */
@@ -85,8 +112,7 @@ export const parseTimelapseQuery = (
     let startUtc: Date | undefined;
     const startRaw = params.get("start");
     if (startRaw !== null) {
-        const d = new Date(startRaw);
-        if (!Number.isNaN(d.getTime())) startUtc = d;
+        startUtc = parseStartDate(startRaw);
     }
     if (!startUtc) {
         // 当日 0 時 UTC を既定値にする（決定的な見やすい初期表示）。

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -566,11 +566,17 @@ export class GlobeScene {
         // 広域ズームでは地球が深度バッファへ寄与せず、太陽メッシュ（後段）が地球の裏側にあっても深度
         // テストで隠れない。そこで「色を書かず深度のみ書く」ソリッド楕円体を地球と同位置に重ね、太陽を
         // 地球シルエットで画素単位に遮蔽する（地球の縁(limb)で太陽ディスクが滑らかに欠ける）。
-        // 色を書かない（disableColorWrite）ので地形/オーバーレイ/背景球の見た目は不変。海面より沈めた
-        // earthSink により地形/オーバーレイ（手前）を深度で誤って棄却しない（背景球と同じ #335 の保険）。
-        // 同一レンダリンググループ（RG_BACKGROUND）内では不透明メッシュはマテリアルの uniqueId 昇順で
-        // 描画される（Babylon PainterSortCompare）。この occluder のマテリアルを太陽メッシュより先に
-        // 生成することで occluder が先に深度を書き、続く太陽が深度テストで正しく遮蔽される。
+        // 色を書かない（disableColorWrite）ので見た目は不変。太陽メッシュと同じく地形と同一グループ
+        // （RG_BACKGROUND）に置くことが重要で、これにより低高度では実際の地形タイル（深度を書く LOD）が
+        // 太陽を遮蔽し、太陽が地面の手前へ突き抜けて見えるのを防ぐ。広域ズームでは地形タイルが深度を
+        // 書かない（ベースレイヤ）ため、このオクルーダが地球シルエットを供給する。
+        // オクルーダ深度が背景球・ベースレイヤ（同じ半径・深度非書き込み）と等深度で争い、広域ズームの
+        // 低い深度精度で z-fighting（背景の青球がチラつく / #335）するのを防ぐため、zOffset でオクルーダの
+        // 深度をわずかに奥へバイアスする。これにより背景球/ベースレイヤが常に手前に描かれて勝つ（チラつき
+        // 解消）一方、はるか遠方（far クリップ手前）の太陽より十分手前に留まるため遮蔽は維持される。
+        // RG_BACKGROUND 内では不透明メッシュはマテリアルの uniqueId 昇順で描画される（Babylon
+        // PainterSortCompare）。この occluder のマテリアルを太陽メッシュより先に生成することで occluder が
+        // 先に深度を書き、続く太陽が深度テストで正しく遮蔽される。
         const sunOccluder = CreateSphere(
             "globe-sun-occluder",
             { diameter: 2, segments: 128 },
@@ -584,6 +590,8 @@ export class GlobeScene {
         sunOccluderMat.backFaceCulling = true;
         // 色は一切書かず深度のみ書く（不可視のオクルーダ）。depthWrite は既定で有効。
         sunOccluderMat.disableColorWrite = true;
+        // 等深度の背景球/ベースレイヤより確実に「奥」に居させ z-fighting を避ける（上記コメント参照）。
+        sunOccluderMat.zOffset = 8;
         sunOccluder.material = sunOccluderMat;
 
         // 太陽メッシュ（#368 / P4-1）。発光する球を planar 同様に infiniteDistance で配置する。
@@ -593,6 +601,9 @@ export class GlobeScene {
         // 座標リベースに影響されずカメラ相対で常に太陽方向の空へ描画される。地球による遮蔽は上記
         // occluder の深度で画素単位に処理する。時刻連動の位置/スケール/表示は globeSceneController。
         // occluder と同じ RG_BACKGROUND に置き、マテリアルは occluder より後に生成する（描画順を保証）。
+        // 太陽は地形と同一グループの共有深度で描かれるため、occluder（地球シルエット）と実際の地形タイル
+        // （深度を書く LOD）の双方に画素単位で遮蔽される。マーカー等（group 1）は太陽より後に描かれるので
+        // 常に太陽の手前に表示される。
         const sunMesh = CreateSphere(
             "globe-sun-mesh",
             { diameter: 1, segments: 12 },

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -26,6 +26,7 @@ import {
 import { GeospatialClippingBehavior } from "@babylonjs/core/Behaviors/Cameras/geospatialClippingBehavior";
 import { Wgs84Ellipsoid } from "@babylonjs/core/Maths/math.geospatial.functions";
 import { CreateSphere } from "@babylonjs/core/Meshes/Builders/sphereBuilder";
+import type { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
 import { PickingInfo } from "@babylonjs/core/Collisions/pickingInfo";
 
@@ -259,6 +260,12 @@ export interface GlobeSceneController {
     circleManager: GlobeCircleManager;
     /** グローブ用モデル（Phase 3）。glb/gltf を接地し地心 up へ起立。 */
     modelManager: GlobeModelManager;
+    /** 太陽光（指向性ライト）。時刻連動の太陽方向駆動（#368 / P4-1）に用いる。 */
+    sunLight: DirectionalLight;
+    /** 環境光（半球ライト）。昼夜係数で強度を補間する（#368 / P4-1）。 */
+    hemiLight: HemisphericLight;
+    /** 太陽メッシュ（発光球）。時刻連動で太陽方向に配置・表示する（#368 / P4-1）。 */
+    sunMesh: Mesh;
     /**
      * 地形クリック購読（pick 非依存・floating origin 対応）。クリック地点の緯度経度・標高を
      * リスナーへ通知する。戻り値で購読解除する。
@@ -553,6 +560,54 @@ export class GlobeScene {
         // 依存しない（#335）。海面より僅かに沈めた earthSink は、深度等値での取り合いを避ける保険。
         earthMat.disableDepthWrite = true;
         earth.material = earthMat;
+
+        // ---- 太陽メッシュ遮蔽用の深度オンリー楕円体（#368 / P4-1） ----
+        // 背景球・ベースレイヤは深度を書かない（disableDepthWrite, 上記 / globeTileManager）ため、
+        // 広域ズームでは地球が深度バッファへ寄与せず、太陽メッシュ（後段）が地球の裏側にあっても深度
+        // テストで隠れない。そこで「色を書かず深度のみ書く」ソリッド楕円体を地球と同位置に重ね、太陽を
+        // 地球シルエットで画素単位に遮蔽する（地球の縁(limb)で太陽ディスクが滑らかに欠ける）。
+        // 色を書かない（disableColorWrite）ので地形/オーバーレイ/背景球の見た目は不変。海面より沈めた
+        // earthSink により地形/オーバーレイ（手前）を深度で誤って棄却しない（背景球と同じ #335 の保険）。
+        // 同一レンダリンググループ（RG_BACKGROUND）内では不透明メッシュはマテリアルの uniqueId 昇順で
+        // 描画される（Babylon PainterSortCompare）。この occluder のマテリアルを太陽メッシュより先に
+        // 生成することで occluder が先に深度を書き、続く太陽が深度テストで正しく遮蔽される。
+        const sunOccluder = CreateSphere(
+            "globe-sun-occluder",
+            { diameter: 2, segments: 128 },
+            scene,
+        );
+        sunOccluder.scaling.copyFrom(earth.scaling);
+        sunOccluder.isPickable = false;
+        sunOccluder.renderingGroupId = RG_BACKGROUND;
+        const sunOccluderMat = new StandardMaterial("globe-sun-occluder-mat", scene);
+        sunOccluderMat.disableLighting = true;
+        sunOccluderMat.backFaceCulling = true;
+        // 色は一切書かず深度のみ書く（不可視のオクルーダ）。depthWrite は既定で有効。
+        sunOccluderMat.disableColorWrite = true;
+        sunOccluder.material = sunOccluderMat;
+
+        // 太陽メッシュ（#368 / P4-1）。発光する球を planar 同様に infiniteDistance で配置する。
+        // infiniteDistance 有効時、Babylon は毎フレーム mesh.position にカメラのワールド位置を
+        // 加算してワールド位置を決める（transformNode: position + cameraWorldPosition）。
+        // よって mesh.position に太陽方向ベクトル×距離を設定すれば、floating origin の
+        // 座標リベースに影響されずカメラ相対で常に太陽方向の空へ描画される。地球による遮蔽は上記
+        // occluder の深度で画素単位に処理する。時刻連動の位置/スケール/表示は globeSceneController。
+        // occluder と同じ RG_BACKGROUND に置き、マテリアルは occluder より後に生成する（描画順を保証）。
+        const sunMesh = CreateSphere(
+            "globe-sun-mesh",
+            { diameter: 1, segments: 12 },
+            scene,
+        );
+        const sunMeshMat = new StandardMaterial("globe-sun-mesh-mat", scene);
+        sunMeshMat.emissiveColor = new Color3(1, 0.95, 0.8);
+        sunMeshMat.disableLighting = true;
+        sunMesh.material = sunMeshMat;
+        sunMesh.isPickable = false;
+        sunMesh.infiniteDistance = true;
+        sunMesh.renderingGroupId = RG_BACKGROUND;
+        // infiniteDistance 利用時はフラスタムカリングの取りこぼしを避けて常時アクティブ化する。
+        sunMesh.alwaysSelectAsActiveMesh = true;
+        sunMesh.setEnabled(false);
 
         // ---- 地形タイルマネージャ ----
         const tileManager = createGlobeTileManager({
@@ -1577,6 +1632,9 @@ export class GlobeScene {
             polygonManager,
             circleManager,
             modelManager,
+            sunLight: sun,
+            hemiLight: hemi,
+            sunMesh,
             subscribeTerrainClick,
             subscribePolygonPointHover,
             subscribePolygonPointClick,

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -262,7 +262,7 @@ export interface GlobeSceneController {
     modelManager: GlobeModelManager;
     /** 太陽光（指向性ライト）。時刻連動の太陽方向駆動（#368 / P4-1）に用いる。 */
     sunLight: DirectionalLight;
-    /** 環境光（半球ライト）。昼夜係数で強度を補間する（#368 / P4-1）。 */
+    /** 環境光（半球ライト）。強度は時刻に依らず一定（昼夜の境界は指向性ライトの幾何で表現, #368 / P4-1）。 */
     hemiLight: HemisphericLight;
     /** 太陽メッシュ（発光球）。時刻連動で太陽方向に配置・表示する（#368 / P4-1）。 */
     sunMesh: Mesh;

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -73,6 +73,7 @@ import {
     CIRCLE_SEGMENTS_MIN,
     CIRCLE_SEGMENTS_MAX,
     MODEL_DEFAULTS,
+    SUN_FALLBACK_DATETIME_ISO,
 } from "../lib/types";
 import type { GlobeMarkerManager } from "../terrain/geo/globeMarkerManager";
 import type {
@@ -1375,7 +1376,11 @@ export const createGlobeSceneController = (
     // 現在の注視点(lat/lon)を基準に太陽方向(ECEF)を再計算して `globe-sun` ライトへ適用する。
     // 太陽方向は computeSunPosition（平面シーン scenes/default.ts と同じ）で求める。明るさは globe では
     // 時刻に依らず一定で、昼夜の境界は指向性ライトの幾何で表現する（applyGlobeSunState 参照）。
+    // `dateTime` 未指定（null）のときは planar と同様、決定的フォールバック日時
+    // （SUN_FALLBACK_DATETIME_ISO）で太陽位置を計算する。これにより初期化時（既定 dateTime=null）でも
+    // globe / planar の太陽反映が一致する。
     let currentSunDateTime: Date | null = null;
+    const fallbackSunDate = new Date(SUN_FALLBACK_DATETIME_ISO);
     const scratchSunDir = new Vector3();
     let globeShadowsWarned = false;
     // 太陽メッシュの配置: planar 同様に infiniteDistance を利用する。infiniteDistance 有効時、
@@ -1430,9 +1435,9 @@ export const createGlobeSceneController = (
     };
 
     const applyGlobeSunState = (): void => {
-        // 固定モードで dateTime 未指定（null）のときは、初期ライト設定を保持する。
-        if (currentSunDateTime === null) return;
-        if (Number.isNaN(currentSunDateTime.getTime())) {
+        // dateTime 未指定（null）のときは決定的フォールバック日時で計算する（planar と挙動を一致させる）。
+        const dateForCalc = currentSunDateTime ?? fallbackSunDate;
+        if (Number.isNaN(dateForCalc.getTime())) {
             console.warn(
                 "[globeSceneController] sun position computation skipped (invalid dateTime)",
             );
@@ -1442,7 +1447,7 @@ export const createGlobeSceneController = (
         const { altitudeDeg, azimuthDeg } = computeSunPosition(
             latDeg,
             lonDeg,
-            currentSunDateTime,
+            dateForCalc,
         );
         if (!Number.isFinite(altitudeDeg) || !Number.isFinite(azimuthDeg)) {
             console.warn(

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -1456,8 +1456,9 @@ export const createGlobeSceneController = (
             return;
         }
         // 太陽方向(ECEF, 地表→太陽)を求め、指向性ライトには符号反転(太陽→地表)を渡す。
+        // sunLight.direction を in-place 更新し、高頻度呼び出し（timelapse）でのアロケーションを避ける。
         sunDirectionEcefToRef(latDeg, lonDeg, altitudeDeg, azimuthDeg, scratchSunDir);
-        gc.sunLight.direction = scratchSunDir.scale(-1);
+        gc.sunLight.direction.copyFrom(scratchSunDir).scaleInPlace(-1);
         // 明るさは時刻に依らず一定（昼夜の境界は指向性ライトの幾何で生じる。上記コメント参照）。
         // 注視点の昼夜でシーン全体を減光しないことで、地球の裏側の昼領域が一律に暗くなる不自然さを避ける。
         gc.sunLight.intensity = GLOBE_SUN_LIGHT_INTENSITY;

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -17,7 +17,15 @@ import type { Scene } from "@babylonjs/core/scene";
 import type { MapType } from "../terrain/gsiTile";
 import { JAPAN_BOUNDS } from "../terrain/gsiTile";
 import { geodeticToEcef, ecefToGeodetic } from "../terrain/geo/ecef";
-import { uiToYawPitch, yawPitchToUi } from "../terrain/geo/cameraMapping";
+import { sunDirectionEcefToRef } from "../terrain/geo/sunDirectionEcef";
+import { computeSunPosition } from "../terrain/sunPosition";
+import { deriveSunState } from "../terrain/sunState";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { Wgs84Ellipsoid } from "@babylonjs/core/Maths/math.geospatial.functions";
+import {
+    uiToYawPitch,
+    yawPitchToUi,
+} from "../terrain/geo/cameraMapping";
 import { assertLatLonInBounds } from "../terrain/overlayCoords";
 import { resolveIcon, resolveText } from "../terrain/marker";
 import {
@@ -1363,6 +1371,97 @@ export const createGlobeSceneController = (
         camera.center = geodeticToEcef(latDeg, lonDeg, 0);
     };
 
+    // ---- 太陽 / 影（globe ライティング統合, #368 / P4-1） ----
+    // timelapse デモは `dateTime` を毎フレーム駆動し setSunState を連打するため、
+    // 現在の注視点(lat/lon)を基準に太陽方向(ECEF)・昼夜の明るさを再計算して
+    // `globe-sun` / `globe-hemi` ライトへ適用する。平面シーン（scenes/default.ts）の
+    // applySunStateForCurrent と同じ太陽計算（computeSunPosition / deriveSunState）を共有する。
+    let currentSunDateTime: Date | null = null;
+    const scratchSunDir = new Vector3();
+    let globeShadowsWarned = false;
+    // 太陽メッシュの配置: planar 同様に infiniteDistance を利用する。infiniteDistance 有効時、
+    // Babylon は毎フレーム mesh.position にカメラのワールド位置を加算してワールド位置を決めるため
+    // （transformNode: worldTranslation = position + cameraWorldPosition）、ここでは mesh.position に
+    // 「太陽方向ベクトル × 距離 D」を設定するだけでよい。これによりカメラがどこに/どの座標系
+    // （floating origin のリベース後でも）あっても、見かけ方向は常に太陽方向そのものになり、
+    // カメラが動いた次フレームでも自動でカメラ相対に追従する（stale 化しない）。
+    // 太陽メッシュのカメラからの距離 D は遠クリップ面 maxZ（高度追従, GeospatialClippingBehavior）の
+    // 手前に収める。GeospatialClippingBehavior は maxZ = horizonDist + planetRadius*0.1 と設定する
+    // （horizonDist = √(|P|²-R²) = カメラから地平線（地球楕円体への接線）までの距離）。太陽メッシュを
+    // この地平線距離に置くと、太陽が地球の縁(limb)へ回り込んだとき occluder（深度のみ楕円体, globe.ts）
+    // の深度とちょうど接し、地球の裏へ進むほど太陽が occluder より奥になって画素単位に遮蔽される。
+    // D を maxZ*0.5 など近くに置くと limb より内側まで太陽が手前に残り「中央が裏に回るまで見える」
+    // 不自然さになるため、地平線距離（maxZ に近い）を採用する。far クリップ余裕のため maxZ*0.97 で上限。
+    const SUN_PLANET_RADIUS = Wgs84Ellipsoid.semiMajorAxis;
+    const SUN_MESH_MAX_FAR_RATIO = 0.97;
+    // 最後に算出した太陽方向(ECEF, 地表→太陽)と、太陽状態が有効か。距離 D / 見かけサイズは
+    // カメラ（ズーム・高度）に依存するため、dateTime 更新時だけでなく毎フレーム再評価する。
+    const currentSunDirEcef = new Vector3();
+    let sunStateValid = false;
+
+    // 太陽メッシュを現在のカメラ状態に合わせて毎フレーム更新する。
+    // 地球による遮蔽は occluder（深度のみ楕円体, globe.ts）の深度テストが画素単位に行うため、ここでは
+    // 位置（太陽方向 × 地平線距離 D）と見かけサイズ（視角一定）のみを設定する。D=地平線距離により太陽は
+    // 地球の縁から滑らかに欠け、地球の裏側では完全に隠れる（カメラが地表近傍なら「地平線下」、宇宙なら
+    // 「地球の背面」を深度で統一的に扱える）。
+    const placeSunMesh = (): void => {
+        if (!sunStateValid) return;
+        gc.sunMesh.setEnabled(true);
+        // maxZ = 地平線距離 + R*0.1 なので、地平線距離 = maxZ - R*0.1。far クリップに太陽ディスクが
+        // 触れないよう maxZ*0.97 を上限にクランプする。
+        const horizonDist = camera.maxZ - SUN_PLANET_RADIUS * 0.1;
+        const sunDist = Math.max(
+            1,
+            Math.min(horizonDist, camera.maxZ * SUN_MESH_MAX_FAR_RATIO),
+        );
+        gc.sunMesh.position.copyFrom(currentSunDirEcef).scaleInPlace(sunDist);
+        // 見かけの大きさ（視角）を一定に保つため、カメラからの距離（= sunDist）に比例させる。
+        const meshScale = sunDist * 0.04;
+        gc.sunMesh.scaling.set(meshScale, meshScale, meshScale);
+    };
+
+    const applyGlobeSunState = (): void => {
+        // 固定モードで dateTime 未指定（null）のときは、初期ライト設定を保持する。
+        if (currentSunDateTime === null) return;
+        if (Number.isNaN(currentSunDateTime.getTime())) {
+            console.warn(
+                "[globeSceneController] sun position computation skipped (invalid dateTime)",
+            );
+            return;
+        }
+        const { latDeg, lonDeg } = currentGeodetic();
+        const { altitudeDeg, azimuthDeg } = computeSunPosition(
+            latDeg,
+            lonDeg,
+            currentSunDateTime,
+        );
+        if (!Number.isFinite(altitudeDeg) || !Number.isFinite(azimuthDeg)) {
+            console.warn(
+                `[globeSceneController] sun position computation failed (lat=${latDeg}, lon=${lonDeg}); skipping update`,
+            );
+            return;
+        }
+        // 太陽方向(ECEF, 地表→太陽)を求め、指向性ライトには符号反転(太陽→地表)を渡す。
+        sunDirectionEcefToRef(latDeg, lonDeg, altitudeDeg, azimuthDeg, scratchSunDir);
+        gc.sunLight.direction = scratchSunDir.scale(-1);
+        // 昼夜係数で明るさを補間する（平面シーンと同方針）。dayFactor は注視点の太陽高度に基づく
+        // シーン全体の明るさで、太陽メッシュの表示可否（地球遮蔽）とは別管理。
+        const { dayFactor } = deriveSunState(altitudeDeg, azimuthDeg);
+        gc.sunLight.intensity = dayFactor;
+        gc.hemiLight.intensity = 0.2 + 0.8 * dayFactor;
+        // 太陽メッシュ（発光球）。infiniteDistance がカメラ位置を加算するため、position には
+        // 太陽方向×距離（カメラからのオフセット）だけを設定する。距離・サイズ・遮蔽は placeSunMesh
+        // が毎フレーム評価する。
+        currentSunDirEcef.copyFrom(scratchSunDir);
+        sunStateValid = true;
+        placeSunMesh();
+    };
+
+    // ズームのみの操作（dateTime 不変）でも太陽の距離・見かけサイズが maxZ に追従するよう毎フレーム
+    // 再配置する。これがないと、ズームイン時に算出した小さな距離・サイズが stale 化し、ズームアウト
+    // 時に太陽が極小化して見えなくなる（地球の弧が見える広域ズームで顕著）。
+    const sunMeshObserver = gc.scene.onBeforeRenderObservable.add(placeSunMesh);
+
     // ---- UI コントロールパネル配線（#275 Phase 4 / P4-1） ----
     // canvas が渡された実行時のみ DOM コントロールパネルを生成・配線する（単体テストの
     // 軽量スタブ呼び出しでは canvas 未指定で no-op）。
@@ -1642,9 +1741,22 @@ export const createGlobeSceneController = (
         // ---- UI コントロールパネル（#275 P4-1 で配線。canvas 未指定時は no-op） ----
         setUiVisibility: (target, visible) => uiSetVisibility(target, visible),
 
-        // ---- 太陽 / 影（globe ライティング統合は P4-0 後続スライス） ----
-        setSunState: () => {},
-        setSunShadows: () => {},
+        // ---- 太陽 / 影（globe ライティング統合, #368 / P4-1） ----
+        // setSunState: 適用すべき日時を保存し、現在の注視点基準で太陽方向・明るさを即時反映する。
+        setSunState: (dateTime) => {
+            currentSunDateTime = dateTime;
+            applyGlobeSunState();
+        },
+        // setSunShadows: globe は floating origin × 地球規模フラスタムのため影投影は未対応。
+        // 太陽方向追従（setSunState）は機能するため、有効化要求時は一度だけ警告して no-op とする。
+        setSunShadows: (enabled) => {
+            if (enabled && !globeShadowsWarned) {
+                globeShadowsWarned = true;
+                console.warn(
+                    "[globeSceneController] sun shadows are not supported on the globe backend; sun direction still follows dateTime.",
+                );
+            }
+        },
 
         // テスト用の idle 判定。globe タイルマネージャの実 idle 状態
         // （初回 sync 済み / 標高ロード中タイル無し / LOD 遷移の pendingRelease 無し に加え、
@@ -1652,6 +1764,7 @@ export const createGlobeSceneController = (
         isTerrainIdle: () => gc.tileManager.isIdle(),
 
         dispose: () => {
+            gc.scene.onBeforeRenderObservable.remove(sunMeshObserver);
             uiDispose();
             gc.dispose();
         },

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -19,7 +19,6 @@ import { JAPAN_BOUNDS } from "../terrain/gsiTile";
 import { geodeticToEcef, ecefToGeodetic } from "../terrain/geo/ecef";
 import { sunDirectionEcefToRef } from "../terrain/geo/sunDirectionEcef";
 import { computeSunPosition } from "../terrain/sunPosition";
-import { deriveSunState } from "../terrain/sunState";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { Wgs84Ellipsoid } from "@babylonjs/core/Maths/math.geospatial.functions";
 import {
@@ -1373,9 +1372,9 @@ export const createGlobeSceneController = (
 
     // ---- 太陽 / 影（globe ライティング統合, #368 / P4-1） ----
     // timelapse デモは `dateTime` を毎フレーム駆動し setSunState を連打するため、
-    // 現在の注視点(lat/lon)を基準に太陽方向(ECEF)・昼夜の明るさを再計算して
-    // `globe-sun` / `globe-hemi` ライトへ適用する。平面シーン（scenes/default.ts）の
-    // applySunStateForCurrent と同じ太陽計算（computeSunPosition / deriveSunState）を共有する。
+    // 現在の注視点(lat/lon)を基準に太陽方向(ECEF)を再計算して `globe-sun` ライトへ適用する。
+    // 太陽方向は computeSunPosition（平面シーン scenes/default.ts と同じ）で求める。明るさは globe では
+    // 時刻に依らず一定で、昼夜の境界は指向性ライトの幾何で表現する（applyGlobeSunState 参照）。
     let currentSunDateTime: Date | null = null;
     const scratchSunDir = new Vector3();
     let globeShadowsWarned = false;
@@ -1385,34 +1384,44 @@ export const createGlobeSceneController = (
     // 「太陽方向ベクトル × 距離 D」を設定するだけでよい。これによりカメラがどこに/どの座標系
     // （floating origin のリベース後でも）あっても、見かけ方向は常に太陽方向そのものになり、
     // カメラが動いた次フレームでも自動でカメラ相対に追従する（stale 化しない）。
-    // 太陽メッシュのカメラからの距離 D は遠クリップ面 maxZ（高度追従, GeospatialClippingBehavior）の
-    // 手前に収める。GeospatialClippingBehavior は maxZ = horizonDist + planetRadius*0.1 と設定する
-    // （horizonDist = √(|P|²-R²) = カメラから地平線（地球楕円体への接線）までの距離）。太陽メッシュを
-    // この地平線距離に置くと、太陽が地球の縁(limb)へ回り込んだとき occluder（深度のみ楕円体, globe.ts）
-    // の深度とちょうど接し、地球の裏へ進むほど太陽が occluder より奥になって画素単位に遮蔽される。
-    // D を maxZ*0.5 など近くに置くと limb より内側まで太陽が手前に残り「中央が裏に回るまで見える」
-    // 不自然さになるため、地平線距離（maxZ に近い）を採用する。far クリップ余裕のため maxZ*0.97 で上限。
+    // 太陽メッシュのカメラからの距離 D は、地球（occluder）の地平線より「奥」かつ遠クリップ面 maxZ の
+    // 手前に置く。GeospatialClippingBehavior は maxZ = horizonDist + planetRadius*0.1 と設定する
+    // （horizonDist = √(|P|²-R²) = カメラから地平線（地球楕円体への接線）までの距離）。
+    //   - D が horizonDist「ちょうど」だと、低高度では horizonDist が小さく（高度1kmで ~113km）、太陽が
+    //     地平線の地形と同じ距離に来て地面へ刺さって見える（ズームイン時の不具合）。
+    //   - そこで D を horizonDist より planetRadius*0.05 だけ奥に置く（= maxZ - planetRadius*0.05）。
+    //     occluder の地表（最遠 t = horizonDist）より必ず奥になるため、地平線より下の方向の太陽は深度で
+    //     遮蔽され、地平線の上（空）の方向では遮蔽されない＝地平線でちょうど切れる。
+    //   - far クリップに太陽ディスク（半径 ≒ D*0.02）が触れないよう maxZ*0.979 を上限にする。
     const SUN_PLANET_RADIUS = Wgs84Ellipsoid.semiMajorAxis;
-    const SUN_MESH_MAX_FAR_RATIO = 0.97;
+    const SUN_HORIZON_MARGIN = SUN_PLANET_RADIUS * 0.05;
+    const SUN_MESH_MAX_FAR_RATIO = 0.979;
+    // globe は地球全体が画面に入るため、昼夜の境界（ターミネータ）は太陽方向の指向性ライトの幾何
+    // （面の向きと太陽方向の内積）で自然に生じる。注視点の太陽高度（dayFactor）でシーン全体を減光すると、
+    // 画面外・地球の裏側で昼の領域まで一律に暗くなり不自然なため、ライト強度は時刻に依らず一定にする。
+    const GLOBE_SUN_LIGHT_INTENSITY = 1.2;
+    const GLOBE_HEMI_LIGHT_INTENSITY = 0.35;
     // 最後に算出した太陽方向(ECEF, 地表→太陽)と、太陽状態が有効か。距離 D / 見かけサイズは
     // カメラ（ズーム・高度）に依存するため、dateTime 更新時だけでなく毎フレーム再評価する。
     const currentSunDirEcef = new Vector3();
     let sunStateValid = false;
 
     // 太陽メッシュを現在のカメラ状態に合わせて毎フレーム更新する。
-    // 地球による遮蔽は occluder（深度のみ楕円体, globe.ts）の深度テストが画素単位に行うため、ここでは
-    // 位置（太陽方向 × 地平線距離 D）と見かけサイズ（視角一定）のみを設定する。D=地平線距離により太陽は
-    // 地球の縁から滑らかに欠け、地球の裏側では完全に隠れる（カメラが地表近傍なら「地平線下」、宇宙なら
-    // 「地球の背面」を深度で統一的に扱える）。
+    // 地球・地形による遮蔽は、太陽メッシュを地形と同一レンダリンググループ（共有深度）に置いたうえで、
+    // occluder（深度のみ楕円体, globe.ts）と実際の地形タイル（深度を書く LOD）の深度テストが画素単位に
+    // 行う。ここでは位置（太陽方向 × 距離 D）と見かけサイズ（視角一定）のみを設定する。D を地形より十分
+    // 奥（地平線より奥・far クリップ手前）に置くことで、太陽は手前の地形や地球の縁から滑らかに欠け、地球の
+    // 裏側では完全に隠れる。
     const placeSunMesh = (): void => {
         if (!sunStateValid) return;
         gc.sunMesh.setEnabled(true);
-        // maxZ = 地平線距離 + R*0.1 なので、地平線距離 = maxZ - R*0.1。far クリップに太陽ディスクが
-        // 触れないよう maxZ*0.97 を上限にクランプする。
-        const horizonDist = camera.maxZ - SUN_PLANET_RADIUS * 0.1;
+        // 地平線より SUN_HORIZON_MARGIN だけ奥（= maxZ - R*0.05）に置き、far クリップ手前へクランプする。
         const sunDist = Math.max(
             1,
-            Math.min(horizonDist, camera.maxZ * SUN_MESH_MAX_FAR_RATIO),
+            Math.min(
+                camera.maxZ - SUN_HORIZON_MARGIN,
+                camera.maxZ * SUN_MESH_MAX_FAR_RATIO,
+            ),
         );
         gc.sunMesh.position.copyFrom(currentSunDirEcef).scaleInPlace(sunDist);
         // 見かけの大きさ（視角）を一定に保つため、カメラからの距離（= sunDist）に比例させる。
@@ -1444,11 +1453,10 @@ export const createGlobeSceneController = (
         // 太陽方向(ECEF, 地表→太陽)を求め、指向性ライトには符号反転(太陽→地表)を渡す。
         sunDirectionEcefToRef(latDeg, lonDeg, altitudeDeg, azimuthDeg, scratchSunDir);
         gc.sunLight.direction = scratchSunDir.scale(-1);
-        // 昼夜係数で明るさを補間する（平面シーンと同方針）。dayFactor は注視点の太陽高度に基づく
-        // シーン全体の明るさで、太陽メッシュの表示可否（地球遮蔽）とは別管理。
-        const { dayFactor } = deriveSunState(altitudeDeg, azimuthDeg);
-        gc.sunLight.intensity = dayFactor;
-        gc.hemiLight.intensity = 0.2 + 0.8 * dayFactor;
+        // 明るさは時刻に依らず一定（昼夜の境界は指向性ライトの幾何で生じる。上記コメント参照）。
+        // 注視点の昼夜でシーン全体を減光しないことで、地球の裏側の昼領域が一律に暗くなる不自然さを避ける。
+        gc.sunLight.intensity = GLOBE_SUN_LIGHT_INTENSITY;
+        gc.hemiLight.intensity = GLOBE_HEMI_LIGHT_INTENSITY;
         // 太陽メッシュ（発光球）。infiniteDistance がカメラ位置を加算するため、position には
         // 太陽方向×距離（カメラからのオフセット）だけを設定する。距離・サイズ・遮蔽は placeSunMesh
         // が毎フレーム評価する。

--- a/src/terrain/geo/sunDirectionEcef.ts
+++ b/src/terrain/geo/sunDirectionEcef.ts
@@ -1,0 +1,80 @@
+/**
+ * 太陽の地理的見かけ位置（高度・方位角）を、グローブシーンの ECEF 太陽方向ベクトルへ変換する。
+ *
+ * 平面シーン（`scenes/default.ts`）は Babylon 左手系（X=東/Y=上/Z=北）で太陽方向を組むが、
+ * グローブシーン（`scenes/globe.ts`）は **右手系 ECEF**（X→経度0 / Y→東経90° / Z→北極、
+ * `geo/ecef` と同一規約）で動く。観測点（lat/lon）でのローカル ENU（East-North-Up）基底を
+ * ECEF で構成し、地平座標（azimuth/altitude）の太陽方向を ECEF へ写す。
+ *
+ * - 副作用なし・Babylon の `Vector3` のみに依存する純粋関数（unit test しやすい）。
+ * - 戻り値は「地表→太陽」を指す ECEF 単位ベクトル。`DirectionalLight.direction` には
+ *   その符号反転（太陽→地表）を渡すこと。
+ */
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+
+const DEG2RAD = Math.PI / 180;
+
+/**
+ * 観測点 `(latDeg, lonDeg)` における地平座標の太陽位置を ECEF 太陽方向単位ベクトルへ変換し
+ * `ref` に書き込む（アロケーション回避）。
+ *
+ * @param latDeg 観測点の緯度[deg]（北緯正）
+ * @param lonDeg 観測点の経度[deg]（東経正）
+ * @param altitudeDeg 太陽の地平高度[deg]（地平線=0、天頂=90、負値は地平線下）
+ * @param azimuthDeg 太陽の方位角[deg]（北=0、東=90、南=180、西=270）
+ * @param ref 結果を書き込む `Vector3`
+ * @returns `ref`（地表→太陽の ECEF 単位ベクトル）
+ */
+export const sunDirectionEcefToRef = (
+    latDeg: number,
+    lonDeg: number,
+    altitudeDeg: number,
+    azimuthDeg: number,
+    ref: Vector3,
+): Vector3 => {
+    const lat = latDeg * DEG2RAD;
+    const lon = lonDeg * DEG2RAD;
+    const alt = altitudeDeg * DEG2RAD;
+    const az = azimuthDeg * DEG2RAD;
+
+    const sinLat = Math.sin(lat);
+    const cosLat = Math.cos(lat);
+    const sinLon = Math.sin(lon);
+    const cosLon = Math.cos(lon);
+
+    // 地平座標の太陽方向を ENU 成分へ分解する。
+    const cosAltitude = Math.cos(alt);
+    const east = Math.sin(az) * cosAltitude;
+    const north = Math.cos(az) * cosAltitude;
+    const up = Math.sin(alt);
+
+    // ECEF（右手系: X→経度0 / Y→東経90° / Z→北極）における ENU 基底ベクトル。
+    //   East  = (-sinLon,           cosLon,            0     )
+    //   North = (-sinLat*cosLon,   -sinLat*sinLon,     cosLat)
+    //   Up    = ( cosLat*cosLon,    cosLat*sinLon,     sinLat)
+    const x =
+        east * -sinLon + north * (-sinLat * cosLon) + up * (cosLat * cosLon);
+    const y =
+        east * cosLon + north * (-sinLat * sinLon) + up * (cosLat * sinLon);
+    const z = north * cosLat + up * sinLat;
+
+    ref.set(x, y, z);
+    return ref.normalize();
+};
+
+/**
+ * {@link sunDirectionEcefToRef} の新規 `Vector3` を返す簡易版。
+ */
+export const sunDirectionEcef = (
+    latDeg: number,
+    lonDeg: number,
+    altitudeDeg: number,
+    azimuthDeg: number,
+): Vector3 =>
+    sunDirectionEcefToRef(
+        latDeg,
+        lonDeg,
+        altitudeDeg,
+        azimuthDeg,
+        new Vector3(),
+    );

--- a/tests/clockOverlay.unit.spec.ts
+++ b/tests/clockOverlay.unit.spec.ts
@@ -35,6 +35,9 @@ describe("longitudeToOffsetMs", () => {
     it("(-180,180] へ正規化する", () => {
         expect(longitudeToOffsetMs(190)).toBe(longitudeToOffsetMs(-170));
         expect(longitudeToOffsetMs(360)).toBe(0);
+        // 経度 180° は -180° へ折り返さず +180°（UTC+12）として扱う（#370 レビュー対応）。
+        expect(longitudeToOffsetMs(180)).toBe(12 * H);
+        expect(longitudeToOffsetMs(-180)).toBe(12 * H);
     });
 
     it("非有限値は 0", () => {

--- a/tests/clockOverlay.unit.spec.ts
+++ b/tests/clockOverlay.unit.spec.ts
@@ -9,50 +9,101 @@ import { describe, it, expect, beforeEach } from "@jest/globals";
 import {
     computeClockAngles,
     formatClockLabel,
+    formatUtcOffsetLabel,
+    longitudeToOffsetMs,
     mountClock,
     renderClockSvg,
 } from "../src/demos/timelapse/clockOverlay";
 
+const H = 3600000;
+
+describe("longitudeToOffsetMs", () => {
+    it("経度0°は UTC（オフセット0）", () => {
+        expect(longitudeToOffsetMs(0)).toBe(0);
+    });
+
+    it("経度は 15° ごとに 1 時間（東経=正）", () => {
+        expect(longitudeToOffsetMs(15)).toBe(H);
+        expect(longitudeToOffsetMs(135)).toBe(9 * H);
+        expect(longitudeToOffsetMs(-75)).toBe(-5 * H);
+    });
+
+    it("東京（経度139.76）は約 +9h19m", () => {
+        expect(longitudeToOffsetMs(139.76)).toBeCloseTo(9.317333 * H, -2);
+    });
+
+    it("(-180,180] へ正規化する", () => {
+        expect(longitudeToOffsetMs(190)).toBe(longitudeToOffsetMs(-170));
+        expect(longitudeToOffsetMs(360)).toBe(0);
+    });
+
+    it("非有限値は 0", () => {
+        expect(longitudeToOffsetMs(NaN)).toBe(0);
+    });
+});
+
+describe("formatUtcOffsetLabel", () => {
+    it("正・負・端数を整形する", () => {
+        expect(formatUtcOffsetLabel(0)).toBe("UTC+0");
+        expect(formatUtcOffsetLabel(9 * H)).toBe("UTC+9");
+        expect(formatUtcOffsetLabel(-5 * H)).toBe("UTC-5");
+        expect(formatUtcOffsetLabel(longitudeToOffsetMs(139.76))).toBe(
+            "UTC+9:19",
+        );
+    });
+});
+
 describe("computeClockAngles", () => {
-    it("15:00:00 UTC (= 00:00 JST) で全針 0°", () => {
-        const a = computeClockAngles(new Date("2025-01-01T15:00:00Z"));
+    it("offset 既定（UTC）: 00:00 UTC で全針 0°", () => {
+        const a = computeClockAngles(new Date("2025-01-01T00:00:00Z"));
         expect(a.hourDeg).toBe(0);
         expect(a.minuteDeg).toBe(0);
     });
 
-    it("21:00:00 UTC (= 06:00 JST) で時針 180°", () => {
-        const a = computeClockAngles(new Date("2025-01-01T21:00:00Z"));
+    it("offset +9h: 15:00 UTC (= 00:00 地方時) で全針 0°", () => {
+        const a = computeClockAngles(new Date("2025-01-01T15:00:00Z"), 9 * H);
+        expect(a.hourDeg).toBe(0);
+        expect(a.minuteDeg).toBe(0);
+    });
+
+    it("offset +9h: 21:00 UTC (= 06:00 地方時) で時針 180°", () => {
+        const a = computeClockAngles(new Date("2025-01-01T21:00:00Z"), 9 * H);
         expect(a.hourDeg).toBe(180);
     });
 
-    it("03:30:15 UTC (= 12:30:15 JST) で連続的な角度（時針が小数で進む）", () => {
-        const a = computeClockAngles(new Date("2025-01-01T03:30:15Z"));
-        // JST 12:30:15 → 時針: (0 + 30/60 + 15/3600) * 30 ≈ 15.125°
+    it("offset +9h: 03:30:15 UTC (= 12:30:15 地方時) で連続的な角度", () => {
+        const a = computeClockAngles(new Date("2025-01-01T03:30:15Z"), 9 * H);
         expect(a.hourDeg).toBeCloseTo(15.125, 3);
         expect(a.minuteDeg).toBeCloseTo(30 * 6 + (15 / 60) * 6, 3);
     });
 
     it("Invalid Date は全角度 0", () => {
-        const a = computeClockAngles(new Date("invalid"));
+        const a = computeClockAngles(new Date("invalid"), 9 * H);
         expect(a).toEqual({ hourDeg: 0, minuteDeg: 0 });
     });
 });
 
 describe("formatClockLabel", () => {
-    it("HH:MM JST 形式でゼロ埋め（UTCから+9h）", () => {
+    it("offset 既定（UTC）で HH:MM UTC+0", () => {
         expect(formatClockLabel(new Date("2025-06-21T03:07:00Z"))).toBe(
-            "12:07 JST",
+            "03:07 UTC+0",
         );
     });
 
-    it("日付跨ぎも JST として表示", () => {
-        expect(formatClockLabel(new Date("2025-06-21T15:30:00Z"))).toBe(
-            "00:30 JST",
+    it("offset +9h でゼロ埋め・オフセット表示", () => {
+        expect(formatClockLabel(new Date("2025-06-21T03:07:00Z"), 9 * H)).toBe(
+            "12:07 UTC+9",
         );
     });
 
-    it("Invalid Date は --:--", () => {
-        expect(formatClockLabel(new Date("invalid"))).toBe("--:-- JST");
+    it("日付跨ぎも地方時として表示", () => {
+        expect(formatClockLabel(new Date("2025-06-21T15:30:00Z"), 9 * H)).toBe(
+            "00:30 UTC+9",
+        );
+    });
+
+    it("Invalid Date は --:-- とオフセット", () => {
+        expect(formatClockLabel(new Date("invalid"), 9 * H)).toBe("--:-- UTC+9");
     });
 });
 
@@ -81,10 +132,10 @@ describe("mountClock", () => {
 
     it("マウント後、update で transform 属性が変わる", () => {
         const handle = mountClock(svg, label);
-        // 21:00 UTC = 06:00 JST → 時針 180°
-        handle.update(new Date("2025-01-01T21:00:00Z"));
+        // 21:00 UTC + offset 9h = 06:00 地方時 → 時針 180°
+        handle.update(new Date("2025-01-01T21:00:00Z"), 9 * H);
         const hour = svg.querySelector("#tl-clock-hand-hour");
         expect(hour?.getAttribute("transform")).toBe("rotate(180 50 50)");
-        expect(label.textContent).toBe("06:00 JST");
+        expect(label.textContent).toBe("06:00 UTC+9");
     });
 });

--- a/tests/clockOverlay.unit.spec.ts
+++ b/tests/clockOverlay.unit.spec.ts
@@ -54,6 +54,11 @@ describe("formatUtcOffsetLabel", () => {
             "UTC+9:19",
         );
     });
+
+    it("ほぼ 0 の負値は UTC+0 に正規化する（#370 レビュー対応）", () => {
+        expect(formatUtcOffsetLabel(-1)).toBe("UTC+0");
+        expect(formatUtcOffsetLabel(-29999)).toBe("UTC+0");
+    });
 });
 
 describe("computeClockAngles", () => {

--- a/tests/globeSceneController.unit.spec.ts
+++ b/tests/globeSceneController.unit.spec.ts
@@ -77,6 +77,7 @@ const makeStub = (
         radius,
         yaw,
         pitch,
+        maxZ: 1_000_000,
     };
     const clickListeners: GlobeTerrainClickListener[] = [];
     const hoverListeners: GlobePolygonPointListener[] = [];
@@ -95,6 +96,14 @@ const makeStub = (
         };
     const gc = {
         camera,
+        // 太陽方向・明るさ反映（setSunState）が参照するライト/メッシュの最小スタブ。
+        sunLight: { direction: new Vector3(0, 1, 0), intensity: 0 },
+        hemiLight: { intensity: 0 },
+        sunMesh: {
+            position: new Vector3(),
+            scaling: new Vector3(1, 1, 1),
+            setEnabled: jest.fn(),
+        },
         // 太陽メッシュの毎フレーム再配置オブザーバ登録/解除に必要な最小 scene スタブ。
         scene: {
             onBeforeRenderObservable: {
@@ -517,6 +526,19 @@ describe("createGlobeSceneController (P4-0 globe backend adapter)", () => {
         const c = createGlobeSceneController(gc, "std");
         c.dispose();
         expect(disposed()).toBe(true);
+    });
+
+    it("setSunState(null) は決定的フォールバック日時で太陽を反映する（planar と挙動一致, #370 レビュー対応）", () => {
+        const { gc } = makeStub(35, 139, 1000, 0, 0);
+        const sunLight = (gc as unknown as { sunLight: { direction: Vector3; intensity: number } }).sunLight;
+        const hemiLight = (gc as unknown as { hemiLight: { intensity: number } }).hemiLight;
+        const sunMesh = (gc as unknown as { sunMesh: { setEnabled: jest.Mock } }).sunMesh;
+        const c = createGlobeSceneController(gc, "std");
+        c.setSunState(null);
+        // null フォールバックでも太陽計算が走り、ライト強度が一定値へ更新される（早期 return しない）。
+        expect(sunLight.intensity).toBeGreaterThan(0);
+        expect(hemiLight.intensity).toBeGreaterThan(0);
+        expect(sunMesh.setEnabled).toHaveBeenCalledWith(true);
     });
 });
 

--- a/tests/globeSceneController.unit.spec.ts
+++ b/tests/globeSceneController.unit.spec.ts
@@ -95,6 +95,13 @@ const makeStub = (
         };
     const gc = {
         camera,
+        // 太陽メッシュの毎フレーム再配置オブザーバ登録/解除に必要な最小 scene スタブ。
+        scene: {
+            onBeforeRenderObservable: {
+                add: jest.fn(() => ({})),
+                remove: jest.fn(),
+            },
+        },
         // isTerrainIdle / marker アダプタ / mapType 切替が参照する tileManager スタブ。
         tileManager: {
             isIdle: () => idle,

--- a/tests/sunDirectionEcef.unit.spec.ts
+++ b/tests/sunDirectionEcef.unit.spec.ts
@@ -1,0 +1,43 @@
+/**
+ * `src/terrain/geo/sunDirectionEcef.ts` の純粋関数ユニットテスト (#368 / P4-1)。
+ *
+ * 太陽の地平座標(azimuth/altitude)@観測点(lat/lon) を、右手系 ECEF
+ * （X→経度0 / Y→東経90° / Z→北極）の太陽方向単位ベクトルへ変換する関数の代表値を固定する。
+ */
+import { describe, it, expect } from "@jest/globals";
+import { sunDirectionEcef } from "../src/terrain/geo/sunDirectionEcef";
+
+const expectVecClose = (
+    actual: { x: number; y: number; z: number },
+    expected: [number, number, number],
+    digits = 6,
+): void => {
+    expect(actual.x).toBeCloseTo(expected[0], digits);
+    expect(actual.y).toBeCloseTo(expected[1], digits);
+    expect(actual.z).toBeCloseTo(expected[2], digits);
+};
+
+describe("sunDirectionEcef", () => {
+    it("戻り値は単位ベクトル", () => {
+        const v = sunDirectionEcef(35.68, 139.76, 42, 180);
+        expect(Math.hypot(v.x, v.y, v.z)).toBeCloseTo(1, 6);
+    });
+
+    it("lat=0,lon=0 で天頂の太陽 → +X 軸（経度0 の地表 up）", () => {
+        // 天頂(altitude=90)では方位角は無関係。
+        expectVecClose(sunDirectionEcef(0, 0, 90, 0), [1, 0, 0]);
+        expectVecClose(sunDirectionEcef(0, 0, 90, 123), [1, 0, 0]);
+    });
+
+    it("lat=0,lon=0 で北の地平線上の太陽 → +Z 軸（北極方向）", () => {
+        expectVecClose(sunDirectionEcef(0, 0, 0, 0), [0, 0, 1]);
+    });
+
+    it("lat=0,lon=0 で東の地平線上の太陽 → +Y 軸（東経90°方向）", () => {
+        expectVecClose(sunDirectionEcef(0, 0, 0, 90), [0, 1, 0]);
+    });
+
+    it("lat=90（北極）で天頂の太陽 → +Z 軸", () => {
+        expectVecClose(sunDirectionEcef(90, 0, 90, 0), [0, 0, 1]);
+    });
+});

--- a/tests/timelapseClock.unit.spec.ts
+++ b/tests/timelapseClock.unit.spec.ts
@@ -9,6 +9,7 @@ import { describe, it, expect } from "@jest/globals";
 import {
     MS_PER_DAY,
     computeSimulatedDate,
+    parseStartDate,
     parseTimelapseQuery,
     sanitizeTimelapseOptions,
 } from "../src/demos/timelapse/timelapseClock";
@@ -73,6 +74,44 @@ describe("computeSimulatedDate", () => {
     });
 });
 
+describe("parseStartDate", () => {
+    it("Z 付き UTC をそのまま解釈する", () => {
+        expect(parseStartDate("2024-01-01T12:00:00Z")?.toISOString()).toBe(
+            "2024-01-01T12:00:00.000Z",
+        );
+    });
+
+    it("タイムゾーン無指定は UTC として解釈する", () => {
+        expect(parseStartDate("2024-06-01T09:30:00")?.toISOString()).toBe(
+            "2024-06-01T09:30:00.000Z",
+        );
+    });
+
+    it("秒なし日時もタイムゾーン無指定は UTC として解釈する", () => {
+        expect(parseStartDate("2024-06-01T09:30")?.toISOString()).toBe(
+            "2024-06-01T09:30:00.000Z",
+        );
+    });
+
+    it("空白へ化けた +hh:mm を復元する", () => {
+        expect(parseStartDate("2024-06-01T09:30:00 09:00")?.toISOString()).toBe(
+            "2024-06-01T00:30:00.000Z",
+        );
+    });
+
+    it("日付のみは UTC 0 時（ES 仕様どおり）", () => {
+        expect(parseStartDate("2024-06-01")?.toISOString()).toBe(
+            "2024-06-01T00:00:00.000Z",
+        );
+    });
+
+    it("空文字・解釈不能は undefined", () => {
+        expect(parseStartDate("")).toBeUndefined();
+        expect(parseStartDate("   ")).toBeUndefined();
+        expect(parseStartDate("not-a-date")).toBeUndefined();
+    });
+});
+
 describe("parseTimelapseQuery", () => {
     const now = isoUtc("2025-06-21T07:30:00Z");
 
@@ -86,6 +125,30 @@ describe("parseTimelapseQuery", () => {
     it("?start=ISO8601 を採用", () => {
         const r = parseTimelapseQuery("?start=2024-01-01T12:00:00Z", now);
         expect(r.startUtc.toISOString()).toBe("2024-01-01T12:00:00.000Z");
+    });
+
+    it("?start のタイムゾーン無指定はローカルではなく UTC として解釈する", () => {
+        const r = parseTimelapseQuery("?start=2024-06-01T09:30:00", now);
+        expect(r.startUtc.toISOString()).toBe("2024-06-01T09:30:00.000Z");
+    });
+
+    it("?start の +hh:mm オフセット（URL で空白へ化けた形）を復元して解釈する", () => {
+        // URLSearchParams は '+' を空白へデコードするため、生値は '...T09:30:00 09:00' になる。
+        const r = parseTimelapseQuery("?start=2024-06-01T09:30:00 09:00", now);
+        expect(r.startUtc.toISOString()).toBe("2024-06-01T00:30:00.000Z");
+    });
+
+    it("?start の %2B エンコード済み +hh:mm オフセットを解釈する", () => {
+        const r = parseTimelapseQuery(
+            "?start=2024-06-01T09:30:00%2B09:00",
+            now,
+        );
+        expect(r.startUtc.toISOString()).toBe("2024-06-01T00:30:00.000Z");
+    });
+
+    it("?start の -hh:mm オフセットを解釈する", () => {
+        const r = parseTimelapseQuery("?start=2024-06-01T09:30:00-05:00", now);
+        expect(r.startUtc.toISOString()).toBe("2024-06-01T14:30:00.000Z");
     });
 
     it("?speed=120 が反映される", () => {

--- a/tests/timelapseIndex.unit.spec.ts
+++ b/tests/timelapseIndex.unit.spec.ts
@@ -10,7 +10,7 @@
  *   - 完全指定 (@lat,lon,altitude,azimuth,tilt): 全フィールドを返す
  */
 import { describe, it, expect } from "@jest/globals";
-import { resolveCameraInit, resolveEngine, resolveShowSunShadows } from "../src/demos/timelapse/index";
+import { resolveCameraInit, resolveEngine, resolveShowSunShadows, resolveTerrainEngine } from "../src/demos/timelapse/index";
 
 describe("resolveCameraInit", () => {
     it("URL 未指定は空オブジェクトを返す", () => {
@@ -76,5 +76,23 @@ describe("resolveShowSunShadows (timelapse)", () => {
     it("未指定・その他は true（タイムラプスは既定 ON）", () => {
         expect(resolveShowSunShadows("")).toBe(true);
         expect(resolveShowSunShadows("?showSunShadows=true")).toBe(true);
+    });
+});
+
+describe("resolveTerrainEngine (timelapse)", () => {
+    it("?terrainEngine=globe → 'globe'", () => {
+        expect(resolveTerrainEngine("?terrainEngine=globe")).toBe("globe");
+    });
+
+    it("?terrainEngine=planar → 'planar'", () => {
+        expect(resolveTerrainEngine("?terrainEngine=planar")).toBe("planar");
+    });
+
+    it("不正値は undefined（lib 既定 planar にフォールバック）", () => {
+        expect(resolveTerrainEngine("?terrainEngine=foo")).toBeUndefined();
+    });
+
+    it("未指定は undefined", () => {
+        expect(resolveTerrainEngine("")).toBeUndefined();
     });
 });


### PR DESCRIPTION
## 概要
globe バックエンド（`?terrainEngine=globe`）で timelapse の 24h 太陽アニメーションを動作させる（Phase 4 / Issue #368, 親 #349）。太陽方向を ECEF で算出し、発光する太陽メッシュを `infiniteDistance` でカメラ相対に配置する。地球による遮蔽は深度バッファを用いて**画素単位**に行う。

## 背景
globe では背景球・ベースレイヤが `disableDepthWrite`（z-fighting/レイヤリング回避, #335）のため、広域ズームで地球が深度バッファに寄与せず、太陽メッシュが地球の裏側にあっても深度テストで隠れなかった。従来の解析的な中心遮蔽判定では、ディスク中心が地球の裏に回るまで全体が手前に見える hard-pop が不自然だった。

## 実装
- **`src/terrain/geo/sunDirectionEcef.ts`（新規）**: ENU(方位/高度)→右手系 ECEF 太陽方向の純関数。
- **`src/scenes/globe.ts`**:
  - 太陽メッシュ（発光球, `infiniteDistance`）を追加。
  - **深度オンリーのオクルーダ楕円体 `globe-sun-occluder`**（`disableColorWrite=true`, 深度書き込みは既定 on）を地球と同位置に重ねて追加。色を書かないので地形/オーバーレイ/背景球の見た目は不変。
  - 同一レンダリンググループ(0)内の不透明描画順が `material.uniqueId` 昇順（Babylon `PainterSortCompare`）であることを利用し、オクルーダのマテリアルを太陽より**先に生成**して先に深度を書く。
- **`src/scenes/globeSceneController.ts`**:
  - `setSunState` / `setSunShadows` を実装。
  - 太陽メッシュを `onBeforeRenderObservable` で毎フレーム再配置（ズーム追従・stale 化防止）。距離は**地平線距離** `D = maxZ - R*0.05`（far クリップ手前にクランプ）。遮蔽は深度に委譲し、解析的判定（`rayEllipsoidNearHitToRef`）は撤去。
- **`src/demos/timelapse/index.ts`**: globe 時の既定カメラ（azimuth 65° / tilt 75°）を配線。

## 影響範囲
- 画面: timelapse（globe エンジン）の太陽表示・昼夜ライティング。planar エンジンは不変。
- API/型: globe シーンの公開 IF に `sunLight`/`hemiLight`/`sunMesh` を追加（内部利用）。

## 検証
- `npm run typecheck` / `npm run lint`: green
- `npm run test:unit`: 1235 件 green（`sunDirectionEcef`・`timelapseIndex` のケース追加）
- `npm run test:visuals`: 新規 "Sunrise sun mesh visible"（WebGL2/WebGPU）pass。`timelapseBackLink` の失敗は clean tree でも再現する環境要因（GSI タイル実ネットワーク不通, planar エンジン）で本変更と無関係。
- Playwright 目視: 高度1500km・高チルトで日の出を掃引し、地平線下=完全に隠れる → 縁から細いスリット → 半円 → 全円、と滑らかに昇る per-pixel 遮蔽を確認（hard-pop 解消）。

## 既知のトレードオフ
- オクルーダは海面より 1500m 沈めている（背景球と同じ #335 の z-fighting 保険）。低高度かつ海上のみ、太陽の地平線没入が約1.2°遅れる。陸上は実地形タイル（深度書き込みあり）がより正確に遮蔽するため顕在化せず、globe/宇宙視点では 0.01° 以下で無視可能。

Closes #368