### PR TITLE
docs: agents の frontmatter に description を追加 (#396)

### DIFF
--- a/.github/agents/00_orchestrator.md
+++ b/.github/agents/00_orchestrator.md
@@ -1,5 +1,6 @@
 ---
 title: Orchestrator Agent (Local)
+description: 開発タスクを中央集権型で進行管理し、各専門役割を切り替えながらローカル環境で安全に完了させる司令塔エージェント。
 role: orchestrator
 pattern: agents-as-tools
 version: 0.1

--- a/.github/agents/10_planner.md
+++ b/.github/agents/10_planner.md
@@ -1,5 +1,6 @@
 ---
 title: Planner Agent (Local)
+description: 要件をタスクへ分解し、Issue 作成とローカルで再現可能な作業手順の策定を担うプランナーエージェント。
 role: planner
 version: 0.1
 ---

--- a/.github/agents/20_architect.md
+++ b/.github/agents/20_architect.md
@@ -1,5 +1,6 @@
 ---
 title: Architect Agent (Local)
+description: 最小差分で拡張可能な設計方針・インターフェース・移行計画を提示する設計エージェント。
 role: architect
 version: 0.1
 ---

--- a/.github/agents/30_coder.md
+++ b/.github/agents/30_coder.md
@@ -1,5 +1,6 @@
 ---
 title: Coder Agent (Local)
+description: 最小差分で実装し、対応する Unit test を作成してローカルで動作確認できる状態まで仕上げる実装エージェント。
 role: coder
 version: 0.2
 ---

--- a/.github/agents/40_tester.md
+++ b/.github/agents/40_tester.md
@@ -1,5 +1,6 @@
 ---
 title: Tester Agent (Local)
+description: 壊れやすい境界と重要フローを優先して Unit test を追加し、3DCG は目視確認ゲートで妥当性を担保するテストエージェント。
 role: tester
 version: 0.2
 ---

--- a/.github/agents/50_reviewer.md
+++ b/.github/agents/50_reviewer.md
@@ -1,5 +1,6 @@
 ---
 title: Reviewer Agent (Local)
+description: セキュリティ・品質・パフォーマンス・ベストプラクティスの4層レビューで再現性のある品質ゲートを提供するレビューエージェント。
 role: reviewer
 version: 0.2
 ---

--- a/.github/agents/60_security.md
+++ b/.github/agents/60_security.md
@@ -1,5 +1,6 @@
 ---
 title: Security Agent (Local)
+description: 安全性・権限・情報漏洩を点検し、危険操作を HITL で確実に停止させるセキュリティエージェント。
 role: security
 version: 0.1
 ---

--- a/.github/agents/handoff_template.md
+++ b/.github/agents/handoff_template.md
@@ -1,5 +1,6 @@
 ---
 title: Handoff Template
+description: 役割間の受け渡しで添付する、目的・タスク・制約・期待成果物を記述するハンドオフテンプレート。
 version: 0.1
 ---
 # Context

--- a/.github/agents/workflow.md
+++ b/.github/agents/workflow.md
@@ -1,5 +1,6 @@
 ---
 title: Local Multi-Agent Workflow (Agents-as-Tools)
+description: Planner から Security までの各役割を単一コンテキストで切り替えながら進行する、ローカルマルチエージェント運用の標準フロー手順書。
 version: 0.1
 ---
 # 標準フロー


### PR DESCRIPTION
## 概要

`.github/agents/` 配下の各 Markdown ファイルの frontmatter に `description` が存在しなかったため追加した。

Closes #396

## 変更内容

以下9ファイルの frontmatter に、役割・内容を端的に表す `description` を追加：

- `00_orchestrator.md` / `10_planner.md` / `20_architect.md` / `30_coder.md` / `40_tester.md` / `50_reviewer.md` / `60_security.md` / `handoff_template.md` / `workflow.md`

## 影響範囲

- ドキュメント（エージェント定義）のみ。コード挙動への影響なし。