### PR TITLE
feat(scenes): globe の skybox を太陽位置で昼夜・茜色に変化 (#380)

### DIFF
--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -274,6 +274,12 @@ export interface GlobeSceneController {
     /** 太陽メッシュ（発光球）。時刻連動で太陽方向に配置・表示する（#368 / P4-1）。 */
     sunMesh: Mesh;
     /**
+     * 時刻連動の背景（skybox）基調色（Issue #380）。`scene.clearColor` は毎フレーム
+     * この色から `SPACE_SKY_COLOR`（宇宙黒）へ高度連動で lerp して決まる。
+     * 太陽位置に応じた更新は controller（globeSceneController）が `deriveSkyColor` で行う。
+     */
+    skyBaseColor: Color3;
+    /**
      * 地形クリック購読（pick 非依存・floating origin 対応）。クリック地点の緯度経度・標高を
      * リスナーへ通知する。戻り値で購読解除する。
      */
@@ -1596,6 +1602,9 @@ export class GlobeScene {
         // 戻り値から代入される controller」をまだ初期化前に参照し TDZ エラーになるため。
         // frame=0 の最初のフレームで即同期し、以降は syncIntervalFrames ごとに再評価する。
         let frame = 0;
+        // 時刻連動の背景基調色（Issue #380）。controller が deriveSkyColor で更新する。
+        // 初期値は昼空色（dateTime 反映前のフォールバック）。
+        const skyBaseColor = DAY_SKY_COLOR.clone();
         const observer = scene.onBeforeRenderObservable.add(() => {
             applyKeyboardPan();
             // カメラ ECEF と測地座標・lookAt を 1 フレーム 1 回だけ計算し、seat と衝突で共有する
@@ -1607,10 +1616,11 @@ export class GlobeScene {
             // 真の測地高度 altMeters を用い、約 12km から暗化開始・75km でほぼ黒に収束させる。
             const spaceFactor = computeSpaceFactor(camGeo.altMeters);
             // 毎フレーム Color3 を新規生成しないよう、各チャンネルを直接 lerp して set する。
+            // 基調色は時刻連動の skyBaseColor（昼=青/夜=紺/日の出入り=茜, Issue #380）。
             scene.clearColor.set(
-                DAY_SKY_COLOR.r + (SPACE_SKY_COLOR.r - DAY_SKY_COLOR.r) * spaceFactor,
-                DAY_SKY_COLOR.g + (SPACE_SKY_COLOR.g - DAY_SKY_COLOR.g) * spaceFactor,
-                DAY_SKY_COLOR.b + (SPACE_SKY_COLOR.b - DAY_SKY_COLOR.b) * spaceFactor,
+                skyBaseColor.r + (SPACE_SKY_COLOR.r - skyBaseColor.r) * spaceFactor,
+                skyBaseColor.g + (SPACE_SKY_COLOR.g - skyBaseColor.g) * spaceFactor,
+                skyBaseColor.b + (SPACE_SKY_COLOR.b - skyBaseColor.b) * spaceFactor,
                 1,
             );
             // ズーム中（ホイール〜慣性減衰）は seat を止め、鉛直の引っ張り合いによる揺れを防ぐ。
@@ -1667,6 +1677,7 @@ export class GlobeScene {
             sunLight: sun,
             hemiLight: hemi,
             sunMesh,
+            skyBaseColor,
             subscribeTerrainClick,
             subscribePolygonPointHover,
             subscribePolygonPointClick,

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -19,6 +19,7 @@ import { JAPAN_BOUNDS } from "../terrain/gsiTile";
 import { geodeticToEcef, ecefToGeodetic } from "../terrain/geo/ecef";
 import { sunDirectionEcefToRef } from "../terrain/geo/sunDirectionEcef";
 import { computeSunPosition } from "../terrain/sunPosition";
+import { deriveSkyColor } from "../terrain/sunState";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { Wgs84Ellipsoid } from "@babylonjs/core/Maths/math.geospatial.functions";
 import {
@@ -1463,6 +1464,9 @@ export const createGlobeSceneController = (
         // 注視点の昼夜でシーン全体を減光しないことで、地球の裏側の昼領域が一律に暗くなる不自然さを避ける。
         gc.sunLight.intensity = GLOBE_SUN_LIGHT_INTENSITY;
         gc.hemiLight.intensity = GLOBE_HEMI_LIGHT_INTENSITY;
+        // 時刻連動の背景基調色（Issue #380）。注視点の太陽高度から昼=青/夜=紺/日の出入り=茜 を導き、
+        // globe.ts の clearColor ループが毎フレームこの色から宇宙黒へ高度連動で lerp する。
+        gc.skyBaseColor.copyFrom(deriveSkyColor(altitudeDeg));
         // 太陽メッシュ（発光球）。infiniteDistance がカメラ位置を加算するため、position には
         // 太陽方向×距離（カメラからのオフセット）だけを設定する。距離・サイズ・遮蔽は placeSunMesh
         // が毎フレーム評価する。
@@ -1475,6 +1479,28 @@ export const createGlobeSceneController = (
     // 再配置する。これがないと、ズームイン時に算出した小さな距離・サイズが stale 化し、ズームアウト
     // 時に太陽が極小化して見えなくなる（地球の弧が見える広域ズームで顕著）。
     const sunMeshObserver = gc.scene.onBeforeRenderObservable.add(placeSunMesh);
+
+    // 注視点の移動（パン）でも背景色が昼夜境界（ターミネータ）を跨いで追従するよう、中心の
+    // 緯度経度が変化したら太陽状態を再計算する（planar が centerChanged で再計算するのと挙動を揃える, #380）。
+    // 太陽の ECEF 方向は dateTime 固定なら中心移動に対して実質不変だが、注視点のローカル太陽高度は
+    // 変わるため skyBaseColor の更新が必要。毎フレームの天文計算を避けるため中心変化時のみ実行する。
+    let lastSunCenterLat = Number.NaN;
+    let lastSunCenterLon = Number.NaN;
+    const skyColorObserver = gc.scene.onBeforeRenderObservable.add(() => {
+        // 太陽未初期化（setSunState 未呼び出し）の間は no-op（placeSunMesh と同じ方針）。
+        // 実利用では JpmapTerrain 初期化時に必ず setSunState が呼ばれるため、初回反映後にパン追従する。
+        if (!sunStateValid) return;
+        const { latDeg, lonDeg } = currentGeodetic();
+        if (
+            Math.abs(latDeg - lastSunCenterLat) < 0.01 &&
+            Math.abs(lonDeg - lastSunCenterLon) < 0.01
+        ) {
+            return;
+        }
+        lastSunCenterLat = latDeg;
+        lastSunCenterLon = lonDeg;
+        applyGlobeSunState();
+    });
 
     // ---- UI コントロールパネル配線（#275 Phase 4 / P4-1） ----
     // canvas が渡された実行時のみ DOM コントロールパネルを生成・配線する（単体テストの
@@ -1779,6 +1805,7 @@ export const createGlobeSceneController = (
 
         dispose: () => {
             gc.scene.onBeforeRenderObservable.remove(sunMeshObserver);
+            gc.scene.onBeforeRenderObservable.remove(skyColorObserver);
             uiDispose();
             gc.dispose();
         },

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -1491,6 +1491,13 @@ export const createGlobeSceneController = (
         // 実利用では JpmapTerrain 初期化時に必ず setSunState が呼ばれるため、初回反映後にパン追従する。
         if (!sunStateValid) return;
         const { latDeg, lonDeg } = currentGeodetic();
+        // 初回（last* が NaN）は setSunState が直前に applyGlobeSunState を実行済みのため、
+        // 比較用の中心だけ記録して return し、初期化直後の重複計算を避ける。
+        if (Number.isNaN(lastSunCenterLat) || Number.isNaN(lastSunCenterLon)) {
+            lastSunCenterLat = latDeg;
+            lastSunCenterLon = lonDeg;
+            return;
+        }
         if (
             Math.abs(latDeg - lastSunCenterLat) < 0.01 &&
             Math.abs(lonDeg - lastSunCenterLon) < 0.01

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -1483,29 +1483,35 @@ export const createGlobeSceneController = (
     // 注視点の移動（パン）でも背景色が昼夜境界（ターミネータ）を跨いで追従するよう、中心の
     // 緯度経度が変化したら太陽状態を再計算する（planar が centerChanged で再計算するのと挙動を揃える, #380）。
     // 太陽の ECEF 方向は dateTime 固定なら中心移動に対して実質不変だが、注視点のローカル太陽高度は
-    // 変わるため skyBaseColor の更新が必要。毎フレームの天文計算を避けるため中心変化時のみ実行する。
-    let lastSunCenterLat = Number.NaN;
-    let lastSunCenterLon = Number.NaN;
+    // 変わるため skyBaseColor の更新が必要。
+    // per-frame コスト削減のため、変化検出は ECEF 座標差分（三角関数なし）で行い、しきい値を超えた
+    // ときだけ applyGlobeSunState を呼ぶ（測地逆変換 ecefToGeodetic はその中で 1 回だけ走る）。
+    // しきい値 1km は緯度 0.01°（≒1.1km）相当で、従来の lat/lon 比較と同程度の感度。
+    const SUN_CENTER_MOVE_THRESHOLD_M = 1000;
+    const SUN_CENTER_MOVE_THRESHOLD_SQ =
+        SUN_CENTER_MOVE_THRESHOLD_M * SUN_CENTER_MOVE_THRESHOLD_M;
+    const lastSunCenterEcef = new Vector3();
+    let sunCenterInitialized = false;
     const skyColorObserver = gc.scene.onBeforeRenderObservable.add(() => {
         // 太陽未初期化（setSunState 未呼び出し）の間は no-op（placeSunMesh と同じ方針）。
         // 実利用では JpmapTerrain 初期化時に必ず setSunState が呼ばれるため、初回反映後にパン追従する。
         if (!sunStateValid) return;
-        const { latDeg, lonDeg } = currentGeodetic();
-        // 初回（last* が NaN）は setSunState が直前に applyGlobeSunState を実行済みのため、
-        // 比較用の中心だけ記録して return し、初期化直後の重複計算を避ける。
-        if (Number.isNaN(lastSunCenterLat) || Number.isNaN(lastSunCenterLon)) {
-            lastSunCenterLat = latDeg;
-            lastSunCenterLon = lonDeg;
+        const center = camera.center;
+        // 初回は setSunState が直前に applyGlobeSunState を実行済みのため、比較用の中心のみ
+        // 記録して return し、初期化直後の重複計算を避ける。
+        if (!sunCenterInitialized) {
+            lastSunCenterEcef.copyFrom(center);
+            sunCenterInitialized = true;
             return;
         }
+        // ECEF 座標差分で中心移動を検出（三角関数を伴う逆測地変換を毎フレーム走らせない）。
         if (
-            Math.abs(latDeg - lastSunCenterLat) < 0.01 &&
-            Math.abs(lonDeg - lastSunCenterLon) < 0.01
+            Vector3.DistanceSquared(center, lastSunCenterEcef) <
+            SUN_CENTER_MOVE_THRESHOLD_SQ
         ) {
             return;
         }
-        lastSunCenterLat = latDeg;
-        lastSunCenterLon = lonDeg;
+        lastSunCenterEcef.copyFrom(center);
         applyGlobeSunState();
     });
 

--- a/src/terrain/sunState.ts
+++ b/src/terrain/sunState.ts
@@ -19,6 +19,16 @@ const DEG2RAD = Math.PI / 180;
 const DAY_CLEAR_COLOR = new Color3(0.75, 0.86, 0.95);
 /** 夜の深い紺色。`Skybox` を非表示にした際に背景として見える */
 const NIGHT_CLEAR_COLOR = new Color3(0.02, 0.03, 0.08);
+/** 日の出・日の入りの茜色（暖色のオレンジ赤）。地平線付近でブレンドする（Issue #380） */
+const DUSK_CLEAR_COLOR = new Color3(0.8, 0.4, 0.22);
+
+/**
+ * 茜色が現れる太陽高度の半幅（度）。地平線（高度 0°）を中心に ±この範囲で茜色を強める。
+ * 民間薄明（±6°）よりやや広く取り、日の出/入り前後を滑らかに彩る。
+ */
+const DUSK_BAND_DEG = 8;
+/** 茜色ブレンドの最大強度（0..1）。1.0 だと地平線でほぼ完全に茜色になる。 */
+const DUSK_STRENGTH = 0.7;
 
 /** Scene へ適用する太陽パラメータ束。Babylon.js への依存はここで吸収する。 */
 export interface SunState {
@@ -106,4 +116,28 @@ export function deriveSunState(
         clearColor,
         visibleAboveHorizon,
     };
+}
+
+/**
+ * 太陽高度（度）から「時刻連動の背景（skybox）色」を導く純関数（Issue #380）。
+ *
+ * SkyMaterial を使わない globe シーン向けに、太陽位置だけで空色を決める。
+ * - 夜（高度 < -6°）: 深い紺（`NIGHT_CLEAR_COLOR`）
+ * - 昼（高度 > +6°）: 薄い青空（`DAY_CLEAR_COLOR`）
+ * - 日の出・日の入り（地平線付近）: 茜色（`DUSK_CLEAR_COLOR`）を重ねる
+ *
+ * planar シーン（`deriveSunState` + SkyMaterial）と色味の方向性を揃えつつ、
+ * 高度連動の宇宙黒化（`computeSpaceFactor`）は呼び出し側で別途合成する。
+ *
+ * @param altitudeDeg 太陽高度（度, -90..90, 地平線=0）。非有限値は昼色フォールバック。
+ */
+export function deriveSkyColor(altitudeDeg: number): Color3 {
+    if (!Number.isFinite(altitudeDeg)) return DAY_CLEAR_COLOR.clone();
+    // 夜→昼の基調色（紺→青）。薄明帯（-6°..+6°）で連続補間。
+    const dayFactor = smoothstep(-6, 6, altitudeDeg);
+    const base = Color3.Lerp(NIGHT_CLEAR_COLOR, DAY_CLEAR_COLOR, dayFactor);
+    // 地平線（高度 0°）を中心に三角プロファイルで茜色を強める。±DUSK_BAND_DEG の外では 0。
+    const duskFactor =
+        Math.max(0, 1 - Math.abs(altitudeDeg) / DUSK_BAND_DEG) * DUSK_STRENGTH;
+    return Color3.Lerp(base, DUSK_CLEAR_COLOR, duskFactor);
 }

--- a/src/terrain/sunState.ts
+++ b/src/terrain/sunState.ts
@@ -122,9 +122,11 @@ export function deriveSunState(
  * 太陽高度（度）から「時刻連動の背景（skybox）色」を導く純関数（Issue #380）。
  *
  * SkyMaterial を使わない globe シーン向けに、太陽位置だけで空色を決める。
- * - 夜（高度 < -6°）: 深い紺（`NIGHT_CLEAR_COLOR`）
- * - 昼（高度 > +6°）: 薄い青空（`DAY_CLEAR_COLOR`）
- * - 日の出・日の入り（地平線付近）: 茜色（`DUSK_CLEAR_COLOR`）を重ねる
+ * 紺→青の基調色は薄明帯（±6°）で連続補間し、さらに地平線付近（±`DUSK_BAND_DEG`=8°）で
+ * 茜色を重ねる。そのため色が変化する高度帯は、基調色（±6°）と茜色（±8°）の和集合になる。
+ * - 夜（高度 ≲ -8°）: 深い紺（`NIGHT_CLEAR_COLOR`）
+ * - 昼（高度 ≳ +8°）: 薄い青空（`DAY_CLEAR_COLOR`）
+ * - 日の出・日の入り（地平線付近 ±8°）: 上記基調色に茜色（`DUSK_CLEAR_COLOR`）をブレンド
  *
  * planar シーン（`deriveSunState` + SkyMaterial）と色味の方向性を揃えつつ、
  * 高度連動の宇宙黒化（`computeSpaceFactor`）は呼び出し側で別途合成する。

--- a/tests/globeSceneController.unit.spec.ts
+++ b/tests/globeSceneController.unit.spec.ts
@@ -6,6 +6,7 @@
  * 往復精度を確認する。overlay 未対応・viewMode "3d" 固定・mapType 切替の暫定挙動もあわせて検証する。
  */
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { Color3 } from "@babylonjs/core/Maths/math.color";
 
 import { jest } from "@jest/globals";
 
@@ -104,6 +105,8 @@ const makeStub = (
             scaling: new Vector3(1, 1, 1),
             setEnabled: jest.fn(),
         },
+        // 時刻連動の背景基調色（#380）。applyGlobeSunState が copyFrom で更新する。
+        skyBaseColor: new Color3(0.75, 0.86, 0.95),
         // 太陽メッシュの毎フレーム再配置オブザーバ登録/解除に必要な最小 scene スタブ。
         scene: {
             onBeforeRenderObservable: {

--- a/tests/sunState.unit.spec.ts
+++ b/tests/sunState.unit.spec.ts
@@ -8,6 +8,7 @@
 import { describe, it, expect } from "@jest/globals";
 
 import { deriveSunState } from "../src/terrain/sunState";
+import { deriveSkyColor } from "../src/terrain/sunState";
 
 describe("deriveSunState", () => {
     it("真昼（高度 60°）は dayFactor=1、skyLuminance≈1、太陽メッシュ可視", () => {
@@ -119,5 +120,49 @@ describe("deriveSunState", () => {
         expect(deriveSunState(0, 0).skyAzimuth).toBeCloseTo(0, 5);
         expect(deriveSunState(0, 90).skyAzimuth).toBeCloseTo(0.25, 5);
         expect(deriveSunState(0, 359.999).skyAzimuth).toBeLessThan(1);
+    });
+});
+
+describe("deriveSkyColor (Issue #380)", () => {
+    it("真昼（高度 60°）は青空色（青 > 赤）", () => {
+        const c = deriveSkyColor(60);
+        expect(c.r).toBeCloseTo(0.75, 5);
+        expect(c.g).toBeCloseTo(0.86, 5);
+        expect(c.b).toBeCloseTo(0.95, 5);
+        expect(c.b).toBeGreaterThan(c.r);
+    });
+
+    it("夜間（高度 -30°）は深い紺（暗く青寄り）", () => {
+        const c = deriveSkyColor(-30);
+        expect(c.r).toBeCloseTo(0.02, 5);
+        expect(c.g).toBeCloseTo(0.03, 5);
+        expect(c.b).toBeCloseTo(0.08, 5);
+    });
+
+    it("地平線付近（高度 0°）は茜色（赤が緑・青より強い暖色）", () => {
+        const c = deriveSkyColor(0);
+        expect(c.r).toBeGreaterThan(c.g);
+        expect(c.r).toBeGreaterThan(c.b);
+        // 昼の青空（青優勢）でも夜の紺でもないことを確認
+        expect(c.r).toBeGreaterThan(0.4);
+    });
+
+    it("茜色は地平線で最も強く、±DUSK_BAND_DEG(8°) の外では消える", () => {
+        // 茜色の強さは赤と青の差（r - b）で測る。地平線で最大、帯の外で 0。
+        const horizon = deriveSkyColor(0);
+        const mid = deriveSkyColor(4);
+        const outside = deriveSkyColor(20);
+        const redness = (c: { r: number; b: number }) => c.r - c.b;
+        expect(redness(horizon)).toBeGreaterThan(redness(mid));
+        expect(redness(mid)).toBeGreaterThan(0);
+        // 帯の外（高度 20°）は昼空色そのもの（茜ブレンド無し）
+        expect(outside.r).toBeCloseTo(0.75, 5);
+        expect(outside.b).toBeGreaterThan(outside.r);
+    });
+
+    it("非有限値は昼空色へフォールバックする", () => {
+        const c = deriveSkyColor(Number.NaN);
+        expect(c.r).toBeCloseTo(0.75, 5);
+        expect(c.b).toBeCloseTo(0.95, 5);
     });
 });


### PR DESCRIPTION
Closes #380

## 概要
globe シーンの背景色（skybox）を注視点のローカル太陽高度に応じて変化させる。
- 昼: 青空（現状維持）
- 夜: 深い紺（planar と同色 0.02,0.03,0.08）
- 日の出・日の入り: 茜色（暖色）を地平線付近でブレンド
- 高度連動の宇宙黒化（#371）は維持。

planar（`default.ts`）は #35/#371 で実装済みのため変更せず、挙動を globe に揃えた。

## 変更内容
- `src/terrain/sunState.ts`: 純関数 `deriveSkyColor(altitudeDeg)` を追加（夜→茜→昼を連続補間、非有限は昼色フォールバック）。
- `src/scenes/globe.ts`: `GlobeSceneController.skyBaseColor` を導入。render ループの `clearColor` を固定の昼空色から「時刻連動の基調色 → 宇宙黒（spaceFactor）」の lerp に変更。
- `src/scenes/globeSceneController.ts`: `applyGlobeSunState` で `skyBaseColor` を更新。注視点移動（パン）でも昼夜境界を跨いで追従するよう中心変化検出オブザーバを追加（太陽未初期化時は no-op）。
- tests: `deriveSkyColor` 単体テスト追加、globe コントローラのスタブ更新。

## 影響範囲
- 画面: globe シーンの背景色のみ（planar 不変）。
- API/型: `GlobeSceneController` に `skyBaseColor: Color3` を追加（内部型）。

## テスト
- `npm run lint` / `npm run typecheck`: PASS
- `npm run test:unit`: 1278 件 PASS
- `npm run test:visuals`（Skybox VR, planar 対象）: 4 件 PASS（planar 回帰なし）
- globe は自動 VR 非対象のため、昼/夜/日の出の目視確認（HITL）を実施し承認済み。