### PR TITLE
fix(viewer): tilt のクランプ上限を 75°→89° に緩和 (#377)

### DIFF
--- a/src/demos/avatar-controller/cameraControl.ts
+++ b/src/demos/avatar-controller/cameraControl.ts
@@ -21,8 +21,8 @@ export const TILT_SPEED_DPS = 60;
 /** チルト最小値（度）。camera.lowerBetaLimit ≈ 0.1 rad に対応。 */
 export const TILT_MIN_DEG = 6;
 
-/** チルト最大値（度）。camera.upperBetaLimit = π/2 - π/12 ≈ 75° に対応。 */
-export const TILT_MAX_DEG = 75;
+/** チルト最大値（度）。camera.upperBetaLimit = π/2 - π/180 ≈ 89° に対応 (#377)。 */
+export const TILT_MAX_DEG = 89;
 
 /** カメラ制御の計算結果 */
 export interface CameraControlResult {

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -52,7 +52,7 @@ const HEIGHT_SCALE = 1.0;
 // から外れて表示されない。zoom 8（タイル辺 ≒ 128km）が遠方の山まで表示できる下限。
 const MIN_ZOOM = 8;
 // Quadtree root 探索範囲（minZoom タイル単位の ±N 格子）。
-// 最大 tilt（beta ≈ 75°）の水平視野は遠クリッピング（400km）近くまで達するため、zoom8 で ±4
+// 最大 tilt（beta ≈ 89°）の水平視野は遠クリッピング（400km）近くまで達するため、zoom8 で ±4
 // （9×9、概ね ±512km カバー）を既定とする。視錐台外の root は AABB カリングで即除外される。
 const ROOT_SEARCH_RADIUS = 4;
 
@@ -441,8 +441,8 @@ export class DefaultScene implements CreateSceneClass {
         // 2D モード中は lowerBetaLimit を 0 に変更するため、3D 復帰用に元の値を保持する。
         const lowerBetaLimit3d = 0.1;
 
-        // チルト制限（地面から15° = beta上限 5π/12）
-        camera.upperBetaLimit = Math.PI / 2 - Math.PI / 12;
+        // チルト制限（地面から1° = beta上限 89π/180）。実態として水平近くまで表示可能なため上限を 89° に合わせる (#377)。
+        camera.upperBetaLimit = Math.PI / 2 - Math.PI / 180;
         // beta=0（真下視点）はArcRotateCameraのジンバルロック・数値不安定を招くため最小値を設定
         camera.lowerBetaLimit = lowerBetaLimit3d;
 

--- a/src/terrain/urlState.ts
+++ b/src/terrain/urlState.ts
@@ -70,11 +70,12 @@ const ALTITUDE_MAX = WGS84_SEMI_MAJOR_AXIS_M * GLOBE_MAX_RADIUS_SCALE;
 /**
  * altitude / tilt のクランプ範囲。
  * - altitude: [50, {@link ALTITUDE_MAX}] (m)。上限は globe の最大 radius に合わせる (#369)。
- * - tilt: [{@link TILT_MIN_DEG}, 75]（deg）。下限は {@link TILT_MIN_RAD} rad を度換算した値
+ * - tilt: [{@link TILT_MIN_DEG}, 89]（deg）。下限は {@link TILT_MIN_RAD} rad を度換算した値。
+ *   上限はカメラの upperBetaLimit（≈ 89°）に合わせる (#377)。
  */
 export const CAMERA_URL_LIMITS = {
     altitude: { min: 50, max: ALTITUDE_MAX },
-    tilt: { min: TILT_MIN_DEG, max: 75 },
+    tilt: { min: TILT_MIN_DEG, max: 89 },
     zoomLevel: { min: 5, max: 23 },
 } as const;
 
@@ -169,7 +170,7 @@ export const clampAltitude = (v: number): number => {
 export const clampZoomLevel = (v: number): number =>
     clamp(v, CAMERA_URL_LIMITS.zoomLevel.min, CAMERA_URL_LIMITS.zoomLevel.max);
 
-/** tilt を [TILT_MIN_DEG, 75]（deg）にクランプする */
+/** tilt を [TILT_MIN_DEG, 89]（deg）にクランプする */
 export const clampTilt = (v: number): number =>
     clamp(v, CAMERA_URL_LIMITS.tilt.min, CAMERA_URL_LIMITS.tilt.max);
 

--- a/tests/cameraControl.unit.spec.ts
+++ b/tests/cameraControl.unit.spec.ts
@@ -64,7 +64,7 @@ describe("computeCameraControl", () => {
                 false,
                 45,
             );
-            // 0.5秒 × 60°/s = 30° 増加。45+30=75=MAX なのでクランプされずフル変化
+            // 0.5秒 × 60°/s = 30° 増加。45+30=75<MAX(89) なのでクランプされずフル変化
             expect(result.deltaTilt).toBeCloseTo(TILT_SPEED_DPS * 0.5, 1);
         });
 

--- a/tests/validation.spec.ts
+++ b/tests/validation.spec.ts
@@ -244,7 +244,7 @@ const SUNRISE_LAT = 35.690206;
 const SUNRISE_LON = 139.766166;
 
 /**
- * Skybox 比較用シーン準備：固定 dateTime でロード後、`viewer.tilt` を最大まで倒す。
+ * Skybox 比較用シーン準備：固定 dateTime でロード後、`viewer.tilt` を大きめ（75°）に倒す。
  */
 async function waitForSceneWithSkybox(
     page: import("@playwright/test").Page,
@@ -264,7 +264,7 @@ async function waitForSceneWithSkybox(
     );
     await page.waitForLoadState("networkidle", { timeout: 30000 });
 
-    // チルト最大に倒して画面上部に空を映す。
+    // チルトを大きめ（SKYBOX_TILT_DEG = 75°）に倒して画面上部に空を映す。
     // `viewer.tilt` setter は内部で beta クランプ済み（upperBetaLimit ≈ 89°）。
     await page.evaluate((tiltValue) => {
         (window as any).viewer.tilt = tiltValue;

--- a/tests/validation.spec.ts
+++ b/tests/validation.spec.ts
@@ -265,7 +265,7 @@ async function waitForSceneWithSkybox(
     await page.waitForLoadState("networkidle", { timeout: 30000 });
 
     // チルト最大に倒して画面上部に空を映す。
-    // `viewer.tilt` setter は内部で beta クランプ済み（upperBetaLimit ≈ 75°）。
+    // `viewer.tilt` setter は内部で beta クランプ済み（upperBetaLimit ≈ 89°）。
     await page.evaluate((tiltValue) => {
         (window as any).viewer.tilt = tiltValue;
     }, SKYBOX_TILT_DEG);


### PR DESCRIPTION
## 概要
Viewer の URL の tilt 角が 75° でクランプされていた問題を修正。実態として水平近く（90°近く）まで表示可能なため、上限を 89° に緩和し統一した。

Closes #377

## 変更内容
- `src/scenes/default.ts`: `camera.upperBetaLimit` を `π/2 − π/180`（89°）に
- `src/terrain/urlState.ts`: `CAMERA_URL_LIMITS.tilt.max` を 75 → 89
- `src/demos/avatar-controller/cameraControl.ts`: `TILT_MAX_DEG` を 75 → 89
- `tests/`（cameraControl, validation）: stale なコメントを更新

## 影響範囲
- 画面: Viewer のチルト最大角が 75°→89° に拡大
- URL: `@lat,lon,alt,az,tilt` の tilt が 89° まで保持・復元（既存の tilt≤75 URL は後方互換）
- API/型: 変更なし

## 検証
- ✅ `npm run typecheck`
- ✅ `npm run lint`
- ✅ `npm run test:unit`（57 suites / 1268 tests passed）
- ⏸ `npm run test:visuals`: tilt=75° の描画は不変のためベースライン影響なし（スキップ）