### PR TITLE
feat(demos): avatar-controller を terrainEngine=globe で起動可能に配線 (#382)

### DIFF
--- a/src/demos/avatar-controller/index.ts
+++ b/src/demos/avatar-controller/index.ts
@@ -15,12 +15,15 @@
  * - 地面クリックでスポーン地点を変更
  * - 進行方向に自動回転
  * - 地形追従（`altitudeMode: "terrain"`, `gravity: true`）
+ * - 地形バックエンド: `?terrainEngine=globe|planar`（既定 planar, #275 Phase 4 / P4-2）
+ *   globe では自動スクロール追従はカメラ中心（viewer.lat/lon）駆動で行う
  */
 import { JpmapTerrain } from "../../lib/jpmapTerrain";
 import type { JpmapTerrainOptions, TerrainClickEvent } from "../../lib/types";
 import {
     parseCameraStateFromUrl,
     parseMapTypeFromUrl,
+    resolveTerrainEngine,
 } from "../../terrain/urlState";
 import { GamepadManager } from "@babylonjs/core/Gamepads/gamepadManager";
 import type { GenericPad } from "@babylonjs/core/Gamepads/gamepad";
@@ -89,9 +92,20 @@ const start = async (): Promise<void> => {
 
     const camera = parseCameraStateFromUrl(location.href);
     const mapType = parseMapTypeFromUrl(location.href);
+    const terrainEngine = resolveTerrainEngine(location.search);
+    // globe バックエンドでは ArcRotateCamera("terrain-camera") と external frustum
+    // 系（detachTileCamera / refreshTerrainWithExternalFrustum）が存在しない（globe では
+    // GeospatialCamera ベースでタイルは camera.center 駆動で自動ストリーミングされる）。
+    // そのため自動スクロール追従はカメラ中心（viewer.lat/lon）を直接動かす方式に切替える。
+    const isGlobe = terrainEngine === "globe";
 
     const opts: JpmapTerrainOptions = {
         engine: resolveEngine(location.search),
+        ...(terrainEngine ? { terrainEngine } : {}),
+        // globe は組み込みの WASD / ドラッグパンを持つ。本デモは WASD をアバター操作に
+        // 使い、カメラは自動スクロールでアバターを追従させるため、globe では組み込み
+        // ユーザーパンを無効化して二重スクロール（カメラ競合）を防ぐ。
+        ...(isGlobe ? { enableKeyboardPan: false } : {}),
         lat: camera?.lat ?? TOKYO_STATION.lat,
         lon: camera?.lon ?? TOKYO_STATION.lon,
         altitude: camera?.altitude ?? 500,
@@ -428,9 +442,13 @@ const start = async (): Promise<void> => {
         const js: MoveVector = joystick.pressed
             ? { vx: joystick.value.vx, vy: joystick.value.vy }
             : { vx: 0, vy: 0 };
-        // 画面（カメラ）方位に合わせて回転: 入力の "up" = カメラ前方
+        // 画面（カメラ）方位に合わせて回転: 入力の "up" = カメラ前方。
+        // `rotateByAzimuth` は planar（ArcRotateCamera alpha 由来, 北=0°・反時計回り正）の
+        // 方位規約に合わせてある。globe の azimuth は標準（北=0°・時計回り正）で handedness が
+        // 逆のため、globe では符号を反転して入力をカメラ前方へ正しく揃える。
         const screen = combineInputs([kb, gp, js]);
-        return rotateByAzimuth(screen, viewer.azimuth);
+        const headingAzimuth = isGlobe ? -viewer.azimuth : viewer.azimuth;
+        return rotateByAzimuth(screen, headingAzimuth);
     };
 
     let rafId = 0;
@@ -553,19 +571,21 @@ const start = async (): Promise<void> => {
         const isMovingForScroll = isJumping(jumpState)
             ? moveVectorMagnitude(jumpState.lockedDirection) > MOVING_THRESHOLD
             : mag > MOVING_THRESHOLD;
-        if (isMovingForScroll && autoScrollEnabled && arcCamera) {
+        if (isMovingForScroll && autoScrollEnabled && (arcCamera || isGlobe)) {
             const cameraLatNow = viewer.lat;
             const cameraLonNow = viewer.lon;
             // 2D (ortho) モードでは altitude/tilt から可視範囲を推定できないため、
             // ortho サイズを extent として渡す。
             // 短辺側を使うことでアスペクト比に関わらず画面外に出ないことを保証する。
+            // globe は常に "3d" のためこの分岐には入らない。
             const is2D = viewer.viewMode === "2d";
-            const viewExtentOverride = is2D
-                ? Math.min(
-                      arcCamera.orthoTop ?? 0,
-                      arcCamera.orthoRight ?? 0,
-                  ) || undefined
-                : undefined;
+            const viewExtentOverride =
+                is2D && arcCamera
+                    ? Math.min(
+                          arcCamera.orthoTop ?? 0,
+                          arcCamera.orthoRight ?? 0,
+                      ) || undefined
+                    : undefined;
             const scroll = computeAutoScroll({
                 avatarLat,
                 avatarLon,
@@ -578,32 +598,39 @@ const start = async (): Promise<void> => {
                 viewExtentOverride,
             });
             if (scroll.scrolled) {
-                // 初回スクロール時に detach する（初期表示の境界タイル欠けを防ぐ）
-                if (!tileCameraDetached) {
-                    viewer.detachTileCamera();
-                    tileCameraDetached = true;
-                }
-                // (1) camera.target を直接動かして滑らかに追従 (setter は呼ばない)
-                const dLat = scroll.lat - cameraLatNow;
-                const dLon = scroll.lon - cameraLonNow;
-                const metersPerDegLon =
-                    METERS_PER_DEGREE_LAT *
-                    Math.cos((cameraLatNow * Math.PI) / 180);
-                arcCamera.target.x += dLon * metersPerDegLon;
-                arcCamera.target.z += dLat * METERS_PER_DEGREE_LAT;
+                if (isGlobe) {
+                    // globe: カメラ中心を直接動かす。タイルは camera.center 駆動で
+                    // 自動ストリーミングされるため external frustum refresh は不要。
+                    viewer.lat = scroll.lat;
+                    viewer.lon = scroll.lon;
+                } else if (arcCamera) {
+                    // 初回スクロール時に detach する（初期表示の境界タイル欠けを防ぐ）
+                    if (!tileCameraDetached) {
+                        viewer.detachTileCamera();
+                        tileCameraDetached = true;
+                    }
+                    // (1) camera.target を直接動かして滑らかに追従 (setter は呼ばない)
+                    const dLat = scroll.lat - cameraLatNow;
+                    const dLon = scroll.lon - cameraLonNow;
+                    const metersPerDegLon =
+                        METERS_PER_DEGREE_LAT *
+                        Math.cos((cameraLatNow * Math.PI) / 180);
+                    arcCamera.target.x += dLon * metersPerDegLon;
+                    arcCamera.target.z += dLat * METERS_PER_DEGREE_LAT;
 
-                // (2) 距離スロットル + in-flight ガード付きでタイル refresh
-                const refLatNow = viewer.lat;
-                const refLonNow = viewer.lon;
-                const movedLat =
-                    (refLatNow - lastRefreshLat) * METERS_PER_DEGREE_LAT;
-                const movedLon =
-                    (refLonNow - lastRefreshLon) *
-                    METERS_PER_DEGREE_LAT *
-                    Math.cos((refLatNow * Math.PI) / 180);
-                const movedM = Math.hypot(movedLat, movedLon);
-                if (movedM >= SCROLL_REFRESH_DISTANCE_M) {
-                    triggerTileRefresh(timestamp);
+                    // (2) 距離スロットル + in-flight ガード付きでタイル refresh
+                    const refLatNow = viewer.lat;
+                    const refLonNow = viewer.lon;
+                    const movedLat =
+                        (refLatNow - lastRefreshLat) * METERS_PER_DEGREE_LAT;
+                    const movedLon =
+                        (refLonNow - lastRefreshLon) *
+                        METERS_PER_DEGREE_LAT *
+                        Math.cos((refLatNow * Math.PI) / 180);
+                    const movedM = Math.hypot(movedLat, movedLon);
+                    if (movedM >= SCROLL_REFRESH_DISTANCE_M) {
+                        triggerTileRefresh(timestamp);
+                    }
                 }
             }
         }

--- a/src/demos/avatar-controller/index.ts
+++ b/src/demos/avatar-controller/index.ts
@@ -102,9 +102,10 @@ const start = async (): Promise<void> => {
     const opts: JpmapTerrainOptions = {
         engine: resolveEngine(location.search),
         ...(terrainEngine ? { terrainEngine } : {}),
-        // globe は組み込みの WASD / ドラッグパンを持つ。本デモは WASD をアバター操作に
-        // 使い、カメラは自動スクロールでアバターを追従させるため、globe では組み込み
-        // ユーザーパンを無効化して二重スクロール（カメラ競合）を防ぐ。
+        // globe は組み込みの WASD キーボードパンを持つ。本デモは WASD をアバター操作に
+        // 使い、カメラは自動スクロールでアバターを追従させるため、globe では WASD パンのみ
+        // 無効化して二重スクロール（カメラ競合）を防ぐ。ドラッグパンは手動での視点移動用に
+        // 有効のまま残す。
         ...(isGlobe ? { enableKeyboardPan: false } : {}),
         lat: camera?.lat ?? TOKYO_STATION.lat,
         lon: camera?.lon ?? TOKYO_STATION.lon,

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -92,6 +92,9 @@ export class JpmapTerrain {
     /** ドラッグによるマップのパン操作 (Issue #259)。既定 ON */
     private _enablePan: boolean;
 
+    /** WASD キーボードによるマップのパン操作（globe のみ）。既定 ON */
+    private _enableKeyboardPan: boolean;
+
     private _canvas: HTMLCanvasElement | null = null;
     private _engine: AbstractEngine | null = null;
     private _scene: Scene | null = null;
@@ -150,6 +153,9 @@ export class JpmapTerrain {
             options.showSunShadows ?? JPMAP_TERRAIN_DEFAULTS.showSunShadows;
         this._enablePan =
             options.enablePan ?? JPMAP_TERRAIN_DEFAULTS.enablePan;
+        this._enableKeyboardPan =
+            options.enableKeyboardPan ??
+            JPMAP_TERRAIN_DEFAULTS.enableKeyboardPan;
     }
 
     /**
@@ -235,6 +241,7 @@ export class JpmapTerrain {
                 viewMode: this._viewMode,
                 onViewModeChange: (next) => this._handleViewModeChange(next),
                 enablePan: this._enablePan,
+                enableKeyboardPan: this._enableKeyboardPan,
                 onCameraInteractionEnd: () => {
                     // #225: ドラッグリリース時にスナップショットを無効化し、
                     // 次フレームで新しいベースラインを取得させる。

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -93,6 +93,13 @@ export interface JpmapTerrainOptions {
      * 砲撃ゲームのように戦場を常に中央へ固定したいデモで使用する。
      */
     enablePan?: boolean;
+    /**
+     * WASD キーボードによるマップのパン操作を有効にするかどうか（globe バックエンドのみ）。
+     * 既定 `true`。`false` を指定すると WASD によるカメラパンを無効化する（左ドラッグパン・
+     * 回転・ズームは有効のまま）。WASD を独自操作に使うデモ（avatar-controller など）で、
+     * 組み込みの WASD パンとの競合を避けるために使用する。planar では WASD パン自体が無いため無効。
+     */
+    enableKeyboardPan?: boolean;
 }
 
 /**
@@ -133,6 +140,7 @@ export const JPMAP_TERRAIN_DEFAULTS = {
     autoSunPosition: false as boolean,
     showSunShadows: false as boolean,
     enablePan: true as boolean,
+    enableKeyboardPan: true as boolean,
 } as const;
 
 /**

--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -399,6 +399,11 @@ export interface DefaultSceneInitOptions {
      */
     enablePan?: boolean;
     /**
+     * WASD キーボードによるマップのパン操作を有効にするかどうか（globe バックエンドのみ有効）。
+     * 既定 `true`。planar では WASD パンが存在しないため無視される。
+     */
+    enableKeyboardPan?: boolean;
+    /**
      * シーン構築完了時に外部操作用コントローラを受け取るコールバック (T5)。
      * `JpmapTerrain` の get/set/flyTo はこのコントローラ経由でカメラ・位置を更新する。
      */

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -176,6 +176,18 @@ export interface GlobeSceneInitOptions {
     mapType?: MapType;
     /** クロスレベル標高スナップを有効化するか（既定 true）。 */
     snapEnabled?: boolean;
+    /**
+     * ユーザーによるマップのパン操作（左ドラッグ / WASD キーボード）を有効にするか（既定 true）。
+     * `false` の場合は組み込みのドラッグパン・WASD パンを無効化する（回転・ズームは有効のまま）。
+     * カメラを外部（例: アバター追従）から駆動するデモで、組み込みパンとの競合を避けるために使う。
+     */
+    enablePan?: boolean;
+    /**
+     * WASD キーボードによるマップのパン操作を有効にするか（既定 true）。
+     * `false` の場合は WASD パンのみ無効化する（左ドラッグパン・回転・ズームは有効のまま）。
+     * WASD を独自操作に使うデモ（avatar-controller など）で組み込み WASD パンとの競合を避けるために使う。
+     */
+    enableKeyboardPan?: boolean;
     /** 同期統計のコールバック（情報表示・テスト用）。 */
     onSyncStats?: (stats: GlobeSceneSyncInfo) => void;
 }
@@ -336,6 +348,12 @@ export class GlobeScene {
         const tilt = options.tilt ?? GLOBE_SCENE_DEFAULTS.tilt;
         const mapType: MapType = options.mapType ?? "std";
         const snapEnabled = options.snapEnabled ?? true;
+        // ユーザーパン（左ドラッグ / WASD）を有効にするか。外部からカメラを駆動する
+        // デモ（アバター追従など）では false にして組み込みパンとの競合を避ける。
+        const panEnabled = options.enablePan !== false;
+        // WASD キーボードパンの個別ゲート。ドラッグパンは有効のまま WASD だけ無効化したい
+        // デモ（avatar-controller）のために enablePan とは別に制御する。
+        const keyboardPanEnabled = options.enableKeyboardPan !== false;
 
         // Large World Rendering: 真の ECEF（百万 m オーダー）でも精度を保つため floating origin を有効化。
         const scene = new Scene(engine, { useFloatingOrigin: true });
@@ -471,6 +489,7 @@ export class GlobeScene {
                 return;
             }
             if (!dragging) return;
+            if (!panEnabled) return;
             const dx = e.clientX - lastX;
             const dy = e.clientY - lastY;
             lastX = e.clientX;
@@ -509,6 +528,7 @@ export class GlobeScene {
          * （北固定ではなく「画面で奥が W」）。真下視点では前後左右が定義できないためスキップ。
          */
         const applyKeyboardPan = (): void => {
+            if (!panEnabled || !keyboardPanEnabled) return;
             if (pressed.size === 0) return;
             let fwd = 0;
             let side = 0;

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -1059,6 +1059,8 @@ export class GlobeSceneAdapter {
                 azimuth: options?.azimuth,
                 tilt: options?.tilt,
                 mapType,
+                enablePan: options?.enablePan,
+                enableKeyboardPan: options?.enableKeyboardPan,
             },
         );
 


### PR DESCRIPTION
## 概要

#349 P4-2（接地・モデル系）で記入もれだった **avatar-controller** の globe バックエンド対応です（#275 Phase 4）。

## 変更内容

- `?terrainEngine=globe|planar` を解決して `JpmapTerrain` に配線（既定 planar）。
- **globe 自動スクロール追従**: globe は `GeospatialCamera` ベースでタイルを `camera.center` から自動ストリーミングするため、追従はカメラ中心（`viewer.lat/lon`）を直接駆動する方式に切替（external frustum refresh は globe では no-op のため不要）。
- **WASD 競合の解消**: globe 組み込みの WASD パンと本デモのアバター WASD 操作が競合していた。`enableKeyboardPan` オプションを新設し、globe では WASD パンのみ無効化（**ドラッグパン・回転・ズームは維持**）。
- **移動方向のカメラ追従**: globe の azimuth 規約（北=0°・時計回り正）と planar 由来 `rotateByAzimuth` 規約の handedness 差を吸収するため、globe では方位符号を反転。

## 影響範囲

- API: `JpmapTerrainOptions` / `DefaultSceneInitOptions` / `GlobeSceneInitOptions` に optional な `enableKeyboardPan`（既定 true）を追加。後方互換。
- planar: WASD パンを持たないため `enableKeyboardPan` は無視。既存挙動に変更なし。
- 画面: avatar-controller デモのみ（globe 時の挙動）。

## 検証

- typecheck / lint パス
- test:unit 1278 passed
- test:visuals 18 passed / 1 failed（`timelapseBackLink.spec.ts` — clean main でも同一エラー(`tileCache.fixture.ts:147` の `route.fetch`)で再現する既存 flaky。本変更とは無関係）
- headless 確認: globe でドラッグ→地図移動 / WASD→アバター移動・地図はキーボードで不動 / W がカメラ前方へ移動

Closes #382
