### PR TITLE
fix(urlState): globe では緯度経度を JAPAN_BOUNDS でクランプしない (#375)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,8 @@ npm start
 
 ### 緯度経度の扱い
 
-- 緯度経度は `JAPAN_BOUNDS`（緯度 20〜46、経度 122〜154）でクランプされます
+- 緯度経度は `JAPAN_BOUNDS`（緯度 20〜46、経度 122〜154）でクランプされます（`terrainEngine=planar` / 既定）
+- `terrainEngine=globe` の場合は全球を描画できるため、クランプ範囲を全球（緯度 -90〜90、経度 -180〜180）に拡張します（#375）
 - カメラ移動に追従して URL のパスが自動更新されます（既存のクエリパラメータは保持）
 
 実装の詳細は `src/demos/viewer/index.ts` および `src/terrain/urlState.ts` を参照してください。

--- a/src/demos/viewer/index.ts
+++ b/src/demos/viewer/index.ts
@@ -16,7 +16,7 @@
  * `window.showToast` を露出する。これらは公開 API ではない。
  */
 import { JpmapTerrain } from "../../lib/jpmapTerrain";
-import type { EngineType, JpmapTerrainOptions } from "../../lib/types";
+import type { EngineType, JpmapTerrainOptions, TerrainEngine } from "../../lib/types";
 import { showToast } from "../../terrain/controlPanel";
 import {
     parseCameraStateFromUrl,
@@ -28,7 +28,6 @@ import {
     resolveTerrainEngine,
     type CameraUrlState,
 } from "../../terrain/urlState";
-import type { TerrainEngine } from "../../lib/types";
 
 const DEMO_MOUNT_ID = "root";
 
@@ -72,8 +71,9 @@ export const resolveCameraState = (
  */
 export const resolveLatLon = (
     url: string,
+    terrainEngine?: TerrainEngine,
 ): { lat: number; lon: number } | undefined => {
-    const state = resolveCameraState(url);
+    const state = resolveCameraState(url, terrainEngine);
     return state ? { lat: state.lat, lon: state.lon } : undefined;
 };
 

--- a/src/demos/viewer/index.ts
+++ b/src/demos/viewer/index.ts
@@ -28,6 +28,7 @@ import {
     resolveTerrainEngine,
     type CameraUrlState,
 } from "../../terrain/urlState";
+import type { TerrainEngine } from "../../lib/types";
 
 const DEMO_MOUNT_ID = "root";
 
@@ -61,7 +62,9 @@ export { resolveTerrainEngine };
  */
 export const resolveCameraState = (
     url: string,
-): CameraUrlState | undefined => parseCameraStateFromUrl(url) ?? undefined;
+    terrainEngine?: TerrainEngine,
+): CameraUrlState | undefined =>
+    parseCameraStateFromUrl(url, { terrainEngine }) ?? undefined;
 
 /**
  * URL から初期表示の緯度経度を解決する。
@@ -146,7 +149,7 @@ const start = async (): Promise<void> => {
     }
     const engine = resolveEngine(location.search);
     const terrainEngine = resolveTerrainEngine(location.search);
-    const cameraState = resolveCameraState(location.href);
+    const cameraState = resolveCameraState(location.href, terrainEngine);
     const dateTime = resolveDateTime(location.search);
     const autoSunPosition = resolveAutoSunPosition(location.search);
     const showSunShadows = resolveShowSunShadows(location.search);

--- a/src/demos/viewer/index.ts
+++ b/src/demos/viewer/index.ts
@@ -57,6 +57,9 @@ export { resolveTerrainEngine };
  * 内部的に {@link parseCameraStateFromUrl} を再利用する薄いラッパー。
  *
  * @param url 解析対象 URL（`location.href` 等）
+ * @param terrainEngine クランプ範囲を切り替える地形バックエンド (#375)。
+ *   `"globe"` なら全球（`WORLD_BOUNDS`）、`"planar"` なら日本域（`JAPAN_BOUNDS`）でクランプする。
+ *   未指定時は URL クエリ `?terrainEngine=` をフォールバック解決する（明示指定が優先）。
  * @returns 取得できた場合は `CameraUrlState`、取得できない場合は `undefined`
  */
 export const resolveCameraState = (

--- a/src/terrain/urlState.ts
+++ b/src/terrain/urlState.ts
@@ -9,6 +9,23 @@ export interface LatLon {
     lon: number;
 }
 
+/**
+ * globe バックエンド用の緯度経度クランプ範囲（全球）。
+ * planar は日本被覆域（{@link JAPAN_BOUNDS}）のみ描画するためクランプするが、
+ * globe（GeospatialCamera）は地球全体を描画できるため全球を許容する (#375)。
+ */
+export const WORLD_BOUNDS = { minLat: -90, maxLat: 90, minLon: -180, maxLon: 180 } as const;
+
+/**
+ * terrainEngine に応じた緯度経度クランプ範囲を返す (#375)。
+ * - `globe` → {@link WORLD_BOUNDS}（全球）
+ * - それ以外（planar / 未指定）→ {@link JAPAN_BOUNDS}（日本被覆域）
+ */
+const resolveLatLonBounds = (
+    terrainEngine?: TerrainEngine,
+): typeof JAPAN_BOUNDS | typeof WORLD_BOUNDS =>
+    terrainEngine === "globe" ? WORLD_BOUNDS : JAPAN_BOUNDS;
+
 /** カメラ姿勢を含む URL 状態 (Issue #64) */
 export interface CameraUrlState extends LatLon {
     altitude: number;
@@ -156,8 +173,15 @@ const pickFinite = (raw: string | undefined, fallback: number): number => {
  *
  * 3 番目のトークンが `z` で終わる場合（例: `14.50z`）は Google Maps 互換の
  * ズームレベルとして解釈し、`zoomLevel` フィールドに格納する (#254)。
+ *
+ * `options.terrainEngine` が `"globe"` の場合、緯度経度を {@link WORLD_BOUNDS}（全球）で
+ * クランプする。未指定 / `"planar"` の場合は従来どおり {@link JAPAN_BOUNDS} でクランプする (#375)。
  */
-export const parseCameraStateFromUrl = (url: string): CameraUrlState | null => {
+export const parseCameraStateFromUrl = (
+    url: string,
+    options?: { terrainEngine?: TerrainEngine },
+): CameraUrlState | null => {
+    const bounds = resolveLatLonBounds(options?.terrainEngine);
     try {
         const parsed = new URL(url, "http://localhost");
 
@@ -168,8 +192,8 @@ export const parseCameraStateFromUrl = (url: string): CameraUrlState | null => {
             const lat = Number(atMatch[1]);
             const lon = Number(atMatch[2]);
             if (isFinite(lat) && isFinite(lon)) {
-                const clampedLat = clamp(lat, JAPAN_BOUNDS.minLat, JAPAN_BOUNDS.maxLat);
-                const clampedLon = clamp(lon, JAPAN_BOUNDS.minLon, JAPAN_BOUNDS.maxLon);
+                const clampedLat = clamp(lat, bounds.minLat, bounds.maxLat);
+                const clampedLon = clamp(lon, bounds.minLon, bounds.maxLon);
 
                 const rawThird = atMatch[3];
                 if (rawThird !== undefined && rawThird.endsWith("z")) {
@@ -208,8 +232,8 @@ export const parseCameraStateFromUrl = (url: string): CameraUrlState | null => {
             const lon = Number(lonStr);
             if (isFinite(lat) && isFinite(lon)) {
                 return {
-                    lat: clamp(lat, JAPAN_BOUNDS.minLat, JAPAN_BOUNDS.maxLat),
-                    lon: clamp(lon, JAPAN_BOUNDS.minLon, JAPAN_BOUNDS.maxLon),
+                    lat: clamp(lat, bounds.minLat, bounds.maxLat),
+                    lon: clamp(lon, bounds.minLon, bounds.maxLon),
                     altitude: clampAltitude(CAMERA_URL_DEFAULTS.altitude),
                     azimuth: normalizeAzimuth(CAMERA_URL_DEFAULTS.azimuth),
                     tilt: clampTilt(CAMERA_URL_DEFAULTS.tilt),
@@ -229,8 +253,11 @@ export const parseCameraStateFromUrl = (url: string): CameraUrlState | null => {
  *
  * @deprecated 新規コードでは {@link parseCameraStateFromUrl} を使用してください。
  */
-export const parseLatLonFromUrl = (url: string): LatLon | null => {
-    const state = parseCameraStateFromUrl(url);
+export const parseLatLonFromUrl = (
+    url: string,
+    options?: { terrainEngine?: TerrainEngine },
+): LatLon | null => {
+    const state = parseCameraStateFromUrl(url, options);
     if (state === null) return null;
     return { lat: state.lat, lon: state.lon };
 };

--- a/src/terrain/urlState.ts
+++ b/src/terrain/urlState.ts
@@ -176,14 +176,21 @@ const pickFinite = (raw: string | undefined, fallback: number): number => {
  *
  * `options.terrainEngine` が `"globe"` の場合、緯度経度を {@link WORLD_BOUNDS}（全球）で
  * クランプする。未指定 / `"planar"` の場合は従来どおり {@link JAPAN_BOUNDS} でクランプする (#375)。
+ * `options` 未指定時は URL クエリ `?terrainEngine=` をフォールバックとして解決するため、
+ * 呼び出し側が options を渡さなくても globe URL を1本で正しく復元できる (#375)。
  */
 export const parseCameraStateFromUrl = (
     url: string,
     options?: { terrainEngine?: TerrainEngine },
 ): CameraUrlState | null => {
-    const bounds = resolveLatLonBounds(options?.terrainEngine);
     try {
         const parsed = new URL(url, "http://localhost");
+
+        // options 未指定時は URL クエリ `?terrainEngine=` をフォールバック解決する (#375)。
+        // これにより呼び出し側が options を渡し忘れても URL 1本で globe 復元できる。
+        const terrainEngine =
+            options?.terrainEngine ?? resolveTerrainEngine(parsed.search);
+        const bounds = resolveLatLonBounds(terrainEngine);
 
         // pathname + hash のみに @lat,lon を適用（userinfo やクエリ値の @ を誤検出しない）
         const target = parsed.pathname + parsed.hash;

--- a/src/terrain/urlState.ts
+++ b/src/terrain/urlState.ts
@@ -176,8 +176,9 @@ const pickFinite = (raw: string | undefined, fallback: number): number => {
  *
  * `options.terrainEngine` が `"globe"` の場合、緯度経度を {@link WORLD_BOUNDS}（全球）で
  * クランプする。未指定 / `"planar"` の場合は従来どおり {@link JAPAN_BOUNDS} でクランプする (#375)。
- * `options` 未指定時は URL クエリ `?terrainEngine=` をフォールバックとして解決するため、
- * 呼び出し側が options を渡さなくても globe URL を1本で正しく復元できる (#375)。
+ * `options` 未指定（または `options.terrainEngine` 未指定）時は URL クエリ `?terrainEngine=` を
+ * フォールバックとして解決するため、呼び出し側が terrainEngine を渡さなくても globe URL を
+ * 1本で正しく復元できる (#375)。
  */
 export const parseCameraStateFromUrl = (
     url: string,
@@ -186,8 +187,8 @@ export const parseCameraStateFromUrl = (
     try {
         const parsed = new URL(url, "http://localhost");
 
-        // options 未指定時は URL クエリ `?terrainEngine=` をフォールバック解決する (#375)。
-        // これにより呼び出し側が options を渡し忘れても URL 1本で globe 復元できる。
+        // options.terrainEngine 未指定時は URL クエリ `?terrainEngine=` をフォールバック解決する (#375)。
+        // これにより呼び出し側が terrainEngine を渡し忘れても URL 1本で globe 復元できる。
         const terrainEngine =
             options?.terrainEngine ?? resolveTerrainEngine(parsed.search);
         const bounds = resolveLatLonBounds(terrainEngine);

--- a/tests/urlState.unit.spec.ts
+++ b/tests/urlState.unit.spec.ts
@@ -439,6 +439,7 @@ describe("urlState", () => {
                 "http://localhost/viewer/@-120.0,200.0",
                 { terrainEngine: "globe" }
             );
+            expect(result).not.toBeNull();
             expect(result!.lat).toBe(-90);
             expect(result!.lon).toBe(180);
         });
@@ -448,12 +449,14 @@ describe("urlState", () => {
                 "http://localhost/viewer/@17.316969,38.639148",
                 { terrainEngine: "planar" }
             );
+            expect(planar).not.toBeNull();
             expect(planar!.lat).toBe(20);
             expect(planar!.lon).toBe(122);
 
             const noEngine = parseCameraStateFromUrl(
                 "http://localhost/viewer/@17.316969,38.639148"
             );
+            expect(noEngine).not.toBeNull();
             expect(noEngine!.lat).toBe(20);
             expect(noEngine!.lon).toBe(122);
         });
@@ -463,6 +466,7 @@ describe("urlState", () => {
             const result = parseCameraStateFromUrl(
                 "http://localhost/viewer/@17.316969,38.639148?terrainEngine=globe"
             );
+            expect(result).not.toBeNull();
             expect(result!.lat).toBeCloseTo(17.316969, 6);
             expect(result!.lon).toBeCloseTo(38.639148, 6);
         });
@@ -473,6 +477,7 @@ describe("urlState", () => {
                 "http://localhost/viewer/@17.316969,38.639148?terrainEngine=globe",
                 { terrainEngine: "planar" }
             );
+            expect(result).not.toBeNull();
             expect(result!.lat).toBe(20);
             expect(result!.lon).toBe(122);
         });

--- a/tests/urlState.unit.spec.ts
+++ b/tests/urlState.unit.spec.ts
@@ -422,6 +422,41 @@ describe("urlState", () => {
                 tilt: CAMERA_URL_DEFAULTS.tilt,
             });
         });
+
+        // #375: globe では JAPAN_BOUNDS でクランプせず全球の緯度経度を許容する。
+        it("terrainEngine=globe では日本域外の緯度経度をクランプしない (#375)", () => {
+            const result = parseCameraStateFromUrl(
+                "http://localhost/viewer/@17.316969,38.639148,18396200,0.00,49.68",
+                { terrainEngine: "globe" }
+            );
+            expect(result).not.toBeNull();
+            expect(result!.lat).toBeCloseTo(17.316969, 6);
+            expect(result!.lon).toBeCloseTo(38.639148, 6);
+        });
+
+        it("terrainEngine=globe でも全球範囲外は WORLD_BOUNDS でクランプされる (#375)", () => {
+            const result = parseCameraStateFromUrl(
+                "http://localhost/viewer/@-120.0,200.0",
+                { terrainEngine: "globe" }
+            );
+            expect(result!.lat).toBe(-90);
+            expect(result!.lon).toBe(180);
+        });
+
+        it("terrainEngine=planar / 未指定では従来どおり JAPAN_BOUNDS でクランプする (#375)", () => {
+            const planar = parseCameraStateFromUrl(
+                "http://localhost/viewer/@17.316969,38.639148",
+                { terrainEngine: "planar" }
+            );
+            expect(planar!.lat).toBe(20);
+            expect(planar!.lon).toBe(122);
+
+            const noEngine = parseCameraStateFromUrl(
+                "http://localhost/viewer/@17.316969,38.639148"
+            );
+            expect(noEngine!.lat).toBe(20);
+            expect(noEngine!.lon).toBe(122);
+        });
     });
 
     describe("clampAltitude / clampTilt / normalizeAzimuth", () => {

--- a/tests/urlState.unit.spec.ts
+++ b/tests/urlState.unit.spec.ts
@@ -457,6 +457,25 @@ describe("urlState", () => {
             expect(noEngine!.lat).toBe(20);
             expect(noEngine!.lon).toBe(122);
         });
+
+        // #375: options 未指定でも URL クエリ ?terrainEngine=globe をフォールバック解決する。
+        it("options 未指定でも URL の ?terrainEngine=globe でクランプ範囲が全球になる (#375)", () => {
+            const result = parseCameraStateFromUrl(
+                "http://localhost/viewer/@17.316969,38.639148?terrainEngine=globe"
+            );
+            expect(result!.lat).toBeCloseTo(17.316969, 6);
+            expect(result!.lon).toBeCloseTo(38.639148, 6);
+        });
+
+        it("options.terrainEngine は URL クエリより優先される (#375)", () => {
+            // URL は globe だが options で planar を明示 → JAPAN_BOUNDS でクランプ。
+            const result = parseCameraStateFromUrl(
+                "http://localhost/viewer/@17.316969,38.639148?terrainEngine=globe",
+                { terrainEngine: "planar" }
+            );
+            expect(result!.lat).toBe(20);
+            expect(result!.lon).toBe(122);
+        });
     });
 
     describe("clampAltitude / clampTilt / normalizeAzimuth", () => {


### PR DESCRIPTION
## 概要

viewer の globe バックエンドで、URL の緯度経度が日本域外でも `JAPAN_BOUNDS`（緯度20〜46/経度122〜154）へ無条件クランプされ、日本が見える位置にずれていた問題を修正する。

## 原因

`parseCameraStateFromUrl`（`src/terrain/urlState.ts`）が terrainEngine に関係なく lat/lon を `JAPAN_BOUNDS` でクランプしていた。globe は全球を描画できるため、アフリカ等の指定が日本へ丸められていた。

## 変更内容

- `parseCameraStateFromUrl` / `parseLatLonFromUrl` に `options.terrainEngine` を追加
  - `globe` → 全球 `WORLD_BOUNDS`（緯度 -90〜90 / 経度 -180〜180）でクランプ
  - `planar` / 未指定 → 従来どおり `JAPAN_BOUNDS`（後方互換）
- viewer の `resolveCameraState` から terrainEngine を渡すよう変更
- urlState のユニットテスト追加（globe非クランプ / WORLD_BOUNDSクランプ / planarクランプ）
- README のクランプ仕様を更新

## 影響範囲

- API: `parseCameraStateFromUrl` / `parseLatLonFromUrl` に optional 引数追加（既定挙動は不変）
- 画面: viewer(globe) の URL 初期表示位置

## 検証

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run test:unit` ✅（1266 passed）
- 目視確認: 問題URLでアフリカが正面表示されること ✅

Closes #375