### PR TITLE
feat(demos): flight を terrainEngine=globe で動作可能に配線 (P4-3) (#402)

### DIFF
--- a/src/demos/flight/afterburner.ts
+++ b/src/demos/flight/afterburner.ts
@@ -40,6 +40,24 @@ export interface AfterburnerContext {
     modelNodeName: string;
 }
 
+/**
+ * 毎フレームの更新コンテキスト。globe バックエンドのトレイルは TrailMesh の自動更新が
+ * 使えず（真 ECEF を float32 頂点バッファへ焼くと精度落ち + floating origin 非対応）、
+ * 軌道パラメータから真 ECEF を都度算出してリビルドするため、これらの値を受け取る。
+ */
+export interface AfterburnerUpdateContext {
+    /** 軌道の中心緯度 */
+    centerLat: number;
+    /** 軌道の中心経度 */
+    centerLon: number;
+    /** 軌道半径 (m) */
+    radiusM: number;
+    /** 飛行機の絶対標高 (m) */
+    altitudeM: number;
+    /** 現在の軌道角度 (deg) */
+    angleDeg: number;
+}
+
 export interface Afterburner {
     /** トレイル生成を開始（Follow モード ON 時に呼ぶ） */
     start(ctx: AfterburnerContext): void;
@@ -49,6 +67,11 @@ export interface Afterburner {
     reset(): void;
     /** 表示/非表示切替 */
     setVisible(visible: boolean): void;
+    /**
+     * 毎フレーム更新（globe バックエンド用）。planar は TrailMesh が自動更新するため no-op。
+     * Follow モードかつモデルロード後に呼ぶこと。
+     */
+    update(ctx: AfterburnerUpdateContext): void;
     /** リソース解放 */
     dispose(): void;
 }
@@ -210,6 +233,9 @@ export const createAfterburner = (scene: Scene): Afterburner => {
         rightTrail?.reset();
     };
 
+    // planar は TrailMesh が beforeRender で自動更新するため、毎フレーム update は不要。
+    const update = (): void => {};
+
     const setVisible = (v: boolean): void => {
         visible = v;
         leftTrail?.setEnabled(v);
@@ -236,5 +262,5 @@ export const createAfterburner = (scene: Scene): Afterburner => {
         material.dispose();
     };
 
-    return { start, stop, reset, setVisible, dispose };
+    return { start, stop, reset, setVisible, update, dispose };
 };

--- a/src/demos/flight/globeAfterburner.ts
+++ b/src/demos/flight/globeAfterburner.ts
@@ -1,0 +1,374 @@
+/**
+ * globe バックエンド用アフターバーナーエフェクト (Issue #349 / P4-3)。
+ *
+ * planar 版（`afterburner.ts`）は Babylon `TrailMesh` を使うが、TrailMesh は generator の
+ * **絶対位置（world座標）を毎フレーム float32 頂点バッファへ焼き込む**設計のため、globe
+ * （真 ECEF ≈ 6.4e6 + floating origin）では:
+ *   1. float32 量子化（~0.76m）でトレイルがジッターする
+ *   2. 焼き込み済み頂点は floating origin リベース対象外で位置がずれる
+ * という二重の問題が起きる（リボン/ウェイポイントで解決済みの問題と同質）。
+ *
+ * そこで本モジュールは `routeLine.ts` の globe 対応と同じ「アンカー（真 ECEF）= メッシュの
+ * translation、各頂点はアンカーからのローカル小座標」パターンで短尺トレイルを自作する。
+ * トレイル頂点は常にアンカーとの差分（数十 m）なので float32 で精度十分、translation は
+ * floating origin により CPU 側で float64 リベースされる。絶対 ECEF 履歴を保持して毎フレーム
+ * ローカル座標へ変換するため、グリッド原点ジャンプの影響も受けない。
+ */
+
+import { Color3, Color4 } from "@babylonjs/core/Maths/math.color";
+import { Constants } from "@babylonjs/core/Engines/constants";
+import { GlowLayer } from "@babylonjs/core/Layers/glowLayer";
+import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
+import { CreateRibbon } from "@babylonjs/core/Meshes/Builders/ribbonBuilder";
+import { Mesh } from "@babylonjs/core/Meshes/mesh";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { VertexBuffer } from "@babylonjs/core/Buffers/buffer";
+import type { Scene } from "@babylonjs/core/scene";
+
+import { circularOrbitPosition, circularOrbitHeading } from "../avatar/orbit";
+import { geodeticToEcefToRef } from "../../terrain/geo/ecef";
+import { geographicTangentBasisToRef } from "../../terrain/geo/cameraMapping";
+import type {
+    Afterburner,
+    AfterburnerUpdateContext,
+} from "./afterburner";
+
+// ─── 調整可能な定数 ─────────────────────────────────────
+/** 左右エンジンの横方向オフセット (m)。planar 版と揃える */
+const ENGINE_LATERAL_OFFSET_M = 1.4;
+/** エンジン位置の後方オフセット (m) */
+const ENGINE_REAR_OFFSET_M = 4.5;
+/** エンジン位置の垂直オフセット (m) */
+const ENGINE_VERTICAL_OFFSET_M = 1.5;
+/** トレイルのサンプル点数（履歴フレーム数）。多いほど長く・負荷大 */
+const SAMPLE_COUNT = 14;
+/** エンジン側（先端）の炎の半幅 (m)。末端へ向けて 0 にテーパーする */
+const HALF_WIDTH_HEAD_M = 0.6;
+
+/**
+ * 軌道パラメータから左右エンジンの真 ECEF 位置を求めて `leftRef`/`rightRef` に書き込む。
+ *
+ * 飛行機ローカル基底（Babylon 規約: X=右, Y=上, Z=前方, 後方=-Z）を ENU/ECEF に写像する:
+ * - forward(進行方向, 水平) = east·sin(h) + north·cos(h)   （h = compass heading[rad], 0=北）
+ * - right                    = east·cos(h) - north·sin(h)
+ * - up                       = 地心 up（ECEF 正規化）
+ * エンジン位置 = 機体中心 + right·(±lateral) + up·vertical + forward·(-rear)。
+ *
+ * @returns 接線基底が計算できれば true、極などの特異点で計算不能なら false（呼び出し側は更新スキップ）。
+ */
+export const computeEngineEcefToRef = (
+    centerLat: number,
+    centerLon: number,
+    radiusM: number,
+    altitudeM: number,
+    angleDeg: number,
+    leftRef: Vector3,
+    rightRef: Vector3,
+    scratch?: {
+        plane: Vector3;
+        east: Vector3;
+        north: Vector3;
+    },
+): boolean => {
+    const plane = scratch?.plane ?? new Vector3();
+    const east = scratch?.east ?? new Vector3();
+    const north = scratch?.north ?? new Vector3();
+
+    const planePos = circularOrbitPosition(centerLat, centerLon, radiusM, angleDeg);
+    geodeticToEcefToRef(planePos.lat, planePos.lon, altitudeM, plane);
+    if (!geographicTangentBasisToRef(plane, east, north)) return false;
+
+    const r = plane.length();
+    if (r < 1) return false;
+    // 地心 up = 機体 ECEF を正規化
+    const ux = plane.x / r;
+    const uy = plane.y / r;
+    const uz = plane.z / r;
+
+    const hRad = (circularOrbitHeading(angleDeg) * Math.PI) / 180;
+    const sinH = Math.sin(hRad);
+    const cosH = Math.cos(hRad);
+
+    // forward / right ベクトル（ENU → ECEF）
+    const fx = east.x * sinH + north.x * cosH;
+    const fy = east.y * sinH + north.y * cosH;
+    const fz = east.z * sinH + north.z * cosH;
+    const rx = east.x * cosH - north.x * sinH;
+    const ry = east.y * cosH - north.y * sinH;
+    const rz = east.z * cosH - north.z * sinH;
+
+    // 共通オフセット（上方 + 後方）
+    const baseX = plane.x + ux * ENGINE_VERTICAL_OFFSET_M - fx * ENGINE_REAR_OFFSET_M;
+    const baseY = plane.y + uy * ENGINE_VERTICAL_OFFSET_M - fy * ENGINE_REAR_OFFSET_M;
+    const baseZ = plane.z + uz * ENGINE_VERTICAL_OFFSET_M - fz * ENGINE_REAR_OFFSET_M;
+
+    leftRef.set(
+        baseX - rx * ENGINE_LATERAL_OFFSET_M,
+        baseY - ry * ENGINE_LATERAL_OFFSET_M,
+        baseZ - rz * ENGINE_LATERAL_OFFSET_M,
+    );
+    rightRef.set(
+        baseX + rx * ENGINE_LATERAL_OFFSET_M,
+        baseY + ry * ENGINE_LATERAL_OFFSET_M,
+        baseZ + rz * ENGINE_LATERAL_OFFSET_M,
+    );
+    return true;
+};
+
+/**
+ * トレイル履歴（絶対 ECEF, [0]=末端〜[N-1]=先端/エンジン側）から、アンカー相対のローカル
+ * リボン頂点（左右2列）を `outLeft`/`outRight` に書き込む純関数。
+ *
+ * 各サンプルで進行方向（前後の点の差分）と地心 up の外積から横方向（cross-track）を求め、
+ * 先端 `halfWidthHeadM` から末端 0 へテーパーした半幅で左右に振り分ける。
+ *
+ * @returns 書き込んだサンプル数。
+ */
+export const buildTrailRibbonLocal = (
+    history: Vector3[],
+    anchor: Vector3,
+    halfWidthHeadM: number,
+    outLeft: Vector3[],
+    outRight: Vector3[],
+): number => {
+    const n = history.length;
+    for (let i = 0; i < n; i++) {
+        const p = history[i];
+        const lx = p.x - anchor.x;
+        const ly = p.y - anchor.y;
+        const lz = p.z - anchor.z;
+
+        // 進行方向（前後の点の差分）
+        const a = history[Math.max(0, i - 1)];
+        const b = history[Math.min(n - 1, i + 1)];
+        const dirX = b.x - a.x;
+        const dirY = b.y - a.y;
+        const dirZ = b.z - a.z;
+
+        // 地心 up（点 p の正規化）
+        const pl = Math.hypot(p.x, p.y, p.z) || 1;
+        const ux = p.x / pl;
+        const uy = p.y / pl;
+        const uz = p.z / pl;
+
+        // 横方向 = normalize(cross(dir, up))
+        let perpX = dirY * uz - dirZ * uy;
+        let perpY = dirZ * ux - dirX * uz;
+        let perpZ = dirX * uy - dirY * ux;
+        const perpLen = Math.hypot(perpX, perpY, perpZ);
+        if (perpLen < 1e-6) {
+            // 退化（静止 or dir∥up）: 幅 0 にして中心線へ畳む
+            perpX = 0;
+            perpY = 0;
+            perpZ = 0;
+        } else {
+            perpX /= perpLen;
+            perpY /= perpLen;
+            perpZ /= perpLen;
+        }
+
+        // テーパー: 先端(t=1)で halfWidthHeadM、末端(t=0)で 0
+        const t = n > 1 ? i / (n - 1) : 1;
+        const hw = halfWidthHeadM * t;
+
+        outLeft[i].set(lx - perpX * hw, ly - perpY * hw, lz - perpZ * hw);
+        outRight[i].set(lx + perpX * hw, ly + perpY * hw, lz + perpZ * hw);
+    }
+    return n;
+};
+
+/**
+ * トレイルのサンプル位置 t(0=末端,1=先端) に対する炎の頂点カラー（RGBA）を返す。
+ * 先端は明るい黄、末端へ向けてオレンジ→赤へ落ち、アルファも 0 へフェードする（additive 前提）。
+ */
+export const computeFlameColor = (t: number): Color4 => {
+    // 先端(黄白)→末端(赤)
+    const r = 1.0;
+    const g = 0.3 + 0.6 * t;
+    const b = 0.05 + 0.25 * t;
+    // 末端で透明、先端で最も明るい（additive なのでアルファ=寄与度）
+    const alpha = t * t;
+    return new Color4(r, g, b, alpha);
+};
+
+interface TrailRibbon {
+    mesh: Mesh;
+    pathArray: Vector3[][];
+    colorBuffer: Float32Array;
+    colorInitialized: boolean;
+    history: Vector3[];
+}
+
+const createAfterburnerMaterial = (scene: Scene): StandardMaterial => {
+    const mat = new StandardMaterial("globe-afterburner-mat", scene);
+    mat.disableLighting = true;
+    mat.emissiveColor = new Color3(1.0, 0.7, 0.2);
+    mat.diffuseColor = new Color3(0, 0, 0);
+    mat.specularColor = new Color3(0, 0, 0);
+    mat.alpha = 1;
+    mat.alphaMode = Constants.ALPHA_ADD;
+    mat.backFaceCulling = false;
+    return mat;
+};
+
+/**
+ * globe 用アフターバーナーを作成する。planar 版と同じ `Afterburner` インターフェースを実装し、
+ * 毎フレーム `update()` で軌道パラメータから真 ECEF を算出してトレイルをリビルドする。
+ */
+export const createGlobeAfterburner = (scene: Scene): Afterburner => {
+    const material = createAfterburnerMaterial(scene);
+    let glow: GlowLayer | null = null;
+    let ribbons: TrailRibbon[] = [];
+    let running = false;
+    let visible = true;
+    let disposed = false;
+    let initialized = false;
+
+    // スクラッチ（毎フレーム allocation を避ける）
+    const curLeft = new Vector3();
+    const curRight = new Vector3();
+    const anchor = new Vector3();
+    const scratch = { plane: new Vector3(), east: new Vector3(), north: new Vector3() };
+
+    const makeRibbon = (name: string): TrailRibbon => {
+        const left: Vector3[] = [];
+        const right: Vector3[] = [];
+        const history: Vector3[] = [];
+        for (let i = 0; i < SAMPLE_COUNT; i++) {
+            left.push(new Vector3());
+            right.push(new Vector3());
+            history.push(new Vector3());
+        }
+        const pathArray = [left, right];
+        const mesh = CreateRibbon(
+            name,
+            { pathArray, updatable: true, sideOrientation: Mesh.DOUBLESIDE },
+            scene,
+        );
+        mesh.material = material;
+        mesh.isPickable = false;
+        mesh.alwaysSelectAsActiveMesh = true;
+        mesh.renderingGroupId = 1;
+        mesh.hasVertexAlpha = true;
+        mesh.setEnabled(visible);
+        return {
+            mesh,
+            pathArray,
+            colorBuffer: new Float32Array(SAMPLE_COUNT * 2 * 4),
+            colorInitialized: false,
+            history,
+        };
+    };
+
+    const disposeMeshes = (): void => {
+        for (const r of ribbons) r.mesh.dispose();
+        ribbons = [];
+        glow?.dispose();
+        glow = null;
+        initialized = false;
+    };
+
+    // globe トレイルは軌道パラメータ（update のコンテキスト）から真 ECEF を都度算出するため、
+    // start の AfterburnerContext（modelNodeName 等の generator 情報）は使用しない。
+    // 引数は planar 版と Afterburner インターフェースを統一するためのダミー。
+    const start = (): void => {
+        if (disposed || running) return;
+        disposeMeshes();
+        glow = new GlowLayer("globe-afterburner-glow", scene, { blurKernelSize: 64 });
+        glow.intensity = 1.5;
+        // [0]=左エンジン, [1]=右エンジン
+        ribbons = [makeRibbon("globe-afterburner-left"), makeRibbon("globe-afterburner-right")];
+        for (const r of ribbons) glow.addIncludedOnlyMesh(r.mesh);
+        glow.isEnabled = visible;
+        running = true;
+        initialized = false;
+    };
+
+    const stop = (): void => {
+        if (!running) return;
+        disposeMeshes();
+        running = false;
+    };
+
+    /** 全履歴を現在のエンジン位置に揃えてトレイルを畳む（origin ジャンプ後などに呼ぶ）。 */
+    const reset = (): void => {
+        initialized = false;
+    };
+
+    const setVisible = (v: boolean): void => {
+        visible = v;
+        for (const r of ribbons) r.mesh.setEnabled(v);
+        if (glow) glow.isEnabled = v;
+    };
+
+    const updateRibbon = (r: TrailRibbon, current: Vector3): void => {
+        const n = r.history.length;
+        if (!initialized) {
+            // 履歴を現在位置で初期化（原点→機体の伸びた折れ線を防ぐ）
+            for (let i = 0; i < n; i++) r.history[i].copyFrom(current);
+        } else {
+            // 1フレーム分シフトして末尾（先端）に現在位置を追加
+            for (let i = 0; i < n - 1; i++) r.history[i].copyFrom(r.history[i + 1]);
+            r.history[n - 1].copyFrom(current);
+        }
+
+        buildTrailRibbonLocal(r.history, anchor, HALF_WIDTH_HEAD_M, r.pathArray[0], r.pathArray[1]);
+        r.mesh.position.copyFrom(anchor);
+
+        CreateRibbon(r.mesh.name, { pathArray: r.pathArray, updatable: true, instance: r.mesh });
+
+        // 頂点カラーは t = i/(n-1)（頂点インデックス）のみに依存しフレーム間で不変なので、
+        // 初回のみ計算・アップロードする（毎フレームの allocation と GPU 転送を避ける）。
+        if (!r.colorInitialized) {
+            for (let i = 0; i < n; i++) {
+                const t = n > 1 ? i / (n - 1) : 1;
+                const col = computeFlameColor(t);
+                const i0 = i * 4;
+                const i1 = (n + i) * 4;
+                r.colorBuffer[i0] = col.r;
+                r.colorBuffer[i0 + 1] = col.g;
+                r.colorBuffer[i0 + 2] = col.b;
+                r.colorBuffer[i0 + 3] = col.a;
+                r.colorBuffer[i1] = col.r;
+                r.colorBuffer[i1 + 1] = col.g;
+                r.colorBuffer[i1 + 2] = col.b;
+                r.colorBuffer[i1 + 3] = col.a;
+            }
+            r.mesh.setVerticesData(VertexBuffer.ColorKind, r.colorBuffer, true);
+            r.colorInitialized = true;
+        }
+    };
+
+    const update = (ctx: AfterburnerUpdateContext): void => {
+        if (!running || ribbons.length < 2) return;
+        const ok = computeEngineEcefToRef(
+            ctx.centerLat,
+            ctx.centerLon,
+            ctx.radiusM,
+            ctx.altitudeM,
+            ctx.angleDeg,
+            curLeft,
+            curRight,
+            scratch,
+        );
+        if (!ok) return;
+        // アンカー = 左右エンジンの中点（先端付近）。
+        anchor.set(
+            (curLeft.x + curRight.x) * 0.5,
+            (curLeft.y + curRight.y) * 0.5,
+            (curLeft.z + curRight.z) * 0.5,
+        );
+        updateRibbon(ribbons[0], curLeft);
+        updateRibbon(ribbons[1], curRight);
+        initialized = true;
+    };
+
+    const dispose = (): void => {
+        if (disposed) return;
+        disposed = true;
+        stop();
+        material.dispose();
+    };
+
+    return { start, stop, reset, setVisible, update, dispose };
+};

--- a/src/demos/flight/index.ts
+++ b/src/demos/flight/index.ts
@@ -16,6 +16,8 @@
  */
 import { FreeCamera } from "@babylonjs/core/Cameras/freeCamera";
 import { Matrix, Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { Color3 } from "@babylonjs/core/Maths/math.color";
+import type { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { Frustum } from "@babylonjs/core/Maths/math.frustum";
 import { Plane } from "@babylonjs/core/Maths/math.plane";
 
@@ -24,12 +26,16 @@ import type { JpmapTerrainOptions, TerrainClickEvent } from "../../lib/types";
 import {
     parseCameraStateFromUrl,
     parseMapTypeFromUrl,
+    resolveTerrainEngine,
 } from "../../terrain/urlState";
 import { circularOrbitPosition, circularOrbitHeading } from "../avatar/orbit";
+import { geodeticToEcefToRef } from "../../terrain/geo/ecef";
+import { geographicTangentBasisToRef } from "../../terrain/geo/cameraMapping";
 import { createRouteLine, type RouteLine } from "./routeLine";
 import { createWaypointManager, type WaypointManager } from "./waypoints";
 import { createFlightAudio, type FlightAudio } from "./flightAudio";
 import { createAfterburner, type Afterburner } from "./afterburner";
+import { createGlobeAfterburner } from "./globeAfterburner";
 import { toTileXY, TILE_MAX_ZOOM } from "../../terrain/gsiTile";
 import planeGlbUrl from "../../../assets/plane.glb";
 
@@ -65,6 +71,17 @@ const DEFAULT_SPEED_MPS = 100;
 const DEFAULT_ALTITUDE_M = 2000;
 /** カメラ初期高度 (m) — ズームアウトで飛行機を見渡す */
 const INITIAL_CAMERA_ALTITUDE = 6000;
+/**
+ * 3D/2D モードで飛行機を見つけやすくするための発光（emissive）色。
+ * tick 内で点滅させて目立たせる。Follow モードでは元の emissive に戻す。
+ */
+const BEACON_EMISSIVE_COLOR = new Color3(1.0, 0.25, 0.05);
+/**
+ * globe バックエンドのカメラ初期高度 (m)。
+ * globe(GeospatialCamera) は planar(ArcRotateCamera) と画角・投影が異なり、6000m では
+ * 円軌道（半径 2000m / 高度 2000m）の飛行機がフレーム外に出る。全周を見渡せるよう高めに設定。
+ */
+const GLOBE_INITIAL_CAMERA_ALTITUDE = 14000;
 /** クリック可能距離 (m) */
 const MAX_CLICK_DISTANCE_M = 20000;
 
@@ -95,12 +112,19 @@ const start = async (): Promise<void> => {
 
     const camera = parseCameraStateFromUrl(location.href);
     const mapType = parseMapTypeFromUrl(location.href);
+    // `?terrainEngine=globe|planar`（未指定/不正は undefined → lib 既定 planar）。
+    const terrainEngine = resolveTerrainEngine(location.search);
 
     const opts: JpmapTerrainOptions = {
         engine: resolveEngine(location.search),
+        terrainEngine,
         lat: camera?.lat ?? TOKYO_STATION.lat,
         lon: camera?.lon ?? TOKYO_STATION.lon,
-        altitude: camera?.altitude ?? INITIAL_CAMERA_ALTITUDE,
+        altitude:
+            camera?.altitude ??
+            (terrainEngine === "globe"
+                ? GLOBE_INITIAL_CAMERA_ALTITUDE
+                : INITIAL_CAMERA_ALTITUDE),
         azimuth: camera?.azimuth,
         tilt: camera?.tilt ?? 45,
         mapType: mapType ?? "standard",
@@ -108,6 +132,9 @@ const start = async (): Promise<void> => {
     };
 
     const viewer = await JpmapTerrain.create(mount, opts);
+    // globe バックエンドでは floating origin の offset = アクティブカメラ位置のため、
+    // Follow カメラ（FreeCamera）は真の ECEF 座標で配置する必要がある（後述）。
+    const isGlobe = viewer.terrainEngine === "globe";
 
     if (process.env.NODE_ENV !== "production") {
         (window as unknown as { viewer: JpmapTerrain }).viewer = viewer;
@@ -124,6 +151,18 @@ const start = async (): Promise<void> => {
     let lastTimestamp: number | null = null;
     let currentCameraMode: CameraMode = "3d";
     let followCamera: FreeCamera | null = null;
+    /**
+     * Follow モード進入直前の 3D/2D カメラ状態。Follow から 3D/2D へ戻る際に復元し、
+     * 元のカメラ位置（注視点・高度・方位・俯角）を保つ（Follow 追従位置で上書きされるのを防ぐ）。
+     */
+    let saved3dCamera:
+        | { lat: number; lon: number; altitude: number; azimuth: number; tilt: number }
+        | null = null;
+    // globe Follow カメラ配置用の再利用スクラッチ（毎フレーム allocation を避ける）。
+    const followTargetEcef = new Vector3();
+    const followEastEcef = new Vector3();
+    const followNorthEcef = new Vector3();
+    const followUpEcef = new Vector3();
     // Follow カメラの可変パラメータ
     let followCamRadius = FOLLOW_CAMERA_RADIUS;
     let followCamHeightOffset = FOLLOW_CAMERA_HEIGHT_OFFSET;
@@ -197,6 +236,7 @@ const start = async (): Promise<void> => {
                 altitudeM,
                 angleDeg,
                 modelNodeName: `model-${MODEL_ID}`,
+                isGlobe,
             });
         }
     };
@@ -235,10 +275,16 @@ const start = async (): Promise<void> => {
     if (pipMount) {
         const pipOpts: JpmapTerrainOptions = {
             engine: opts.engine,
+            terrainEngine,
             lat: initPos.lat,
             lon: initPos.lon,
             altitude: altitudeM,
-            azimuth: -circularOrbitHeading(angleDeg),
+            // PIP belly カメラは機体の heading 方向（前方）を見る。方位の符号は backend で異なる:
+            // globe(GeospatialCamera) はカメラ視線方位 = azimuth（0=北,+=東回り、ComputeLookAtFromYawPitch
+            // 由来）なので azimuth=heading。planar(ArcRotateCamera) は従来規約に合わせ -heading。
+            azimuth: isGlobe
+                ? circularOrbitHeading(angleDeg)
+                : -circularOrbitHeading(angleDeg),
             tilt: PIP_BELLY_TILT_DEG,
             // PIP は写真タイルを表示 (Issue #264)
             mapType: "photo",
@@ -351,6 +397,47 @@ const start = async (): Promise<void> => {
         if (!followCamera) return;
         const scene = viewer.__debugScene;
         if (!scene) return;
+
+        if (isGlobe) {
+            // globe: floating origin の offset はアクティブカメラ（= この FreeCamera）の
+            // globalPosition。よって FreeCamera を「真の ECEF」で配置すれば、
+            // 機体・地形（真の ECEF メッシュ）がカメラ相対に正しくリベースされ描画される。
+            // 機体まわりの ENU 基底（east/north/up）でオフセットを組み、planar と同じ
+            // 「後方へ followCamRadius・上方へ followCamHeightOffset」を地心 up 基準で再現する。
+            const planePos = circularOrbitPosition(
+                centerLat,
+                centerLon,
+                radiusM,
+                angleDeg,
+            );
+            geodeticToEcefToRef(planePos.lat, planePos.lon, altitudeM, followTargetEcef);
+            if (
+                !geographicTangentBasisToRef(
+                    followTargetEcef,
+                    followEastEcef,
+                    followNorthEcef,
+                )
+            ) {
+                return;
+            }
+            followUpEcef.copyFrom(followTargetEcef).normalize();
+
+            const camRotRad =
+                ((circularOrbitHeading(angleDeg) + followCamRotationOffset) *
+                    Math.PI) /
+                180;
+            const s = Math.sin(camRotRad);
+            const c = Math.cos(camRotRad);
+
+            followCamera.position.copyFrom(followTargetEcef);
+            followEastEcef.scaleAndAddToRef(followCamRadius * s, followCamera.position);
+            followNorthEcef.scaleAndAddToRef(followCamRadius * c, followCamera.position);
+            followUpEcef.scaleAndAddToRef(followCamHeightOffset, followCamera.position);
+            // 地心 up を上方向にして水平線のロールを防ぐ。
+            followCamera.upVector.copyFrom(followUpEcef);
+            followCamera.setTarget(followTargetEcef);
+            return;
+        }
 
         const targetNode = scene.getTransformNodeByName(`model-${MODEL_ID}`);
         if (!targetNode) return;
@@ -472,22 +559,35 @@ const start = async (): Promise<void> => {
                 flightAudio.startEngineSound();
             }
 
-            // アフターバーナー開始 (Issue #276)
+            // アフターバーナー開始 (Issue #276 / globe: Issue #349)
             // モデルロード完了後に start() する。未ロードなら pending フラグを立て
             // tick() 内でリトライすることで「原点→機体位置」の折れ線トレイルを防ぐ。
+            // planar は TrailMesh（機体 TransformNode を generator）で自動更新する。
+            // globe は機体ノード名が `globe-model-*-root` で公開 API から取得できず、かつ
+            // TrailMesh が真 ECEF を float32 頂点へ焼くと精度落ち + floating origin 非対応の
+            // ため、軌道パラメータから真 ECEF を都度算出してリビルドするカスタムトレイル
+            // （createGlobeAfterburner）を使う。globe は generator 不要なので即 start 可能。
             if (!afterburner && scene) {
-                afterburner = createAfterburner(scene);
+                afterburner = isGlobe
+                    ? createGlobeAfterburner(scene)
+                    : createAfterburner(scene);
             }
             if (afterburner) {
-                const handle = viewer.getModel(MODEL_ID);
-                if (handle?.loaded) {
-                    afterburner.start({
-                        modelNodeName: `model-${MODEL_ID}`,
-                    });
+                if (isGlobe) {
+                    // globe は軌道パラメータから算出するためモデルロード待ち不要。
+                    afterburner.start({ modelNodeName: `model-${MODEL_ID}` });
                     afterburner.setVisible(showAfterburner);
                 } else {
-                    // 未ロード: tick() 内でモデルロード完了を検知してから start する
-                    afterburnerStartPending = true;
+                    const handle = viewer.getModel(MODEL_ID);
+                    if (handle?.loaded) {
+                        afterburner.start({
+                            modelNodeName: `model-${MODEL_ID}`,
+                        });
+                        afterburner.setVisible(showAfterburner);
+                    } else {
+                        // 未ロード: tick() 内でモデルロード完了を検知してから start する
+                        afterburnerStartPending = true;
+                    }
                 }
             }
         }
@@ -498,9 +598,12 @@ const start = async (): Promise<void> => {
         if (!scene || !followCamera) return;
 
         detachFollowPointerHandlers();
-        const arcCam = scene.getCameraByName("terrain-camera");
-        if (arcCam) {
-            scene.activeCamera = arcCam;
+        // 地形カメラへ復帰する。planar は "terrain-camera"、globe は "globe-camera"。
+        const terrainCam =
+            scene.getCameraByName("terrain-camera") ??
+            scene.getCameraByName("globe-camera");
+        if (terrainCam) {
+            scene.activeCamera = terrainCam;
         }
         // Follow 中の最新タイル中心座標で ArcRotateCamera を再配置してから
         // attachTileCamera を呼ぶ。そうしないと旧座標のタイルがロードされる。
@@ -667,14 +770,36 @@ const start = async (): Promise<void> => {
         cameraFollowBtn?.classList.toggle("active", currentCameraMode === "follow");
     };
 
+    const restore3dCamera = (): void => {
+        if (!saved3dCamera) return;
+        viewer.lat = saved3dCamera.lat;
+        viewer.lon = saved3dCamera.lon;
+        viewer.altitude = saved3dCamera.altitude;
+        viewer.azimuth = saved3dCamera.azimuth;
+        viewer.tilt = saved3dCamera.tilt;
+    };
+
     const switchCameraMode = (mode: CameraMode): void => {
         if (mode === currentCameraMode) return;
+
+        const leavingFollow = currentCameraMode === "follow";
+
+        // Follow へ入る直前に現在の 3D/2D カメラ状態を保存し、Follow→3D/2D 復帰時に復元する。
+        if (mode === "follow" && !leavingFollow) {
+            saved3dCamera = {
+                lat: viewer.lat,
+                lon: viewer.lon,
+                altitude: viewer.altitude,
+                azimuth: viewer.azimuth,
+                tilt: viewer.tilt,
+            };
+        }
 
         // Follow モードから離脱する場合は、先に viewMode を確定させてから
         // deactivateFollowCamera を呼ぶ。attachTileCamera 内の
         // refreshFromCamera が正しいフラスタム（2D orthographic /
         // 3D perspective）で可視タイルを計算できるようにする。
-        if (currentCameraMode === "follow") {
+        if (leavingFollow) {
             viewer.viewMode = mode === "follow" ? "3d" : mode;
             deactivateFollowCamera();
         }
@@ -685,10 +810,14 @@ const start = async (): Promise<void> => {
             case "3d":
                 viewer.viewMode = "3d";
                 viewer.updateModel(MODEL_ID, { scaling: { x: MODEL_SCALE_NORMAL, y: MODEL_SCALE_NORMAL, z: MODEL_SCALE_NORMAL } });
+                // Follow から戻ったときは保存しておいた 3D カメラ位置を復元する
+                // （deactivateFollowCamera が Follow 追従位置で上書きするため、その後に再設定）。
+                if (leavingFollow) restore3dCamera();
                 break;
             case "2d":
                 viewer.viewMode = "2d";
                 viewer.updateModel(MODEL_ID, { scaling: { x: MODEL_SCALE_NORMAL, y: MODEL_SCALE_NORMAL, z: MODEL_SCALE_NORMAL } });
+                if (leavingFollow) restore3dCamera();
                 break;
             case "follow":
                 // Follow モードでは先に 3D に戻してから FollowCamera を起動
@@ -743,11 +872,28 @@ const start = async (): Promise<void> => {
     // - alwaysSelectAsActiveMesh=true: 飛行機の frustum culling 判定が
     //   ワールド行列更新と非同期に走るフレームでも active mesh から外れないように。
     let planeRenderTuned = false;
+    /**
+     * 機体ルート TransformNode を backend 非依存で解決する。
+     * - planar: `model-${MODEL_ID}`
+     * - globe: `globe-model-N-root`
+     *
+     * 前提: このデモはメイン Viewer に機体を1体のみ追加する（`globe-model-*-root` は機体だけ）。
+     * globe 側は配列順で最初に一致したノードを返すため、将来 scene に複数 globe モデルを
+     * 追加する場合は addModel 時の model id を保持して `getTransformNodeByName(`${id}-root`)`
+     * で厳密参照すること。
+     */
+    const getPlaneRoot = (): TransformNode | null => {
+        const scene = viewer.__debugScene;
+        if (!scene) return null;
+        return (
+            scene.getTransformNodeByName(`model-${MODEL_ID}`) ??
+            scene.transformNodes.find((n) => /^globe-model-\d+-root$/.test(n.name)) ??
+            null
+        );
+    };
     const tunePlaneRenderSettings = (): void => {
         if (planeRenderTuned) return;
-        const scene = viewer.__debugScene;
-        if (!scene) return;
-        const root = scene.getTransformNodeByName(`model-${MODEL_ID}`);
+        const root = getPlaneRoot();
         if (!root) return;
         const meshes = root.getChildMeshes(false);
         if (meshes.length === 0) return;
@@ -758,10 +904,53 @@ const start = async (): Promise<void> => {
         planeRenderTuned = true;
     };
 
+    // --- 機体の発光ビーコン (3D/2D モードで見つけやすくする) ---
+    // 機体マテリアルの emissiveColor を点滅させる。元の値を保持し、Follow では復元する。
+    type EmissiveTarget = { material: { emissiveColor: Color3 }; original: Color3 };
+    let planeEmissiveTargets: EmissiveTarget[] | null = null;
+    const collectPlaneEmissive = (): void => {
+        if (planeEmissiveTargets) return;
+        const root = getPlaneRoot();
+        if (!root) return;
+        const meshes = root.getChildMeshes(false);
+        if (meshes.length === 0) return;
+        const targets: EmissiveTarget[] = [];
+        const seen = new Set<unknown>();
+        for (const mesh of meshes) {
+            const material = mesh.material as unknown as { emissiveColor?: Color3 } | null;
+            if (!material || !material.emissiveColor || seen.has(material)) continue;
+            seen.add(material);
+            targets.push({
+                material: material as { emissiveColor: Color3 },
+                original: material.emissiveColor.clone(),
+            });
+        }
+        if (targets.length > 0) planeEmissiveTargets = targets;
+    };
+    const updatePlaneBeacon = (timestamp: number): void => {
+        collectPlaneEmissive();
+        if (!planeEmissiveTargets) return;
+        if (currentCameraMode === "follow") {
+            // Follow では機体を間近で見るため発光を解除し、元の見た目に戻す。
+            for (const t of planeEmissiveTargets) t.material.emissiveColor.copyFrom(t.original);
+            return;
+        }
+        // 約 1.5Hz で 0..1 を往復する点滅係数。
+        const blink = 0.5 + 0.5 * Math.sin(timestamp * 0.01);
+        for (const t of planeEmissiveTargets) {
+            t.material.emissiveColor.set(
+                BEACON_EMISSIVE_COLOR.r * blink,
+                BEACON_EMISSIVE_COLOR.g * blink,
+                BEACON_EMISSIVE_COLOR.b * blink,
+            );
+        }
+    };
+
     const tick = (timestamp: number): void => {
         const handle = viewer.getModel(MODEL_ID);
         if (!handle) return;
         tunePlaneRenderSettings();
+        updatePlaneBeacon(timestamp);
 
         if (animating && lastTimestamp !== null) {
             const dtSec = (timestamp - lastTimestamp) / 1000;
@@ -890,12 +1079,16 @@ const start = async (): Promise<void> => {
         // updateModel で root.position が確定した後にトレイルをリセットする。
         // refreshTerrainWithExternalFrustum が走ったフレームでのみ1回だけ実行。
         // gridResidual ジャンプで旧座標の頂点が残り折れ線になるのを防止する。
+        // globe トレイルは絶対 ECEF 履歴で構築され origin ジャンプの影響を受けないため、
+        // reset するとタイル境界ごとに炎が一瞬畳まれて見えてしまう。planar のみ reset する。
         if (afterburnerResetNeeded && afterburner) {
             afterburnerResetNeeded = false;
-            const scene = viewer.__debugScene;
-            const root = scene?.getTransformNodeByName(`model-${MODEL_ID}`);
-            root?.computeWorldMatrix(true);
-            afterburner.reset();
+            if (!isGlobe) {
+                const scene = viewer.__debugScene;
+                const root = scene?.getTransformNodeByName(`model-${MODEL_ID}`);
+                root?.computeWorldMatrix(true);
+                afterburner.reset();
+            }
         }
 
         // モデルロード完了後に afterburner を start するリトライ処理。
@@ -907,6 +1100,18 @@ const start = async (): Promise<void> => {
                 modelNodeName: `model-${MODEL_ID}`,
             });
             afterburner.setVisible(showAfterburner);
+        }
+
+        // globe アフターバーナーの毎フレーム更新（軌道パラメータから真 ECEF を算出して
+        // トレイルをリビルド）。planar は TrailMesh が自動更新するため update は no-op。
+        if (afterburner && currentCameraMode === "follow" && showAfterburner) {
+            afterburner.update({
+                centerLat,
+                centerLon,
+                radiusM,
+                altitudeM,
+                angleDeg,
+            });
         }
 
         // Follow モード: 毎フレームカメラ位置を飛行機の後方に直接設定 + コンパス同期
@@ -942,6 +1147,8 @@ const start = async (): Promise<void> => {
                         centerLon,
                         radiusM,
                         modelNodeName: `model-${MODEL_ID}`,
+                        isGlobe,
+                        altitudeM,
                     },
                     timestamp,
                 );
@@ -968,6 +1175,7 @@ const start = async (): Promise<void> => {
                         altitudeM,
                         angleDeg,
                         modelNodeName: `model-${MODEL_ID}`,
+                        isGlobe,
                     },
                     timestamp,
                 );
@@ -996,7 +1204,8 @@ const start = async (): Promise<void> => {
             pipViewer.lat = pos.lat + dLatDeg;
             pipViewer.lon = pos.lon + dLonDeg;
             pipViewer.altitude = altitudeM;
-            pipViewer.azimuth = -heading;
+            // 方位の符号は backend 依存（globe: 視線方位=azimuth=heading / planar: -heading）。
+            pipViewer.azimuth = isGlobe ? heading : -heading;
             pipViewer.tilt = PIP_BELLY_TILT_DEG;
         }
 

--- a/src/demos/flight/routeLine.ts
+++ b/src/demos/flight/routeLine.ts
@@ -59,9 +59,11 @@ export interface RouteLineContext {
     /** model の TransformNode 名。実際の world position 取得用 */
     modelNodeName: string;
     /**
-     * globe バックエンドかどうか。true の場合、頂点を「真の ECEF」で構築する。
-     * （floating origin の offset = アクティブカメラ位置のため、planar の
-     * absolutePosition 基準では二重リベースで位置がずれる）
+     * globe バックエンドかどうか。true の場合、リボンメッシュの position を「真の ECEF」
+     * アンカー（機体直下）に置き、各頂点はそのアンカー相対のローカル小座標で構築する。
+     * （floating origin の offset = アクティブカメラ位置のため、planar の absolutePosition
+     * 基準では二重リベースで位置がずれる。アンカー方式なら position が float64 でリベースされ、
+     * 頂点は数百 m オーダーで float32 でも精度十分・ジッターを抑えられる）
      */
     isGlobe?: boolean;
     /** 飛行機の絶対標高 (m)。globe モードでの頂点 ECEF 計算に使用 */

--- a/src/demos/flight/routeLine.ts
+++ b/src/demos/flight/routeLine.ts
@@ -20,6 +20,8 @@ import { VertexBuffer } from "@babylonjs/core/Buffers/buffer";
 import type { Scene } from "@babylonjs/core/scene";
 
 import { circularOrbitPosition, circularOrbitHeading } from "../avatar/orbit";
+import { geodeticToEcefToRef } from "../../terrain/geo/ecef";
+import { geographicTangentBasisToRef } from "../../terrain/geo/cameraMapping";
 
 // ─── 調整可能な定数 ─────────────────────────────────────
 /** 飛行機中心から先頭までの距離 (m) */
@@ -56,6 +58,14 @@ export interface RouteLineContext {
     radiusM: number;
     /** model の TransformNode 名。実際の world position 取得用 */
     modelNodeName: string;
+    /**
+     * globe バックエンドかどうか。true の場合、頂点を「真の ECEF」で構築する。
+     * （floating origin の offset = アクティブカメラ位置のため、planar の
+     * absolutePosition 基準では二重リベースで位置がずれる）
+     */
+    isGlobe?: boolean;
+    /** 飛行機の絶対標高 (m)。globe モードでの頂点 ECEF 計算に使用 */
+    altitudeM?: number;
 }
 
 export interface RouteLine {
@@ -146,22 +156,47 @@ export const createRouteLine = (scene: Scene): RouteLine => {
     const colorBuffer = new Float32Array(SAMPLE_COUNT * 2 * 4);
     let colorBufferInitialized = false;
 
+    // globe モード用の再利用スクラッチ（毎フレーム allocation を避ける）
+    const gEcef = new Vector3();
+    const gEast = new Vector3();
+    const gNorth = new Vector3();
+    const gAnchor = new Vector3();
+
     const update = (ctx: RouteLineContext, time: number): void => {
         const { angleDeg, centerLat, centerLon, radiusM, modelNodeName } = ctx;
+        const isGlobe = ctx.isGlobe === true;
+        const altitudeM = ctx.altitudeM ?? 0;
 
-        // 飛行機の root TransformNode からワールド位置を取得
-        const root = ctx.scene.getTransformNodeByName(modelNodeName);
-        if (!root) return;
-        const childMesh = root.getChildMeshes(false)[0];
-        if (!childMesh) return;
-        childMesh.computeWorldMatrix(true);
-        const planeWorldPos = childMesh.absolutePosition;
+        // 飛行機の root TransformNode からワールド位置を取得（flat のみ）。
+        // globe では機体ノード名が異なり（`globe-model-*`）、位置は lat/lon/alt から
+        // 直接 ECEF 算出するため、planar のノード参照は行わない。
+        let planeWorldPos: Vector3 | null = null;
+        if (!isGlobe) {
+            const root = ctx.scene.getTransformNodeByName(modelNodeName);
+            if (!root) return;
+            const childMesh = root.getChildMeshes(false)[0];
+            if (!childMesh) return;
+            childMesh.computeWorldMatrix(true);
+            planeWorldPos = childMesh.absolutePosition;
+        }
 
         const startArcLen = ROUTE_START_OFFSET_M;
         const endArcLen = ROUTE_START_OFFSET_M + ROUTE_LENGTH_M;
 
         // 飛行機の現在 lat/lon
         const planePos = circularOrbitPosition(centerLat, centerLon, radiusM, angleDeg);
+
+        // globe: リボンは機体直近（近接）のため、頂点を真の ECEF（~6.4e6）で焼くと
+        // float32 精度（~0.5m）のジッターが目立つ。そこで機体直下を **アンカー（真の
+        // ECEF）= リボンメッシュの position（translation）** とし、各頂点はアンカーからの
+        // **ローカル小座標** で表現する。translation は floating origin により CPU 側で
+        // float64 リベースされ、頂点（数百 m）は float32 でも精度十分でジッターを抑えられる。
+        if (isGlobe) {
+            geodeticToEcefToRef(planePos.lat, planePos.lon, altitudeM, gAnchor);
+            ribbon.position.copyFrom(gAnchor);
+        } else {
+            ribbon.position.setAll(0);
+        }
 
         const timeSec = time * 0.001;
 
@@ -176,35 +211,64 @@ export const createRouteLine = (scene: Scene): RouteLine => {
             // 未来の位置を lat/lon で計算
             const futurePos = circularOrbitPosition(centerLat, centerLon, radiusM, futureAngle);
 
-            // lat/lon 差分をメートル換算で world offset に変換
-            const dLat = futurePos.lat - planePos.lat;
-            const dLon = futurePos.lon - planePos.lon;
-            const cosLat = Math.cos((planePos.lat * Math.PI) / 180);
-            const offsetX = dLon * 111320 * cosLat;
-            const offsetZ = dLat * 111320;
-
-            // 未来点のワールド座標 (Y は飛行機のワールド Y に合わせる)
-            const wx = planeWorldPos.x + offsetX;
-            const wz = planeWorldPos.z + offsetZ;
-            const wy = planeWorldPos.y + RIBBON_Y_OFFSET_M;
-
             // 未来点での接線方向（進行方向に垂直にリボン幅を出す）
             const futureHeading = circularOrbitHeading(futureAngle);
             const fhRad = (futureHeading * Math.PI) / 180;
             const perpX = Math.cos(fhRad);
             const perpZ = -Math.sin(fhRad);
 
-            // 左右のパスを設定
-            pathArray[0][i].set(
-                wx - perpX * RIBBON_HALF_WIDTH_M,
-                wy,
-                wz - perpZ * RIBBON_HALF_WIDTH_M,
-            );
-            pathArray[1][i].set(
-                wx + perpX * RIBBON_HALF_WIDTH_M,
-                wy,
-                wz + perpZ * RIBBON_HALF_WIDTH_M,
-            );
+            if (isGlobe) {
+                // 未来点の真の ECEF を求め、アンカーからのローカル小座標に変換する。
+                geodeticToEcefToRef(
+                    futurePos.lat,
+                    futurePos.lon,
+                    altitudeM + RIBBON_Y_OFFSET_M,
+                    gEcef,
+                );
+                if (!geographicTangentBasisToRef(gEcef, gEast, gNorth)) {
+                    continue;
+                }
+                // アンカー相対のローカル座標（数百 m オーダー）。
+                const lx = gEcef.x - gAnchor.x;
+                const ly = gEcef.y - gAnchor.y;
+                const lz = gEcef.z - gAnchor.z;
+                // planar の perp(perpX=east, perpZ=north) を ENU 基底に写像する。
+                const px =
+                    gEast.x * perpX * RIBBON_HALF_WIDTH_M +
+                    gNorth.x * perpZ * RIBBON_HALF_WIDTH_M;
+                const py =
+                    gEast.y * perpX * RIBBON_HALF_WIDTH_M +
+                    gNorth.y * perpZ * RIBBON_HALF_WIDTH_M;
+                const pz =
+                    gEast.z * perpX * RIBBON_HALF_WIDTH_M +
+                    gNorth.z * perpZ * RIBBON_HALF_WIDTH_M;
+                pathArray[0][i].set(lx - px, ly - py, lz - pz);
+                pathArray[1][i].set(lx + px, ly + py, lz + pz);
+            } else {
+                // lat/lon 差分をメートル換算で world offset に変換
+                const dLat = futurePos.lat - planePos.lat;
+                const dLon = futurePos.lon - planePos.lon;
+                const cosLat = Math.cos((planePos.lat * Math.PI) / 180);
+                const offsetX = dLon * 111320 * cosLat;
+                const offsetZ = dLat * 111320;
+
+                // 未来点のワールド座標 (Y は飛行機のワールド Y に合わせる)
+                const wx = planeWorldPos!.x + offsetX;
+                const wz = planeWorldPos!.z + offsetZ;
+                const wy = planeWorldPos!.y + RIBBON_Y_OFFSET_M;
+
+                // 左右のパスを設定
+                pathArray[0][i].set(
+                    wx - perpX * RIBBON_HALF_WIDTH_M,
+                    wy,
+                    wz - perpZ * RIBBON_HALF_WIDTH_M,
+                );
+                pathArray[1][i].set(
+                    wx + perpX * RIBBON_HALF_WIDTH_M,
+                    wy,
+                    wz + perpZ * RIBBON_HALF_WIDTH_M,
+                );
+            }
 
             // 頂点カラーを colorBuffer に直接書き込み (path0[i], path1[i] それぞれ)
             const col = computeGradientColor(t, timeSec);

--- a/src/demos/flight/waypoints.ts
+++ b/src/demos/flight/waypoints.ts
@@ -8,11 +8,14 @@
 
 import { CreateDisc } from "@babylonjs/core/Meshes/Builders/discBuilder";
 import { Mesh } from "@babylonjs/core/Meshes/mesh";
+import { Quaternion, Vector3 } from "@babylonjs/core/Maths/math.vector";
 import type { Scene } from "@babylonjs/core/scene";
 
 import { circularOrbitPosition, circularOrbitHeading } from "../avatar/orbit";
 import { createWaypointMaterial, updateWaypointMaterialTime } from "./waypointShader";
 import { createPassEffect } from "./waypointEffect";
+import { geodeticToEcefToRef } from "../../terrain/geo/ecef";
+import { surfaceOrientationToRef } from "../../terrain/geo/overlayPlacement";
 
 // ─── 定数 ────────────────────────────────────────────────
 /**
@@ -42,6 +45,13 @@ export interface WaypointManagerContext {
     altitudeM: number;
     angleDeg: number;
     modelNodeName: string;
+    /**
+     * globe バックエンドかどうか。true の場合、各ウェイポイントを「真の ECEF」位置
+     * （mesh.position = translation, CPU 側で floating origin リベースされ精度十分）へ置き、
+     * 向きは地表接線（ENU）基底で立たせる。planar の world 軸オフセット＋rotation.y では
+     * ECEF 上でリングがエッジオン化し実質不可視になるため分岐する。
+     */
+    isGlobe?: boolean;
 }
 
 export interface WaypointManager {
@@ -92,6 +102,9 @@ export const createWaypointManager = (scene: Scene, options?: WaypointManagerOpt
     let waypoints: WaypointState[] = [];
     let materials: ReturnType<typeof createWaypointMaterial>[] = [];
     let lastTime = 0;
+    // globe モード用の再利用スクラッチ
+    const gWpEcef = new Vector3();
+    const gWpQuat = new Quaternion();
     /** 次に復活するウェイポイントを配置する角度 (度, 単調増加) */
     let nextSpawnAngleDeg = 0;
     /** 1ウェイポイント分の角度ステップ (度) */
@@ -166,13 +179,17 @@ export const createWaypointManager = (scene: Scene, options?: WaypointManagerOpt
 
         const timeSec = time * 0.001;
 
-        // 飛行機のワールド座標
-        const root = scene.getTransformNodeByName(ctx.modelNodeName);
-        if (!root) return;
-        const childMesh = root.getChildMeshes(false)[0];
-        if (!childMesh) return;
-        childMesh.computeWorldMatrix(true);
-        const planeWorldPos = childMesh.absolutePosition;
+        // 飛行機のワールド座標（flat のみ）。globe では機体ノード名が異なるため、
+        // ウェイポイント位置は各自の lat/lon/alt から真の ECEF を直接算出する。
+        let planeWorldPos: Vector3 | null = null;
+        if (!ctx.isGlobe) {
+            const root = scene.getTransformNodeByName(ctx.modelNodeName);
+            if (!root) return;
+            const childMesh = root.getChildMeshes(false)[0];
+            if (!childMesh) return;
+            childMesh.computeWorldMatrix(true);
+            planeWorldPos = childMesh.absolutePosition;
+        }
 
         const planeGeo = circularOrbitPosition(
             ctx.centerLat, ctx.centerLon, ctx.radiusM, ctx.angleDeg,
@@ -220,6 +237,31 @@ export const createWaypointManager = (scene: Scene, options?: WaypointManagerOpt
             // ─── メッシュ位置更新 ───
             const active = !wp.passed || wp.fadeAlpha > 0;
             if (active) {
+                if (ctx.isGlobe) {
+                    // globe: ウェイポイント自身の lat/lon を真の ECEF に変換して配置し、
+                    // 地表接線（ENU）基底で「立たせる」。mesh.position は translation のため
+                    // floating origin リベースが効き、リング法線が進行方向を向く。
+                    const wpGeo = circularOrbitPosition(
+                        ctx.centerLat, ctx.centerLon, ctx.radiusM, wp.angleDeg,
+                    );
+                    geodeticToEcefToRef(wpGeo.lat, wpGeo.lon, ctx.altitudeM, gWpEcef);
+                    wp.mesh.position.copyFrom(gWpEcef);
+                    const heading = circularOrbitHeading(wp.angleDeg);
+                    if (surfaceOrientationToRef(gWpEcef, heading, gWpQuat)) {
+                        if (!wp.mesh.rotationQuaternion) {
+                            wp.mesh.rotationQuaternion = gWpQuat.clone();
+                        } else {
+                            wp.mesh.rotationQuaternion.copyFrom(gWpQuat);
+                        }
+                    }
+                    wp.mesh.setEnabled(true);
+
+                    if (materials[i]) {
+                        updateWaypointMaterialTime(materials[i], timeSec);
+                    }
+                    continue;
+                }
+
                 const wpGeo = circularOrbitPosition(
                     ctx.centerLat, ctx.centerLon, ctx.radiusM, wp.angleDeg,
                 );
@@ -230,9 +272,9 @@ export const createWaypointManager = (scene: Scene, options?: WaypointManagerOpt
                 const offsetZ = dLat * 111320;
 
                 wp.mesh.position.set(
-                    planeWorldPos.x + offsetX,
-                    planeWorldPos.y,
-                    planeWorldPos.z + offsetZ,
+                    planeWorldPos!.x + offsetX,
+                    planeWorldPos!.y,
+                    planeWorldPos!.z + offsetZ,
                 );
                 wp.mesh.setEnabled(true);
 

--- a/src/lib/internal/engineFactory.ts
+++ b/src/lib/internal/engineFactory.ts
@@ -15,6 +15,32 @@ import { WebGPUEngine } from "@babylonjs/core/Engines/webgpuEngine";
 
 import type { EngineType } from "../types";
 
+/** `createBabylonEngine` の追加オプション。 */
+export interface CreateBabylonEngineOptions {
+    /**
+     * 高精度行列（float64）を有効化するか（globe / large world 用）。
+     *
+     * globe は真の ECEF（~6.4e6 m）でメッシュを配置するため、行列が既定の Float32 だと
+     * floating origin リベース時に ~0.76m へ量子化されてジッターが出る。Babylon は
+     * `useHighPrecisionMatrix` を **最初に生成された Engine** で有効化すると、追跡済みの
+     * 全行列（floating origin の一時行列を含む）を float64 へ移行する
+     * （`PerformanceConfigurator.SetMatrixPrecision`）。scene 側の `useFloatingOrigin` だけでは
+     * 不十分で、engine 側の本オプションが必須（@babylonjs/core abstractEngine の仕様）。
+     */
+    highPrecisionMatrix?: boolean;
+}
+
+/**
+ * 一度 high precision を要求したら以後も維持するためのラッチ。
+ *
+ * 行列精度は `PerformanceConfigurator` のグローバル状態で、Engine 生成のたびに
+ * `SetMatrixPrecision(!!useHighPrecisionMatrix)` が呼ばれる。globe Engine の後に
+ * 既定（float32）の Engine を生成すると float32 へ巻き戻り、以後生成される行列が
+ * 精度不足になる。globe（PIP 等の二次 Viewer 含む）で一貫して float64 を保つため、
+ * 一度 true になったら以後の Engine 生成でも true を渡す。
+ */
+let highPrecisionMatrixLatched = false;
+
 /**
  * Babylon.js Engine を生成する。
  * `preferred="webgpu"` でも WebGPU 非対応環境では WebGL2 (`Engine`) にフォールバック。
@@ -22,7 +48,13 @@ import type { EngineType } from "../types";
 export async function createBabylonEngine(
     canvas: HTMLCanvasElement,
     preferred: EngineType,
+    options?: CreateBabylonEngineOptions,
 ): Promise<AbstractEngine> {
+    if (options?.highPrecisionMatrix) {
+        highPrecisionMatrixLatched = true;
+    }
+    const useHighPrecisionMatrix = highPrecisionMatrixLatched;
+
     if (preferred === "webgpu") {
         const supported = await WebGPUEngine.IsSupportedAsync;
         if (supported) {
@@ -30,10 +62,11 @@ export async function createBabylonEngine(
             const engine = new WebGPUEngine(canvas, {
                 adaptToDeviceRatio: true,
                 antialias: true,
+                useHighPrecisionMatrix,
             });
             await engine.initAsync();
             return engine;
         }
     }
-    return new Engine(canvas, true);
+    return new Engine(canvas, true, { useHighPrecisionMatrix });
 }

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -220,6 +220,9 @@ export class JpmapTerrain {
             const engine = await createBabylonEngine(
                 canvas,
                 options.engine ?? JPMAP_TERRAIN_DEFAULTS.engine,
+                // globe（真の ECEF / floating origin）は high precision matrix（float64）が必須。
+                // 未設定だと真の ECEF が Float32 で量子化されメッシュがジッターする。
+                { highPrecisionMatrix: this._terrainEngine === "globe" },
             );
             this._engine = engine;
 

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -356,6 +356,9 @@ export class GlobeScene {
         const keyboardPanEnabled = options.enableKeyboardPan !== false;
 
         // Large World Rendering: 真の ECEF（百万 m オーダー）でも精度を保つため floating origin を有効化。
+        // これだけでは不十分で、行列を float64 にする high precision matrix を **engine 側**で
+        // 有効化する必要がある（engineFactory が terrainEngine==="globe" のとき
+        // useHighPrecisionMatrix を渡す）。両方揃って初めてジッターのない large world になる。
         const scene = new Scene(engine, { useFloatingOrigin: true });
         scene.clearColor = new Color4(0.75, 0.86, 0.95, 1);
         // EcefFromLatLonAltToRef は常に右手系 ECEF（X→経度0, Y→東経90°, Z→北極）を出力し、

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -1374,6 +1374,18 @@ export const createGlobeSceneController = (
         camera.center = geodeticToEcef(latDeg, lonDeg, 0);
     };
 
+    // 外部追従カメラ（flight FollowCamera 等）によるタイル制御フラグ。
+    // detachTileCamera() で true、attachTileCamera() で false。true の間のみ
+    // refreshTerrainWithExternalFrustum が GeospatialCamera の center/radius を上書きする。
+    let externalTileControl = false;
+    // 外部指定のコンパス回転角（度）。null の間は camera.yaw 連動。
+    // flight の Follow モードがカメラ方位を直接渡すために使う（planar 等価）。
+    let externalCompassDeg: number | null = null;
+    // 外部 frustum 追従時のタイル LOD 基準半径 (m)。GeospatialCamera は描画には使われず
+    // （描画は外部 FreeCamera）、syncTiles の SSE 評価にのみ使う。flight の既定飛行高度
+    // （~2000m）から見たときに十分な詳細度になるよう設定し、lodBias で増減する。
+    const FOLLOW_TILE_BASE_RADIUS_M = 2000;
+
     // ---- 太陽 / 影（globe ライティング統合, #368 / P4-1） ----
     // timelapse デモは `dateTime` を毎フレーム駆動し setSunState を連打するため、
     // 現在の注視点(lat/lon)を基準に太陽方向(ECEF)を再計算して `globe-sun` ライトへ適用する。
@@ -1565,11 +1577,15 @@ export const createGlobeSceneController = (
         let prevScaleText = "";
         let prevBarPx = Number.NaN;
         const updateOverlayUi = (): void => {
-            // コンパス: 北矢印が実際の北を指すよう azimuth の逆回転を適用する。
+            // コンパス: 外部指定があればその値を優先し、なければ北矢印が実際の北を
+            // 指すよう azimuth の逆回転を適用する。
             // azimuthDeg は浮動小数のためほぼ毎フレーム変化しうる。0.1 度に丸めて比較し、
             // 視覚的に意味のある変化があるときだけ DOM(style.transform) を書く。
-            const az = yawPitchToUi(camera.yaw, camera.pitch).azimuthDeg;
-            const deg = Math.round(-az * 10) / 10;
+            const deg =
+                externalCompassDeg !== null
+                    ? Math.round(externalCompassDeg * 10) / 10
+                    : Math.round(-yawPitchToUi(camera.yaw, camera.pitch).azimuthDeg * 10) /
+                      10;
             if (deg !== prevCompassDeg) {
                 ui.compass.style.transform = `rotate(${deg}deg)`;
                 prevCompassDeg = deg;
@@ -1787,11 +1803,31 @@ export const createGlobeSceneController = (
             }
         },
 
-        // ---- external frustum / tile camera（flight 用, P4-0 後続スライス） ----
-        refreshTerrainWithExternalFrustum: () => Promise.resolve(),
-        detachTileCamera: () => {},
-        attachTileCamera: () => {},
-        setExternalCompassDegrees: () => {},
+        // ---- external frustum / tile camera（flight FollowCamera 用, #275 P4-3 / #402） ----
+        // globe はタイル選択を GeospatialCamera の center/radius から行う（frustum 非対応）。
+        // 外部追従カメラ（flight）では、機体 lat/lon を GeospatialCamera.center に据え、
+        // radius で LOD を制御する。実タイルロードは onBeforeRender の syncTiles が次フレームで
+        // 反映するため、本メソッドは同期更新のみ行い解決済み Promise を返す。
+        refreshTerrainWithExternalFrustum: (lat, lon, _frustumPlanes, _cameraPosition, lodBias) => {
+            if (!externalTileControl) return Promise.resolve();
+            const elev = gc.tileManager.terrainElevAt(lat, lon) ?? 0;
+            camera.center = geodeticToEcef(lat, lon, elev);
+            const bias = typeof lodBias === "number" ? lodBias : 0;
+            camera.radius = FOLLOW_TILE_BASE_RADIUS_M * Math.pow(2, -bias);
+            return Promise.resolve();
+        },
+        detachTileCamera: () => {
+            externalTileControl = true;
+        },
+        attachTileCamera: () => {
+            externalTileControl = false;
+            // 通常制御へ戻す際、コンパス上書きも解除する。
+            externalCompassDeg = null;
+        },
+        setExternalCompassDegrees: (degrees) => {
+            // 次フレームの updateOverlayUi で反映される（null で camera.yaw 連動へ復帰）。
+            externalCompassDeg = degrees;
+        },
 
         // ---- UI コントロールパネル（#275 P4-1 で配線。canvas 未指定時は no-op） ----
         setUiVisibility: (target, visible) => uiSetVisibility(target, visible),

--- a/tests/engineFactory.unit.spec.ts
+++ b/tests/engineFactory.unit.spec.ts
@@ -86,4 +86,27 @@ describe("createBabylonEngine", () => {
         expect(webgpuInitAsync).not.toHaveBeenCalled();
         expect(engineConstructor).toHaveBeenCalledTimes(1);
     });
+
+    it("highPrecisionMatrix=true で Engine に useHighPrecisionMatrix:true を渡す (large world / ジッター対策)", async () => {
+        await createBabylonEngine(canvas(), "webgl2", {
+            highPrecisionMatrix: true,
+        });
+
+        // new Engine(canvas, antialias, options, ...) の第3引数 options を検証。
+        const options = engineConstructor.mock.calls[0]?.[2] as
+            | { useHighPrecisionMatrix?: boolean }
+            | undefined;
+        expect(options?.useHighPrecisionMatrix).toBe(true);
+    });
+
+    it("WebGPU でも highPrecisionMatrix=true で useHighPrecisionMatrix:true を渡す", async () => {
+        await createBabylonEngine(canvas(), "webgpu", {
+            highPrecisionMatrix: true,
+        });
+
+        const options = webgpuConstructor.mock.calls[0]?.[1] as
+            | { useHighPrecisionMatrix?: boolean }
+            | undefined;
+        expect(options?.useHighPrecisionMatrix).toBe(true);
+    });
 });

--- a/tests/globeAfterburner.unit.spec.ts
+++ b/tests/globeAfterburner.unit.spec.ts
@@ -1,0 +1,177 @@
+/**
+ * `src/demos/flight/globeAfterburner.ts` の純関数 unit test (Issue #349 / P4-3)。
+ *
+ * - computeEngineEcefToRef: 軌道パラメータ → 左右エンジンの真 ECEF
+ * - buildTrailRibbonLocal: 絶対 ECEF 履歴 → アンカー相対のローカルリボン頂点
+ * - computeFlameColor: トレイル位置 → 炎カラー(RGBA)
+ *
+ * Babylon の重い描画モジュール（GlowLayer/StandardMaterial/CreateRibbon 等）は
+ * unstable_mockModule で分離する（純関数は Vector3/Color4 などの math のみ実体を使う）。
+ */
+import { describe, it, expect, jest, beforeAll } from "@jest/globals";
+
+jest.unstable_mockModule("@babylonjs/core/Layers/glowLayer", () => ({
+    GlowLayer: class {},
+}));
+jest.unstable_mockModule("@babylonjs/core/Materials/standardMaterial", () => ({
+    StandardMaterial: class {},
+}));
+jest.unstable_mockModule("@babylonjs/core/Meshes/Builders/ribbonBuilder", () => ({
+    CreateRibbon: jest.fn(),
+}));
+jest.unstable_mockModule("@babylonjs/core/Meshes/mesh", () => ({
+    Mesh: class {
+        static DOUBLESIDE = 2;
+    },
+}));
+jest.unstable_mockModule("@babylonjs/core/Buffers/buffer", () => ({
+    VertexBuffer: { ColorKind: "color" },
+}));
+jest.unstable_mockModule("@babylonjs/core/Engines/constants", () => ({
+    Constants: { ALPHA_ADD: 1 },
+}));
+
+const { Vector3 } = await import("@babylonjs/core/Maths/math.vector");
+const { geodeticToEcef } = await import("../src/terrain/geo/ecef");
+const { circularOrbitPosition } = await import("../src/demos/avatar/orbit");
+
+let computeEngineEcefToRef: typeof import("../src/demos/flight/globeAfterburner").computeEngineEcefToRef;
+let buildTrailRibbonLocal: typeof import("../src/demos/flight/globeAfterburner").buildTrailRibbonLocal;
+let computeFlameColor: typeof import("../src/demos/flight/globeAfterburner").computeFlameColor;
+
+beforeAll(async () => {
+    const mod = await import("../src/demos/flight/globeAfterburner");
+    computeEngineEcefToRef = mod.computeEngineEcefToRef;
+    buildTrailRibbonLocal = mod.buildTrailRibbonLocal;
+    computeFlameColor = mod.computeFlameColor;
+});
+
+const TOKYO = { lat: 35.681236, lon: 139.767125 };
+
+describe("computeEngineEcefToRef", () => {
+    it("左右エンジンが機体中心の周囲に対称配置され、横間隔 ≈ 2×lateral(2.8m) になる", () => {
+        const left = new Vector3();
+        const right = new Vector3();
+        const ok = computeEngineEcefToRef(
+            TOKYO.lat,
+            TOKYO.lon,
+            2000,
+            2000,
+            0,
+            left,
+            right,
+        );
+        expect(ok).toBe(true);
+
+        // 左右の距離 = 2 × ENGINE_LATERAL_OFFSET_M (1.4) = 2.8m
+        const sep = Vector3.Distance(left, right);
+        expect(sep).toBeGreaterThan(2.7);
+        expect(sep).toBeLessThan(2.9);
+
+        // 両エンジンとも機体中心(真 ECEF)から数 m 以内（rear/vertical/lateral オフセット程度）
+        const planeEcef = geodeticToEcef(TOKYO.lat, TOKYO.lon, 2000);
+        // 機体中心は回転に依存するため、angleDeg=0 の位置で算出
+        const pp = circularOrbitPosition(TOKYO.lat, TOKYO.lon, 2000, 0);
+        const planeAtAngle = geodeticToEcef(pp.lat, pp.lon, 2000);
+        expect(Vector3.Distance(left, planeAtAngle)).toBeLessThan(8);
+        expect(Vector3.Distance(right, planeAtAngle)).toBeLessThan(8);
+        // planeEcef は中心点。エンジンはその近傍（同オーダー）にあること。
+        expect(Number.isFinite(planeEcef.x)).toBe(true);
+    });
+
+    it("全成分が有限値である", () => {
+        const left = new Vector3();
+        const right = new Vector3();
+        computeEngineEcefToRef(TOKYO.lat, TOKYO.lon, 1500, 1000, 123, left, right);
+        for (const v of [left, right]) {
+            expect(Number.isFinite(v.x)).toBe(true);
+            expect(Number.isFinite(v.y)).toBe(true);
+            expect(Number.isFinite(v.z)).toBe(true);
+        }
+    });
+});
+
+describe("buildTrailRibbonLocal", () => {
+    const makeHistory = (n: number): InstanceType<typeof Vector3>[] => {
+        // 東京付近を東方向へ等間隔に進む履歴 ([0]=末端, [n-1]=先端)
+        const hist: InstanceType<typeof Vector3>[] = [];
+        for (let i = 0; i < n; i++) {
+            const lon = TOKYO.lon + i * 0.00002; // 約 1.8m/ステップ
+            hist.push(geodeticToEcef(TOKYO.lat, lon, 2000));
+        }
+        return hist;
+    };
+
+    it("先端をアンカーにすると先端ローカル中心が原点付近、末端は幅0に畳まれる", () => {
+        const n = 14;
+        const history = makeHistory(n);
+        const anchor = history[n - 1].clone(); // 先端をアンカー
+        const left = Array.from({ length: n }, () => new Vector3());
+        const right = Array.from({ length: n }, () => new Vector3());
+
+        const written = buildTrailRibbonLocal(history, anchor, 0.6, left, right);
+        expect(written).toBe(n);
+
+        // 先端(i=n-1): ローカル中心 ≈ 原点、左右間隔 ≈ 2×halfWidth(1.2m)
+        const headCenter = left[n - 1].add(right[n - 1]).scale(0.5);
+        expect(headCenter.length()).toBeLessThan(1e-3);
+        const headSep = Vector3.Distance(left[n - 1], right[n - 1]);
+        expect(headSep).toBeGreaterThan(1.0);
+        expect(headSep).toBeLessThan(1.4);
+
+        // 末端(i=0): テーパーで幅 0 → 左右一致
+        expect(Vector3.Distance(left[0], right[0])).toBeLessThan(1e-6);
+
+        // 末端は先端(アンカー)から離れている（履歴の広がり分）
+        expect(left[0].length()).toBeGreaterThan(1.0);
+    });
+
+    it("全頂点が有限値である", () => {
+        const n = 14;
+        const history = makeHistory(n);
+        const anchor = history[n - 1].clone();
+        const left = Array.from({ length: n }, () => new Vector3());
+        const right = Array.from({ length: n }, () => new Vector3());
+        buildTrailRibbonLocal(history, anchor, 0.6, left, right);
+        for (let i = 0; i < n; i++) {
+            for (const v of [left[i], right[i]]) {
+                expect(Number.isFinite(v.x)).toBe(true);
+                expect(Number.isFinite(v.y)).toBe(true);
+                expect(Number.isFinite(v.z)).toBe(true);
+            }
+        }
+    });
+
+    it("静止履歴（全点同一）でも NaN を出さず幅0に畳む", () => {
+        const n = 6;
+        const p = geodeticToEcef(TOKYO.lat, TOKYO.lon, 2000);
+        const history = Array.from({ length: n }, () => p.clone());
+        const anchor = p.clone();
+        const left = Array.from({ length: n }, () => new Vector3());
+        const right = Array.from({ length: n }, () => new Vector3());
+        buildTrailRibbonLocal(history, anchor, 0.6, left, right);
+        for (let i = 0; i < n; i++) {
+            expect(Vector3.Distance(left[i], right[i])).toBeLessThan(1e-6);
+            expect(Number.isFinite(left[i].x)).toBe(true);
+        }
+    });
+});
+
+describe("computeFlameColor", () => {
+    it("末端(t=0)はアルファ0、先端(t=1)はアルファ最大・R=1", () => {
+        const tail = computeFlameColor(0);
+        const head = computeFlameColor(1);
+        expect(tail.a).toBeCloseTo(0, 6);
+        expect(head.a).toBeCloseTo(1, 6);
+        expect(head.r).toBeCloseTo(1, 6);
+    });
+
+    it("アルファは t に対して単調非減少", () => {
+        let prev = -1;
+        for (let i = 0; i <= 10; i++) {
+            const a = computeFlameColor(i / 10).a;
+            expect(a).toBeGreaterThanOrEqual(prev);
+            prev = a;
+        }
+    });
+});

--- a/tests/globeSceneControllerUi.unit.spec.ts
+++ b/tests/globeSceneControllerUi.unit.spec.ts
@@ -239,3 +239,69 @@ describe("globe UI コントロールパネル配線 (#275 P4-1)", () => {
         expect(() => errorCb!({ message: "denied" })).not.toThrow();
     });
 });
+
+describe("globe external frustum / tile camera 配線 (#275 P4-3 / #402)", () => {
+    it("setExternalCompassDegrees: 外部指定値を優先し、null で yaw 連動へ復帰する", () => {
+        const camera = makeCamera();
+        camera.yaw = 0.5;
+        const { gc, onBeforeRender } = makeGcWithScene(camera);
+        const c = createGlobeSceneController(gc, "std", undefined, makeCanvas());
+
+        const compass = document.querySelector(".cp-compass") as HTMLElement;
+        expect(compass).not.toBeNull();
+
+        // 外部指定: 次フレームの updateOverlayUi で rotate(42deg) を書く。
+        c.setExternalCompassDegrees(42);
+        onBeforeRender.fire();
+        expect(compass.style.transform).toBe("rotate(42deg)");
+
+        // null 復帰: yaw 由来の角度へ戻る（42 ではない）。
+        c.setExternalCompassDegrees(null);
+        onBeforeRender.fire();
+        expect(compass.style.transform).not.toBe("rotate(42deg)");
+    });
+
+    it("refreshTerrainWithExternalFrustum: detach 中のみ center/radius を上書きする", async () => {
+        const camera = makeCamera();
+        const { gc } = makeGcWithScene(camera);
+        const c = createGlobeSceneController(gc, "std", undefined, makeCanvas());
+
+        const planes = [
+            { normal: { x: 0, y: 0, z: 1 }, d: 0 },
+            { normal: { x: 0, y: 0, z: -1 }, d: 0 },
+            { normal: { x: 1, y: 0, z: 0 }, d: 0 },
+            { normal: { x: -1, y: 0, z: 0 }, d: 0 },
+            { normal: { x: 0, y: 1, z: 0 }, d: 0 },
+            { normal: { x: 0, y: -1, z: 0 }, d: 0 },
+        ];
+        const camPos = { x: 0, y: 0, z: 0 };
+
+        // detach 前は no-op（center/radius は変わらない）。
+        const centerBefore = { ...camera.center };
+        const radiusBefore = camera.radius;
+        await c.refreshTerrainWithExternalFrustum(36, 140, planes, camPos, 0);
+        expect(camera.center).toEqual(centerBefore);
+        expect(camera.radius).toBe(radiusBefore);
+
+        // detach 後は center を lat/lon に据え、radius を base*2^-lodBias にする。
+        c.detachTileCamera();
+        await c.refreshTerrainWithExternalFrustum(36, 140, planes, camPos, 1);
+        // terrainElevAt() は null → 標高 0 で center を設定する。
+        const expected = geodeticToEcef(36, 140, 0);
+        expect(camera.center.x).toBeCloseTo(expected.x, 3);
+        expect(camera.center.y).toBeCloseTo(expected.y, 3);
+        expect(camera.center.z).toBeCloseTo(expected.z, 3);
+        // FOLLOW_TILE_BASE_RADIUS_M(2000) * 2^-1 = 1000。
+        expect(camera.radius).toBeCloseTo(1000, 6);
+
+        // lodBias=0 では base 半径そのもの。
+        await c.refreshTerrainWithExternalFrustum(36, 140, planes, camPos, 0);
+        expect(camera.radius).toBeCloseTo(2000, 6);
+
+        // attach で外部制御を解除すると再び no-op に戻る。
+        c.attachTileCamera();
+        const centerAfterAttach = { ...camera.center };
+        await c.refreshTerrainWithExternalFrustum(10, 10, planes, camPos, 0);
+        expect(camera.center).toEqual(centerAfterAttach);
+    });
+});

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -23,11 +23,12 @@ import { jest } from "@jest/globals";
 const engineDispose = jest.fn();
 // engine.resize 呼び出し回数を T7 テストで検証できるよう、最後に作った engine の resize を保持する。
 let lastEngineResize: jest.Mock = jest.fn();
-// 実際の `createBabylonEngine(canvas, preferred)` のシグネチャに合わせる。
-// 関数本体では未使用だが、`createEngineMock.mock.calls[i][1]` で第 2 引数（engine 種別）を
-// 検証する用途があるため、可変引数ではなく明示的なパラメータとして宣言する。
+// 実際の `createBabylonEngine(canvas, preferred, options)` のシグネチャに合わせる。
+// 関数本体では未使用だが、`createEngineMock.mock.calls[i][1]`（engine 種別）や
+// `[i][2]`（high precision matrix オプション）を検証する用途があるため、可変引数ではなく
+// 明示的なパラメータとして宣言する。
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const createEngineMock = jest.fn(async (_canvas: unknown, _preferred?: "webgpu" | "webgl2") => {
+const createEngineMock = jest.fn(async (_canvas: unknown, _preferred?: "webgpu" | "webgl2", _options?: { highPrecisionMatrix?: boolean }) => {
     const resize = jest.fn();
     lastEngineResize = resize;
     return {
@@ -1304,9 +1305,11 @@ describe("JpmapTerrain (skeleton)", () => {
             createEngineMock.mockClear();
             await create(createMountElement(), { engine: "webgl2" });
             expect(createEngineMock).toHaveBeenCalledTimes(1);
-            // createBabylonEngine(canvas, preferredEngine) のシグネチャ
+            // createBabylonEngine(canvas, preferredEngine, options) のシグネチャ
             const callArgs = createEngineMock.mock.calls[0];
             expect(callArgs[1]).toBe("webgl2");
+            // planar 既定では high precision matrix は不要（globe のみ true）。
+            expect(callArgs[2]).toEqual({ highPrecisionMatrix: false });
         });
 
         it("engine 未指定時はデフォルト (webgpu) で engineFactory を呼ぶ", async () => {

--- a/tests/waypoints.unit.spec.ts
+++ b/tests/waypoints.unit.spec.ts
@@ -62,6 +62,16 @@ jest.unstable_mockModule("@babylonjs/core/Maths/math.color", () => ({
 
 jest.unstable_mockModule("@babylonjs/core/Maths/math.vector", () => ({
     Vector3: jest.fn((x = 0, y = 0, z = 0) => ({ x, y, z })),
+    Quaternion: jest.fn(() => ({ copyFrom: jest.fn(), clone: jest.fn() })),
+}));
+
+jest.unstable_mockModule("../src/terrain/geo/ecef", () => ({
+    geodeticToEcefToRef: jest.fn(),
+    DEG2RAD: Math.PI / 180,
+}));
+
+jest.unstable_mockModule("../src/terrain/geo/overlayPlacement", () => ({
+    surfaceOrientationToRef: jest.fn(() => false),
 }));
 
 jest.unstable_mockModule("@babylonjs/core/Materials/Textures/texture", () => ({

--- a/tests/waypoints.unit.spec.ts
+++ b/tests/waypoints.unit.spec.ts
@@ -20,7 +20,7 @@ jest.unstable_mockModule("@babylonjs/core/Meshes/Builders/discBuilder", () => ({
             isPickable: false,
             alwaysSelectAsActiveMesh: false,
             rotation: { x: 0, y: 0, z: 0 },
-            position: { x: 0, y: 0, z: 0, set: jest.fn(), clone: jest.fn(() => ({ x: 0, y: 0, z: 0 })) },
+            position: { x: 0, y: 0, z: 0, set: jest.fn(), copyFrom: jest.fn(), clone: jest.fn(() => ({ x: 0, y: 0, z: 0 })) },
             visibility: 1,
             scaling,
             enabled: true,
@@ -62,7 +62,7 @@ jest.unstable_mockModule("@babylonjs/core/Maths/math.color", () => ({
 
 jest.unstable_mockModule("@babylonjs/core/Maths/math.vector", () => ({
     Vector3: jest.fn((x = 0, y = 0, z = 0) => ({ x, y, z })),
-    Quaternion: jest.fn(() => ({ copyFrom: jest.fn(), clone: jest.fn() })),
+    Quaternion: jest.fn(() => ({ copyFrom: jest.fn(), clone: jest.fn(() => ({ _quat: true, copyFrom: jest.fn() })) })),
 }));
 
 jest.unstable_mockModule("../src/terrain/geo/ecef", () => ({
@@ -103,6 +103,8 @@ const createMockScene = (): Scene => ({
 describe("createWaypointManager", () => {
     let createWaypointManager: typeof import("../src/demos/flight/waypoints").createWaypointManager;
     let CreateDiscMock: jest.Mock;
+    let geodeticToEcefToRefMock: jest.Mock;
+    let surfaceOrientationToRefMock: jest.Mock;
 
     beforeAll(async () => {
         const waypoints = await import("../src/demos/flight/waypoints");
@@ -110,6 +112,12 @@ describe("createWaypointManager", () => {
 
         const discModule = await import("@babylonjs/core/Meshes/Builders/discBuilder");
         CreateDiscMock = discModule.CreateDisc as unknown as jest.Mock;
+
+        const ecefModule = await import("../src/terrain/geo/ecef");
+        geodeticToEcefToRefMock = ecefModule.geodeticToEcefToRef as unknown as jest.Mock;
+
+        const overlayModule = await import("../src/terrain/geo/overlayPlacement");
+        surfaceOrientationToRefMock = overlayModule.surfaceOrientationToRef as unknown as jest.Mock;
     });
 
     it("creates a WaypointManager with update/reset/dispose", () => {
@@ -292,6 +300,96 @@ describe("createWaypointManager", () => {
         );
 
         expect(onPass).toHaveBeenCalledTimes(1);
+    });
+
+    // Issue #349 P4-3 レビュー指摘: globe 分岐（真 ECEF 配置 + ENU 姿勢）の回帰検知。
+    // isGlobe=true で geodeticToEcefToRef が呼ばれ、surfaceOrientationToRef の結果に応じて
+    // rotationQuaternion が設定される/されないことを検証する。
+    it("globe: isGlobe=true で geodeticToEcefToRef を呼び、姿勢成功時に rotationQuaternion を設定する", () => {
+        CreateDiscMock.mockClear();
+        geodeticToEcefToRefMock.mockClear();
+        // 姿勢計算が成功するケース
+        surfaceOrientationToRefMock.mockReturnValue(true);
+
+        const scene = createMockScene();
+        // globe 経路は機体ノードを参照しないため、ノード未取得でも配置されることを保証する。
+        scene.getTransformNodeByName = jest.fn(() => null);
+        const mgr = createWaypointManager(scene);
+        mgr.reset({
+            centerLat: 35.68,
+            centerLon: 139.77,
+            radiusM: 2000,
+            altitudeM: 2000,
+            angleDeg: 0,
+            modelNodeName: "globe-model-0-root",
+            isGlobe: true,
+        });
+
+        const firstMesh = CreateDiscMock.mock.results[0].value as {
+            position: { copyFrom: jest.Mock };
+            rotationQuaternion?: unknown;
+        };
+
+        mgr.update(
+            {
+                centerLat: 35.68,
+                centerLon: 139.77,
+                radiusM: 2000,
+                altitudeM: 2000,
+                angleDeg: 10,
+                modelNodeName: "globe-model-0-root",
+                isGlobe: true,
+            },
+            1000,
+        );
+
+        // globe 分岐: 各ウェイポイントの ECEF 変換が呼ばれている
+        expect(geodeticToEcefToRefMock).toHaveBeenCalled();
+        // mesh.position は ECEF アンカーへ copyFrom される
+        expect(firstMesh.position.copyFrom).toHaveBeenCalled();
+        // 姿勢成功時は rotationQuaternion が設定される（clone のセンチネルが入る）
+        expect(firstMesh.rotationQuaternion).toBeDefined();
+    });
+
+    it("globe: surfaceOrientationToRef が失敗すると rotationQuaternion を設定しない", () => {
+        CreateDiscMock.mockClear();
+        geodeticToEcefToRefMock.mockClear();
+        // 姿勢計算が退化（極など）で失敗するケース
+        surfaceOrientationToRefMock.mockReturnValue(false);
+
+        const scene = createMockScene();
+        scene.getTransformNodeByName = jest.fn(() => null);
+        const mgr = createWaypointManager(scene);
+        mgr.reset({
+            centerLat: 35.68,
+            centerLon: 139.77,
+            radiusM: 2000,
+            altitudeM: 2000,
+            angleDeg: 0,
+            modelNodeName: "globe-model-0-root",
+            isGlobe: true,
+        });
+
+        const firstMesh = CreateDiscMock.mock.results[0].value as {
+            rotationQuaternion?: unknown;
+        };
+
+        mgr.update(
+            {
+                centerLat: 35.68,
+                centerLon: 139.77,
+                radiusM: 2000,
+                altitudeM: 2000,
+                angleDeg: 10,
+                modelNodeName: "globe-model-0-root",
+                isGlobe: true,
+            },
+            1000,
+        );
+
+        // ECEF 配置は行われるが、姿勢失敗時は rotationQuaternion 未設定のまま
+        expect(geodeticToEcefToRefMock).toHaveBeenCalled();
+        expect(firstMesh.rotationQuaternion).toBeUndefined();
     });
 
     it("does not call onPass if options not provided", () => {


### PR DESCRIPTION
## 概要
flight デモを `?terrainEngine=globe`（ECEF + Babylon floating origin）で成立させる P4-3 の実装です。

Closes #402

## 変更点
- **FollowCamera**: globe 用に分岐（FreeCamera を真 ECEF 配置 / ENU 基底 / 地心 up）
- **ルートリボン・ウェイポイント**: globe 分岐（アンカー真 ECEF + ローカル小頂点）。機体ノード参照を planar 限定にし、globe は lat/lon/alt から ECEF 直接算出
- **ジッター根本対策**: Engine に `useHighPrecisionMatrix`（float64 行列）を導入。`engineFactory` に `highPrecisionMatrix` オプション + 巻き戻し防止ラッチを追加
- **PIP 方位**: backend 別に分岐（globe: `heading` / planar: `-heading`）
- **globe 3D 初期高度**: 機体を可視化できるよう引き上げ（`GLOBE_INITIAL_CAMERA_ALTITUDE`）
- **カメラ復元**: 3D→Follow→3D で 3D カメラ状態(lat/lon/altitude/azimuth/tilt)を保存・復元
- **機体発光**: 3D/2D モードで機体 emissive を点滅（`getPlaneRoot` で backend 非依存に解決）
- **globe アフターバーナー**（新規 `globeAfterburner.ts`）: `TrailMesh` 非互換のため、真 ECEF アンカー + ローカル頂点のカスタムトレイルを自作。`Afterburner` IF に `update()` を追加（planar は no-op）
- `globeSceneController` の no-op スタブ4種を実装

## 影響範囲
flight デモの globe 経路（新規挙動）。**planar 既存挙動は維持**。API/外部送信/依存追加なし。

## 検証
- `npm run test:unit` → **1304 件 全通過**（globe アフターバーナー純関数テスト7件含む）
- `npm run lint` / `npm run typecheck` → エラーなし
- 3DCG 目視確認（globe）: Follow 切替・リボン/ウェイポイント・PIP 方位・3D⇄Follow カメラ復元・アフターバーナー軌跡 — **確認済み**
- セルフレビュー（4層）承認・セキュリティ点検 OK（重大リスクなし）

## レビュー指摘の対応
- [perf] globe アフターバーナーの頂点カラーを毎フレーム再計算→初回のみに変更
- [品質] `getPlaneRoot` の単一モデル前提を doc 明記
- [nit] globe `start` の ctx 未使用をコメント補足