### PR TITLE
fix(globe): 極付近の独自パン高速回転を緯度ダンピングで抑制 (#356)

### DIFF
--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -36,6 +36,7 @@ import { DEG2RAD, geodeticToEcef, geodeticToEcefToRef, ecefToGeodetic, type Geod
 import {
     cameraTangentBasisToRef,
     panCenterOnSphereToRef,
+    polePanSpeedMultiplier,
     clampRadiusForGroundClearance,
     rayEllipsoidNearHitToRef,
 } from "../terrain/geo/cameraMapping";
@@ -481,6 +482,8 @@ export class GlobeScene {
             // マップを掴んで引く挙動: 右ドラッグ→center 西（content 右へ）、下ドラッグ→center 北（前方）。
             tangent.copyFrom(dragRight).scaleInPlace(-dx * mpp);
             tangent.addInPlace(dragFwd.scaleInPlace(dy * mpp));
+            // 極付近の高速回転を抑える（#356）。極では東西の一定メートル移動が経度の巨大変化に対応する。
+            tangent.scaleInPlace(polePanSpeedMultiplier(camera.center, camera.radius));
             camera.center = panCenterOnSphereToRef(camera.center, tangent, panned);
         };
         canvas.addEventListener("pointerdown", onPointerDown);
@@ -520,6 +523,8 @@ export class GlobeScene {
             tangent.addInPlace(dragRight.scaleInPlace(side));
             if (tangent.lengthSquared() < 1e-12) return;
             tangent.normalize().scaleInPlace(step);
+            // 極付近の高速回転を抑える（#356）。左ドラッグパンと同一の減速を WASD にも適用する。
+            tangent.scaleInPlace(polePanSpeedMultiplier(camera.center, camera.radius));
             camera.center = panCenterOnSphereToRef(camera.center, tangent, panned);
         };
 

--- a/src/terrain/geo/cameraMapping.ts
+++ b/src/terrain/geo/cameraMapping.ts
@@ -24,6 +24,9 @@ const ECEF_POLE = new Vector3(0, 0, 1);
 /** 接線基底が縮退（特異点）とみなす長さ二乗のしきい値。 */
 const DEGENERATE_EPS = 1e-12;
 
+/** パン減速の高さ（長さ次元[m]）方向の 0 除算回避用しきい値。`DEGENERATE_EPS`（長さ二乗）とは次元が異なる。 */
+const MIN_PAN_HEIGHT_EPS = 1e-6;
+
 /** 既存 UI の azimuth/tilt[deg] → `GeospatialCamera` の yaw/pitch[rad]。 */
 export const uiToYawPitch = (
     azimuthDeg: number,
@@ -126,7 +129,7 @@ export const polePanSpeedMultiplier = (
     const sineLat = Math.min(1, Math.max(-1, center.z / centerRadius));
     const cosLat = Math.sqrt(Math.max(0, 1 - sineLat * sineLat));
     const latitudeDampening = Math.sqrt(cosLat); // sqrt で赤道付近の効きを弱める
-    const height = Math.max(cameraHeight, DEGENERATE_EPS);
+    const height = Math.max(cameraHeight, MIN_PAN_HEIGHT_EPS);
     // 地表付近（height が小さい）では係数を 1 へ寄せ、緯度減速を無効化する。
     const latitudeDampeningScale = Math.max(1, centerRadius / height);
     const m = latitudeDampeningScale * latitudeDampening;

--- a/src/terrain/geo/cameraMapping.ts
+++ b/src/terrain/geo/cameraMapping.ts
@@ -105,13 +105,23 @@ export const cameraTangentBasisToRef = (
  *
  * @param center      注視点(ECEF)。`center.z/|center|` が球面緯度の sin。
  * @param cameraHeight カメラの対地高度相当[m]（独自パンでは `camera.radius` を渡す）。
- * @returns           [0,1] のパン速度係数。`center` が原点近傍など退化時は 1。
+ * @returns           [0,1] のパン速度係数。`center` が原点近傍、または `center`/`cameraHeight` が
+ *                    非有限（NaN/Infinity）などの退化時は 1（呼び出し側で NaN が伝播しないよう保証）。
  */
 export const polePanSpeedMultiplier = (
     center: Vector3,
     cameraHeight: number,
 ): number => {
     const centerRadius = center.length();
+    // 非有限入力は NaN を返さず減速なし(1)に倒す（呼び出し側の tangent.scaleInPlace(NaN) で
+    // カメラ中心が壊れるのを防ぐ。Math.max/min は NaN を潰せないため明示ガードする）。
+    if (
+        !Number.isFinite(centerRadius) ||
+        !Number.isFinite(center.z) ||
+        !Number.isFinite(cameraHeight)
+    ) {
+        return 1;
+    }
     if (centerRadius < 1) return 1;
     const sineLat = Math.min(1, Math.max(-1, center.z / centerRadius));
     const cosLat = Math.sqrt(Math.max(0, 1 - sineLat * sineLat));

--- a/src/terrain/geo/cameraMapping.ts
+++ b/src/terrain/geo/cameraMapping.ts
@@ -94,6 +94,36 @@ export const cameraTangentBasisToRef = (
 };
 
 /**
+ * 極付近のパン減速係数（[0,1]）を返す。極では東西の一定メートル移動が経度（極回りの方位角）の
+ * 巨大な変化に対応し、地球が高速回転して見える（#356）。Babylon 組み込みパン
+ * (`geospatialCameraMovement.computeCurrentFrameDeltas`) の緯度ダンピングと同等の式で、
+ * 独自パン（`scenes/globe.ts`）にも極減速を与える。
+ *
+ * - 赤道では 1.0（減速なし）、極へ近づくほど 0 へ漸近する（`sqrt(cos(lat))`）。
+ * - 高度が低い（`cameraHeight` が地心距離に対して小さい）ほど減速を緩め、地表付近では
+ *   緯度の影響を受けないようにする（`max(1, centerRadius/height)` でスケール）。
+ *
+ * @param center      注視点(ECEF)。`center.z/|center|` が球面緯度の sin。
+ * @param cameraHeight カメラの対地高度相当[m]（独自パンでは `camera.radius` を渡す）。
+ * @returns           [0,1] のパン速度係数。`center` が原点近傍など退化時は 1。
+ */
+export const polePanSpeedMultiplier = (
+    center: Vector3,
+    cameraHeight: number,
+): number => {
+    const centerRadius = center.length();
+    if (centerRadius < 1) return 1;
+    const sineLat = Math.min(1, Math.max(-1, center.z / centerRadius));
+    const cosLat = Math.sqrt(Math.max(0, 1 - sineLat * sineLat));
+    const latitudeDampening = Math.sqrt(cosLat); // sqrt で赤道付近の効きを弱める
+    const height = Math.max(cameraHeight, DEGENERATE_EPS);
+    // 地表付近（height が小さい）では係数を 1 へ寄せ、緯度減速を無効化する。
+    const latitudeDampeningScale = Math.max(1, centerRadius / height);
+    const m = latitudeDampeningScale * latitudeDampening;
+    return Math.min(1, Math.max(0, m));
+};
+
+/**
  * 注視点(center)を接線移動量 `tangentMove`[m] だけ動かし、地心距離 |center| を保つよう
  * 球面へ再投影した結果を `ref` に書き込む。パン共通の後処理。
  */

--- a/tests/geoCameraMapping.unit.spec.ts
+++ b/tests/geoCameraMapping.unit.spec.ts
@@ -19,6 +19,7 @@ import {
     geographicTangentBasisToRef,
     cameraTangentBasisToRef,
     panCenterOnSphereToRef,
+    polePanSpeedMultiplier,
     clampRadiusForGroundClearance,
     rayEllipsoidNearHitToRef,
 } from "../src/terrain/geo/cameraMapping";
@@ -257,5 +258,61 @@ describe("rayEllipsoidNearHitToRef", () => {
             expect(ref.x).toBe(123);
             expect(Number.isNaN(ref.x)).toBe(false);
         }
+    });
+});
+
+describe("polePanSpeedMultiplier", () => {
+    const R = 6378137; // WGS84 semi-major axis 相当
+
+    it("赤道では 1.0（減速なし）", () => {
+        const center = new Vector3(R, 0, 0);
+        expect(polePanSpeedMultiplier(center, R)).toBeCloseTo(1, 12);
+    });
+
+    it("高高度では極へ近づくほど 1 未満へ減速する", () => {
+        const eq = polePanSpeedMultiplier(new Vector3(R, 0, 0), R);
+        const mid = polePanSpeedMultiplier(
+            new Vector3(R * Math.cos(Math.PI / 4), 0, R * Math.sin(Math.PI / 4)),
+            R,
+        );
+        const high = polePanSpeedMultiplier(
+            new Vector3(R * Math.cos((80 * Math.PI) / 180), 0, R * Math.sin((80 * Math.PI) / 180)),
+            R,
+        );
+        expect(eq).toBeGreaterThan(mid);
+        expect(mid).toBeGreaterThan(high);
+        expect(high).toBeGreaterThan(0);
+        expect(high).toBeLessThan(1);
+    });
+
+    it("極（高高度）では 0 へ漸近する", () => {
+        const center = new Vector3(0, 0, R);
+        expect(polePanSpeedMultiplier(center, R)).toBeCloseTo(0, 12);
+    });
+
+    it("地表付近（低高度）では緯度に依らず 1（減速無効）", () => {
+        const nearPole = new Vector3(
+            R * Math.cos((80 * Math.PI) / 180),
+            0,
+            R * Math.sin((80 * Math.PI) / 180),
+        );
+        expect(polePanSpeedMultiplier(nearPole, 1000)).toBeCloseTo(1, 12);
+    });
+
+    it("常に [0,1] に収まる / 退化入力は 1", () => {
+        const samples: Array<[Vector3, number]> = [
+            [new Vector3(R, 0, 0), R],
+            [new Vector3(0, 0, R), R],
+            [new Vector3(0, 0, R), 1],
+            [new Vector3(-R, 0, 0), R * 10],
+            [new Vector3(0, 0, -R), R / 100],
+        ];
+        for (const [center, h] of samples) {
+            const m = polePanSpeedMultiplier(center, h);
+            expect(m).toBeGreaterThanOrEqual(0);
+            expect(m).toBeLessThanOrEqual(1);
+        }
+        // 原点近傍（地心距離 < 1）は退化として 1 を返す。
+        expect(polePanSpeedMultiplier(new Vector3(0, 0, 0), R)).toBe(1);
     });
 });

--- a/tests/geoCameraMapping.unit.spec.ts
+++ b/tests/geoCameraMapping.unit.spec.ts
@@ -315,4 +315,19 @@ describe("polePanSpeedMultiplier", () => {
         // 原点近傍（地心距離 < 1）は退化として 1 を返す。
         expect(polePanSpeedMultiplier(new Vector3(0, 0, 0), R)).toBe(1);
     });
+
+    it("非有限入力（NaN/Infinity）は NaN を返さず 1（退化扱い）", () => {
+        const badSamples: Array<[Vector3, number]> = [
+            [new Vector3(R, 0, 0), NaN],
+            [new Vector3(R, 0, 0), Infinity],
+            [new Vector3(NaN, 0, 0), R],
+            [new Vector3(0, 0, NaN), R],
+            [new Vector3(Infinity, 0, 0), R],
+        ];
+        for (const [center, h] of badSamples) {
+            const m = polePanSpeedMultiplier(center, h);
+            expect(Number.isNaN(m)).toBe(false);
+            expect(m).toBe(1);
+        }
+    });
 });


### PR DESCRIPTION
Closes #356

## 概要
地球全体が見えるまでズームアウトし、北極/南極を正面にして左右ドラッグや WASD で動かすと、地球が高速回転して操作できない問題を修正する。

## 原因
floating origin（`useFloatingOrigin`）下では Babylon `GeospatialCamera` の pick 依存パンが機能しないため、`src/scenes/globe.ts` で独自パン（左ドラッグ `onPointerMove` / WASD `applyKeyboardPan`）を実装している。この独自パンは Babylon 組み込みパンが持つ緯度ダンピングを欠いており、極付近では東西の一定メートル移動が経度（極回りの方位角）の巨大な変化に対応するため高速回転して見えていた。

## 修正
- `src/terrain/geo/cameraMapping.ts`: 緯度ダンピング純関数 `polePanSpeedMultiplier(center, cameraHeight)` を追加。Babylon 組み込み（`geospatialCameraMovement.computeCurrentFrameDeltas`）同等の式（`sqrt(cos(lat))` と `max(1, centerRadius/height)` スケール、`[0,1]` クランプ）。赤道=1.0、極で 0 へ漸近、地表付近では減速無効。
- `src/scenes/globe.ts`: 左ドラッグ／WASD 両パンの `panCenterOnSphereToRef` 直前に同一係数を適用。
- `tests/geoCameraMapping.unit.spec.ts`: 純関数の単体テスト5件を追加。

## 影響範囲
- グローブ表示のパン操作（左ドラッグ/WASD）。中緯度・赤道の操作感は不変。API/型/共有URL形式の変更なし。

## 検証
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test:unit` ✅（1262件）
- `npm run test:visuals` ✅（19件、スナップショット差分なし）
- 目視確認（極正面・最大ズームアウトで高速回転が解消、中緯度劣化なし）✅

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>