### PR TITLE
Architectエージェントのモデルをclaude-opus-4-8に更新

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -1,7 +1,7 @@
 ---
 name: architect
 description: 最小差分で拡張可能な設計方針・インターフェース・移行計画を提示する。「設計して」「アーキテクチャを考えて」「API設計して」に対応。新規API/DB変更時は必ず使用。
-model: claude-sonnet-4-6
+model: claude-opus-4-8
 ---
 # Architect Agent (Local)
 

--- a/.github/agents/20_architect.md
+++ b/.github/agents/20_architect.md
@@ -3,7 +3,7 @@ title: Architect Agent (Local)
 description: 最小差分で拡張可能な設計方針・インターフェース・移行計画を提示する設計エージェント。
 role: architect
 version: 0.1
-model: claude-sonnet-4-6
+model: claude-opus-4-8
 ---
 # 目的
 最小差分で拡張可能な設計を提示し、ローカル開発で安全に実装できるようにする。


### PR DESCRIPTION
## 概要
Architectエージェント定義のモデルを `claude-sonnet-4-6` から `claude-opus-4-8` に更新しました。

## 変更内容
- `.claude/agents/architect.md`
- `.github/agents/20_architect.md`

## 影響範囲
- エージェント設定のみ。アプリのコード・挙動への影響なし。

Closes #400