### PR TITLE
fix(scenes): planar影フィルタをPoissonに変更しWebGPUクラッシュを解消 (#393)

### DIFF
--- a/src/scenes/default.ts
+++ b/src/scenes/default.ts
@@ -2328,8 +2328,14 @@ export class DefaultScene implements CreateSceneClass {
                 // フィルタ選定: `useBlurExponentialShadowMap` は内部で BlurPostProcess を
                 // 利用するが、WebGPU 経路で `infiniteDistance` のメッシュ（太陽メッシュ等）
                 // と相互作用して表示が破綻するケースが確認されたため、PostProcess を伴わない
-                // PCF (Percentage Closer Filtering) を採用する。WebGL2/WebGPU 双方で安定。
-                sg.usePercentageCloserFiltering = true;
+                // フィルタを採用する。
+                // PCF (`usePercentageCloserFiltering`) は WebGPU で comparison 付き
+                // depth-stencil サンプラ（`shadowTexture1` / `shadowTexture1Sampler`）を要求し、
+                // 影マップのテクスチャがバインドされず `createBindGroup` がクラッシュして
+                // マップ全体が描画できない事象が発生する (#393)。
+                // Poisson sampling は通常テクスチャとしてバインドされ PostProcess も伴わないため、
+                // WebGL2 / WebGPU 双方で安定して動作する。
+                sg.usePoissonSampling = true;
                 sg.bias = 0.0001;
                 sg.setDarkness(0.4);
                 tileManager.setShadowHooks(shadowHooks);


### PR DESCRIPTION
Closes #393

## 概要
タイムラプス（planar + WebGPU 既定）で初回レンダリング時に WebGPU の `createBindGroup` 例外が発生し、白画面になりマップが表示できないバグを修正する。

## 根本原因
影フィルタの PCF（`usePercentageCloserFiltering`）は WebGPU で comparison 付き depth-stencil サンプラ（`shadowTexture1` / `shadowTexture1Sampler`）を要求するが、影マップテクスチャがバインドされず `createBindGroup` が `Required member is undefined` で例外を投げ、地形を含む全描画が停止していた。headed Chromium + WebGPU で再現し原因を特定（receiver 有効化のタイミングではなく PCF の depth-comparison サンプラ自体が WebGPU 経路で破綻）。

## 修正
`src/scenes/default.ts` の太陽影フィルタを **PCF → Poisson sampling** に変更。Poisson は通常テクスチャとしてバインドされ、PostProcess も伴わない（既存の blur-exponential 回避要件も満たす）ため WebGL2 / WebGPU 双方で安定する。差分は実質1行。

## 影響範囲
- 画面: planar 太陽影の描画フィルタ（見た目はソフトシャドウのまま）。globe バックエンドや API・型に変更なし。

## 検証（実機 WebGPU で再現確認済み）
- timelapse + planar + WebGPU: クラッシュ解消・地形表示 OK
- timelapse + planar + WebGL2: 正常
- viewer + planar + `showSunShadows=true` + WebGPU: 正常
- `npm run typecheck` / `npm run lint` / `npm run test:unit`（1293件）/ `npm run test:visuals`（19件）すべて成功・回帰なし
- 実ブラウザでの目視確認（HITL）済み