### PR TITLE
高度では空が黒になっていく演出 (#371)

### DIFF
--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -19,7 +19,7 @@ import { createControlPanel, snapScale, formatScale, showToast } from "../terrai
 import { attachResizeRefresh } from "../terrain/resizeRefresh";
 import { createTileManager } from "../terrain/tileManager";
 import type { FrustumPlane } from "../terrain/visibleTiles";
-import { createSkybox } from "../terrain/skybox";
+import { createSkybox, computeSpaceFactor } from "../terrain/skybox";
 import { computeSunPosition } from "../terrain/sunPosition";
 import { deriveSunState } from "../terrain/sunState";
 import { resolveTiltCollision, TILT_MAX_RADIUS_INCREASE_RATIO } from "../terrain/cameraCollision";
@@ -62,6 +62,9 @@ const CAMERA_LOWER_RADIUS = 50;
 const CAMERA_UPPER_RADIUS = 75000;
 /** 遠クリッピング面（メートル） */
 const CAMERA_FAR_CLIP = 400000;
+
+/** 高高度（宇宙空間）の背景色。黒。Issue #371 の高度連動暗化で `clearColor` の到達点とする。 */
+const SPACE_CLEAR_COLOR = new Color3(0, 0, 0);
 
 /**
  * 2D (orthographic) モードでのカメラ最低高度（メートル）。
@@ -2375,16 +2378,15 @@ export class DefaultScene implements CreateSceneClass {
                 return;
             }
             const state = deriveSunState(altitudeDeg, azimuthDeg);
-            // SkyMaterial 更新
-            skyboxHandle.applySunToSky(state);
+            // 高度連動の暗化（高高度ほど空を黒く＝宇宙空間へ）。Issue #371。
+            const spaceFactor = computeSpaceFactor(camera.radius);
+            // SkyMaterial 更新（時刻連動 + 高度連動）
+            skyboxHandle.applySunToSky(state, spaceFactor);
             // 夜は SkyMaterial の物理モデルが破綻するため Skybox を消し、`clearColor`（夜色）を背景に出す。
             skyboxHandle.mesh.setEnabled(state.skyVisible);
-            scene.clearColor.set(
-                state.clearColor.r,
-                state.clearColor.g,
-                state.clearColor.b,
-                1,
-            );
+            // 背景色も高度に応じて黒へ寄せ、Skybox 非表示時（夜）でも宇宙の黒を表現する。
+            const bg = Color3.Lerp(state.clearColor, SPACE_CLEAR_COLOR, spaceFactor);
+            scene.clearColor.set(bg.r, bg.g, bg.b, 1);
             // 指向性ライト方向 = 太陽から地表向き = -sunDir
             sunLight.direction = state.sunDir.scale(-1);
             sunLight.intensity = state.dayFactor;

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -2385,8 +2385,13 @@ export class DefaultScene implements CreateSceneClass {
             // 夜は SkyMaterial の物理モデルが破綻するため Skybox を消し、`clearColor`（夜色）を背景に出す。
             skyboxHandle.mesh.setEnabled(state.skyVisible);
             // 背景色も高度に応じて黒へ寄せ、Skybox 非表示時（夜）でも宇宙の黒を表現する。
-            const bg = Color3.Lerp(state.clearColor, SPACE_CLEAR_COLOR, spaceFactor);
-            scene.clearColor.set(bg.r, bg.g, bg.b, 1);
+            // 毎更新で Color3 を新規生成しないよう、各チャンネルを直接 lerp して set する。
+            scene.clearColor.set(
+                state.clearColor.r + (SPACE_CLEAR_COLOR.r - state.clearColor.r) * spaceFactor,
+                state.clearColor.g + (SPACE_CLEAR_COLOR.g - state.clearColor.g) * spaceFactor,
+                state.clearColor.b + (SPACE_CLEAR_COLOR.b - state.clearColor.b) * spaceFactor,
+                1,
+            );
             // 指向性ライト方向 = 太陽から地表向き = -sunDir
             sunLight.direction = state.sunDir.scale(-1);
             sunLight.intensity = state.dayFactor;

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -1606,8 +1606,13 @@ export class GlobeScene {
             // 高度連動の背景暗化（高高度ほど宇宙の黒へ）。Issue #371。
             // 真の測地高度 altMeters を用い、約 12km から暗化開始・75km でほぼ黒に収束させる。
             const spaceFactor = computeSpaceFactor(camGeo.altMeters);
-            const bg = Color3.Lerp(DAY_SKY_COLOR, SPACE_SKY_COLOR, spaceFactor);
-            scene.clearColor.set(bg.r, bg.g, bg.b, 1);
+            // 毎フレーム Color3 を新規生成しないよう、各チャンネルを直接 lerp して set する。
+            scene.clearColor.set(
+                DAY_SKY_COLOR.r + (SPACE_SKY_COLOR.r - DAY_SKY_COLOR.r) * spaceFactor,
+                DAY_SKY_COLOR.g + (SPACE_SKY_COLOR.g - DAY_SKY_COLOR.g) * spaceFactor,
+                DAY_SKY_COLOR.b + (SPACE_SKY_COLOR.b - DAY_SKY_COLOR.b) * spaceFactor,
+                1,
+            );
             // ズーム中（ホイール〜慣性減衰）は seat を止め、鉛直の引っ張り合いによる揺れを防ぐ。
             seatCenterOnTerrain(camGeo.altMeters, isZoomActive());
             enforceGroundClearance(camEcef, camGeo);

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -45,6 +45,7 @@ import { createGlobeMarkerManager, type GlobeMarkerManager } from "../terrain/ge
 import { createGlobePolygonManager, type GlobePolygonManager, type GlobePolygonPickablePoint } from "../terrain/geo/globePolygonManager";
 import { createGlobeCircleManager, type GlobeCircleManager } from "../terrain/geo/globeCircleManager";
 import { createGlobeModelManager, type GlobeModelManager } from "../terrain/geo/globeModelManager";
+import { computeSpaceFactor } from "../terrain/skybox";
 
 /** グローブシーンの既定パラメータ（富士山周辺）。 */
 export const GLOBE_SCENE_DEFAULTS = {
@@ -123,6 +124,11 @@ const MIN_GROUND_CLEARANCE = 50;
 
 /** WASD パン対象キー。 */
 const PAN_KEYS = new Set(["w", "a", "s", "d"]);
+
+/** 低高度（地表付近）の背景色（青空）。`scene.clearColor` の初期値と一致。 */
+const DAY_SKY_COLOR = new Color3(0.75, 0.86, 0.95);
+/** 高高度（宇宙空間）の背景色（黒）。Issue #371 の高度連動暗化の到達点。 */
+const SPACE_SKY_COLOR = new Color3(0, 0, 0);
 
 /**
  * 最大チルト[deg]（pitch 上限, Issue #335 UX ガード）。完全水平（90°=地平線真正面）では
@@ -1597,6 +1603,11 @@ export class GlobeScene {
             // わずかに動かすため衝突はその直前のスナップショットを使うが、毎フレーム補正のため実用上問題ない。
             const camEcef = computeCameraEcef(); // lookAt バッファも更新される
             const camGeo = ecefToGeodetic(camEcef);
+            // 高度連動の背景暗化（高高度ほど宇宙の黒へ）。Issue #371。
+            // 真の測地高度 altMeters を用い、約 12km から暗化開始・75km でほぼ黒に収束させる。
+            const spaceFactor = computeSpaceFactor(camGeo.altMeters);
+            const bg = Color3.Lerp(DAY_SKY_COLOR, SPACE_SKY_COLOR, spaceFactor);
+            scene.clearColor.set(bg.r, bg.g, bg.b, 1);
             // ズーム中（ホイール〜慣性減衰）は seat を止め、鉛直の引っ張り合いによる揺れを防ぐ。
             seatCenterOnTerrain(camGeo.altMeters, isZoomActive());
             enforceGroundClearance(camEcef, camGeo);

--- a/src/terrain/skybox.ts
+++ b/src/terrain/skybox.ts
@@ -4,18 +4,53 @@ import { SkyMaterial } from "@babylonjs/materials/sky/skyMaterial";
 import type { Mesh } from "@babylonjs/core/Meshes/mesh";
 import type { SunState } from "./sunState";
 
+/** SkyMaterial.rayleigh の基準値（低高度・地表での青空散乱量）。 */
+const BASE_RAYLEIGH = 2;
+
+/**
+ * 空が暗化し始める高度（メートル）。現実の大気では成層圏付近からレイリー散乱が
+ * 急速に弱まり空が暗い青へ転じるため、約 12km を開始点とする（Issue #371）。
+ */
+export const SPACE_FADE_START_M = 12000;
+/**
+ * 空がほぼ黒（宇宙空間）になる高度（メートル）。カメラ高度上限（75km）に合わせる。
+ * 現実のカーマンライン（100km）には届かないが、上限で「ほぼ黒」へ収束させる。
+ */
+export const SPACE_FADE_END_M = 75000;
+
+/** `t` を `[edge0, edge1]` で正規化し Hermite smoothstep で滑らかにする。 */
+const smoothstep = (edge0: number, edge1: number, t: number): number => {
+    if (edge1 === edge0) return t < edge0 ? 0 : 1;
+    const x = Math.max(0, Math.min(1, (t - edge0) / (edge1 - edge0)));
+    return x * x * (3 - 2 * x);
+};
+
+/**
+ * カメラ高度（メートル）から「宇宙度」を導く純関数。
+ * 0=低高度の青空、1=高高度でほぼ黒。`SPACE_FADE_START_M`〜`SPACE_FADE_END_M` を
+ * smoothstep で連続補間する（Issue #371）。
+ */
+export function computeSpaceFactor(altitudeMeters: number): number {
+    if (!Number.isFinite(altitudeMeters)) return 0;
+    return smoothstep(SPACE_FADE_START_M, SPACE_FADE_END_M, altitudeMeters);
+}
+
 /**
  * `createSkybox` の戻り値。Mesh 単体だけでなく、太陽位置を流し込むための
- * `applySunToSky` も合わせて返す。利用側は `applySunToSky(state)` を毎更新ごとに呼び、
- * `inclination` / `azimuth` / `luminance` をワンセットで反映する。
+ * `applySunToSky` も合わせて返す。利用側は `applySunToSky(state, spaceFactor)` を毎更新ごとに呼び、
+ * `inclination` / `azimuth` / `luminance` と高度連動の暗化をワンセットで反映する。
  */
 export interface SkyboxHandle {
     /** Skybox メッシュ */
     mesh: Mesh;
     /** SkyMaterial インスタンス（テスト・デバッグ用に露出） */
     material: SkyMaterial;
-    /** 太陽位置パラメータを SkyMaterial へ流し込む */
-    applySunToSky(state: SunState): void;
+    /**
+     * 太陽位置パラメータと高度連動の暗化を SkyMaterial へ流し込む。
+     * @param state 時刻連動の太陽パラメータ
+     * @param spaceFactor 高度連動の宇宙度（0=青空, 1=ほぼ黒）。既定 0。
+     */
+    applySunToSky(state: SunState, spaceFactor?: number): void;
 }
 
 export function createSkybox(scene: Scene): SkyboxHandle {
@@ -25,7 +60,7 @@ export function createSkybox(scene: Scene): SkyboxHandle {
     skyMaterial.backFaceCulling = false;
     skyMaterial.turbidity = 10;
     skyMaterial.luminance = 1;
-    skyMaterial.rayleigh = 2;
+    skyMaterial.rayleigh = BASE_RAYLEIGH;
     skyMaterial.mieCoefficient = 0.005;
     skyMaterial.mieDirectionalG = 0.8;
     skyMaterial.inclination = 0.25;
@@ -36,10 +71,13 @@ export function createSkybox(scene: Scene): SkyboxHandle {
     skybox.isPickable = false;
     skybox.infiniteDistance = true;
 
-    const applySunToSky = (state: SunState): void => {
+    const applySunToSky = (state: SunState, spaceFactor = 0): void => {
+        const f = Math.max(0, Math.min(1, spaceFactor));
         skyMaterial.inclination = state.skyInclination;
         skyMaterial.azimuth = state.skyAzimuth;
-        skyMaterial.luminance = state.skyLuminance;
+        // 高度が上がるほど輝度とレイリー散乱を 0 へ落とし、空を黒（宇宙）へ近づける。
+        skyMaterial.luminance = state.skyLuminance * (1 - f);
+        skyMaterial.rayleigh = BASE_RAYLEIGH * (1 - f);
     };
 
     return { mesh: skybox, material: skyMaterial, applySunToSky };

--- a/src/terrain/skybox.ts
+++ b/src/terrain/skybox.ts
@@ -72,7 +72,11 @@ export function createSkybox(scene: Scene): SkyboxHandle {
     skybox.infiniteDistance = true;
 
     const applySunToSky = (state: SunState, spaceFactor = 0): void => {
-        const f = Math.max(0, Math.min(1, spaceFactor));
+        // 非有限値（NaN/Infinity）は 0 扱いにしてから [0,1] へクランプし、NaN が
+        // luminance / rayleigh に流れて描画が破綻するのを防ぐ。
+        const f = Number.isFinite(spaceFactor)
+            ? Math.max(0, Math.min(1, spaceFactor))
+            : 0;
         skyMaterial.inclination = state.skyInclination;
         skyMaterial.azimuth = state.skyAzimuth;
         // 高度が上がるほど輝度とレイリー散乱を 0 へ落とし、空を黒（宇宙）へ近づける。

--- a/tests/skybox.unit.spec.ts
+++ b/tests/skybox.unit.spec.ts
@@ -53,10 +53,8 @@ jest.unstable_mockModule("@babylonjs/materials/sky/skyMaterial", () => ({
     SkyMaterial: jest.fn(() => mockSkyMaterialInstance),
 }));
 
-const { createSkybox } = await import("../src/terrain/skybox");
-const { computeSpaceFactor, SPACE_FADE_START_M, SPACE_FADE_END_M } = await import(
-    "../src/terrain/skybox"
-);
+const { createSkybox, computeSpaceFactor, SPACE_FADE_START_M, SPACE_FADE_END_M } =
+    await import("../src/terrain/skybox");
 const { CreateBox } = await import("@babylonjs/core/Meshes/Builders/boxBuilder");
 
 const mockScene = {} as never;
@@ -144,6 +142,12 @@ describe("createSkybox", () => {
         handle.applySunToSky(state, 0.5);
         expect(mockSkyMaterialInstance.luminance).toBeCloseTo(0.25, 5);
         expect(mockSkyMaterialInstance.rayleigh).toBeCloseTo(1, 5);
+        // 非有限値（NaN）は 0 扱いとし、NaN が SkyMaterial へ流れない。
+        handle.applySunToSky(state, Number.NaN);
+        expect(Number.isNaN(mockSkyMaterialInstance.luminance)).toBe(false);
+        expect(Number.isNaN(mockSkyMaterialInstance.rayleigh)).toBe(false);
+        expect(mockSkyMaterialInstance.luminance).toBeCloseTo(0.5, 5);
+        expect(mockSkyMaterialInstance.rayleigh).toBeCloseTo(2, 5);
     });
 });
 

--- a/tests/skybox.unit.spec.ts
+++ b/tests/skybox.unit.spec.ts
@@ -54,6 +54,9 @@ jest.unstable_mockModule("@babylonjs/materials/sky/skyMaterial", () => ({
 }));
 
 const { createSkybox } = await import("../src/terrain/skybox");
+const { computeSpaceFactor, SPACE_FADE_START_M, SPACE_FADE_END_M } = await import(
+    "../src/terrain/skybox"
+);
 const { CreateBox } = await import("@babylonjs/core/Meshes/Builders/boxBuilder");
 
 const mockScene = {} as never;
@@ -115,5 +118,60 @@ describe("createSkybox", () => {
     it("skybox に SkyMaterial が割り当てられる", () => {
         createSkybox(mockScene);
         expect(mockMesh.material).toBe(mockSkyMaterialInstance);
+    });
+
+    it("applySunToSky は spaceFactor で luminance / rayleigh を暗化する", () => {
+        const handle = createSkybox(mockScene);
+        const state = {
+            sunDir: new Vector3(0, 1, 0),
+            dayFactor: 1,
+            skyInclination: 0.1,
+            skyAzimuth: 0.7,
+            skyLuminance: 0.5,
+            skyVisible: true,
+            clearColor: new Color3(0.75, 0.86, 0.95),
+            visibleAboveHorizon: true,
+        };
+        // spaceFactor=1 で空はほぼ黒（luminance/rayleigh が 0）。
+        handle.applySunToSky(state, 1);
+        expect(mockSkyMaterialInstance.luminance).toBeCloseTo(0, 5);
+        expect(mockSkyMaterialInstance.rayleigh).toBeCloseTo(0, 5);
+        // spaceFactor=0 では従来どおり（luminance=skyLuminance, rayleigh=2）。
+        handle.applySunToSky(state, 0);
+        expect(mockSkyMaterialInstance.luminance).toBeCloseTo(0.5, 5);
+        expect(mockSkyMaterialInstance.rayleigh).toBeCloseTo(2, 5);
+        // 中間（0.5）は線形に減衰。
+        handle.applySunToSky(state, 0.5);
+        expect(mockSkyMaterialInstance.luminance).toBeCloseTo(0.25, 5);
+        expect(mockSkyMaterialInstance.rayleigh).toBeCloseTo(1, 5);
+    });
+});
+
+describe("computeSpaceFactor", () => {
+    it("開始高度以下では 0（青空）", () => {
+        expect(computeSpaceFactor(0)).toBe(0);
+        expect(computeSpaceFactor(SPACE_FADE_START_M)).toBe(0);
+        expect(computeSpaceFactor(-100)).toBe(0);
+    });
+
+    it("終了高度以上では 1（ほぼ黒）", () => {
+        expect(computeSpaceFactor(SPACE_FADE_END_M)).toBe(1);
+        expect(computeSpaceFactor(SPACE_FADE_END_M + 10000)).toBe(1);
+    });
+
+    it("中間高度では 0..1 で単調増加する", () => {
+        const mid = (SPACE_FADE_START_M + SPACE_FADE_END_M) / 2;
+        const v = computeSpaceFactor(mid);
+        expect(v).toBeGreaterThan(0);
+        expect(v).toBeLessThan(1);
+        const lower = computeSpaceFactor(mid - 5000);
+        const upper = computeSpaceFactor(mid + 5000);
+        expect(lower).toBeLessThan(v);
+        expect(upper).toBeGreaterThan(v);
+    });
+
+    it("非有限値は 0 を返す", () => {
+        expect(computeSpaceFactor(Number.NaN)).toBe(0);
+        expect(computeSpaceFactor(Number.POSITIVE_INFINITY)).toBe(0);
     });
 });


### PR DESCRIPTION
## 概要
カメラ高度を上げるほど空を徐々に黒く（宇宙空間風に）する演出を追加する。低高度では従来どおり青空。空色が切り替わる高度は現実準拠（約12kmから暗化開始、75kmでほぼ黒）。

Closes #371

## 変更内容
- `src/terrain/skybox.ts`
  - `computeSpaceFactor(altitudeMeters)` 純関数と暗化バンド定数（`SPACE_FADE_START_M=12000` / `SPACE_FADE_END_M=75000`）を追加。
  - `applySunToSky(state, spaceFactor)` で高度連動の `luminance` / `rayleigh` 減衰を反映。
- `src/scenes/default.ts`
  - 描画更新時に `camera.radius`（高度）から `spaceFactor` を算出し、SkyMaterial と背景色（黒へ補間）に反映。
- `src/scenes/globe.ts`
  - 描画ループで真の測地高度 `altMeters` から `spaceFactor` を算出し、`scene.clearColor` を青空→黒へ補間。
- `tests/skybox.unit.spec.ts`
  - `computeSpaceFactor` の境界値と暗化（luminance/rayleigh 減衰）のユニットテストを追加。

## 影響範囲
- 画面: default / globe 両シーンの空（背景）描画。低高度（<12km）は従来挙動と同一。
- API/型: `SkyboxHandle.applySunToSky` に省略可能な第2引数 `spaceFactor` を追加（後方互換）。
- globe の初期高度は60km（既定 `radius:60000`）のため初期表示でも暗めになる（現実準拠）。

## 検証
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run test:unit`（1273）✅
- `npm run test:visuals`（19）✅
- 目視確認（HITL）: default / globe で高度を上げ空が黒くなることを確認 ✅