### PR TITLE
fix(urlState): globe の URL 高度クランプ上限を拡張 (#369)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ npm start
 **3D モード**
 
 - 形式: `/@<lat>,<lon>,<altitude>,<azimuth>,<tilt>`
-- `altitude`: カメラのワールド高度（m）。範囲 [50, 25512548]（上限は globe バックエンドの最大 radius = planetRadius×4 に合わせる。planar は実質 ≈78776m まで）
+- `altitude`: カメラの高さ（m）。範囲 [50, 25512548]
+  - planar バックエンドでは **カメラのワールド高度**（`camera.position.y`）を表す。値は実質 ≈78776m（富士山頂 + upperRadiusLimit 75km）まで。
+  - globe バックエンド（`terrainEngine=globe`）では意味が異なり、**GeospatialCamera の `radius`**（注視点＝地表点からのカメラ距離）を表す。上限 25,512,548m は globe の最大 radius = planetRadius×4 に由来する。
 - `azimuth`: 方位角（度）。0 = 北、時計回り正
 - `tilt`: 仰角（度）。範囲 [約5.7, 75]
 - 省略した場合は既定値（altitude=2000, azimuth=0, tilt=45）で補完されます

--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ npm start
 **3D モード**
 
 - 形式: `/@<lat>,<lon>,<altitude>,<azimuth>,<tilt>`
-- `altitude`: カメラの高さ（m）。範囲 [50, 25512548]
+- `altitude`: カメラの高さ（m）。範囲 [50, 25,512,548]
   - planar バックエンドでは **カメラのワールド高度**（`camera.position.y`）を表す。値は実質 ≈78776m（富士山頂 + upperRadiusLimit 75km）まで。
-  - globe バックエンド（`terrainEngine=globe`）では意味が異なり、**GeospatialCamera の `radius`**（注視点＝地表点からのカメラ距離）を表す。上限 25,512,548m は globe の最大 radius = planetRadius×4 に由来する。
+  - globe バックエンド（`terrainEngine=globe`）では意味が異なり、**GeospatialCamera の `radius`**（注視点＝地表点からのカメラ距離）を表す。上限は globe の最大 radius = planetRadius×4 に由来する。
 - `azimuth`: 方位角（度）。0 = 北、時計回り正
 - `tilt`: 仰角（度）。範囲 [約5.7, 75]
 - 省略した場合は既定値（altitude=2000, azimuth=0, tilt=45）で補完されます

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ npm start
 **3D モード**
 
 - 形式: `/@<lat>,<lon>,<altitude>,<azimuth>,<tilt>`
-- `altitude`: カメラのワールド高度（m）。範囲 [50, 80000]
+- `altitude`: カメラのワールド高度（m）。範囲 [50, 25512548]（上限は globe バックエンドの最大 radius = planetRadius×4 に合わせる。planar は実質 ≈78776m まで）
 - `azimuth`: 方位角（度）。0 = 北、時計回り正
 - `tilt`: 仰角（度）。範囲 [約5.7, 75]
 - 省略した場合は既定値（altitude=2000, azimuth=0, tilt=45）で補完されます

--- a/spec/package.md
+++ b/spec/package.md
@@ -399,9 +399,9 @@ interface MarkerOptions {
 **2D モードにおけるパス形式（Issue #254）:**
 
 - 3D モードのパス形式: `/@<lat>,<lon>,<altitude>,<azimuth>,<tilt>`
-  - `altitude` はカメラの高さ（m）。範囲 [50, 25512548]。バックエンドにより意味が異なる (#369):
+  - `altitude` はカメラの高さ（m）。範囲 [50, 25,512,548]。バックエンドにより意味が異なる (#369):
     - planar: **カメラのワールド高度**（`camera.position.y`）。値は実質 ≈78776m（富士山頂 + upperRadiusLimit 75km）まで。
-    - globe（`terrainEngine=globe`）: **GeospatialCamera の `radius`**（注視点＝地表点からのカメラ距離）。上限 25,512,548m は globe の最大 radius = planetRadius×4 に由来する。
+    - globe（`terrainEngine=globe`）: **GeospatialCamera の `radius`**（注視点＝地表点からのカメラ距離）。上限は globe の最大 radius = planetRadius×4 に由来する。
 - 2D モードのパス形式: `/@<lat>,<lon>,<zoom>z`（Google Maps 互換）
   - `zoom` は Web Mercator ズームレベル（小数 2 桁）。範囲 [5, 23]
   - 2D では平行投影のためカメラの海抜高度は表示範囲に影響しないため、altitude の代わりにズームレベルを使用する

--- a/spec/package.md
+++ b/spec/package.md
@@ -399,7 +399,9 @@ interface MarkerOptions {
 **2D モードにおけるパス形式（Issue #254）:**
 
 - 3D モードのパス形式: `/@<lat>,<lon>,<altitude>,<azimuth>,<tilt>`
-  - `altitude` はカメラのワールド高度（m）。範囲 [50, 25512548]（上限は globe バックエンドの最大 radius = planetRadius×4 ≈ 25,512,548m に合わせる。planar 由来の値は実質 ≈78776m まで。#369）
+  - `altitude` はカメラの高さ（m）。範囲 [50, 25512548]。バックエンドにより意味が異なる (#369):
+    - planar: **カメラのワールド高度**（`camera.position.y`）。値は実質 ≈78776m（富士山頂 + upperRadiusLimit 75km）まで。
+    - globe（`terrainEngine=globe`）: **GeospatialCamera の `radius`**（注視点＝地表点からのカメラ距離）。上限 25,512,548m は globe の最大 radius = planetRadius×4 に由来する。
 - 2D モードのパス形式: `/@<lat>,<lon>,<zoom>z`（Google Maps 互換）
   - `zoom` は Web Mercator ズームレベル（小数 2 桁）。範囲 [5, 23]
   - 2D では平行投影のためカメラの海抜高度は表示範囲に影響しないため、altitude の代わりにズームレベルを使用する

--- a/spec/package.md
+++ b/spec/package.md
@@ -399,7 +399,7 @@ interface MarkerOptions {
 **2D モードにおけるパス形式（Issue #254）:**
 
 - 3D モードのパス形式: `/@<lat>,<lon>,<altitude>,<azimuth>,<tilt>`
-  - `altitude` はカメラのワールド高度（m）。範囲 [50, 80000]
+  - `altitude` はカメラのワールド高度（m）。範囲 [50, 25512548]（上限は globe バックエンドの最大 radius = planetRadius×4 ≈ 25,512,548m に合わせる。planar 由来の値は実質 ≈78776m まで。#369）
 - 2D モードのパス形式: `/@<lat>,<lon>,<zoom>z`（Google Maps 互換）
   - `zoom` は Web Mercator ズームレベル（小数 2 桁）。範囲 [5, 23]
   - 2D では平行投影のためカメラの海抜高度は表示範囲に影響しないため、altitude の代わりにズームレベルを使用する

--- a/src/terrain/urlState.ts
+++ b/src/terrain/urlState.ts
@@ -31,12 +31,22 @@ const TILT_MIN_RAD = 0.1;
 const TILT_MIN_DEG = (TILT_MIN_RAD * 180) / Math.PI;
 
 /**
+ * altitude のクランプ上限 (m)。
+ * globe（GeospatialCamera）バックエンドはカメラの `radius` を altitude として URL に書き出す。
+ * GeospatialCamera の既定 `radiusMax` は planetRadius × 4（WGS84 semiMajorAxis 6,378,137m × 4
+ * = 25,512,548m）であり、高高度（全球視点）でもクランプで丸めないよう上限をこの値に合わせる (#369)。
+ * planar では camera.position.y が upperRadiusLimit（75km）で自前クランプされるため、
+ * 本上限の引き上げは planar の URL 復元挙動に影響しない（planar 由来の値は最大でも ≈ 78776m）。
+ */
+const ALTITUDE_MAX = 25_512_548;
+
+/**
  * altitude / tilt のクランプ範囲。
- * - altitude: camera.position.y（= target.y + radius·cos β）の最大が Mt.Fuji 3776m + 75000m radius ≈ 78776m に達するため [50, 80000] (m)
+ * - altitude: [50, {@link ALTITUDE_MAX}] (m)。上限は globe の最大 radius に合わせる (#369)。
  * - tilt: [{@link TILT_MIN_DEG}, 75]（deg）。下限は {@link TILT_MIN_RAD} rad を度換算した値
  */
 export const CAMERA_URL_LIMITS = {
-    altitude: { min: 50, max: 80000 },
+    altitude: { min: 50, max: ALTITUDE_MAX },
     tilt: { min: TILT_MIN_DEG, max: 75 },
     zoomLevel: { min: 5, max: 23 },
 } as const;
@@ -122,7 +132,7 @@ export const CAMERA_URL_DEFAULTS = {
 const AT_PATTERN =
     /@(-?\d+\.?\d*),(-?\d+\.?\d*)(?:,(-?\d+\.?\d*z?))?(?:,(-?\d+\.?\d*))?(?:,(-?\d+\.?\d*))?/;
 
-/** altitude を [50, 80000] にクランプし整数化する */
+/** altitude を [50, {@link ALTITUDE_MAX}] にクランプし整数化する */
 export const clampAltitude = (v: number): number => {
     const c = clamp(v, CAMERA_URL_LIMITS.altitude.min, CAMERA_URL_LIMITS.altitude.max);
     return Math.round(c);

--- a/src/terrain/urlState.ts
+++ b/src/terrain/urlState.ts
@@ -31,14 +31,24 @@ const TILT_MIN_RAD = 0.1;
 const TILT_MIN_DEG = (TILT_MIN_RAD * 180) / Math.PI;
 
 /**
+ * WGS84 楕円体の長半径 (m)。`@babylonjs/core` の `Wgs84Ellipsoid.semiMajorAxis` と同値。
+ * 本モジュールを Babylon 非依存（jest を軽く保つ）に保つため数値として定義する。
+ */
+const WGS84_SEMI_MAJOR_AXIS_M = 6_378_137;
+
+/** GeospatialCamera 既定 `radiusMax` の planetRadius 倍率（planetRadius × 4）。 */
+const GLOBE_MAX_RADIUS_SCALE = 4;
+
+/**
  * altitude のクランプ上限 (m)。
  * globe（GeospatialCamera）バックエンドはカメラの `radius` を altitude として URL に書き出す。
- * GeospatialCamera の既定 `radiusMax` は planetRadius × 4（WGS84 semiMajorAxis 6,378,137m × 4
- * = 25,512,548m）であり、高高度（全球視点）でもクランプで丸めないよう上限をこの値に合わせる (#369)。
- * planar では camera.position.y が upperRadiusLimit（75km）で自前クランプされるため、
- * 本上限の引き上げは planar の URL 復元挙動に影響しない（planar 由来の値は最大でも ≈ 78776m）。
+ * GeospatialCamera の既定 `radiusMax` は planetRadius × 4（= {@link WGS84_SEMI_MAJOR_AXIS_M} ×
+ * {@link GLOBE_MAX_RADIUS_SCALE} = 25,512,548m）であり、高高度（全球視点）でもクランプで丸めない
+ * よう上限をこの値に合わせる (#369)。planar では camera.position.y が upperRadiusLimit（75km）で
+ * 自前クランプされるため、本上限の引き上げは planar の URL 復元挙動に影響しない
+ * （planar 由来の値は最大でも ≈ 78776m）。
  */
-const ALTITUDE_MAX = 25_512_548;
+const ALTITUDE_MAX = WGS84_SEMI_MAJOR_AXIS_M * GLOBE_MAX_RADIUS_SCALE;
 
 /**
  * altitude / tilt のクランプ範囲。

--- a/tests/urlState.unit.spec.ts
+++ b/tests/urlState.unit.spec.ts
@@ -368,7 +368,7 @@ describe("urlState", () => {
 
         it("altitude が範囲外の場合はクランプして整数化される", () => {
             const tooHigh = parseCameraStateFromUrl(
-                "http://localhost/@35.0,139.0,99999999,0,45"
+                `http://localhost/@35.0,139.0,${CAMERA_URL_LIMITS.altitude.max + 1},0,45`
             );
             expect(tooHigh!.altitude).toBe(CAMERA_URL_LIMITS.altitude.max);
 
@@ -427,7 +427,9 @@ describe("urlState", () => {
     describe("clampAltitude / clampTilt / normalizeAzimuth", () => {
         it("clampAltitude は範囲外をクランプし整数化する", () => {
             expect(clampAltitude(0)).toBe(CAMERA_URL_LIMITS.altitude.min);
-            expect(clampAltitude(99_999_999)).toBe(CAMERA_URL_LIMITS.altitude.max);
+            expect(clampAltitude(CAMERA_URL_LIMITS.altitude.max + 1)).toBe(
+                CAMERA_URL_LIMITS.altitude.max
+            );
             expect(clampAltitude(1234.7)).toBe(1235);
         });
 

--- a/tests/urlState.unit.spec.ts
+++ b/tests/urlState.unit.spec.ts
@@ -368,7 +368,7 @@ describe("urlState", () => {
 
         it("altitude が範囲外の場合はクランプして整数化される", () => {
             const tooHigh = parseCameraStateFromUrl(
-                "http://localhost/@35.0,139.0,999999,0,45"
+                "http://localhost/@35.0,139.0,99999999,0,45"
             );
             expect(tooHigh!.altitude).toBe(CAMERA_URL_LIMITS.altitude.max);
 
@@ -427,7 +427,7 @@ describe("urlState", () => {
     describe("clampAltitude / clampTilt / normalizeAzimuth", () => {
         it("clampAltitude は範囲外をクランプし整数化する", () => {
             expect(clampAltitude(0)).toBe(CAMERA_URL_LIMITS.altitude.min);
-            expect(clampAltitude(1_000_000)).toBe(CAMERA_URL_LIMITS.altitude.max);
+            expect(clampAltitude(99_999_999)).toBe(CAMERA_URL_LIMITS.altitude.max);
             expect(clampAltitude(1234.7)).toBe(1235);
         });
 


### PR DESCRIPTION
## 概要

`terrainEngine=globe`（geospatial バックエンド）で、URL の `@lat,lon,altitude,...` の altitude が常に `80000` に固定され、URL を開くと地表付近まで寄ってしまうバグを修正する。

## 原因

globe はカメラの `radius` を altitude として URL に書き出すが、共有関数 `clampAltitude`（`src/terrain/urlState.ts`）が planar 基準の `[50, 80000]` にクランプしていた。globe のカメラ最大 radius は `GeospatialCamera` の既定 `radiusMax = planetRadius × 4 ≈ 25,512,548m` に達するため、高高度が 80000 に丸められていた。

## 修正

- `CAMERA_URL_LIMITS.altitude.max` を `80000` → `25_512_548`（= WGS84 semiMajorAxis 6,378,137m × 4）に引き上げ。
- planar は `camera.position.y` が `upperRadiusLimit`(75km) で自前クランプされるため、URL 復元挙動に影響なし（planar 由来の値は最大でも ≈ 78776m）。

## 影響範囲

- 機能: globe の URL カメラ高度の保存／復元（planar は不変）
- ドキュメント: `README.md` / `spec/package.md` の altitude 範囲記述を更新

## 検証

- `npm run test:unit`: 1263 passed
- `npm run typecheck`: pass
- `npm run lint`: pass
- 目視確認: 高高度の globe URL を開いて高度が保持されることを確認済み（HITL）

Closes #369