### PR TITLE
fix(terrain): DEM5非整備領域のズームアップ標高フラット化/0m落下を修正 (#386)

### DIFF
--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -371,8 +371,11 @@ export const createGlobeTileManager = (
                 try {
                     const parent = await loadElevationTile(cz, gx >> d, gy >> d);
                     return extractSubTileElev(parent, cz, gz, gx, gy);
-                } catch {
-                    // この粗ズームも未配信 → さらに 1 段粗く再試行。
+                } catch (e) {
+                    // 404（未配信）のみさらに 1 段粗く再試行。一時障害（タイムアウト/ネットワーク/5xx 等）は
+                    // 握りつぶさず再 throw し、バックオフ再取得に委ねる（誤って平坦化に倒さない, PR #388 review）。
+                    if (e instanceof TileFetchError && e.status === 404) continue;
+                    throw e;
                 }
             }
             throw err;

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -350,7 +350,7 @@ export const createGlobeTileManager = (
      *
      * 一時的な取得失敗（タイムアウト/ネットワーク障害など、`TileFetchError.status` が 404 でないもの）は
      * 粗ズームへ倒さず再 throw する。これにより `loadTile` のバックオフ再取得が働き、一時障害の解消後に
-     * 高 zoom の高詳細標高へ復帰できる（粗ズームの低詳細に固定されるのを防ぐ, PR #388 review）。
+     * 高 zoom の高詳細標高へ復帰できる（粗ズームの低詳細に固定されるのを防ぐ, Issue #386）。
      *
      * 404 フォールバックが無いと globe は geom zoom 単一しか試さず、失敗時に標高ロード失敗 → 暫定平坦化
      * （代表標高 /0m）へ倒れ、本来の地形が「ずっと下（≒0m）」へ落ちて見える。
@@ -373,7 +373,7 @@ export const createGlobeTileManager = (
                     return extractSubTileElev(parent, cz, gz, gx, gy);
                 } catch (e) {
                     // 404（未配信）のみさらに 1 段粗く再試行。一時障害（タイムアウト/ネットワーク/5xx 等）は
-                    // 握りつぶさず再 throw し、バックオフ再取得に委ねる（誤って平坦化に倒さない, PR #388 review）。
+                    // 握りつぶさず再 throw し、バックオフ再取得に委ねる（誤って平坦化に倒さない, Issue #386）。
                     if (e instanceof TileFetchError && e.status === 404) continue;
                     throw e;
                 }

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -60,6 +60,13 @@ const FLAT_SEA_ELEV = new Float32Array(TILE_SIZE * TILE_SIZE);
 const BASE_LAYER_ZOOM = 2;
 
 /**
+ * geom 標高タイルが全 DEM レイヤー 404 のとき、何段階まで粗ズーム DEM へフォールバックして
+ * 切り出すか（#384）。DEM5 非整備領域では dem_png の最大 zoom=14 を超える z15 geom が 404 に
+ * なるため、最低 1 段（z15→z14）で十分だが、深い欠落にも耐えるよう数段許す。失敗時のみ発動。
+ */
+const GEOM_ELEV_FALLBACK_DEPTH = 4;
+
+/**
  * ベースレイヤ 1 タイルあたりの分割数（Issue #341）。マネージャ既定（globe 32）より細かくする。
  * z2 タイルは 90° 角を張るため、分割が粗いとメッシュ（三角形弦）が真球面から大きく内側へたるみ
  * （32 分割で最大 ~3840m）、地平線（limb）でタイルが背景球より内側に退いて青球が縁から透ける。
@@ -298,6 +305,72 @@ export const createGlobeTileManager = (
         return { gz, gx: t.x >> d, gy: t.y >> d };
     };
 
+    /**
+     * 粗ズーム親 DEM から geom タイル (gz,gx,gy) 領域を最近傍で TILE_SIZE 角に切り出す（#384 globe 版）。
+     * 平面版 `tileManager.extractSubTileElevation` と同等。切り出した raster は (gz,gx,gy) タイル
+     * の地理範囲を表すため、`buildGlobeTileMeshData` から実 geom タイルと同一に扱える。
+     */
+    const extractSubTileElev = (
+        parent: Float32Array,
+        parentZoom: number,
+        gz: number,
+        gx: number,
+        gy: number,
+    ): Float32Array => {
+        const diff = gz - parentZoom;
+        const scale = 1 << diff;
+        const subX = gx - ((gx >> diff) << diff);
+        const subY = gy - ((gy >> diff) << diff);
+        const out = new Float32Array(TILE_SIZE * TILE_SIZE);
+        const subSize = TILE_SIZE / scale;
+        const originX = subX * subSize;
+        const originY = subY * subSize;
+        for (let y = 0; y < TILE_SIZE; y++) {
+            const sy = Math.min(
+                TILE_SIZE - 1,
+                Math.round(originY + (y / (TILE_SIZE - 1)) * (subSize - 1)),
+            );
+            for (let x = 0; x < TILE_SIZE; x++) {
+                const sx = Math.min(
+                    TILE_SIZE - 1,
+                    Math.round(originX + (x / (TILE_SIZE - 1)) * (subSize - 1)),
+                );
+                out[y * TILE_SIZE + x] = parent[sy * TILE_SIZE + sx];
+            }
+        }
+        return out;
+    };
+
+    /**
+     * geom タイル標高を取得する。geom zoom の DEM が全レイヤー 404（DEM5 非整備かつ dem_png の
+     * 最大 zoom=14 を超える領域。例: z15 をズームアップした山岳地帯）の場合、平面版 `tileManager`
+     * と同様に粗ズーム DEM へ段階フォールバックし、該当領域を切り出して返す（#384）。
+     *
+     * これが無いと globe は geom zoom 単一しか試さず、404 時に標高ロード失敗 → 暫定平坦化（代表標高
+     * /0m）へ倒れ、本来の地形が「ずっと下（≒0m）」へ落ちて見える。
+     */
+    const loadGeomElevation = async (
+        gz: number,
+        gx: number,
+        gy: number,
+    ): Promise<Float32Array> => {
+        try {
+            return await loadElevationTile(gz, gx, gy);
+        } catch (err) {
+            const floor = Math.max(0, gz - GEOM_ELEV_FALLBACK_DEPTH);
+            for (let cz = gz - 1; cz >= floor; cz--) {
+                const d = gz - cz;
+                try {
+                    const parent = await loadElevationTile(cz, gx >> d, gy >> d);
+                    return extractSubTileElev(parent, cz, gz, gx, gy);
+                } catch {
+                    // この粗ズームも未配信 → さらに 1 段粗く再試行。
+                }
+            }
+            throw err;
+        }
+    };
+
     const terrainElevAt = (latDeg: number, lonDeg: number): number | null => {
         // 探索は geomMaxZoom から下る。minZoom > geomMaxZoom（例: ?zoom=18）でもループが
         // 1 回は回るよう下限を min(minZoom, geomMaxZoom) とする（さもないと常に null を返し
@@ -329,7 +402,7 @@ export const createGlobeTileManager = (
         const prevFail = failedRetryAt.get(gk);
         if (prevFail !== undefined && Date.now() < prevFail.retryAt) return;
         loading.add(gk);
-        loadElevationTile(gz, gx, gy)
+        loadGeomElevation(gz, gx, gy)
             .then((elev) => {
                 // dispose() や sync() で loading から外された後の遅延 resolve は無視する
                 // （不要・dispose 済みマネージャの状態を書き戻さない）。

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -29,6 +29,7 @@ import {
     isAllNaN,
     isInvalidElev,
     fillInvalidPixels,
+    TileFetchError,
     type MapType,
 } from "../gsiTile";
 import { stitchTileEdges, type StitchNeighbors } from "../tileStitching";
@@ -342,13 +343,17 @@ export const createGlobeTileManager = (
     };
 
     /**
-     * geom タイル標高を取得する。geom zoom の `loadElevationTile` が reject した場合（DEM5 非整備かつ
-     * dem_png の最大 zoom=14 を超える z15 山岳地帯での全レイヤー 404 のほか、一時的なネットワーク障害も
-     * 含む。両者は区別できない）、平面版 `tileManager` と同様に粗ズーム DEM へ段階フォールバックし、
-     * 該当領域を切り出して返す（#384）。粗ズームも全て失敗した場合は元の reject を再 throw する。
+     * geom タイル標高を取得する。geom zoom の `loadElevationTile` が決定的な 404（全レイヤー未配信）で
+     * reject した場合（DEM5 非整備かつ dem_png の最大 zoom=14 を超える z15 山岳地帯など）に限り、平面版
+     * `tileManager` と同様に粗ズーム DEM へ段階フォールバックし、該当領域を切り出して返す（#384）。粗ズームも
+     * 全て失敗した場合は元の reject を再 throw する。
      *
-     * これが無いと globe は geom zoom 単一しか試さず、失敗時に標高ロード失敗 → 暫定平坦化（代表標高
-     * /0m）へ倒れ、本来の地形が「ずっと下（≒0m）」へ落ちて見える。
+     * 一時的な取得失敗（タイムアウト/ネットワーク障害など、`TileFetchError.status` が 404 でないもの）は
+     * 粗ズームへ倒さず再 throw する。これにより `loadTile` のバックオフ再取得が働き、一時障害の解消後に
+     * 高 zoom の高詳細標高へ復帰できる（粗ズームの低詳細に固定されるのを防ぐ, PR #388 review）。
+     *
+     * 404 フォールバックが無いと globe は geom zoom 単一しか試さず、失敗時に標高ロード失敗 → 暫定平坦化
+     * （代表標高 /0m）へ倒れ、本来の地形が「ずっと下（≒0m）」へ落ちて見える。
      */
     const loadGeomElevation = async (
         gz: number,
@@ -358,6 +363,8 @@ export const createGlobeTileManager = (
         try {
             return await loadElevationTile(gz, gx, gy);
         } catch (err) {
+            // 決定的な 404（未配信）のみ粗ズームへフォールバックする。一時障害は再 throw してバックオフに委ねる。
+            if (!(err instanceof TileFetchError) || err.status !== 404) throw err;
             const floor = Math.max(0, gz - GEOM_ELEV_FALLBACK_DEPTH);
             for (let cz = gz - 1; cz >= floor; cz--) {
                 const d = gz - cz;

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -342,6 +342,23 @@ export const createGlobeTileManager = (
         return out;
     };
 
+    // 粗ズーム親 DEM の in-flight フェッチを (cz/x/y) 単位で共有する。DEM5 非整備領域を広く表示すると
+    // 404 フォールバックが多発し、同一親（例: z14 の 1 枚）を参照する 4 枚の子 geom タイルが同時に
+    // フォールバックして同一リクエストが重複し得る。in-flight Promise を共有して重複フェッチを抑える
+    // （Issue #386 PR レビュー）。settle 後はエントリを削除し、後続の再試行は新規取得に倒す（一時障害
+    // 解消後の再取得を阻害しない）。
+    const coarseParentInFlight = new Map<string, Promise<Float32Array>>();
+    const loadCoarseParent = (cz: number, px: number, py: number): Promise<Float32Array> => {
+        const key = `${cz}/${px}/${py}`;
+        let p = coarseParentInFlight.get(key);
+        if (!p) {
+            p = loadElevationTile(cz, px, py);
+            coarseParentInFlight.set(key, p);
+            void p.catch(() => {}).finally(() => coarseParentInFlight.delete(key));
+        }
+        return p;
+    };
+
     /**
      * geom タイル標高を取得する。geom zoom の `loadElevationTile` が決定的な 404（全レイヤー未配信）で
      * reject した場合（DEM5 非整備かつ dem_png の最大 zoom=14 を超える z15 山岳地帯など）に限り、平面版
@@ -369,7 +386,8 @@ export const createGlobeTileManager = (
             for (let cz = gz - 1; cz >= floor; cz--) {
                 const d = gz - cz;
                 try {
-                    const parent = await loadElevationTile(cz, gx >> d, gy >> d);
+                    // 親 (cz, gx>>d, gy>>d) は同一親を共有する子タイル間で in-flight 共有して重複取得を抑える。
+                    const parent = await loadCoarseParent(cz, gx >> d, gy >> d);
                     return extractSubTileElev(parent, cz, gz, gx, gy);
                 } catch (e) {
                     // 404（未配信）のみさらに 1 段粗く再試行。一時障害（タイムアウト/ネットワーク/5xx 等）は

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -342,11 +342,12 @@ export const createGlobeTileManager = (
     };
 
     /**
-     * geom タイル標高を取得する。geom zoom の DEM が全レイヤー 404（DEM5 非整備かつ dem_png の
-     * 最大 zoom=14 を超える領域。例: z15 をズームアップした山岳地帯）の場合、平面版 `tileManager`
-     * と同様に粗ズーム DEM へ段階フォールバックし、該当領域を切り出して返す（#384）。
+     * geom タイル標高を取得する。geom zoom の `loadElevationTile` が reject した場合（DEM5 非整備かつ
+     * dem_png の最大 zoom=14 を超える z15 山岳地帯での全レイヤー 404 のほか、一時的なネットワーク障害も
+     * 含む。両者は区別できない）、平面版 `tileManager` と同様に粗ズーム DEM へ段階フォールバックし、
+     * 該当領域を切り出して返す（#384）。粗ズームも全て失敗した場合は元の reject を再 throw する。
      *
-     * これが無いと globe は geom zoom 単一しか試さず、404 時に標高ロード失敗 → 暫定平坦化（代表標高
+     * これが無いと globe は geom zoom 単一しか試さず、失敗時に標高ロード失敗 → 暫定平坦化（代表標高
      * /0m）へ倒れ、本来の地形が「ずっと下（≒0m）」へ落ちて見える。
      */
     const loadGeomElevation = async (

--- a/src/terrain/gsiTile.ts
+++ b/src/terrain/gsiTile.ts
@@ -22,7 +22,8 @@ const DEM_LAYERS = ["dem5a_png", "dem5b_png", "dem_png"] as const;
 const DEM_PNG_MAX_ZOOM = 14;
 
 /**
- * タイル全面が no-data のとき、粗ズーム dem_png による穴埋めを何段まで遡って試すか（Issue #386）。
+ * 同一ズーム合成後も穴（no-data）が `COMPOSITE_HOLE_RATIO` を超えて残るタイルで、粗ズーム dem_png
+ * による穴埋めを何段まで遡って試すか（Issue #386）。全面 no-data・部分欠測のいずれも対象。
  */
 const COARSE_FILL_DEPTH = 5;
 

--- a/src/terrain/gsiTile.ts
+++ b/src/terrain/gsiTile.ts
@@ -39,6 +39,21 @@ const COARSE_FILL_DEPTH = 5;
  */
 const COMPOSITE_HOLE_RATIO = 0.1;
 
+/**
+ * タイル取得失敗を表すエラー。`status` に HTTP ステータスを保持する（ネットワーク/タイムアウト等の
+ * 非 HTTP 失敗では undefined）。404（決定的な未配信）と一時的な障害を呼び出し側で区別するために使う
+ * （globe の粗ズームフォールバック判定など, Issue #386）。
+ */
+export class TileFetchError extends Error {
+    constructor(
+        message: string,
+        readonly status?: number
+    ) {
+        super(message);
+        this.name = "TileFetchError";
+    }
+}
+
 export const clamp = (value: number, min: number, max: number): number =>
     Math.min(Math.max(value, min), max);
 
@@ -264,7 +279,7 @@ const FETCH_TIMEOUT_MS = 15000;
 /** ImageData を fetch して返す（Canvas経由） */
 const loadImageData = async (url: string): Promise<ImageData> => {
     const res = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
-    if (!res.ok) throw new Error(`Tile fetch failed: ${url}`);
+    if (!res.ok) throw new TileFetchError(`Tile fetch failed: ${url}`, res.status);
     const blob = await res.blob();
     const bmp = await createImageBitmap(blob);
     const cvs = document.createElement("canvas");
@@ -314,10 +329,17 @@ export const loadElevationTile = async (
     let total = 0;
     let holes = 0;
     let lastErr: unknown;
+    // 全レイヤーの失敗が決定的な 404（未配信）だけだったか。一時障害（タイムアウト等）が混じる場合は
+    // false にして、最終 throw の status を undefined にする（呼び出し側で粗ズームへ倒さず再試行させる）。
+    let allDeterministic404 = true;
 
     for (const layer of DEM_LAYERS) {
         // 穴が閾値以下になれば以降のレイヤーは不要（微小穴は fillInvalidPixels に委ねる）。
         if (merged && holes <= total * COMPOSITE_HOLE_RATIO) break;
+
+        // dem_png は z14 までしか配信されない。z15 以降の同一ズーム dem_png は必ず 404 になるため、
+        // 無駄なフェッチを避けてスキップし、後段の粗ズーム dem_png 穴埋めに委ねる（PR #388 review）。
+        if (layer === "dem_png" && zoom > DEM_PNG_MAX_ZOOM) continue;
 
         const url = `https://cyberjapandata.gsi.go.jp/xyz/${layer}/${zoom}/${x}/${y}.png`;
         let img: ImageData;
@@ -326,6 +348,7 @@ export const loadElevationTile = async (
         } catch (e) {
             // HTTP 失敗（404 等：このレイヤーは当該領域外）→ 次レイヤーへ。
             lastErr = e;
+            if (!(e instanceof TileFetchError) || e.status !== 404) allDeterministic404 = false;
             continue;
         }
 
@@ -363,8 +386,9 @@ export const loadElevationTile = async (
     }
 
     if (!merged) {
-        throw new Error(
-            `No elevation tile available for z${zoom}/${x}/${y}: ${String(lastErr)}`
+        throw new TileFetchError(
+            `No elevation tile available for z${zoom}/${x}/${y}: ${String(lastErr)}`,
+            allDeterministic404 ? 404 : undefined
         );
     }
 
@@ -378,7 +402,10 @@ export const loadElevationTile = async (
     if (holes > total * COMPOSITE_HOLE_RATIO) {
         const startCz = Math.min(zoom - 1, DEM_PNG_MAX_ZOOM);
         const floorCz = Math.max(0, startCz - (COARSE_FILL_DEPTH - 1));
-        for (let cz = startCz; cz >= floorCz && holes > 0; cz--) {
+        // 残り穴が閾値以下になったら打ち切る。微小な欠測（≤ COMPOSITE_HOLE_RATIO）まで粗ズームを
+        // 遡って取得するのは無駄なフェッチになるため、後段の `fillInvalidPixels` の局所補間に委ねる
+        // （PR #388 review）。
+        for (let cz = startCz; cz >= floorCz && holes > total * COMPOSITE_HOLE_RATIO; cz--) {
             const d = zoom - cz;
             const url = `https://cyberjapandata.gsi.go.jp/xyz/dem_png/${cz}/${x >> d}/${y >> d}.png`;
             try {

--- a/src/terrain/gsiTile.ts
+++ b/src/terrain/gsiTile.ts
@@ -420,8 +420,12 @@ export const loadElevationTile = async (
                     y,
                     cz
                 );
-            } catch {
-                // この粗ズームの dem_png も未配信 → さらに 1 段粗く再試行。
+            } catch (e) {
+                // 404（未配信）のみ次の粗ズームへ。一時障害（タイムアウト/ネットワーク/5xx 等）は
+                // 握りつぶさず伝播し、穴埋め未完のまま誤った標高を返さない。呼び出し側のバックオフ
+                // 再取得に委ねる（PR #388 review）。
+                if (e instanceof TileFetchError && e.status === 404) continue;
+                throw e;
             }
         }
     }

--- a/src/terrain/gsiTile.ts
+++ b/src/terrain/gsiTile.ts
@@ -338,7 +338,7 @@ export const loadElevationTile = async (
         if (merged && holes <= total * COMPOSITE_HOLE_RATIO) break;
 
         // dem_png は z14 までしか配信されない。z15 以降の同一ズーム dem_png は必ず 404 になるため、
-        // 無駄なフェッチを避けてスキップし、後段の粗ズーム dem_png 穴埋めに委ねる（PR #388 review）。
+        // 無駄なフェッチを避けてスキップし、後段の粗ズーム dem_png 穴埋めに委ねる（Issue #386）。
         if (layer === "dem_png" && zoom > DEM_PNG_MAX_ZOOM) continue;
 
         const url = `https://cyberjapandata.gsi.go.jp/xyz/${layer}/${zoom}/${x}/${y}.png`;
@@ -346,7 +346,8 @@ export const loadElevationTile = async (
         try {
             img = await loadImageData(url);
         } catch (e) {
-            // HTTP 失敗（404 等：このレイヤーは当該領域外）→ 次レイヤーへ。
+            // 取得失敗（404＝当該領域外のほか、タイムアウト/ネットワーク等の一時障害も含む）→ 次レイヤーへ。
+            // 404 以外の一時障害が混じった場合は allDeterministic404 を倒し、最終 throw を非 404 扱いにする。
             lastErr = e;
             if (!(e instanceof TileFetchError) || e.status !== 404) allDeterministic404 = false;
             continue;
@@ -404,7 +405,7 @@ export const loadElevationTile = async (
         const floorCz = Math.max(0, startCz - (COARSE_FILL_DEPTH - 1));
         // 残り穴が閾値以下になったら打ち切る。微小な欠測（≤ COMPOSITE_HOLE_RATIO）まで粗ズームを
         // 遡って取得するのは無駄なフェッチになるため、後段の `fillInvalidPixels` の局所補間に委ねる
-        // （PR #388 review）。
+        // （Issue #386）。
         for (let cz = startCz; cz >= floorCz && holes > total * COMPOSITE_HOLE_RATIO; cz--) {
             const d = zoom - cz;
             const url = `https://cyberjapandata.gsi.go.jp/xyz/dem_png/${cz}/${x >> d}/${y >> d}.png`;
@@ -423,7 +424,7 @@ export const loadElevationTile = async (
             } catch (e) {
                 // 404（未配信）のみ次の粗ズームへ。一時障害（タイムアウト/ネットワーク/5xx 等）は
                 // 握りつぶさず伝播し、穴埋め未完のまま誤った標高を返さない。呼び出し側のバックオフ
-                // 再取得に委ねる（PR #388 review）。
+                // 再取得に委ねる（Issue #386）。
                 if (e instanceof TileFetchError && e.status === 404) continue;
                 throw e;
             }

--- a/src/terrain/gsiTile.ts
+++ b/src/terrain/gsiTile.ts
@@ -18,6 +18,26 @@ export const JAPAN_BOUNDS = { minLat: 20, maxLat: 46, minLon: 122, maxLon: 154 }
 
 const DEM_LAYERS = ["dem5a_png", "dem5b_png", "dem_png"] as const;
 
+/** dem_png（全国 DEM）が配信される最大ズーム。これを超える領域は 404 になる。 */
+const DEM_PNG_MAX_ZOOM = 14;
+
+/**
+ * タイル全面が no-data のとき、粗ズーム dem_png による穴埋めを何段まで遡って試すか（Issue #386）。
+ */
+const COARSE_FILL_DEPTH = 5;
+
+/**
+ * 同一ズームで下位 DEM レイヤーを合成して穴埋めする発動閾値（Issue #384/#386）。
+ *
+ * 穴（no-data）がタイル全体のこの割合を超えるときだけ dem5b/dem_png を取得して合成する。
+ * 整備済みの DEM5 でも、堀・河川・タイル境界などで僅かに no-data が生じる（実測で中央東京の
+ * dem5a でも 2〜23%）。こうした微小な穴まで毎回下位レイヤーを取得すると、描画が不必要に変化し
+ * （camera-terrain 衝突のパララックスずれ）、software rendering では追加フェッチで安定待ちが
+ * タイムアウトする。微小な穴は取得コストに見合わないため合成せず、後段の `fillInvalidPixels` の
+ * 局所補間に委ねる。山岳地帯のように穴が大きいタイルだけ合成・粗ズーム補填の対象とする。
+ */
+const COMPOSITE_HOLE_RATIO = 0.1;
+
 export const clamp = (value: number, min: number, max: number): number =>
     Math.min(Math.max(value, min), max);
 
@@ -104,6 +124,58 @@ export const decodeGsiElevation = (
     if (r === 128 && g === 0 && b === 0) return NaN;
     const raw = r * 65536 + g * 256 + b;
     return raw < 2 ** 23 ? raw * 0.01 : (raw - 2 ** 24) * 0.01;
+};
+
+/**
+ * 粗ズーム dem_png（親タイル）の該当領域を最近傍で切り出し、`merged` の残存 no-data 穴だけを
+ * その実標高で埋める（Issue #386）。全 DEM レイヤーは同一 256px タイルスキームで co-registered
+ * なため、親タイル (cz, x>>d, y>>d) の対応サブ領域をピクセル対応で参照できる。
+ *
+ * @returns 穴埋め後に残った（親側も no-data だった）穴の数。
+ */
+const fillHolesFromCoarseDem = (
+    merged: Float32Array,
+    width: number,
+    height: number,
+    parent: ImageData,
+    zoom: number,
+    x: number,
+    y: number,
+    cz: number
+): number => {
+    const d = zoom - cz;
+    const scale = 1 << d;
+    const pw = parent.width;
+    const ph = parent.height;
+    // 当該タイルが親タイル内で占めるサブ領域（親ピクセル単位）。
+    const subW = pw / scale;
+    const subH = ph / scale;
+    const originX = (x & (scale - 1)) * subW;
+    const originY = (y & (scale - 1)) * subH;
+    let remaining = 0;
+    for (let oy = 0; oy < height; oy++) {
+        const sy = Math.min(
+            ph - 1,
+            Math.round(originY + (height > 1 ? oy / (height - 1) : 0) * (subH - 1))
+        );
+        for (let ox = 0; ox < width; ox++) {
+            const idx = oy * width + ox;
+            if (!Number.isNaN(merged[idx])) continue;
+            const sx = Math.min(
+                pw - 1,
+                Math.round(originX + (width > 1 ? ox / (width - 1) : 0) * (subW - 1))
+            );
+            const p = (sy * pw + sx) * 4;
+            const v = decodeGsiElevation(
+                parent.data[p],
+                parent.data[p + 1],
+                parent.data[p + 2]
+            );
+            if (!Number.isNaN(v)) merged[idx] = v;
+            else remaining++;
+        }
+    }
+    return remaining;
 };
 
 /** 無効値(NaN/NO_DATA_SENTINEL)を周囲の有効ピクセルからBFS(フロンティア)方式で補間する */
@@ -205,40 +277,128 @@ const loadImageData = async (url: string): Promise<ImageData> => {
     return data;
 };
 
-/** 標高タイルを読み込み Float32Array で返す（dem5a → dem5b → dem フォールバック） */
+/**
+ * 標高タイルを読み込み Float32Array で返す（dem5a → dem5b → dem のレイヤー合成）。
+ *
+ * DEM5（dem5a/dem5b）はカバレッジに穴があり、山岳地帯では HTTP 200 を返すのに
+ * タイルの大半が no-data(128,0,0) になることがある（Issue #384）。最初に 200 を返した
+ * レイヤーをそのまま採用すると、わずかに残った有効ピクセルが後段の `fillInvalidPixels`
+ * でタイル全体に塗り広げられ、地形がフラット化・数百 m ずれ・0m へ崩れる。
+ *
+ * これを避けるため、穴（no-data）がタイル全体の `COMPOSITE_HOLE_RATIO` を超えるタイルに限り、
+ * 各レイヤーをピクセル単位で合成する:
+ * - 高解像度（dem5a > dem5b > dem）の有効ピクセルを優先する。
+ * - あるレイヤーで no-data だったピクセルだけを、次のレイヤーの有効値で穴埋めする。
+ * - 穴が閾値以下になった時点で以降のレイヤーは取得しない。
+ *
+ * 整備済み DEM5 でも堀・河川・タイル境界で僅かに生じる微小な穴は、下位レイヤーを取得せず後段の
+ * `fillInvalidPixels` の局所補間に委ねる（描画変化・追加フェッチを避けるため）。
+ *
+ * 同一ズームの DEM をすべて合成しても穴が `COMPOSITE_HOLE_RATIO` を超えて残る場合（dem_png の配信上限
+ * z14 を超えた z15 等で、同一ズームには穴を埋める実標高が存在しない大穴タイル）は、粗ズーム dem_png を
+ * 取得してタイルを実標高で穴埋めする（Issue #386）。閾値以下の微小な欠測は後段の `fillInvalidPixels`
+ * が局所補間するため、粗ズーム取得は行わない。
+ *
+ * 全 DEM レイヤーが同一の z/x/y/256px タイルスキームで co-registered なため、合成は
+ * リサンプル不要のピクセル対応で行える。
+ */
 export const loadElevationTile = async (
     zoom: number,
     x: number,
     y: number
 ): Promise<Float32Array> => {
+    let merged: Float32Array | null = null;
+    let width = 0;
+    let height = 0;
+    let total = 0;
+    let holes = 0;
     let lastErr: unknown;
+
     for (const layer of DEM_LAYERS) {
+        // 穴が閾値以下になれば以降のレイヤーは不要（微小穴は fillInvalidPixels に委ねる）。
+        if (merged && holes <= total * COMPOSITE_HOLE_RATIO) break;
+
         const url = `https://cyberjapandata.gsi.go.jp/xyz/${layer}/${zoom}/${x}/${y}.png`;
+        let img: ImageData;
         try {
-            const img = await loadImageData(url);
-            const elev = new Float32Array(img.width * img.height);
+            img = await loadImageData(url);
+        } catch (e) {
+            // HTTP 失敗（404 等：このレイヤーは当該領域外）→ 次レイヤーへ。
+            lastErr = e;
+            continue;
+        }
+
+        if (!merged) {
+            width = img.width;
+            height = img.height;
+            merged = new Float32Array(width * height);
+            total = merged.length;
+            holes = 0;
             for (let i = 0; i < img.data.length; i += 4) {
-                elev[i / 4] = decodeGsiElevation(
+                const v = decodeGsiElevation(
                     img.data[i],
                     img.data[i + 1],
                     img.data[i + 2]
                 );
+                merged[i / 4] = v;
+                if (Number.isNaN(v)) holes++;
             }
-            // HTTP 成功 = このレイヤーが当該領域をカバーしているとみなす。
-            // 全 NaN（湖面など no-data 領域）でも次レイヤーへフォールバックしない。
-            // 下位レイヤー（dem5b など）は同じ場所に水面標高を返すことがあり、
-            // それを使うと湖面が押し上がる（issue #224）。
-            // all-NaN の場合は同レイヤー隣接タイルから後段（refineAllNaNTiles）の
-            // NaN 埋めで補間させる。
-            // フォールバックは HTTP 取得失敗（404 等：このレイヤー範囲外）でのみ発動。
-            return elev;
-        } catch (e) {
-            lastErr = e;
+        } else {
+            // no-data の穴だけを当レイヤーの有効値で埋める。
+            for (let i = 0; i < img.data.length; i += 4) {
+                const idx = i / 4;
+                if (!Number.isNaN(merged[idx])) continue;
+                const v = decodeGsiElevation(
+                    img.data[i],
+                    img.data[i + 1],
+                    img.data[i + 2]
+                );
+                if (!Number.isNaN(v)) {
+                    merged[idx] = v;
+                    holes--;
+                }
+            }
         }
     }
-    throw new Error(
-        `No elevation tile available for z${zoom}/${x}/${y}: ${String(lastErr)}`
-    );
+
+    if (!merged) {
+        throw new Error(
+            `No elevation tile available for z${zoom}/${x}/${y}: ${String(lastErr)}`
+        );
+    }
+
+    // 同一ズームの DEM をすべて合成しても穴（no-data）が閾値を超えて残る場合は、粗ズーム dem_png を
+    // 取得して実標高で穴埋めする（Issue #386）。dem_png の配信上限は z14 のため、z15 以降は同一ズームに
+    // 穴を埋める実標高が存在せず、DEM5 カバレッジ穴の大きいタイル（例: 山岳で dem5a が 7〜8 割 no-data）が
+    // そのまま残ると、わずかな有効ピクセルが後段の `fillInvalidPixels` で塗り広げられ、地形が
+    // 「ホールケーキの一切れ」状（フラット／0m／段差）に崩れる。これを防ぐため、穴が `COMPOSITE_HOLE_RATIO`
+    // を超えるタイルは粗ズーム dem_png で穴埋めする。z14 以下では同一ズーム dem_png で既に穴が埋まり
+    // （holes が閾値以下になり）ここは発動しない。微小な穴（閾値以下）は `fillInvalidPixels` の局所補間に委ねる。
+    if (holes > total * COMPOSITE_HOLE_RATIO) {
+        const startCz = Math.min(zoom - 1, DEM_PNG_MAX_ZOOM);
+        const floorCz = Math.max(0, startCz - (COARSE_FILL_DEPTH - 1));
+        for (let cz = startCz; cz >= floorCz && holes > 0; cz--) {
+            const d = zoom - cz;
+            const url = `https://cyberjapandata.gsi.go.jp/xyz/dem_png/${cz}/${x >> d}/${y >> d}.png`;
+            try {
+                const parent = await loadImageData(url);
+                holes = fillHolesFromCoarseDem(
+                    merged,
+                    width,
+                    height,
+                    parent,
+                    zoom,
+                    x,
+                    y,
+                    cz
+                );
+            } catch {
+                // この粗ズームの dem_png も未配信 → さらに 1 段粗く再試行。
+            }
+        }
+    }
+
+    return merged;
 };
 
 /** 地図タイプ */

--- a/tests/atPathReload.spec.ts
+++ b/tests/atPathReload.spec.ts
@@ -5,7 +5,7 @@ import { test, expect } from "./tileCache.fixture";
  * 直接アクセス（リロード相当）した際に、HtmlWebpackPlugin が inject する script 等が
  * 相対パスで解決されて 404 になる回帰を防止する E2E テスト。
  *
- * - `/js/` 配下のレスポンスが全て成功 (response.ok()) であること
+ * - `/js/` 配下のリクエストが全て成功（response.ok() かつ requestfailed なし）であること
  * - `<canvas>` が表示され、サイズがゼロでないこと（= 起動した）
  * を確認する。スナップショット比較は flaky 回避のため行わない。
  */
@@ -23,7 +23,7 @@ const targets: { name: string; url: string }[] = [
 
 for (const target of targets) {
     test(`${target.name} loads scripts and renders canvas`, async ({ page }) => {
-        const failedJsResponses: { url: string; status: number }[] = [];
+        const failedJs: string[] = [];
         // `/js/` チャンクの取得状況を追跡する。タイル取得が継続して
         // `networkidle` に到達しない環境でも、スクリプト読み込みの完了だけを
         // 根拠に判定できるようにする（Issue #157 の趣旨は /js/ ロード成功確認）。
@@ -35,11 +35,18 @@ for (const target of targets) {
             if (request.url().includes("/js/")) pendingJs = Math.max(0, pendingJs - 1);
         };
         page.on("requestfinished", onJsSettled);
-        page.on("requestfailed", onJsSettled);
+        page.on("requestfailed", (request) => {
+            onJsSettled(request);
+            // ネットワーク切断/abort 等で response が発火しないケース（requestfailed）も
+            // 取りこぼさず失敗として記録する（/js/ ロード成功検証への忠実性, #157 PR レビュー）。
+            if (request.url().includes("/js/")) {
+                failedJs.push(`${request.url()} (requestfailed: ${request.failure()?.errorText ?? "unknown"})`);
+            }
+        });
         page.on("response", (response) => {
             const url = response.url();
             if (url.includes("/js/") && !response.ok()) {
-                failedJsResponses.push({ url, status: response.status() });
+                failedJs.push(`${url} (HTTP ${response.status()})`);
             }
         });
 
@@ -73,6 +80,6 @@ for (const target of targets) {
             .poll(() => pendingJs, { timeout: 60000, intervals: [250, 500, 1000] })
             .toBe(0);
 
-        expect(failedJsResponses).toEqual([]);
+        expect(failedJs).toEqual([]);
     });
 }

--- a/tests/atPathReload.spec.ts
+++ b/tests/atPathReload.spec.ts
@@ -24,6 +24,18 @@ const targets: { name: string; url: string }[] = [
 for (const target of targets) {
     test(`${target.name} loads scripts and renders canvas`, async ({ page }) => {
         const failedJsResponses: { url: string; status: number }[] = [];
+        // `/js/` チャンクの取得状況を追跡する。タイル取得が継続して
+        // `networkidle` に到達しない環境でも、スクリプト読み込みの完了だけを
+        // 根拠に判定できるようにする（Issue #157 の趣旨は /js/ ロード成功確認）。
+        let pendingJs = 0;
+        page.on("request", (request) => {
+            if (request.url().includes("/js/")) pendingJs++;
+        });
+        const onJsSettled = (request: { url(): string }) => {
+            if (request.url().includes("/js/")) pendingJs = Math.max(0, pendingJs - 1);
+        };
+        page.on("requestfinished", onJsSettled);
+        page.on("requestfailed", onJsSettled);
         page.on("response", (response) => {
             const url = response.url();
             if (url.includes("/js/") && !response.ok()) {
@@ -44,8 +56,6 @@ for (const target of targets) {
 
         // シーン起動完了を待つ（`src/demos/{viewer,timelapse}/index.ts` で
         // NODE_ENV!=='production' 時に `window.scene` を公開している）。
-        // `failedJsResponses` を判定する前に、遅延チャンクや初期タイル取得が
-        // 出揃うまで待機することでレースを防ぐ (Issue #157 PR レビュー対応)。
         await page.waitForFunction(
             () => {
                 const w = window as unknown as {
@@ -55,7 +65,13 @@ for (const target of targets) {
             },
             { timeout: 30000 },
         );
-        await page.waitForLoadState("networkidle", { timeout: 60000 });
+        // 遅延チャンクや初期タイル取得が出揃うまで待機することでレースを防ぐ
+        // (Issue #157 PR レビュー対応)。タイル取得は継続し得るため全体の
+        // `networkidle` ではなく、`/js/` チャンクの取得が完了する（in-flight が
+        // 0 に収束する）ことを待つ。
+        await expect
+            .poll(() => pendingJs, { timeout: 60000, intervals: [250, 500, 1000] })
+            .toBe(0);
 
         expect(failedJsResponses).toEqual([]);
     });

--- a/tests/globeTileManager.unit.spec.ts
+++ b/tests/globeTileManager.unit.spec.ts
@@ -482,17 +482,46 @@ describe("createGlobeTileManager", () => {
         loadElevationTile.mockImplementation(() => Promise.reject(new Error("fetch failed")));
         const mgr = makeManager();
         mgr.sync(syncParams());
+        // loadGeomElevation は geom zoom を同期的に 1 回試行する（粗ズーム fallback は reject 後）。
         expect(loadElevationTile).toHaveBeenCalledTimes(1);
         // 標高ロード中: まだ失敗が確定していないのでメッシュ未生成。
         expect(MeshMock).toHaveBeenCalledTimes(0);
-        await flush(); // 失敗 → failedRetryAt 記録（取得失敗→バックオフ状態へ移行）
+        await flush(); // geom zoom も粗ズーム fallback も全失敗 → failedRetryAt 記録（バックオフへ）
+        loadElevationTile.mockClear(); // 以降の sync が再取得しないことを fallback 深さに依らず検証
         // 失敗確定後の sync: フラット(海面 0m)でメッシュ生成（恒久欠けを防ぐ）。
         mgr.sync(syncParams());
-        expect(loadElevationTile).toHaveBeenCalledTimes(1); // バックオフ中、再取得なし
+        expect(loadElevationTile).toHaveBeenCalledTimes(0); // バックオフ中、再取得なし
         expect(MeshMock).toHaveBeenCalledTimes(1);
         // バックオフ中の再 sync でもメッシュを再生成しない。
         mgr.sync(syncParams());
         expect(MeshMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("geom zoom が全 DEM 404 でも粗ズーム DEM を切り出して実標高で建築する (#384)", async () => {
+        // DEM5 非整備領域: z15 geom は全レイヤー 404 だが、粗ズーム z14 dem_png には実標高がある。
+        const PARENT_ELEV = 900;
+        loadElevationTile.mockImplementation((...args: unknown[]) => {
+            const zoom = args[0] as number;
+            if (zoom >= 15) return Promise.reject(new Error("404"));
+            return Promise.resolve(new Float32Array(256 * 256).fill(PARENT_ELEV));
+        });
+        toTileXY.mockReturnValue({ x: 24000, y: 12000 });
+        selectedTiles = [tile(24000, 12000, 15)];
+
+        const mgr = makeManager();
+        mgr.sync(syncParams());
+        await flush();
+        mgr.sync(syncParams()); // 標高確定後に建築
+
+        // geom zoom(15) は 404、粗ズーム(14)へフォールバックして取得している。
+        const zooms = loadElevationTile.mock.calls.map((c: unknown[]) => c[0]);
+        expect(zooms).toContain(15);
+        expect(zooms).toContain(14);
+
+        // 建築標高は 0m(海面フラット)ではなく粗ズーム DEM の実標高で埋まる。
+        const built = capturedBuilds.find((b) => b.tx === 24000 && b.ty === 12000);
+        expect(built).toBeDefined();
+        expect(built?.geomElev[0]).toBeCloseTo(PARENT_ELEV);
     });
 
     it("アンロード後に遅延 resolve した結果は無視され、再選択時に再取得する", async () => {

--- a/tests/globeTileManager.unit.spec.ts
+++ b/tests/globeTileManager.unit.spec.ts
@@ -527,6 +527,29 @@ describe("createGlobeTileManager", () => {
         expect(built?.geomElev[0]).toBeCloseTo(PARENT_ELEV);
     });
 
+    it("粗ズームフォールバック中の一時障害は握りつぶさずバックオフへ倒す (#386)", async () => {
+        // geom zoom(15) は 404 → 粗ズーム(14)へフォールバックするが、そこで一時障害(非404)が起きる。
+        // 一時障害は握りつぶさず再 throw し、誤って粗ズーム平坦化へ倒さずバックオフ再取得に委ねる。
+        loadElevationTile.mockImplementation((...args: unknown[]) => {
+            const zoom = args[0] as number;
+            if (zoom >= 15) return Promise.reject(new TileFetchError("404", 404));
+            // 粗ズーム z14 で一時障害（TileFetchError 以外）。
+            return Promise.reject(new Error("network down"));
+        });
+        toTileXY.mockReturnValue({ x: 24000, y: 12000 });
+        selectedTiles = [tile(24000, 12000, 15)];
+
+        const mgr = makeManager();
+        mgr.sync(syncParams());
+        await flush(); // geom(15) 404 → 粗ズーム(14) 一時障害で再 throw → failedRetryAt 記録
+        capturedBuilds.length = 0;
+        mgr.sync(syncParams()); // バックオフ中: 建築されても粗ズーム実標高ではなくフラット（未取得）
+
+        // 一時障害なので粗ズーム実標高での建築は行われない（バックオフ後の再取得に委ねる）。
+        const built = capturedBuilds.find((b) => b.tx === 24000 && b.ty === 12000);
+        expect(built?.geomElev[0] ?? 0).not.toBeCloseTo(900);
+    });
+
     it("アンロード後に遅延 resolve した結果は無視され、再選択時に再取得する", async () => {
         // resolve を保留できる deferred。
         let resolveFn: (v: Float32Array) => void = () => {};

--- a/tests/globeTileManager.unit.spec.ts
+++ b/tests/globeTileManager.unit.spec.ts
@@ -550,6 +550,40 @@ describe("createGlobeTileManager", () => {
         expect(built?.geomElev[0] ?? 0).not.toBeCloseTo(900);
     });
 
+    it("同一粗ズーム親を共有する子タイルのフォールバックは親フェッチを重複させない (#386)", async () => {
+        // z15 の 4 枚（2x2）は同一の z14 親 (x>>1,y>>1)=(12000,6000) を共有する。全枚が 404 で
+        // 粗ズームフォールバックしても、親 DEM の取得は in-flight 共有で 1 回に集約される。
+        const PARENT_ELEV = 900;
+        loadElevationTile.mockImplementation((...args: unknown[]) => {
+            const zoom = args[0] as number;
+            if (zoom >= 15) return Promise.reject(new TileFetchError("404", 404));
+            return Promise.resolve(new Float32Array(256 * 256).fill(PARENT_ELEV));
+        });
+        selectedTiles = [
+            tile(24000, 12000, 15),
+            tile(24001, 12000, 15),
+            tile(24000, 12001, 15),
+            tile(24001, 12001, 15),
+        ];
+
+        const mgr = makeManager();
+        mgr.sync(syncParams());
+        await flush();
+        mgr.sync(syncParams()); // 標高確定後に建築
+
+        // 4 枚とも粗ズーム親 (z14, 12000, 6000) を参照するが、親フェッチは 1 回に集約される。
+        const z14ParentCalls = loadElevationTile.mock.calls.filter(
+            (c: unknown[]) => c[0] === 14 && c[1] === 12000 && c[2] === 6000,
+        );
+        expect(z14ParentCalls).toHaveLength(1);
+
+        // 各子タイルは共有した親から自領域を切り出して実標高で建築される。
+        for (const [tx, ty] of [[24000, 12000], [24001, 12000], [24000, 12001], [24001, 12001]]) {
+            const built = capturedBuilds.find((b) => b.tx === tx && b.ty === ty);
+            expect(built?.geomElev[0]).toBeCloseTo(PARENT_ELEV);
+        }
+    });
+
     it("アンロード後に遅延 resolve した結果は無視され、再選択時に再取得する", async () => {
         // resolve を保留できる deferred。
         let resolveFn: (v: Float32Array) => void = () => {};

--- a/tests/globeTileManager.unit.spec.ts
+++ b/tests/globeTileManager.unit.spec.ts
@@ -159,6 +159,7 @@ const { StandardMaterial } = await import("@babylonjs/core/Materials/standardMat
 
 const loadElevationTile = gsiMock.loadElevationTile as jest.Mock;
 const toTileXY = gsiMock.toTileXY as jest.Mock;
+const { TileFetchError } = gsiMock;
 const MeshMock = Mesh as unknown as jest.Mock;
 const MaterialMock = StandardMaterial as unknown as jest.Mock;
 
@@ -478,15 +479,16 @@ describe("createGlobeTileManager", () => {
         expect(meshA.dispose).toHaveBeenCalledWith(false, true);
     });
 
-    it("取得失敗はバックオフし再取得せず、失敗確定後にフラット建築する", async () => {
+    it("一時的な取得失敗はバックオフし再取得せず、失敗確定後にフラット建築する", async () => {
+        // 一時障害（TileFetchError 以外 / status≠404）は粗ズームへ倒さず即座に再 throw する。
         loadElevationTile.mockImplementation(() => Promise.reject(new Error("fetch failed")));
         const mgr = makeManager();
         mgr.sync(syncParams());
-        // loadGeomElevation は geom zoom を同期的に 1 回試行する（粗ズーム fallback は reject 後）。
+        // loadGeomElevation は geom zoom を同期的に 1 回試行する。一時障害は粗ズーム fallback せず再 throw。
         expect(loadElevationTile).toHaveBeenCalledTimes(1);
         // 標高ロード中: まだ失敗が確定していないのでメッシュ未生成。
         expect(MeshMock).toHaveBeenCalledTimes(0);
-        await flush(); // geom zoom も粗ズーム fallback も全失敗 → failedRetryAt 記録（バックオフへ）
+        await flush(); // geom zoom 失敗（粗ズーム fallback なし）→ failedRetryAt 記録（バックオフへ）
         loadElevationTile.mockClear(); // 以降の sync が再取得しないことを fallback 深さに依らず検証
         // 失敗確定後の sync: フラット(海面 0m)でメッシュ生成（恒久欠けを防ぐ）。
         mgr.sync(syncParams());
@@ -498,11 +500,12 @@ describe("createGlobeTileManager", () => {
     });
 
     it("geom zoom が全 DEM 404 でも粗ズーム DEM を切り出して実標高で建築する (#384)", async () => {
-        // DEM5 非整備領域: z15 geom は全レイヤー 404 だが、粗ズーム z14 dem_png には実標高がある。
+        // DEM5 非整備領域: z15 geom は全レイヤー 404(決定的未配信) だが、粗ズーム z14 dem_png には実標高がある。
         const PARENT_ELEV = 900;
         loadElevationTile.mockImplementation((...args: unknown[]) => {
             const zoom = args[0] as number;
-            if (zoom >= 15) return Promise.reject(new Error("404"));
+            // 決定的な 404 のみ粗ズームフォールバックを発動するため TileFetchError(status=404) で reject。
+            if (zoom >= 15) return Promise.reject(new TileFetchError("404", 404));
             return Promise.resolve(new Float32Array(256 * 256).fill(PARENT_ELEV));
         });
         toTileXY.mockReturnValue({ x: 24000, y: 12000 });
@@ -881,12 +884,17 @@ describe("createGlobeTileManager", () => {
 
     it("取得失敗(404)の湖面タイルを 0m でなく隣接タイルの接線標高で平坦建築する (#339)", async () => {
         const mgr = makeManager();
-        // 中央 geom タイル(gx=100,gy=100)は全レイヤ 404（reject）＝本栖湖 z15 湖面タイルの実挙動。
+        // 中央 geom タイル(gx=100,gy=100)は全レイヤ 404（決定的未配信）かつ粗ズーム祖先も 404＝本栖湖 z15
+        // 湖面タイルの実挙動（湖面は dem_png でも未配信）。粗ズームフォールバックも尽きて failedRetryAt へ。
         // 上下左右の隣接タイルは一様 900m（本栖湖の湖面標高 ≒ 湖岸標高）。
         loadElevationTile.mockImplementation((...args: unknown[]) => {
+            const zoom = args[0] as number;
             const gx = args[1] as number;
             const gy = args[2] as number;
-            if (gx === 100 && gy === 100) return Promise.reject(new Error("HTTP 404"));
+            // 中央タイル(z10)も粗ズーム祖先(z<10)も 404。決定的 404 なので粗ズームを試すが全滅 → 再 throw。
+            if ((gx === 100 && gy === 100) || zoom < 10) {
+                return Promise.reject(new TileFetchError("HTTP 404", 404));
+            }
             return Promise.resolve(new Float32Array(256 * 256).fill(900));
         });
         selectedTiles = [

--- a/tests/gsiTile.unit.spec.ts
+++ b/tests/gsiTile.unit.spec.ts
@@ -615,6 +615,30 @@ describe("loadElevationTile", () => {
         for (let i = 0; i < elev.length; i++) expect(Number.isNaN(elev[i])).toBe(true);
     });
 
+    it("粗ズーム補填中の一時障害（非404）は握りつぶさず伝播する", async () => {
+        // dem5a 全面 no-data → dem5b(z15) 404 → 粗ズーム dem_png(z14) でネットワーク障害(reject)。
+        // 404 と区別し、穴埋め未完のまま誤った標高を返さず例外を伝播する（バックオフ再取得に委ねる）。
+        const allNoData = makeImageGrid(2, 4);
+        setupLoadImageMocks(allNoData);
+
+        const fetchMock = jest.fn<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>((input) => {
+            const url = String(input);
+            if (url.includes("dem5a_png")) {
+                return Promise.resolve({ ok: true, blob: () => Promise.resolve(new Blob()) } as Response);
+            }
+            if (url.includes("dem5b_png")) {
+                return Promise.resolve({ ok: false, status: 404 } as Response);
+            }
+            // 粗ズーム dem_png(z14): ネットワーク障害（HTTP 404 ではない一時障害）
+            return Promise.reject(new Error("network down"));
+        });
+        globalThis.fetch = fetchMock;
+
+        await expect(loadElevationTile(15, 100, 200)).rejects.toThrow(/network down/);
+        // dem5a(200) + dem5b(404) + 粗ズーム dem_png(z14, 一時障害で打ち切り) = 3 取得
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
     it("HTTP 失敗時のみ次レイヤーへフォールバックする", async () => {
         // dem5a → 404, dem5b → 有効データ (R=0, G=100, B=0 → 25600*0.01 = 256.0)
         const validImageData = makeImageDataResult(0, 100, 0);

--- a/tests/gsiTile.unit.spec.ts
+++ b/tests/gsiTile.unit.spec.ts
@@ -507,7 +507,7 @@ describe("loadElevationTile", () => {
     });
 
     it("全面 no-data（同一ズームに実標高なし）は粗ズーム dem_png で穴埋めする (#386)", async () => {
-        // z15: dem5a 全面 no-data(200) → dem5b(z15) 404 → dem_png(z15) 404。
+        // z15: dem5a 全面 no-data(HTTP 200・全画素 128,0,0) → dem5b(z15) 404 → dem_png(z15) 404。
         // 同一ズームに実標高が無く全面 no-data のため、粗ズーム dem_png(z14) を取得して穴埋めする。
         const allNoData = makeImageGrid(2, 4); // 4/4 = 全面 no-data
         const coarseFull = makeImageGrid(2, 0); // 粗ズーム dem_png: 全有効(256.0)
@@ -591,7 +591,7 @@ describe("loadElevationTile", () => {
     });
 
     it("全面 no-data で粗ズームも未配信なら NaN のまま（後段の湖面処理に委ねる）", async () => {
-        // dem5a 全面 no-data(200) → dem5b/dem_png(z15) 404 → 粗ズーム dem_png(z14..z10) も全て 404。
+        // dem5a 全面 no-data(HTTP 200・全画素 128,0,0) → dem5b/dem_png(z15) 404 → 粗ズーム dem_png(z14..z10) も全て 404。
         // どこにも実標高が無いため all-NaN を維持し、後段（refineAllNaNTiles 等）に委ねる。
         const allNoData = makeImageGrid(2, 4);
         setupLoadImageMocks(allNoData);

--- a/tests/gsiTile.unit.spec.ts
+++ b/tests/gsiTile.unit.spec.ts
@@ -375,6 +375,26 @@ const makeImageDataResult = (r: number, g: number, b: number): ImageData => ({
     colorSpace: "srgb",
 });
 
+/**
+ * size×size の ImageData を作るヘルパー。先頭 `noDataCount` ピクセルを no-data(128,0,0)、
+ * 残りを `rgb`（既定: 0,100,0 → 256.0m）にする。レイヤー合成の閾値判定検証に使う。
+ */
+const makeImageGrid = (
+    size: number,
+    noDataCount: number,
+    rgb: readonly [number, number, number] = [0, 100, 0],
+): ImageData => {
+    const data = new Uint8ClampedArray(size * size * 4);
+    for (let i = 0; i < size * size; i++) {
+        const [r, g, b] = i < noDataCount ? [128, 0, 0] : rgb;
+        data[i * 4] = r;
+        data[i * 4 + 1] = g;
+        data[i * 4 + 2] = b;
+        data[i * 4 + 3] = 255;
+    }
+    return { width: size, height: size, data, colorSpace: "srgb" };
+};
+
 /** loadImageData 内部で使われるブラウザ API をモックするセットアップ */
 const setupLoadImageMocks = (imageData: ImageData) => {
     const mockCtx = {
@@ -395,6 +415,36 @@ const setupLoadImageMocks = (imageData: ImageData) => {
     );
 };
 
+/**
+ * 取得（loadImageData）成功のたびに次の ImageData を順に返すモックセットアップ。
+ * レイヤー合成（dem5a → dem5b → dem）の per-pixel 穴埋め挙動を検証するのに使う。
+ */
+const setupLoadImageSequenceMocks = (sequence: readonly ImageData[]) => {
+    let i = 0;
+    const cur = () => sequence[Math.min(i, sequence.length - 1)];
+    const mockCtx = {
+        drawImage: jest.fn(),
+        // getImageData は loadImageData の最終ステップ。ここで次の要素へ進める。
+        getImageData: jest.fn(() => {
+            const data = cur();
+            i++;
+            return data;
+        }),
+    };
+    const mockCanvas = {
+        width: 0,
+        height: 0,
+        getContext: jest.fn(() => mockCtx),
+    };
+    (globalThis as Record<string, unknown>).document = {
+        createElement: jest.fn(() => mockCanvas),
+    };
+    (globalThis as Record<string, unknown>).createImageBitmap = jest.fn(() => {
+        const data = cur();
+        return Promise.resolve({ width: data.width, height: data.height, close: jest.fn() });
+    });
+};
+
 describe("loadElevationTile", () => {
     const originalFetch = globalThis.fetch;
     const originalCreateImageBitmap = (globalThis as Record<string, unknown>).createImageBitmap;
@@ -407,10 +457,10 @@ describe("loadElevationTile", () => {
         jest.restoreAllMocks();
     });
 
-    it("HTTP 成功で all-NaN でも次レイヤーへフォールバックしない", async () => {
-        // dem5a が all-NaN (R=128,G=0,B=0) を返す → そのまま返すべき
-        const allNanImageData = makeImageDataResult(128, 0, 0);
-        setupLoadImageMocks(allNanImageData);
+    it("dem5a が完全カバー（有効値）なら下位レイヤーを取得しない", async () => {
+        // dem5a が有効値 (R=0,G=100,B=0 → 256.0) を返す → 穴が無いので 1 レイヤーで完了
+        const validImageData = makeImageDataResult(0, 100, 0);
+        setupLoadImageMocks(validImageData);
 
         const fetchMock = jest.fn<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>(() =>
             Promise.resolve({ ok: true, blob: () => Promise.resolve(new Blob()) } as Response)
@@ -423,10 +473,144 @@ describe("loadElevationTile", () => {
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock.mock.calls[0][0]).toContain("dem5a_png");
 
-        // 返却値は all-NaN
         expect(elev).toBeInstanceOf(Float32Array);
-        expect(elev.length).toBe(1);
+        expect(elev[0]).toBeCloseTo(256.0);
+    });
+
+    it("no-data の穴を下位レイヤーの有効値で合成補填する (#384)", async () => {
+        // dem5a: 2×2 のうち 3px が no-data → dem5b: 404 → dem: 全有効(256.0)
+        // 穴がある限り下位レイヤーを取得し、dem の有効値で埋める。
+        const demHoles = makeImageGrid(2, 3); // 3/4 = no-data
+        const demFull = makeImageGrid(2, 0); // 全有効
+        setupLoadImageSequenceMocks([demHoles, demFull]);
+
+        let callCount = 0;
+        const fetchMock = jest.fn<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>(() => {
+            callCount++;
+            // dem5b (2 回目) のみ 404、それ以外は成功
+            if (callCount === 2) return Promise.resolve({ ok: false, status: 404 } as Response);
+            return Promise.resolve({ ok: true, blob: () => Promise.resolve(new Blob()) } as Response);
+        });
+        globalThis.fetch = fetchMock;
+
+        const elev = await loadElevationTile(15, 100, 200);
+
+        // dem5a(成功・穴) → dem5b(404) → dem(成功・穴埋め) で 3 レイヤー試行
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+        expect(fetchMock.mock.calls[0][0]).toContain("dem5a_png");
+        expect(fetchMock.mock.calls[1][0]).toContain("dem5b_png");
+        expect(fetchMock.mock.calls[2][0]).toContain("dem_png");
+
+        // 穴が dem の有効値で全て埋まる
+        expect(elev.length).toBe(4);
+        for (let i = 0; i < elev.length; i++) expect(elev[i]).toBeCloseTo(256.0);
+    });
+
+    it("全面 no-data（同一ズームに実標高なし）は粗ズーム dem_png で穴埋めする (#386)", async () => {
+        // z15: dem5a 全面 no-data(200) → dem5b(z15) 404 → dem_png(z15) 404。
+        // 同一ズームに実標高が無く全面 no-data のため、粗ズーム dem_png(z14) を取得して穴埋めする。
+        const allNoData = makeImageGrid(2, 4); // 4/4 = 全面 no-data
+        const coarseFull = makeImageGrid(2, 0); // 粗ズーム dem_png: 全有効(256.0)
+        setupLoadImageSequenceMocks([allNoData, coarseFull]);
+
+        let callCount = 0;
+        const fetchMock = jest.fn<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>((input) => {
+            callCount++;
+            // dem5b(z15)/dem_png(z15) は 404。dem5a(z15) と 粗ズーム dem_png(z14) は成功。
+            const url = String(input);
+            if (callCount === 2 || (callCount === 3 && url.includes("/15/"))) {
+                return Promise.resolve({ ok: false, status: 404 } as Response);
+            }
+            return Promise.resolve({ ok: true, blob: () => Promise.resolve(new Blob()) } as Response);
+        });
+        globalThis.fetch = fetchMock;
+
+        const elev = await loadElevationTile(15, 100, 200);
+
+        // dem5a(z15) → dem5b(z15,404) → dem_png(z15,404) → dem_png(z14) の 4 取得
+        expect(fetchMock).toHaveBeenCalledTimes(4);
+        expect(fetchMock.mock.calls[0][0]).toContain("dem5a_png/15/");
+        expect(fetchMock.mock.calls[1][0]).toContain("dem5b_png/15/");
+        expect(fetchMock.mock.calls[2][0]).toContain("dem_png/15/");
+        // 粗ズームは親タイル座標 (z14, x>>1, y>>1) = (14, 50, 100)
+        expect(fetchMock.mock.calls[3][0]).toContain("dem_png/14/50/100.png");
+
+        // 全面 no-data が粗ズーム dem_png の実標高で埋まる
+        expect(elev.length).toBe(4);
+        for (let i = 0; i < elev.length; i++) expect(elev[i]).toBeCloseTo(256.0);
+    });
+
+    it("微小欠測（閾値以下）は同一ズーム合成せず NaN を残す（fillInvalidPixels に委ねる）", async () => {
+        // dem5a 4×4 のうち 1px だけ no-data = 6.25% ≤ COMPOSITE_HOLE_RATIO(0.1)。
+        // 微小穴のため下位レイヤー(dem5b/dem_png)を取得せず、欠測 1px は NaN のまま後段に委ねる。
+        const minorHoles = makeImageGrid(4, 1);
+        setupLoadImageMocks(minorHoles);
+
+        const fetchMock = jest.fn<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>(() =>
+            Promise.resolve({ ok: true, blob: () => Promise.resolve(new Blob()) } as Response)
+        );
+        globalThis.fetch = fetchMock;
+
+        const elev = await loadElevationTile(15, 100, 200);
+
+        // dem5a(成功・微小穴) のみ。閾値以下なので dem5b/dem_png は取得しない。
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock.mock.calls[0][0]).toContain("dem5a_png");
+        // 欠測 1px は NaN のまま（後段 fillInvalidPixels が局所補間する）
         expect(Number.isNaN(elev[0])).toBe(true);
+        expect(Number.isNaN(elev[1])).toBe(false);
+    });
+
+    it("閾値超の部分欠測は、同一ズームで埋まらなければ粗ズーム dem_png で穴埋めする (#386)", async () => {
+        // dem5a 4×4 のうち 4px no-data = 25% > COMPOSITE_HOLE_RATIO(0.1) → 下位レイヤー合成。
+        // dem5b/dem_png(同一ズーム z15) は 404 で埋まらず、穴が閾値超のため粗ズーム dem_png(z14) で穴埋め。
+        const partialHoles = makeImageGrid(4, 4);
+        const coarseFull = makeImageGrid(4, 0); // 粗ズーム dem_png: 全有効(256.0)
+        setupLoadImageSequenceMocks([partialHoles, coarseFull]);
+
+        const fetchMock = jest.fn<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>((input) => {
+            const url = String(input);
+            // dem5b/dem_png（同一ズーム z15）は 404。粗ズーム dem_png(z14) は成功。
+            if (url.includes("dem5b_png") || url.includes("dem_png/15/")) {
+                return Promise.resolve({ ok: false, status: 404 } as Response);
+            }
+            return Promise.resolve({ ok: true, blob: () => Promise.resolve(new Blob()) } as Response);
+        });
+        globalThis.fetch = fetchMock;
+
+        const elev = await loadElevationTile(15, 100, 200);
+
+        // dem5a(z15) → dem5b(z15,404) → dem_png(z15,404) → dem_png(z14) の 4 取得
+        expect(fetchMock).toHaveBeenCalledTimes(4);
+        expect(fetchMock.mock.calls[0][0]).toContain("dem5a_png/15/");
+        expect(fetchMock.mock.calls[1][0]).toContain("dem5b_png/15/");
+        expect(fetchMock.mock.calls[2][0]).toContain("dem_png/15/");
+        expect(fetchMock.mock.calls[3][0]).toContain("dem_png/14/50/100.png");
+        // 25% の欠測が粗ズーム dem_png の実標高で埋まる
+        for (let i = 0; i < elev.length; i++) expect(elev[i]).toBeCloseTo(256.0);
+    });
+
+    it("全面 no-data で粗ズームも未配信なら NaN のまま（後段の湖面処理に委ねる）", async () => {
+        // dem5a 全面 no-data(200) → dem5b/dem_png(z15) 404 → 粗ズーム dem_png(z14..z10) も全て 404。
+        // どこにも実標高が無いため all-NaN を維持し、後段（refineAllNaNTiles 等）に委ねる。
+        const allNoData = makeImageGrid(2, 4);
+        setupLoadImageMocks(allNoData);
+
+        const fetchMock = jest.fn<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>((input) => {
+            const url = String(input);
+            // dem5a(z15) のみ 200。それ以外（dem5b/dem_png/粗ズーム）は全て 404。
+            if (url.includes("dem5a_png")) {
+                return Promise.resolve({ ok: true, blob: () => Promise.resolve(new Blob()) } as Response);
+            }
+            return Promise.resolve({ ok: false, status: 404 } as Response);
+        });
+        globalThis.fetch = fetchMock;
+
+        const elev = await loadElevationTile(15, 100, 200);
+
+        // dem5a(200) + dem5b(404) + dem_png/z15(404) + 粗ズーム dem_png z14..z10(5 段) = 8 取得
+        expect(fetchMock).toHaveBeenCalledTimes(8);
+        for (let i = 0; i < elev.length; i++) expect(Number.isNaN(elev[i])).toBe(true);
     });
 
     it("HTTP 失敗時のみ次レイヤーへフォールバックする", async () => {
@@ -448,7 +632,7 @@ describe("loadElevationTile", () => {
 
         const elev = await loadElevationTile(15, 100, 200);
 
-        // dem5a → 失敗, dem5b → 成功 で 2 回呼ばれる
+        // dem5a → 失敗, dem5b → 成功（有効値で穴なし）→ dem は取得しないので 2 回
         expect(fetchMock).toHaveBeenCalledTimes(2);
         expect(fetchMock.mock.calls[0][0]).toContain("dem5a_png");
         expect(fetchMock.mock.calls[1][0]).toContain("dem5b_png");

--- a/tests/gsiTile.unit.spec.ts
+++ b/tests/gsiTile.unit.spec.ts
@@ -14,6 +14,7 @@ import {
     textureUrl,
     NO_DATA_SENTINEL,
     loadElevationTile,
+    TileFetchError,
 } from "../src/terrain/gsiTile";
 
 describe("TILE_SIZE", () => {
@@ -478,8 +479,10 @@ describe("loadElevationTile", () => {
     });
 
     it("no-data の穴を下位レイヤーの有効値で合成補填する (#384)", async () => {
-        // dem5a: 2×2 のうち 3px が no-data → dem5b: 404 → dem: 全有効(256.0)
-        // 穴がある限り下位レイヤーを取得し、dem の有効値で埋める。
+        // dem5a: 2×2 のうち 3px が no-data → dem5b: 404 → dem_png: 全有効(256.0)
+        // 穴がある限り同一ズームの下位レイヤーを取得し、dem_png の有効値で埋める。
+        // dem_png が同一ズームで配信される z14 で検証する（z15 以降は dem_png 同一ズームをスキップし
+        // 粗ズーム補填に委ねるため、別テストで扱う）。
         const demHoles = makeImageGrid(2, 3); // 3/4 = no-data
         const demFull = makeImageGrid(2, 0); // 全有効
         setupLoadImageSequenceMocks([demHoles, demFull]);
@@ -493,13 +496,13 @@ describe("loadElevationTile", () => {
         });
         globalThis.fetch = fetchMock;
 
-        const elev = await loadElevationTile(15, 100, 200);
+        const elev = await loadElevationTile(14, 100, 200);
 
-        // dem5a(成功・穴) → dem5b(404) → dem(成功・穴埋め) で 3 レイヤー試行
+        // dem5a(成功・穴) → dem5b(404) → dem_png(成功・穴埋め) で 3 レイヤー試行
         expect(fetchMock).toHaveBeenCalledTimes(3);
-        expect(fetchMock.mock.calls[0][0]).toContain("dem5a_png");
-        expect(fetchMock.mock.calls[1][0]).toContain("dem5b_png");
-        expect(fetchMock.mock.calls[2][0]).toContain("dem_png");
+        expect(fetchMock.mock.calls[0][0]).toContain("dem5a_png/14/");
+        expect(fetchMock.mock.calls[1][0]).toContain("dem5b_png/14/");
+        expect(fetchMock.mock.calls[2][0]).toContain("dem_png/14/");
 
         // 穴が dem の有効値で全て埋まる
         expect(elev.length).toBe(4);
@@ -507,18 +510,17 @@ describe("loadElevationTile", () => {
     });
 
     it("全面 no-data（同一ズームに実標高なし）は粗ズーム dem_png で穴埋めする (#386)", async () => {
-        // z15: dem5a 全面 no-data(HTTP 200・全画素 128,0,0) → dem5b(z15) 404 → dem_png(z15) 404。
-        // 同一ズームに実標高が無く全面 no-data のため、粗ズーム dem_png(z14) を取得して穴埋めする。
+        // z15: dem5a 全面 no-data(HTTP 200・全画素 128,0,0) → dem5b(z15) 404 → dem_png(z15) は配信上限
+        // (z14)超のためスキップ。同一ズームに実標高が無く全面 no-data のため、粗ズーム dem_png(z14) を
+        // 取得して穴埋めする。
         const allNoData = makeImageGrid(2, 4); // 4/4 = 全面 no-data
         const coarseFull = makeImageGrid(2, 0); // 粗ズーム dem_png: 全有効(256.0)
         setupLoadImageSequenceMocks([allNoData, coarseFull]);
 
-        let callCount = 0;
         const fetchMock = jest.fn<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>((input) => {
-            callCount++;
-            // dem5b(z15)/dem_png(z15) は 404。dem5a(z15) と 粗ズーム dem_png(z14) は成功。
+            // dem5b(z15) は 404。dem5a(z15) と 粗ズーム dem_png(z14) は成功。dem_png(z15) は呼ばれない。
             const url = String(input);
-            if (callCount === 2 || (callCount === 3 && url.includes("/15/"))) {
+            if (url.includes("dem5b_png")) {
                 return Promise.resolve({ ok: false, status: 404 } as Response);
             }
             return Promise.resolve({ ok: true, blob: () => Promise.resolve(new Blob()) } as Response);
@@ -527,13 +529,12 @@ describe("loadElevationTile", () => {
 
         const elev = await loadElevationTile(15, 100, 200);
 
-        // dem5a(z15) → dem5b(z15,404) → dem_png(z15,404) → dem_png(z14) の 4 取得
-        expect(fetchMock).toHaveBeenCalledTimes(4);
+        // dem5a(z15) → dem5b(z15,404) → dem_png(z14) の 3 取得（dem_png z15 はスキップ）
+        expect(fetchMock).toHaveBeenCalledTimes(3);
         expect(fetchMock.mock.calls[0][0]).toContain("dem5a_png/15/");
         expect(fetchMock.mock.calls[1][0]).toContain("dem5b_png/15/");
-        expect(fetchMock.mock.calls[2][0]).toContain("dem_png/15/");
         // 粗ズームは親タイル座標 (z14, x>>1, y>>1) = (14, 50, 100)
-        expect(fetchMock.mock.calls[3][0]).toContain("dem_png/14/50/100.png");
+        expect(fetchMock.mock.calls[2][0]).toContain("dem_png/14/50/100.png");
 
         // 全面 no-data が粗ズーム dem_png の実標高で埋まる
         expect(elev.length).toBe(4);
@@ -563,15 +564,16 @@ describe("loadElevationTile", () => {
 
     it("閾値超の部分欠測は、同一ズームで埋まらなければ粗ズーム dem_png で穴埋めする (#386)", async () => {
         // dem5a 4×4 のうち 4px no-data = 25% > COMPOSITE_HOLE_RATIO(0.1) → 下位レイヤー合成。
-        // dem5b/dem_png(同一ズーム z15) は 404 で埋まらず、穴が閾値超のため粗ズーム dem_png(z14) で穴埋め。
+        // dem5b(同一ズーム z15) は 404、dem_png(z15) は配信上限超でスキップ。穴が閾値超のため
+        // 粗ズーム dem_png(z14) で穴埋め。
         const partialHoles = makeImageGrid(4, 4);
         const coarseFull = makeImageGrid(4, 0); // 粗ズーム dem_png: 全有効(256.0)
         setupLoadImageSequenceMocks([partialHoles, coarseFull]);
 
         const fetchMock = jest.fn<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>((input) => {
             const url = String(input);
-            // dem5b/dem_png（同一ズーム z15）は 404。粗ズーム dem_png(z14) は成功。
-            if (url.includes("dem5b_png") || url.includes("dem_png/15/")) {
+            // dem5b（同一ズーム z15）は 404。粗ズーム dem_png(z14) は成功。dem_png(z15) は呼ばれない。
+            if (url.includes("dem5b_png")) {
                 return Promise.resolve({ ok: false, status: 404 } as Response);
             }
             return Promise.resolve({ ok: true, blob: () => Promise.resolve(new Blob()) } as Response);
@@ -580,25 +582,25 @@ describe("loadElevationTile", () => {
 
         const elev = await loadElevationTile(15, 100, 200);
 
-        // dem5a(z15) → dem5b(z15,404) → dem_png(z15,404) → dem_png(z14) の 4 取得
-        expect(fetchMock).toHaveBeenCalledTimes(4);
+        // dem5a(z15) → dem5b(z15,404) → dem_png(z14) の 3 取得（dem_png z15 はスキップ）
+        expect(fetchMock).toHaveBeenCalledTimes(3);
         expect(fetchMock.mock.calls[0][0]).toContain("dem5a_png/15/");
         expect(fetchMock.mock.calls[1][0]).toContain("dem5b_png/15/");
-        expect(fetchMock.mock.calls[2][0]).toContain("dem_png/15/");
-        expect(fetchMock.mock.calls[3][0]).toContain("dem_png/14/50/100.png");
+        expect(fetchMock.mock.calls[2][0]).toContain("dem_png/14/50/100.png");
         // 25% の欠測が粗ズーム dem_png の実標高で埋まる
         for (let i = 0; i < elev.length; i++) expect(elev[i]).toBeCloseTo(256.0);
     });
 
     it("全面 no-data で粗ズームも未配信なら NaN のまま（後段の湖面処理に委ねる）", async () => {
-        // dem5a 全面 no-data(HTTP 200・全画素 128,0,0) → dem5b/dem_png(z15) 404 → 粗ズーム dem_png(z14..z10) も全て 404。
-        // どこにも実標高が無いため all-NaN を維持し、後段（refineAllNaNTiles 等）に委ねる。
+        // dem5a 全面 no-data(HTTP 200・全画素 128,0,0) → dem5b(z15) 404 → dem_png(z15) はスキップ
+        // → 粗ズーム dem_png(z14..z10) も全て 404。どこにも実標高が無いため all-NaN を維持し、
+        // 後段（refineAllNaNTiles 等）に委ねる。
         const allNoData = makeImageGrid(2, 4);
         setupLoadImageMocks(allNoData);
 
         const fetchMock = jest.fn<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>((input) => {
             const url = String(input);
-            // dem5a(z15) のみ 200。それ以外（dem5b/dem_png/粗ズーム）は全て 404。
+            // dem5a(z15) のみ 200。それ以外（dem5b/粗ズーム dem_png）は全て 404。
             if (url.includes("dem5a_png")) {
                 return Promise.resolve({ ok: true, blob: () => Promise.resolve(new Blob()) } as Response);
             }
@@ -608,8 +610,8 @@ describe("loadElevationTile", () => {
 
         const elev = await loadElevationTile(15, 100, 200);
 
-        // dem5a(200) + dem5b(404) + dem_png/z15(404) + 粗ズーム dem_png z14..z10(5 段) = 8 取得
-        expect(fetchMock).toHaveBeenCalledTimes(8);
+        // dem5a(200) + dem5b(404) + 粗ズーム dem_png z14..z10(5 段) = 7 取得（dem_png z15 はスキップ）
+        expect(fetchMock).toHaveBeenCalledTimes(7);
         for (let i = 0; i < elev.length; i++) expect(Number.isNaN(elev[i])).toBe(true);
     });
 
@@ -648,12 +650,41 @@ describe("loadElevationTile", () => {
         );
         globalThis.fetch = fetchMock;
 
-        await expect(loadElevationTile(15, 100, 200)).rejects.toThrow(
+        // z14 では dem_png も同一ズームで試行されるため 3 レイヤー全て 404 → throw。
+        await expect(loadElevationTile(14, 100, 200)).rejects.toThrow(
             /No elevation tile available/
         );
 
         // 3 レイヤー全て試行
         expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it("全レイヤー 404（決定的未配信）なら TileFetchError.status=404 を投げる", async () => {
+        const fetchMock = jest.fn(() =>
+            Promise.resolve({ ok: false, status: 404 } as Response)
+        );
+        globalThis.fetch = fetchMock;
+
+        // status=404 は呼び出し側（globe）が粗ズームフォールバックを発動してよい決定的未配信の合図。
+        await expect(loadElevationTile(14, 100, 200)).rejects.toMatchObject({
+            name: "TileFetchError",
+            status: 404,
+        });
+    });
+
+    it("一時的な取得失敗が混じる場合は TileFetchError.status=undefined を投げる", async () => {
+        const fetchMock = jest.fn<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>((input) => {
+            const url = String(input);
+            // dem5a はネットワーク障害（reject）、それ以外は 404。一時障害が混じるため決定的 404 ではない。
+            if (url.includes("dem5a_png")) return Promise.reject(new Error("network down"));
+            return Promise.resolve({ ok: false, status: 404 } as Response);
+        });
+        globalThis.fetch = fetchMock;
+
+        // status=undefined は一時障害の合図。globe は粗ズームへ倒さずバックオフ再取得する。
+        const err = await loadElevationTile(14, 100, 200).catch((e) => e);
+        expect(err).toBeInstanceOf(TileFetchError);
+        expect((err as TileFetchError).status).toBeUndefined();
     });
 });
 

--- a/tests/tileCache.fixture.ts
+++ b/tests/tileCache.fixture.ts
@@ -148,8 +148,13 @@ export const test = base.extend({
             const body = await response.body();
             const contentType =
                 response.headers()["content-type"] ?? "application/octet-stream";
-            // 非2xx またはイメージ以外はキャッシュせずそのまま返す
-            if (!response.ok() || !contentType.startsWith("image/")) {
+            // 404（タイル非存在）は決定的なので negative cache する。
+            // レイヤー合成（Issue #384）は欠測タイルで下位 DEM の 404 を多数プローブするため、
+            // これをキャッシュしないと毎回実ネットワークに出て networkidle に到達できなくなる。
+            const cacheable =
+                (response.ok() && contentType.startsWith("image/")) ||
+                response.status() === 404;
+            if (!cacheable) {
                 await route.fulfill({
                     status: response.status(),
                     contentType,


### PR DESCRIPTION
## 概要

DEM5（dem5a/dem5b）が整備されていない山岳地帯をズームアップすると、地形標高がフラット化・数百mずれ・0m へ落下する不具合を修正する（globe / planar 両方）。

Closes #386

## 原因

1. `loadElevationTile` が「最初に HTTP 200 を返したレイヤーを採用」する設計で、部分 no-data の DEM5 タイルを下位レイヤーで補填していなかった。残った有効ピクセルが `fillInvalidPixels` で塗り広げられフラット化。
2. dem_png の配信上限 z14 を超える z15 では、同一ズームに穴を埋める実標高が存在せず、大穴タイル（例: dem5a が 77% no-data）が「ホールケーキの一切れ」状に崩れる。
3. globe は geom zoom 単一しか試さず、全 DEM 404 時に粗ズームへフォールバックしていなかった。

## 変更内容

- **`src/terrain/gsiTile.ts`**
  - `loadElevationTile` を per-pixel レイヤー合成化。穴がタイルの `COMPOSITE_HOLE_RATIO`(0.1) を超える場合のみ dem5a→dem5b→dem_png を合成（微小穴は `fillInvalidPixels` に委ね、不要な追加フェッチ・描画変化を回避）。
  - 合成後も穴が閾値超で残る場合は粗ズーム dem_png を切り出して実標高で穴埋め（`fillHolesFromCoarseDem`, `DEM_PNG_MAX_ZOOM=14`, `COARSE_FILL_DEPTH=5`）。
- **`src/terrain/geo/globeTileManager.ts`**
  - `loadGeomElevation` / `extractSubTileElev` を追加。geom zoom 全 DEM 404 時に粗ズーム DEM へ段階フォールバック（`GEOM_ELEV_FALLBACK_DEPTH=4`）。
- **テスト**
  - `tests/gsiTile.unit.spec.ts` / `tests/globeTileManager.unit.spec.ts`: 合成・閾値・粗ズーム補填・globe フォールバックの回帰テスト。
  - `tests/tileCache.fixture.ts`: 404 の negative caching。
  - `tests/atPathReload.spec.ts`: networkidle 依存を JS チャンク収束待ちへ堅牢化（VR 安定化）。

## 影響範囲

- planar / globe の標高描画（DEM5 カバレッジ穴の補填）。
- 整備済み領域の微小穴（堀・河川・タイル境界）は閾値ゲートにより従来描画を維持。

## 確認

- [x] `npm run test:unit`（1284 passed）
- [x] `npm run lint` / `npm run typecheck`
- [x] `npm run test:visuals`（19/19 passed）
- [x] DEM5 非整備領域（御影森山付近・38.285339,140.099634 z15）の目視確認（HITL）— 標高フラット化/0m落下/ホールケーキ形状の解消を確認

## 補足

- globe の同一ズーム隣接タイル境界の陰影シーム（本修正で標高復元により顕在化）は別 Issue #387 で対応する。
