### PR TITLE
fix(terrain): globeで同一ズーム隣接タイルの辺を縫合し陰影シームを解消 (#387)

### DIFF
--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -1025,13 +1025,15 @@ export const createGlobeTileManager = (
             // が出る（planar は `applyStitchedElevation` で縫合済み）。原本 `elevCache` は破壊せず
             // コピーへ適用する。クロスレベルスナップ（CoarseEdge）は LOD 境界辺、本縫合は同一ズーム辺
             // を対象とし排他的に共存する。揃っていた隣接方位を sig に含め、隣接後ロードで再縫合させる。
+            // ここでは隣接収集（軽量）と署名計算のみ行い、256x256 コピー＋`stitchTileEdges` は再建築が
+            // 必要な場合（sig 不一致 or 新規）に限定する。隣接が揃った定常フレームで sig 一致による
+            // 再建築スキップが、無駄な全コピーを伴わないようにするため（#387 レビュー指摘）。
+            let stitchNeighbors: StitchNeighbors | undefined;
             let stitchSig = "";
             if (!isFlatFallback && !isAllNanPending && t.zoom >= minZoom) {
                 const { neighbors, sig: nSig } = collectSameZoomNeighbors(gz, gx, gy);
                 if (nSig.length > 0) {
-                    const copy = Float32Array.from(geomElev);
-                    stitchTileEdges(copy, neighbors, TILE_SIZE);
-                    geomElev = copy;
+                    stitchNeighbors = neighbors;
                     stitchSig = `s${nSig}|`;
                 }
             }
@@ -1072,8 +1074,17 @@ export const createGlobeTileManager = (
             // 既存メッシュは coarse-edge 集合が同一ならそのまま、変化していれば
             // ジオメトリのみ差し替える（テクスチャ・マテリアルは再利用し再読込を避ける）。
             const existing = loaded.get(k);
+            // sig 一致（再建築不要）ならコピー＋縫合に入る前に早期スキップする（#387 レビュー指摘）。
+            if (existing && builtEdgeSig.get(k) === sig) continue;
+
+            // 再建築が確定したのでここで初めて同一ズーム縫合を適用する（原本 elevCache は非破壊）。
+            if (stitchNeighbors) {
+                const copy = Float32Array.from(geomElev);
+                stitchTileEdges(copy, stitchNeighbors, TILE_SIZE);
+                geomElev = copy;
+            }
+
             if (existing) {
-                if (builtEdgeSig.get(k) === sig) continue;
                 applyGeometry(
                     existing,
                     buildGlobeTileMeshData({

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -936,6 +936,32 @@ export const createGlobeTileManager = (
         }
     };
 
+    /**
+     * 同一ズーム隣接（同 geom zoom）の有効標高を `elevCache` から収集する（#387）。
+     * planar の `getNeighborElevations` 相当。実標高タイルの辺を `stitchTileEdges` で平均化し、
+     * タイル境界の陰影シームを解消するために用いる。未解決 all-NaN 隣接（湖面・no-data 全面）は
+     * 有効な辺標高を持たないためシード源にしない（`nanMean` で自然除外されるが署名を意味のある
+     * ものに保つためここでも除外する）。揃っていた隣接方位の署名も返し、隣接が後からロードされた
+     * ら sig 差分で再縫合・再建築させる。
+     */
+    const collectSameZoomNeighbors = (
+        gz: number,
+        gx: number,
+        gy: number,
+    ): { neighbors: StitchNeighbors; sig: string } => {
+        const neighbors: StitchNeighbors = {};
+        const present: string[] = [];
+        for (const [dx, dy, dir] of allNanNeighborOffsets) {
+            const nKey = tileKey(gz, gx + dx, gy + dy);
+            if (allNanGeom.has(nKey)) continue;
+            const nElev = elevCache.get(nKey);
+            if (!nElev) continue;
+            neighbors[dir] = nElev;
+            present.push(dir);
+        }
+        return { neighbors, sig: present.sort().join(",") };
+    };
+
     /** geom 標高が揃った desired タイルをメッシュ化する。 */
     const buildReadyTiles = (tiles: readonly GlobeTile[]): void => {
         for (const t of tiles) {
@@ -987,6 +1013,23 @@ export const createGlobeTileManager = (
                 geomElev = flatElevArray(repElev);
             }
 
+            // 同一ズーム隣接辺スティッチング（#387）。実標高 geom タイル（フラット/暫定 all-NaN
+            // 建築ではない）に限り、同 geom zoom 隣接の有効標高で辺を平均化したコピーを建築入力に
+            // する。隣接 GSI DEM タイルは辺が 1 セルずれるため、平均化しないと境界に段差（陰影シーム）
+            // が出る（planar は `applyStitchedElevation` で縫合済み）。原本 `elevCache` は破壊せず
+            // コピーへ適用する。クロスレベルスナップ（CoarseEdge）は LOD 境界辺、本縫合は同一ズーム辺
+            // を対象とし排他的に共存する。揃っていた隣接方位を sig に含め、隣接後ロードで再縫合させる。
+            let stitchSig = "";
+            if (!isFlatFallback && !isAllNanPending && t.zoom >= minZoom) {
+                const { neighbors, sig: nSig } = collectSameZoomNeighbors(gz, gx, gy);
+                if (nSig.length > 0) {
+                    const copy = Float32Array.from(geomElev);
+                    stitchTileEdges(copy, neighbors, TILE_SIZE);
+                    geomElev = copy;
+                    stitchSig = `s${nSig}|`;
+                }
+            }
+
             // クロスレベル「標高スナップ」は z<=geomMaxZoom の LOD 境界にのみ適用する。
             // crossLevel は細タイル zoom == その geom zoom を前提に、細グローバルピクセルを
             // 粗ラスタへ写像するため。z16-18 は z15 をサブサンプルして共有するので intra-level
@@ -1017,6 +1060,7 @@ export const createGlobeTileManager = (
                 (isFlatFallback ? "flat|" : "") +
                 (isAllNanPending ? "allnan|" : "") +
                 (repElev !== undefined ? `r${Math.round(repElev / 10)}|` : "") +
+                stitchSig +
                 edgeSignature(edges);
 
             // 既存メッシュは coarse-edge 集合が同一ならそのまま、変化していれば

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -943,6 +943,8 @@ export const createGlobeTileManager = (
      * 有効な辺標高を持たないためシード源にしない（`nanMean` で自然除外されるが署名を意味のある
      * ものに保つためここでも除外する）。揃っていた隣接方位の署名も返し、隣接が後からロードされた
      * ら sig 差分で再縫合・再建築させる。
+     * 経度方向（x）は日付変更線で巡回（wrap）するため `%limit` で折り返して隣接を探索し（globeLod の
+     * root seed 生成と同じ規約）、緯度方向（y）は極で巡回しないため範囲外をスキップする。
      */
     const collectSameZoomNeighbors = (
         gz: number,
@@ -951,8 +953,12 @@ export const createGlobeTileManager = (
     ): { neighbors: StitchNeighbors; sig: string } => {
         const neighbors: StitchNeighbors = {};
         const present: string[] = [];
+        const limit = 2 ** gz; // 軸方向タイル数（= 2^gz）
         for (const [dx, dy, dir] of allNanNeighborOffsets) {
-            const nKey = tileKey(gz, gx + dx, gy + dy);
+            const ny = gy + dy;
+            if (ny < 0 || ny >= limit) continue; // y は wrap しない
+            const nx = (((gx + dx) % limit) + limit) % limit; // x は日付変更線で wrap
+            const nKey = tileKey(gz, nx, ny);
             if (allNanGeom.has(nKey)) continue;
             const nElev = elevCache.get(nKey);
             if (!nElev) continue;

--- a/tests/globeTileManager.unit.spec.ts
+++ b/tests/globeTileManager.unit.spec.ts
@@ -976,6 +976,36 @@ describe("createGlobeTileManager", () => {
         expect((built as { geomElev: Float32Array }).geomElev[mid + 0]).toBeCloseTo(100, 3);
     });
 
+    it("日付変更線をまたぐ x=0 と x=limit-1 の同一ズーム隣接を wrap して縫合する (#387)", async () => {
+        const mgr = makeManager();
+        // gz=10 の軸方向タイル数 limit=1024。x=0 と x=1023 は日付変更線で隣接する。
+        // x=0 のタイルは一様 100m、x=1023 は一様 200m。wrap 探索が無いと x=0 の左隣
+        // (x=-1) が拾えず縫合されないが、wrap すれば x=1023 が左隣として縫合される。
+        loadElevationTile.mockImplementation((...args: unknown[]) => {
+            const gx = args[1] as number;
+            const fill = gx === 0 ? 100 : 200;
+            return Promise.resolve(new Float32Array(256 * 256).fill(fill));
+        });
+        selectedTiles = [tile(0, 100, 10), tile(1023, 100, 10)];
+        mgr.sync(syncParams());
+        await flush();
+        mgr.sync(syncParams());
+
+        const mid = 128 * 256;
+        const lastBuild = (tx: number) => {
+            const arr = capturedBuilds.filter((b) => b.tx === tx);
+            return arr[arr.length - 1];
+        };
+        const west = lastBuild(0); // x=0（左隣は wrap で x=1023）
+        const east = lastBuild(1023); // x=1023（右隣は wrap で x=0）
+        expect(west).toBeDefined();
+        expect(east).toBeDefined();
+        // x=0 の左辺（col=0）は wrap 隣接 x=1023 の 200m と平均され 150m。
+        expect((west as { geomElev: Float32Array }).geomElev[mid + 0]).toBeCloseTo(150, 3);
+        // x=1023 の右辺（col=255）は wrap 隣接 x=0 の 100m と平均され 150m。
+        expect((east as { geomElev: Float32Array }).geomElev[mid + 255]).toBeCloseTo(150, 3);
+    });
+
     it("同一ズーム縫合は原本 elevCache を破壊しない (#387)", async () => {
         const mgr = makeManager();
         loadElevationTile.mockImplementation((...args: unknown[]) => {

--- a/tests/globeTileManager.unit.spec.ts
+++ b/tests/globeTileManager.unit.spec.ts
@@ -923,6 +923,78 @@ describe("createGlobeTileManager", () => {
         expect(elev as number).toBeCloseTo(900, 3);
     });
 
+    // ===== 同一ズーム隣接辺スティッチング（Issue #387 / 平面版相当） =====
+
+    it("同一ズーム隣接の実標高タイル辺を平均化してタイル境界の段差を解消する (#387)", async () => {
+        const mgr = makeManager();
+        // 左タイル(gx=100)は一様 100m、右隣(gx=101)は一様 200m の実標高。
+        // 縫合無しでは境界で 100m→200m の段差（陰影シーム）になる。縫合後は両者の接辺が
+        // 平均 150m に揃い、境界が連続する（planar の applyStitchedElevation 相当）。
+        loadElevationTile.mockImplementation((...args: unknown[]) => {
+            const gx = args[1] as number;
+            const fill = gx === 100 ? 100 : 200;
+            return Promise.resolve(new Float32Array(256 * 256).fill(fill));
+        });
+        selectedTiles = [tile(100, 100, 10), tile(101, 100, 10)];
+        mgr.sync(syncParams());
+        await flush(); // 両タイルの実標高が到着し elevCache へ格納される
+        mgr.sync(syncParams()); // 両隣接が揃った状態で縫合・建築
+
+        const mid = 128 * 256; // 中央行の先頭
+        const lastBuild = (tx: number) => {
+            const arr = capturedBuilds.filter((b) => b.tx === tx);
+            return arr[arr.length - 1];
+        };
+        const left = lastBuild(100);
+        const right = lastBuild(101);
+        expect(left).toBeDefined();
+        expect(right).toBeDefined();
+        // 左タイルの右辺（col=255）は右隣 200m と平均され 150m。内部は 100m のまま。
+        expect((left as { geomElev: Float32Array }).geomElev[mid + 255]).toBeCloseTo(150, 3);
+        expect((left as { geomElev: Float32Array }).geomElev[mid + 128]).toBeCloseTo(100, 3);
+        // 右タイルの左辺（col=0）は左隣 100m と平均され 150m。内部は 200m のまま。
+        expect((right as { geomElev: Float32Array }).geomElev[mid + 0]).toBeCloseTo(150, 3);
+        expect((right as { geomElev: Float32Array }).geomElev[mid + 128]).toBeCloseTo(200, 3);
+    });
+
+    it("同一ズーム隣接が無い実標高タイルは縫合せず原本標高で建築する (#387)", async () => {
+        const mgr = makeManager();
+        loadElevationTile.mockImplementation(() =>
+            Promise.resolve(new Float32Array(256 * 256).fill(100)),
+        );
+        selectedTiles = [tile(100, 100, 10)];
+        mgr.sync(syncParams());
+        await flush();
+        mgr.sync(syncParams());
+
+        const builtArr = capturedBuilds.filter((b) => b.tx === 100);
+        const built = builtArr[builtArr.length - 1];
+        expect(built).toBeDefined();
+        const mid = 128 * 256;
+        // 隣接が無いので辺も内部も原本 100m のまま（縫合 no-op）。
+        expect((built as { geomElev: Float32Array }).geomElev[mid + 255]).toBeCloseTo(100, 3);
+        expect((built as { geomElev: Float32Array }).geomElev[mid + 0]).toBeCloseTo(100, 3);
+    });
+
+    it("同一ズーム縫合は原本 elevCache を破壊しない (#387)", async () => {
+        const mgr = makeManager();
+        loadElevationTile.mockImplementation((...args: unknown[]) => {
+            const gx = args[1] as number;
+            const fill = gx === 100 ? 100 : 200;
+            return Promise.resolve(new Float32Array(256 * 256).fill(fill));
+        });
+        selectedTiles = [tile(100, 100, 10), tile(101, 100, 10)];
+        mgr.sync(syncParams());
+        await flush();
+        mgr.sync(syncParams());
+
+        // terrainElevAt は elevCache（縫合前の原本）を参照する。toTileXY モックは常に (100,100) を
+        // 返すため左タイル中心の 100m が得られ、縫合コピーで上書きされていないことを確認する。
+        const elev = mgr.terrainElevAt(35, 139);
+        expect(elev).not.toBeNull();
+        expect(elev as number).toBeCloseTo(100, 3);
+    });
+
     it("未解決 all-NaN タイル上では terrainElevAt が 0m でなく null を返す（代表標高の循環崩壊防止, #339）", async () => {
         const mgr = makeManager();
         // 全タイル全面 no-data（all-NaN）。粗ズーム祖先取得が完了するまで未解決状態が続く。


### PR DESCRIPTION
Closes #387

## 概要
globe（`/geospatial`）terrainEngine で、同一ズーム隣接 geom タイル間の辺が縫合されておらず境界に陰影シーム（段差・継ぎ目）が出ていた問題を修正する。planar 同様に同一ズーム辺を平均化（`stitchTileEdges`）し、境界をシームレスに連続させる。

## 変更内容
- `src/terrain/geo/globeTileManager.ts`
  - `collectSameZoomNeighbors(gz,gx,gy)` を追加。`elevCache` から同一 geom zoom の8近傍有効標高と「揃った隣接方位の署名」を収集する（未解決 all-NaN 隣接はシード源にしない）。
  - `buildReadyTiles` の実標高タイル建築経路（フラット/暫定 all-NaN 以外、`t.zoom >= minZoom`）で、`geomElev` のコピーに `stitchTileEdges` を適用して境界辺を平均化する。原本 `elevCache` は非破壊。
  - 揃った隣接署名（`stitchSig`）を建築署名 `sig` に含め、隣接が後からロードされたら sig 差分で再縫合・再建築する。
  - 既存のスカート（垂直フランジ）／クロスレベルスナップ（`CoarseEdge`）は維持（同一ズーム辺＝stitch、LOD 境界辺＝snap で排他的に共存）。
- `tests/globeTileManager.unit.spec.ts`
  - #387 の unit テストを4件追加（辺平均化・隣接無しで no-op・日付変更線 wrap・原本非破壊）。

## 影響範囲
- globe（`/geospatial`）の標高タイル建築のみ。planar・API・型の変更なし。

## テスト
- `npm run test:unit` … 1293 passed（#387 新規4件含む）
- `npm run lint` … pass
- `npm run typecheck` … pass
- `npm run test:visuals` … 19 passed（スナップショット差分なし）

## 残作業（HITL）
- DEM5 非整備領域（例: 38.312767,140.104752 付近）で globe のタイル境界シーム解消を目視確認（レビュアー側で実施予定）。

## 関連
- Parent: #384 / 関連: #386（標高復元によりシーム顕在化）, #275（陰影シーム磨き込み）
