### PR TITLE
feat(globe): 2Dモード（トップダウン正射）の再定義とオーバーレイ縮退表示 (#395)

### DIFF
--- a/src/demos/distance/index.ts
+++ b/src/demos/distance/index.ts
@@ -107,18 +107,34 @@ const buildPolygonOptions = (
 };
 
 const rebuildPolygon = (viewer: JpmapTerrain, state: DemoState): void => {
-    // 既存ポリゴンを毎回削除→再追加することで edgeLabels をフレッシュに保つ。
-    // `replacePolygonPoints` は spec 上 edgeLabels を全 undefined にリセットするため、
-    // 距離・高低差の動的更新には add/remove を使うのが最も簡潔（#185）。
     const existing = viewer.getPolygon(POLYGON_ID);
+    if (state.points.length === 0) {
+        if (existing) viewer.removePolygon(POLYGON_ID);
+        return;
+    }
+    const options = buildPolygonOptions(state.points, false);
+    // 既存ポリゴンが同じ点数なら in-place 更新する。点座標・点ラベル・辺ラベル（距離/高低差）を
+    // メッシュ再構築なしで反映できるため、ドラッグ編集中の点ラベルのチラつきを防げる（globe）。
+    // updatePolygon は labels/edgeLabels をそのまま渡せるため、add/remove せずに動的更新できる。
+    if (existing && existing.points.length === state.points.length) {
+        viewer.updatePolygon(POLYGON_ID, {
+            points: options.points,
+            labels: options.labels,
+            edgeLabels: options.edgeLabels,
+        });
+        return;
+    }
+    // 点数が変わる追加/削除、または未生成時のみ add/remove で再構築する。
+    // 1 点でも `addPolygon` 可能（#186）。そのまま 点 + 垂線 + 点ラベル を描画する。
     if (existing) viewer.removePolygon(POLYGON_ID);
-    if (state.points.length === 0) return;
-    // 1 点でも `addPolygon` 可能になったため (#186 ライブラリ拡張)、
-    // そのまま 点 + 垂線 + 点ラベル を描画する。
-    viewer.addPolygon(POLYGON_ID, buildPolygonOptions(state.points, false));
+    viewer.addPolygon(POLYGON_ID, options);
 };
 
-const updateStatus = (state: DemoState, statusEl: HTMLElement | null): void => {
+const updateStatus = (
+    state: DemoState,
+    statusEl: HTMLElement | null,
+    is2d: boolean,
+): void => {
     if (!statusEl) return;
     const n = state.points.length;
     const guide =
@@ -132,7 +148,9 @@ const updateStatus = (state: DemoState, statusEl: HTMLElement | null): void => {
               ? n <= 2
                   ? `削除モード（点 ${n}）。点をクリックすると削除します`
                   : `削除モード（点 ${n}）`
-              : `編集モード（点 ${n}）。ドラッグで移動 / Shift+ドラッグで高度`;
+              : is2d
+                ? `編集モード（点 ${n}）。ドラッグで移動`
+                : `編集モード（点 ${n}）。ドラッグで移動 / Shift+ドラッグで高度`;
     statusEl.textContent = `モード: ${state.mode}（点 ${n}）／ ${guide}`;
 };
 
@@ -254,7 +272,7 @@ const start = async (): Promise<void> => {
     const statusEl = document.getElementById(STATUS_ID);
     const onStateChange = (): void => {
         rebuildPolygon(viewer, state);
-        updateStatus(state, statusEl);
+        updateStatus(state, statusEl, viewer.viewMode === "2d");
         // モード切替時はカーソルを既定に戻し、直近位置で再評価する。
         if (renderCanvas) {
             renderCanvas.style.cursor = "";
@@ -295,6 +313,8 @@ const start = async (): Promise<void> => {
         const refreshViewModeBtn = (): void => {
             viewModeBtn.textContent =
                 viewer.viewMode === "3d" ? "2D 表示" : "3D 表示";
+            // 2D/3D で編集ヒント（高度操作の可否）が変わるため再描画する。
+            updateStatus(state, statusEl, viewer.viewMode === "2d");
         };
         viewModeBtn.addEventListener("click", () => {
             viewer.viewMode = viewer.viewMode === "3d" ? "2d" : "3d";
@@ -358,7 +378,9 @@ const start = async (): Promise<void> => {
             return;
         }
         if (state.mode === "edit" && hovering) {
-            renderCanvas.style.cursor = shiftPressed ? "ns-resize" : "move";
+            // 2D ではドラッグの高度変更を無効化しているため ns-resize は出さない。
+            const altitudeEditable = shiftPressed && viewer.viewMode !== "2d";
+            renderCanvas.style.cursor = altitudeEditable ? "ns-resize" : "move";
         }
     };
     if (renderCanvas) {
@@ -416,8 +438,9 @@ const start = async (): Promise<void> => {
         if (e.polygonId !== POLYGON_ID) return;
         const current = state.points[e.index];
         if (!current) return;
-        if (e.pointerEvent.shiftKey) {
+        if (e.pointerEvent.shiftKey && viewer.viewMode !== "2d") {
             // 高度モード: 開始 altitude / clientY / 地表標高を保持。
+            // 2D（トップダウン）では高度変化が見えないため無効化し、通常の lat/lon 移動にする。
             state.altitudeDragStart = {
                 index: e.index,
                 altitude: current.altitude ?? 0,

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -37,6 +37,7 @@ import {
     PolygonOptions,
     PolygonPointOptions,
     PolygonPointPartial,
+    PolygonUpdate,
     SUN_AUTO_UPDATE_INTERVAL_MS,
     TerrainClickListener,
     TerrainEngine,
@@ -1224,6 +1225,17 @@ export class JpmapTerrain {
     ): PolygonHandle {
         this._assertAlive();
         return this._requirePolygonManager().updatePoint(id, index, partial);
+    }
+
+    /**
+     * ポリゴンを部分更新する。`partial` で指定したフィールドのみ反映し、未指定は現状維持。
+     * globe バックエンドでは、点数・closed・各種フラグ・style が変わらず頂点座標／ラベルのみ
+     * 変化する場合、メッシュを再構築せず in-place 更新する（ドラッグ編集時のラベルのチラつき回避）。
+     * dispose 後 / マネージャ未初期化 / 未存在 id は throw。
+     */
+    public updatePolygon(id: string, partial: PolygonUpdate): PolygonHandle {
+        this._assertAlive();
+        return this._requirePolygonManager().update(id, partial);
     }
 
     /**

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -759,6 +759,7 @@ export class GlobeScene {
         const rayRight = new Vector3();
         const rayUpTerm = new Vector3();
         const cursorDir = new Vector3();
+        const cursorOrigin = new Vector3();
         let lastWheelTimeMs = Number.NEGATIVE_INFINITY;
 
         // カーソル下方向の単位レイを**二重精度**で構築する（Issue #327 揺れの精度要因）。
@@ -856,23 +857,24 @@ export class GlobeScene {
         };
 
         // ズーム（zoom-to-cursor）は現在のポインタ位置（scene.pointerX/Y）のレイを使う。
-        const computeCursorRayDirToRef = (ref: Vector3): Vector3 =>
-            computeRayDirForPixelToRef(scene.pointerX, scene.pointerY, ref);
+        // 2D(ORTHOGRAPHIC) では平行投影のため、原点を画素オフセット分ずらし方向を forward 固定に
+        // する必要がある（透視レイ方向 + 単一原点では中心以外でズーム先がずれる）。click ピックと
+        // 同じ computePickRayToRef でモードに応じた origin+dir を構築する (#395 2D zoom-to-cursor)。
 
         movement.handleZoom = (zoomDelta: number): void => {
             if (zoomDelta === 0) return;
             lastWheelTimeMs = performance.now();
             // ネイティブ同様に蓄積（per-frame の zoomDeltaCurrentFrame へ変換される）。
             movement.zoomAccumulatedPixels += zoomDelta;
-            // カーソル方向の単位レイ（二重精度。createPickingRay の Float32 桁落ちを避ける）。
-            computeCursorRayDirToRef(cursorDir);
-            const camEcef = computeCameraEcef(); // 真の ECEF カメラ位置
+            // カーソル位置のレイ（原点 + 単位方向）。createPickingRay の Float32 桁落ちを避け、
+            // ortho では平行投影として正しい原点オフセットを得るため computePickRayToRef を使う。
+            computePickRayToRef(scene.pointerX, scene.pointerY, cursorOrigin, cursorDir);
             // 注視点付近の地形標高（海面=0）を高さに採用した WGS84 楕円体面と交差させる。
             const equatorial = ellipsoidSemiMajor + centerElevation;
             const polar = ellipsoidSemiMinor + centerElevation;
             if (
                 rayEllipsoidNearHitToRef(
-                    camEcef,
+                    cursorOrigin,
                     cursorDir,
                     equatorial,
                     equatorial,

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -1714,6 +1714,20 @@ export class GlobeScene {
             circleManager.setFlatten(flat);
         };
 
+        // viewMode 切替直後に 1 回だけオーバーレイを現在カメラで再アンカーする。これをしないと、
+        // setOverlayFlatten で flat フラグだけが先に変わり、実際の位置・スケール再計算は次フレームの
+        // 毎フレーム update まで遅延するため、切替直後の 1 フレームだけ「ポールは消えたのにアイコンは
+        // 先端位置のまま」等の不整合（チラつき）が出る (#395)。毎フレームループと同じ camEcef/flatScale
+        // を用いて同期する。
+        const reanchorOverlaysForViewMode = (mode: ViewMode): void => {
+            const camEcef = computeCameraEcef();
+            const flatScale =
+                mode === "2d" ? camera.radius / OVERLAY_REF_DISTANCE_M : undefined;
+            markerManager.update(camEcef);
+            polygonManager.update(camEcef, flatScale);
+            circleManager.update(camEcef, flatScale);
+        };
+
         const applyViewModeInternal = (
             next: ViewMode,
             opts?: { silent?: boolean; force?: boolean },
@@ -1737,6 +1751,8 @@ export class GlobeScene {
                 setOverlayFlatten(false);
             }
             currentViewMode = next;
+            // setOverlayFlatten 直後に 1 回だけ再アンカーし、切替フレームの不整合を防ぐ (#395)。
+            reanchorOverlaysForViewMode(next);
             if (!opts?.silent) options.onViewModeChange?.(next);
         };
 

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -24,6 +24,7 @@ import {
     ComputeYawPitchFromLookAtToRef,
 } from "@babylonjs/core/Cameras/geospatialCamera";
 import { GeospatialClippingBehavior } from "@babylonjs/core/Behaviors/Cameras/geospatialClippingBehavior";
+import { Camera } from "@babylonjs/core/Cameras/camera";
 import { Wgs84Ellipsoid } from "@babylonjs/core/Maths/math.geospatial.functions";
 import { CreateSphere } from "@babylonjs/core/Meshes/Builders/sphereBuilder";
 import type { Mesh } from "@babylonjs/core/Meshes/mesh";
@@ -32,6 +33,8 @@ import { PickingInfo } from "@babylonjs/core/Collisions/pickingInfo";
 
 import type { MapType } from "../terrain/gsiTile";
 import { TERRAIN_CLICK_DRAG_THRESHOLD_PX, POLYGON_POINT_DRAG_THRESHOLD_PX } from "../lib/types";
+import type { ViewMode } from "../lib/types";
+import { clampZoomLevel, radiusToZoomLevel, zoomLevelToRadius } from "../terrain/urlState";
 import { DEG2RAD, geodeticToEcef, geodeticToEcefToRef, ecefToGeodetic, type Geodetic } from "../terrain/geo/ecef";
 import {
     cameraTangentBasisToRef,
@@ -45,6 +48,7 @@ import { createGlobeMarkerManager, type GlobeMarkerManager } from "../terrain/ge
 import { createGlobePolygonManager, type GlobePolygonManager, type GlobePolygonPickablePoint } from "../terrain/geo/globePolygonManager";
 import { createGlobeCircleManager, type GlobeCircleManager } from "../terrain/geo/globeCircleManager";
 import { createGlobeModelManager, type GlobeModelManager } from "../terrain/geo/globeModelManager";
+import { OVERLAY_REF_DISTANCE_M } from "../terrain/geo/overlayPlacement";
 import { computeSpaceFactor } from "../terrain/skybox";
 
 /** グローブシーンの既定パラメータ（富士山周辺）。 */
@@ -190,6 +194,18 @@ export interface GlobeSceneInitOptions {
     enableKeyboardPan?: boolean;
     /** 同期統計のコールバック（情報表示・テスト用）。 */
     onSyncStats?: (stats: GlobeSceneSyncInfo) => void;
+    /**
+     * 初期視点モード (#395 / #349)。`"2d"` で Web メルカトル相当のトップダウン正射表示
+     * （高度なし・物理なし・skymap なし・日照なし・オーバーレイ縮退）。既定 `"3d"`。
+     */
+    viewMode?: ViewMode;
+    /**
+     * 2D 時の初期ズームレベル（Google Maps 互換、#254）。指定時は `camera.radius` へ変換する。
+     * 3D 時は無視する。
+     */
+    zoomLevel?: number;
+    /** `viewMode` が実際に変化した際に呼ばれるコールバック (#395 / #193)。 */
+    onViewModeChange?: (viewMode: ViewMode) => void;
 }
 
 /** 同期統計 + カメラ状態。 */
@@ -316,6 +332,14 @@ export interface GlobeSceneController {
     subscribePolygonPointDragEnd: (
         listener: GlobePolygonPointDragListener,
     ) => () => void;
+    /** 現在の視点モード ("3d" | "2d") を返す (#395)。 */
+    getViewMode: () => ViewMode;
+    /** 視点モードを切り替える (#395)。実変化時のみ `onViewModeChange` を発火する。 */
+    setViewMode: (mode: ViewMode) => void;
+    /**
+     * 2D 時のみ現在のズームレベル（Google Maps 互換, #254）を返す。3D 時は undefined。
+     */
+    getZoomLevel: () => number | undefined;
     dispose: () => void;
 }
 
@@ -786,6 +810,51 @@ export class GlobeScene {
             return ref;
         };
 
+        // ピッキング用レイ（原点 + 単位方向）をカメラモードに応じて構築する。
+        // - perspective(3D): 原点 = カメラ ECEF、方向 = 画素ごとに発散（中心から放射）。
+        // - orthographic(2D): 平行投影。方向 = forward（中心画素方向）固定で、原点をカメラ平面上で
+        //   画素オフセット分ずらす。これを怠ると 2D で画面中心以外の頂点が正しくピックできない
+        //   （単一原点 + 発散方向の透視レイは ortho では中心以外の点を外す） (#395 2D 編集)。
+        const computePickRayToRef = (
+            pxCss: number,
+            pyCss: number,
+            originRef: Vector3,
+            dirRef: Vector3,
+        ): void => {
+            if (camera.mode !== Camera.ORTHOGRAPHIC_CAMERA) {
+                originRef.copyFrom(computeCameraEcef());
+                computeRayDirForPixelToRef(pxCss, pyCss, dirRef);
+                return;
+            }
+            // forward（中心画素方向）= カメラ→center。ortho では全画素で共通。
+            ComputeLookAtFromYawPitchToRef(
+                camera.yaw,
+                camera.pitch,
+                camera.center,
+                scene.useRightHandedSystem,
+                rayFwd,
+            );
+            dirRef.copyFrom(rayFwd).normalize();
+            originRef.copyFrom(computeCameraEcef());
+            Vector3.CrossToRef(rayFwd, camera.upVector, rayRight);
+            if (rayRight.lengthSquared() < 1e-12) return; // 退化時は中心原点で代替
+            rayRight.normalize();
+            const hsl = engine.getHardwareScalingLevel();
+            const w = engine.getRenderWidth();
+            const h = engine.getRenderHeight();
+            if (w <= 0 || h <= 0) return;
+            const ndcx = (pxCss / hsl / w) * 2 - 1;
+            const ndcy = 1 - (pyCss / hsl / h) * 2;
+            // ortho フラスタム半寸（applyOrthoFrustum と同式）。原点をこの平面上で動かす。
+            const halfH = camera.radius * Math.tan(camera.fov / 2);
+            const halfW = halfH * (w / h);
+            originRef
+                .addInPlace(rayRight.scaleInPlace(ndcx * halfW))
+                .addInPlace(
+                    rayUpTerm.copyFrom(camera.upVector).scaleInPlace(ndcy * halfH),
+                );
+        };
+
         // ズーム（zoom-to-cursor）は現在のポインタ位置（scene.pointerX/Y）のレイを使う。
         const computeCursorRayDirToRef = (ref: Vector3): Vector3 =>
             computeRayDirForPixelToRef(scene.pointerX, scene.pointerY, ref);
@@ -913,6 +982,7 @@ export class GlobeScene {
             modifier: boolean;
         } | null = null;
         const clickRayDir = new Vector3();
+        const clickOrigin = new Vector3();
         const clickHit = new Vector3();
         const clickHitElev = new Vector3();
 
@@ -921,12 +991,12 @@ export class GlobeScene {
             const rect = canvas.getBoundingClientRect();
             const pxCss = e.clientX - rect.left;
             const pyCss = e.clientY - rect.top;
-            computeRayDirForPixelToRef(pxCss, pyCss, clickRayDir);
-            const camEcef = computeCameraEcef();
+            // 2D ortho では平行レイ（原点を画素オフセット）でないと中心以外で交点がずれる。
+            computePickRayToRef(pxCss, pyCss, clickOrigin, clickRayDir);
             // 1) 海面（h=0）の楕円体と交差させて概略の緯度経度を得る。
             if (
                 !rayEllipsoidNearHitToRef(
-                    camEcef,
+                    clickOrigin,
                     clickRayDir,
                     ellipsoidSemiMajor,
                     ellipsoidSemiMajor,
@@ -948,7 +1018,7 @@ export class GlobeScene {
             if (hasElev) {
                 if (
                     rayEllipsoidNearHitToRef(
-                        camEcef,
+                        clickOrigin,
                         clickRayDir,
                         ellipsoidSemiMajor + elev,
                         ellipsoidSemiMajor + elev,
@@ -1087,8 +1157,7 @@ export class GlobeScene {
         ): { polygonId: string; index: number } | null => {
             const count = polygonManager.getPickablePoints(ppPickBuffer);
             if (count === 0) return null;
-            ppOrigin.copyFrom(computeCameraEcef());
-            computeRayDirForPixelToRef(pxCss, pyCss, ppRayDir);
+            computePickRayToRef(pxCss, pyCss, ppOrigin, ppRayDir);
             // 楕円体（海面）近交点までの距離。これより十分奥の点は裏側として除外する。
             let tEllip = Number.POSITIVE_INFINITY;
             if (
@@ -1143,8 +1212,7 @@ export class GlobeScene {
             pxCss: number,
             pyCss: number,
         ): { lat: number | null; lon: number | null; groundAltitude: number | null } => {
-            ppOrigin.copyFrom(computeCameraEcef());
-            computeRayDirForPixelToRef(pxCss, pyCss, ppRayDir);
+            computePickRayToRef(pxCss, pyCss, ppOrigin, ppRayDir);
             if (
                 !rayEllipsoidNearHitToRef(
                     ppOrigin,
@@ -1192,8 +1260,7 @@ export class GlobeScene {
             pyCss: number,
             startAltMeters: number,
         ): { planeLat: number | null; planeLon: number | null } => {
-            ppOrigin.copyFrom(computeCameraEcef());
-            computeRayDirForPixelToRef(pxCss, pyCss, ppRayDir);
+            computePickRayToRef(pxCss, pyCss, ppOrigin, ppRayDir);
             const eqr = ellipsoidSemiMajor + startAltMeters;
             const pol = ellipsoidSemiMinor + startAltMeters;
             if (
@@ -1214,8 +1281,7 @@ export class GlobeScene {
             pyCss: number,
             startWorld: Vector3,
         ): number | null => {
-            ppOrigin.copyFrom(computeCameraEcef());
-            computeRayDirForPixelToRef(pxCss, pyCss, ppRayDir);
+            computePickRayToRef(pxCss, pyCss, ppOrigin, ppRayDir);
             const startGeo = ecefToGeodetic(startWorld);
             // 測地 up = ecef(alt+1) - ecef(alt) を正規化（楕円体法線。地心方向と微差）。
             geodeticToEcefToRef(
@@ -1616,6 +1682,70 @@ export class GlobeScene {
             if (newRadius !== camera.radius) camera.radius = newRadius;
         };
 
+        // ---- 視点モード 2D/3D (#395 / #349) ----
+        // GeospatialCamera を ORTHOGRAPHIC + pitch=0（トップダウン）へ切替え、Web メルカトル相当の
+        // 2D 正射表示にする。タイルは同一 tileManager 共有のため自動成立する（globeTileManager 無改変）。
+        // 3D パスは不変（2D 限定の分岐を追加するのみ）。
+        const initialViewMode: ViewMode = options.viewMode ?? "3d";
+        let currentViewMode: ViewMode = initialViewMode;
+        // 3D 復帰時に戻す pitch[rad]（2D 切替直前を保存）。初期 pitch（tilt 由来）を既定とする。
+        let savedPitch = camera.pitch;
+
+        // 2D の正射フラスタムを radius・アスペクトから設定する（planar default.ts と同式）。
+        // perspective でターゲット平面に映る範囲 = radius * tan(fov/2) と一致させる。
+        const applyOrthoFrustum = (): void => {
+            const w = engine.getRenderWidth();
+            const h = engine.getRenderHeight();
+            if (w <= 0 || h <= 0) return;
+            const aspect = w / h;
+            const halfH = camera.radius * Math.tan(camera.fov / 2);
+            const halfW = halfH * aspect;
+            camera.orthoTop = halfH;
+            camera.orthoBottom = -halfH;
+            camera.orthoLeft = -halfW;
+            camera.orthoRight = halfW;
+        };
+
+        const setOverlayFlatten = (flat: boolean): void => {
+            markerManager.setFlatten(flat);
+            polygonManager.setFlatten(flat);
+            circleManager.setFlatten(flat);
+        };
+
+        const applyViewModeInternal = (
+            next: ViewMode,
+            opts?: { silent?: boolean; force?: boolean },
+        ): void => {
+            if (next === currentViewMode && !opts?.force) return;
+            if (next === "2d") {
+                // 3D→2D の初回のみ現在 pitch を保存（force 再適用で 0 を保存しないようガード）。
+                if (currentViewMode === "3d") savedPitch = camera.pitch;
+                // GeospatialCamera は pitch を limits.pitchMin(≈ε) でクランプし、looking-straight-down
+                // を内部で安定化（yaw は保持）。論理 tilt=0 のトップダウンとして扱う。
+                camera.pitch = 0;
+                camera.mode = Camera.ORTHOGRAPHIC_CAMERA;
+                applyOrthoFrustum();
+                setOverlayFlatten(true);
+            } else {
+                camera.mode = Camera.PERSPECTIVE_CAMERA;
+                camera.pitch = savedPitch;
+                setOverlayFlatten(false);
+            }
+            currentViewMode = next;
+            if (!opts?.silent) options.onViewModeChange?.(next);
+        };
+
+        const getZoomLevel = (): number | undefined => {
+            // 2D のみズームレベルを公開する（3D は radius=高度で zoomLevel 概念を持たない）。
+            if (currentViewMode !== "2d") return undefined;
+            const h = engine.getRenderHeight();
+            if (h <= 0) return undefined;
+            const g = ecefToGeodetic(camera.center);
+            return clampZoomLevel(
+                radiusToZoomLevel(camera.radius, h, g.latDeg, camera.fov),
+            );
+        };
+
         // render ループは開始しない。DefaultScene と同じく、シーン生成と render ループ管理の
         // 責務を分離し、ループ開始は呼び出し側（デモ / 将来の JpmapTerrain 等）に委ねる
         // （二重起動・上書きを防ぐ）。本シーンのタイル同期は onBeforeRenderObservable で動く。
@@ -1630,36 +1760,76 @@ export class GlobeScene {
         const skyBaseColor = DAY_SKY_COLOR.clone();
         const observer = scene.onBeforeRenderObservable.add(() => {
             applyKeyboardPan();
+            // 2D（トップダウン正射）: 毎フレーム pitch=0 を再代入してチルト操作を無効化し、
+            // radius/リサイズに追従して ortho フラスタムを更新する (#395)。
+            if (currentViewMode === "2d") {
+                camera.pitch = 0;
+                applyOrthoFrustum();
+            }
             // カメラ ECEF と測地座標・lookAt を 1 フレーム 1 回だけ計算し、seat と衝突で共有する
             // （ComputeLookAtFromYawPitchToRef と測地変換の二重実行を避ける）。seat は center を
             // わずかに動かすため衝突はその直前のスナップショットを使うが、毎フレーム補正のため実用上問題ない。
             const camEcef = computeCameraEcef(); // lookAt バッファも更新される
             const camGeo = ecefToGeodetic(camEcef);
-            // 高度連動の背景暗化（高高度ほど宇宙の黒へ）。Issue #371。
-            // 真の測地高度 altMeters を用い、約 12km から暗化開始・75km でほぼ黒に収束させる。
-            const spaceFactor = computeSpaceFactor(camGeo.altMeters);
-            // 毎フレーム Color3 を新規生成しないよう、各チャンネルを直接 lerp して set する。
-            // 基調色は時刻連動の skyBaseColor（昼=青/夜=紺/日の出入り=茜, Issue #380）。
-            scene.clearColor.set(
-                skyBaseColor.r + (SPACE_SKY_COLOR.r - skyBaseColor.r) * spaceFactor,
-                skyBaseColor.g + (SPACE_SKY_COLOR.g - skyBaseColor.g) * spaceFactor,
-                skyBaseColor.b + (SPACE_SKY_COLOR.b - skyBaseColor.b) * spaceFactor,
-                1,
-            );
-            // ズーム中（ホイール〜慣性減衰）は seat を止め、鉛直の引っ張り合いによる揺れを防ぐ。
-            seatCenterOnTerrain(camGeo.altMeters, isZoomActive());
-            enforceGroundClearance(camEcef, camGeo);
+            if (currentViewMode === "3d") {
+                // 高度連動の背景暗化（高高度ほど宇宙の黒へ）。Issue #371。
+                // 真の測地高度 altMeters を用い、約 12km から暗化開始・75km でほぼ黒に収束させる。
+                const spaceFactor = computeSpaceFactor(camGeo.altMeters);
+                // 毎フレーム Color3 を新規生成しないよう、各チャンネルを直接 lerp して set する。
+                // 基調色は時刻連動の skyBaseColor（昼=青/夜=紺/日の出入り=茜, Issue #380）。
+                scene.clearColor.set(
+                    skyBaseColor.r + (SPACE_SKY_COLOR.r - skyBaseColor.r) * spaceFactor,
+                    skyBaseColor.g + (SPACE_SKY_COLOR.g - skyBaseColor.g) * spaceFactor,
+                    skyBaseColor.b + (SPACE_SKY_COLOR.b - skyBaseColor.b) * spaceFactor,
+                    1,
+                );
+                // ズーム中（ホイール〜慣性減衰）は seat を止め、鉛直の引っ張り合いによる揺れを防ぐ。
+                seatCenterOnTerrain(camGeo.altMeters, isZoomActive());
+                enforceGroundClearance(camEcef, camGeo);
+            } else {
+                // 2D: 宇宙黒 lerp / seat / 対地クリアランスはスキップ（高度・物理・日照表現なし）。
+                // SSE 評価の基準標高 centerElevation のみ最新化し、タイル LOD を正しく保つ。
+                const g = ecefToGeodetic(camera.center);
+                const elev = tileManager.terrainElevAt(g.latDeg, g.lonDeg);
+                if (elev !== null) centerElevation = elev;
+            }
             // マーカーの接地・距離スケール更新（フレーム共有の camEcef を渡す）。
             markerManager.update(camEcef);
+            // 2D 正射では、頂点高度やパンに依らず画面上サイズを一定に保つため、距離由来ではなく
+            // radius 比例の固定スケールをポリゴン/サークルへ渡す（ortho フラスタムと相殺してマーカー
+            // 同等になる）。3D（undefined）は従来の距離由来スケールを使う。
+            const flatScale =
+                currentViewMode === "2d"
+                    ? camera.radius / OVERLAY_REF_DISTANCE_M
+                    : undefined;
             // ポリゴンの地形再ドレープ（アウトライン・壁）と距離スケール更新（点/ラベル配置）。
-            polygonManager.update(camEcef);
+            polygonManager.update(camEcef, flatScale);
             // サークルの地形再ドレープと距離スケール更新（点/ラベル配置）。
-            circleManager.update(camEcef);
+            circleManager.update(camEcef, flatScale);
             // モデルの接地・起立更新。
             modelManager.tick();
             if (frame % GLOBE_SCENE_DEFAULTS.syncIntervalFrames === 0) syncTiles();
             frame++;
         });
+
+        // 初期視点モードを反映する (#395)。silent で初期 listener は発火させない。
+        // "3d" は既定の perspective + pitch のままなので force 適用は 2d のみで足りる。
+        if (initialViewMode === "2d") {
+            applyViewModeInternal("2d", { silent: true, force: true });
+            // URL 等から zoomLevel 指定があれば radius へ変換する (#254)。
+            if (options.zoomLevel !== undefined) {
+                const h = engine.getRenderHeight();
+                if (h > 0) {
+                    const g = ecefToGeodetic(camera.center);
+                    camera.radius = zoomLevelToRadius(
+                        options.zoomLevel,
+                        h,
+                        g.latDeg,
+                        camera.fov,
+                    );
+                }
+            }
+        }
 
         const dispose = (): void => {
             // render ループは呼び出し側の所有なので停止しない（呼び出し側が停止する）。
@@ -1707,6 +1877,9 @@ export class GlobeScene {
             subscribePolygonPointDragStart,
             subscribePolygonPointDrag,
             subscribePolygonPointDragEnd,
+            getViewMode: () => currentViewMode,
+            setViewMode: (mode: ViewMode) => applyViewModeInternal(mode),
+            getZoomLevel,
             dispose,
         };
     }

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -1848,6 +1848,11 @@ export class GlobeScene {
                         g.latDeg,
                         camera.fov,
                     );
+                    // radius 変更後に ortho フラスタムとオーバーレイ再アンカーをやり直し、
+                    // 初期化直後（最初の描画フレーム前）に古い radius のまま 1 フレーム不整合に
+                    // なるのを防ぐ（applyViewModeInternal は radius 更新前に一度走っているため）。
+                    applyOrthoFrustum();
+                    reanchorOverlaysForViewMode("2d");
                 }
             }
         }

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -1728,6 +1728,9 @@ export class GlobeScene {
                 camera.mode = Camera.ORTHOGRAPHIC_CAMERA;
                 applyOrthoFrustum();
                 setOverlayFlatten(true);
+                // 2D は skymap 無し（#395）。3D 分岐の宇宙黒への高度連動 lerp を行わないため、
+                // 背景を一定の昼空色へ固定する（3D 復帰時は次フレームの clearColor ループが上書き）。
+                scene.clearColor.set(DAY_SKY_COLOR.r, DAY_SKY_COLOR.g, DAY_SKY_COLOR.b, 1);
             } else {
                 camera.mode = Camera.PERSPECTIVE_CAMERA;
                 camera.pitch = savedPitch;

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -524,28 +524,34 @@ export const createGlobePolygonManagerAdapter = (
                 `JpmapTerrain.updatePolygon[${id}]`,
             );
             const eCount = polygonEdgeCount(points.length, closed);
-            const labels =
-                partial.labels !== undefined
-                    ? points.map((_p, i) => partial.labels?.[i])
-                    : points.map((_p, i) => prev.labels[i]);
-            const edgeLabels =
-                partial.edgeLabels !== undefined
-                    ? Array.from({ length: eCount }, (_v, i) => partial.edgeLabels?.[i])
-                    : Array.from({ length: eCount }, (_v, i) => prev.edgeLabels[i]);
+            // labels / edgeLabels / style は「キーの有無」で判定する（planar 実装と同様）。
+            // `!== undefined` だと `{ labels: undefined }` のような明示クリアを「未指定」と誤判定し
+            // 既存ラベルが残ってしまう（Partial trap）。キー存在なら明示 undefined をクリアとして扱う。
+            const labelsProvided = "labels" in partial;
+            const edgeLabelsProvided = "edgeLabels" in partial;
+            const styleProvided = "style" in partial;
+            const labels = labelsProvided
+                ? points.map((_p, i) => partial.labels?.[i])
+                : points.map((_p, i) => prev.labels[i]);
+            const edgeLabels = edgeLabelsProvided
+                ? Array.from({ length: eCount }, (_v, i) => partial.edgeLabels?.[i])
+                : Array.from({ length: eCount }, (_v, i) => prev.edgeLabels[i]);
             const next: PolygonAdapterEntry = {
                 ...prev,
                 points,
                 closed,
                 altitudeMode,
                 labels,
-                hasLabels: partial.labels !== undefined ? true : prev.hasLabels,
+                hasLabels: labelsProvided
+                    ? partial.labels !== undefined
+                    : prev.hasLabels,
                 edgeLabels,
-                hasEdgeLabels:
-                    partial.edgeLabels !== undefined ? true : prev.hasEdgeLabels,
-                style:
-                    partial.style !== undefined
-                        ? resolvePolygonStyle(partial.style)
-                        : prev.style,
+                hasEdgeLabels: edgeLabelsProvided
+                    ? partial.edgeLabels !== undefined
+                    : prev.hasEdgeLabels,
+                style: styleProvided
+                    ? resolvePolygonStyle(partial.style)
+                    : prev.style,
                 enabled: partial.enabled ?? prev.enabled,
                 verticalsEnabled:
                     partial.verticalsEnabled ?? prev.verticalsEnabled,
@@ -562,7 +568,7 @@ export const createGlobePolygonManagerAdapter = (
                 next.verticalsEnabled === prev.verticalsEnabled &&
                 next.labelsEnabled === prev.labelsEnabled &&
                 next.wallsEnabled === prev.wallsEnabled &&
-                partial.style === undefined &&
+                !styleProvided &&
                 next.points.length === prev.points.length;
             if (
                 structureUnchanged &&

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -1448,6 +1448,9 @@ export const createGlobeSceneController = (
     // 画面外・地球の裏側で昼の領域まで一律に暗くなり不自然なため、ライト強度は時刻に依らず一定にする。
     const GLOBE_SUN_LIGHT_INTENSITY = 1.2;
     const GLOBE_HEMI_LIGHT_INTENSITY = 0.35;
+    // 2D（#395）は「日時による日照表現は無し」。指向性ライト（太陽）を無効化し、環境光のみで
+    // 一様に照らすため、3D より強い環境光を採用する（一般的な Web メルカトル地図相当の見え方）。
+    const HEMI_FLAT_2D_INTENSITY = 1.0;
     // 最後に算出した太陽方向(ECEF, 地表→太陽)と、太陽状態が有効か。距離 D / 見かけサイズは
     // カメラ（ズーム・高度）に依存するため、dateTime 更新時だけでなく毎フレーム再評価する。
     const currentSunDirEcef = new Vector3();
@@ -1460,6 +1463,9 @@ export const createGlobeSceneController = (
     // 奥（地平線より奥・far クリップ手前）に置くことで、太陽は手前の地形や地球の縁から滑らかに欠け、地球の
     // 裏側では完全に隠れる。
     const placeSunMesh = (): void => {
+        // 2D（#395）は太陽メッシュ非表示（日照表現なし）。applyViewModeLighting が disable 済みなので
+        // ここでは再有効化せず即 return する（毎フレームの setEnabled(true) で復活させない）。
+        if (gc.getViewMode() === "2d") return;
         if (!sunStateValid) return;
         gc.sunMesh.setEnabled(true);
         // 地平線より SUN_HORIZON_MARGIN だけ奥（= maxZ - R*0.05）に置き、far クリップ手前へクランプする。
@@ -1477,6 +1483,9 @@ export const createGlobeSceneController = (
     };
 
     const applyGlobeSunState = (): void => {
+        // 2D（#395）は日照表現なし。ライト強度/太陽方向/空色/太陽メッシュは applyViewModeLighting が
+        // 一様化するため、ここでの日時連動更新はスキップする（2D→3D 復帰時に改めて適用される）。
+        if (gc.getViewMode() === "2d") return;
         // dateTime 未指定（null）のときは決定的フォールバック日時で計算する（planar と挙動を一致させる）。
         const dateForCalc = currentSunDateTime ?? fallbackSunDate;
         if (Number.isNaN(dateForCalc.getTime())) {
@@ -1516,10 +1525,35 @@ export const createGlobeSceneController = (
         placeSunMesh();
     };
 
+    // viewMode に応じたライティングを適用する（#395）。
+    // - 2D: 指向性ライト（太陽）と発光する太陽メッシュを無効化し、環境光を強めて一様に照らす
+    //   （skymap/日照表現なし）。
+    // - 3D: 指向性ライトを再有効化し、環境光強度を 3D 既定へ戻す。太陽方向/空色/太陽メッシュは
+    //   既存の applyGlobeSunState（dateTime/中心移動で駆動）と placeSunMesh が復元する。
+    // 適用済み viewMode を記録し、変化時のみ実行する（毎フレーム sunMeshObserver から呼ばれる）。
+    let lightingViewMode: ViewMode | null = null;
+    const applyViewModeLighting = (): void => {
+        const vm = gc.getViewMode();
+        if (vm === lightingViewMode) return;
+        lightingViewMode = vm;
+        if (vm === "2d") {
+            gc.sunLight.setEnabled(false);
+            gc.hemiLight.intensity = HEMI_FLAT_2D_INTENSITY;
+            gc.sunMesh.setEnabled(false);
+        } else {
+            gc.sunLight.setEnabled(true);
+            gc.hemiLight.intensity = GLOBE_HEMI_LIGHT_INTENSITY;
+        }
+    };
+
     // ズームのみの操作（dateTime 不変）でも太陽の距離・見かけサイズが maxZ に追従するよう毎フレーム
     // 再配置する。これがないと、ズームイン時に算出した小さな距離・サイズが stale 化し、ズームアウト
     // 時に太陽が極小化して見えなくなる（地球の弧が見える広域ズームで顕著）。
-    const sunMeshObserver = gc.scene.onBeforeRenderObservable.add(placeSunMesh);
+    // あわせて viewMode 変化時のライティング切替（2D/3D）も毎フレーム評価する。
+    const sunMeshObserver = gc.scene.onBeforeRenderObservable.add(() => {
+        applyViewModeLighting();
+        placeSunMesh();
+    });
 
     // 注視点の移動（パン）でも背景色が昼夜境界（ターミネータ）を跨いで追従するよう、中心の
     // 緯度経度が変化したら太陽状態を再計算する（planar が centerChanged で再計算するのと挙動を揃える, #380）。

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -65,6 +65,7 @@ import type {
     PolygonPointClickListener,
     PolygonPointDragListener,
     PolygonPointDragEvent,
+    ViewMode,
 } from "../lib/types";
 import {
     MARKER_DEFAULTS,
@@ -551,6 +552,30 @@ export const createGlobePolygonManagerAdapter = (
                 labelsEnabled: partial.labelsEnabled ?? prev.labelsEnabled,
                 wallsEnabled: partial.wallsEnabled ?? prev.wallsEnabled,
             };
+            // 構造（点数・closed・各種フラグ・style）が変わらず、頂点座標／ラベルのみの更新なら
+            // in-place 更新を試みる（メッシュ再構築を避け、ドラッグ編集中のラベルのチラつきを防ぐ）。
+            // setContent が false（点数不一致など）を返した場合は従来どおり remove/add で再構築する。
+            const structureUnchanged =
+                next.closed === prev.closed &&
+                next.altitudeMode === prev.altitudeMode &&
+                next.enabled === prev.enabled &&
+                next.verticalsEnabled === prev.verticalsEnabled &&
+                next.labelsEnabled === prev.labelsEnabled &&
+                next.wallsEnabled === prev.wallsEnabled &&
+                partial.style === undefined &&
+                next.points.length === prev.points.length;
+            if (
+                structureUnchanged &&
+                globeMgr.setContent(prev.globeId, {
+                    points: next.points,
+                    labels: next.hasLabels ? next.labels : undefined,
+                    edgeLabels: next.hasEdgeLabels ? next.edgeLabels : undefined,
+                })
+            ) {
+                next.globeId = prev.globeId;
+                entries.set(id, next);
+                return buildHandle(id, next);
+            }
             return buildHandle(id, commitRebuild(id, prev, next));
         },
         remove(id: string): void {
@@ -1061,6 +1086,9 @@ export class GlobeSceneAdapter {
                 mapType,
                 enablePan: options?.enablePan,
                 enableKeyboardPan: options?.enableKeyboardPan,
+                viewMode: options?.viewMode,
+                zoomLevel: options?.zoomLevel,
+                onViewModeChange: options?.onViewModeChange,
             },
         );
 
@@ -1285,7 +1313,6 @@ export const createGlobeSceneController = (
 ): DefaultSceneController => {
     const { camera } = gc;
     let currentMapType: MapType = initialMapType;
-    let viewModeWarned = false;
 
     // 公開 overlay manager 互換アダプタ（P4-0 Slice 2a / 2b-1）。
     const markerManager = createGlobeMarkerManagerAdapter(
@@ -1538,6 +1565,9 @@ export const createGlobeSceneController = (
     ) => void = () => {};
     let uiDispose: () => void = () => {};
     let updateMapToggleLabel: ((m: MapType) => void) | undefined;
+    // 視点切替ボタンのラベル更新（UI 生成時に実体を代入。canvas 未指定時は undefined）。
+    // adapter.setViewMode（外部 API）と UI クリックの双方からラベルを同期するため外に出す。
+    let updateViewModeToggleLabel: ((m: ViewMode) => void) | undefined;
 
     /**
      * 地図種別を切り替える共通処理（UI ボタン / `controller.setMapType` の双方から呼ぶ）。
@@ -1556,10 +1586,21 @@ export const createGlobeSceneController = (
         // UI 破棄後にアニメーション（requestAnimationFrame）が camera を更新し続けないための
         // ガードフラグ。uiDispose で true にし、各 rAF ループは次フレームをスケジュールしない。
         let uiDisposed = false;
-        // globe は 2D(ortho) を持たないため視点切替ボタンは常時非表示にする（#275 P4-1）。
-        // createUiVisibilityController は生成時の display を初期値として捕捉するため、
-        // 先に "none" にしておけば setUiVisibility("viewModeButton", true) でも再表示されない。
-        ui.viewModeButton.style.display = "none";
+        // 視点切替ボタン: globe バックエンドでも 2D(ortho) を有効化 (#395 / #349)。
+        // ラベルは「次に切り替える先」を示すアクションとして表示する（planar default.ts と同パターン）。
+        updateViewModeToggleLabel = (mode: ViewMode): void => {
+            ui.viewModeButton.textContent = mode === "3d" ? "2D" : "3D";
+            ui.viewModeButton.setAttribute(
+                "aria-label",
+                mode === "3d" ? "視点切替: 2D に変更" : "視点切替: 3D に変更",
+            );
+        };
+        updateViewModeToggleLabel(gc.getViewMode());
+        ui.viewModeButton.addEventListener("click", () => {
+            // gc.setViewMode は実変化時のみ onViewModeChange を発火する。ラベルは現在値で同期する。
+            gc.setViewMode(gc.getViewMode() === "3d" ? "2d" : "3d");
+            updateViewModeToggleLabel?.(gc.getViewMode());
+        });
 
         // 地図切替ボタンのラベル/aria を現在の mapType に合わせて更新する。
         updateMapToggleLabel = (m: MapType): void => {
@@ -1747,8 +1788,8 @@ export const createGlobeSceneController = (
         getAltitude: () => camera.radius,
         getAzimuth: () => yawPitchToUi(camera.yaw, camera.pitch).azimuthDeg,
         getTilt: () => yawPitchToUi(camera.yaw, camera.pitch).tiltDeg,
-        // globe は 2D(ズームレベル)概念を持たないため undefined。
-        getZoomLevel: () => undefined,
+        // 2D 時のみズームレベル（Google Maps 互換, #254）を返す。3D 時は undefined。
+        getZoomLevel: () => gc.getZoomLevel(),
 
         setLat: (value: number) => {
             const { lonDeg } = currentGeodetic();
@@ -1791,16 +1832,13 @@ export const createGlobeSceneController = (
             applyMapType(toGlobeMapType(value), true);
         },
 
-        // ---- viewMode ----
-        // globe は GeospatialCamera ベースで 2D(ortho) を持たない。常に "3d" として扱う。
-        getViewMode: () => "3d",
+        // ---- viewMode (#395 / #349) ----
+        // globe バックエンドでも 2D(ortho) を有効化。GlobeSceneController へ委譲する。
+        getViewMode: () => gc.getViewMode(),
         setViewMode: (value) => {
-            if (value === "2d" && !viewModeWarned) {
-                viewModeWarned = true;
-                console.warn(
-                    "[globeSceneController] viewMode \"2d\" is not supported on the globe backend; staying in 3d.",
-                );
-            }
+            gc.setViewMode(value);
+            // UI ボタンのラベルも現在値へ同期する（外部 API 経由の変化に追従）。
+            updateViewModeToggleLabel?.(gc.getViewMode());
         },
 
         // ---- external frustum / tile camera（flight FollowCamera 用, #275 P4-3 / #402） ----

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -1534,13 +1534,16 @@ export const createGlobeSceneController = (
     // viewMode に応じたライティングを適用する（#395）。
     // - 2D: 指向性ライト（太陽）と発光する太陽メッシュを無効化し、環境光を強めて一様に照らす
     //   （skymap/日照表現なし）。
-    // - 3D: 指向性ライトを再有効化し、環境光強度を 3D 既定へ戻す。太陽方向/空色/太陽メッシュは
-    //   既存の applyGlobeSunState（dateTime/中心移動で駆動）と placeSunMesh が復元する。
+    // - 3D: 指向性ライトを再有効化し、環境光強度を 3D 既定へ戻す。2D→3D 復帰時のみ
+    //   applyGlobeSunState() を呼んで太陽方向/空色/sunStateValid/メッシュを再計算する。2D 中は
+    //   applyGlobeSunState が early-return するため、2D 中の setSunState や初期 viewMode=2d 起動で
+    //   太陽状態が未初期化/古い日時のまま残るのを防ぐ（初期 3D 起動では既に適用済みのため不要）。
     // 適用済み viewMode を記録し、変化時のみ実行する（毎フレーム sunMeshObserver から呼ばれる）。
     let lightingViewMode: ViewMode | null = null;
     const applyViewModeLighting = (): void => {
         const vm = gc.getViewMode();
         if (vm === lightingViewMode) return;
+        const prev = lightingViewMode;
         lightingViewMode = vm;
         if (vm === "2d") {
             gc.sunLight.setEnabled(false);
@@ -1549,6 +1552,8 @@ export const createGlobeSceneController = (
         } else {
             gc.sunLight.setEnabled(true);
             gc.hemiLight.intensity = GLOBE_HEMI_LIGHT_INTENSITY;
+            // 2D→3D 復帰時のみ太陽状態を再計算する（applyGlobeSunState が hemi 強度も 3D 既定へ戻す）。
+            if (prev === "2d") applyGlobeSunState();
         }
     };
 

--- a/src/terrain/circle.ts
+++ b/src/terrain/circle.ts
@@ -40,6 +40,12 @@ import {
 
 const RENDERING_GROUP_ID = 1;
 const SUBTERRAIN_RENDERING_GROUP_ID = 0;
+/**
+ * ラベルは専用の上位グループで描画する。レンダリンググループ間は既定で深度バッファが
+ * クリアされるため、ラベルが円周線（`RENDERING_GROUP_ID`）の背後に回り込んでも文字が
+ * 常に手前へ描かれ、可読性を保てる（2D/3D 共通）。
+ */
+const LABEL_RENDERING_GROUP_ID = 2;
 const LABEL_MAX_DT_SIZE = 1024;
 const LABEL_MIN_DT_SIZE = 32;
 const LABEL_GAP_FONT_RATIO = 0.0;
@@ -180,7 +186,7 @@ const createLabelMesh = (
         scene,
     );
     mesh.billboardMode = AbstractMesh.BILLBOARDMODE_ALL;
-    mesh.renderingGroupId = RENDERING_GROUP_ID;
+    mesh.renderingGroupId = LABEL_RENDERING_GROUP_ID;
     mesh.isPickable = false;
     mesh.parent = parent;
 

--- a/src/terrain/geo/globeCircleManager.ts
+++ b/src/terrain/geo/globeCircleManager.ts
@@ -74,8 +74,13 @@ export interface GlobeCircleManager {
     remove(id: string): void;
     /** 表示/非表示を切り替える（中心点・円周線・壁・ラベルをまとめて）。 */
     setEnabled(id: string, enabled: boolean): void;
+    /**
+     * 2D（トップダウン正射）縮退の有効/無効を切り替える (#395)。内部ポリゴンへ委譲し、
+     * `true` で壁（カーテン）を無効化して接地リングのみを残す。`false` で復元する。
+     */
+    setFlatten(flat: boolean): void;
     /** 毎フレーム: 地形へ再ドレープし距離スケールを更新する。 */
-    update(cameraEcef?: Vector3): void;
+    update(cameraEcef?: Vector3, flatScale?: number): void;
     /** 全サークルを破棄する。 */
     dispose(): void;
 }
@@ -199,7 +204,8 @@ export const createGlobeCircleManager = (
         add,
         remove,
         setEnabled,
-        update: (cameraEcef) => polygons.update(cameraEcef),
+        setFlatten: (flat) => polygons.setFlatten(flat),
+        update: (cameraEcef, flatScale) => polygons.update(cameraEcef, flatScale),
         dispose: () => {
             disposed = true;
             polygons.dispose();

--- a/src/terrain/geo/globeMarkerManager.ts
+++ b/src/terrain/geo/globeMarkerManager.ts
@@ -165,7 +165,6 @@ export const createGlobeMarkerManager = (
             undefined,
             flat ? 0 : undefined,
         );
-        const lineHeight = computeOverlayLineHeight(dist);
 
         // ポール: 地心 up 沿い、地表から lineHeight。径は距離スケールでスクリーン定。
         // 2D（flat）ではポールを描かず、アイコン/ラベルを地表へアンカーする (#395)。
@@ -176,6 +175,9 @@ export const createGlobeMarkerManager = (
             }
             return;
         }
+        // lineHeight は 3D（!flat）でのみ使うため、flat 早期 return の後に算出して
+        // 2D の毎フレーム・全マーカーでの不要計算を避ける。
+        const lineHeight = computeOverlayLineHeight(dist);
         orientYToUpToRef(up, quat);
         node.lineMesh.rotationQuaternion!.copyFrom(quat);
         const diameter = node.poleBaseDiameter * distScale;

--- a/src/terrain/geo/globeMarkerManager.ts
+++ b/src/terrain/geo/globeMarkerManager.ts
@@ -85,6 +85,11 @@ export interface GlobeMarkerManager {
     /** 表示/非表示を切り替える。 */
     setEnabled(id: string, enabled: boolean): void;
     /**
+     * 2D（トップダウン正射）縮退の有効/無効を切り替える (#395)。`true` で全マーカーの
+     * ドロップ線（ポール）を無効化し、アイコン/ラベルを地表へアンカーする。`false` で復元する。
+     */
+    setFlatten(flat: boolean): void;
+    /**
      * 毎フレーム: 地形標高へ接地・距離スケール・ポール向き（地心 up）を更新する。
      * `cameraEcef` は呼び出し側がフレーム単位で 1 回計算した値を渡す（再計算回避）。
      */
@@ -125,6 +130,9 @@ export const createGlobeMarkerManager = (
     let seq = 0;
     // dispose 後の use-after-dispose を防ぐフラグ（平面版 MarkerManager と同様）。
     let disposed = false;
+    // 2D（トップダウン正射）縮退フラグ (#395)。true の間はポールを無効化し、
+    // アイコン/ラベルを地表へアンカーする。3D 復帰（false）で元の表示へ戻る。
+    let flat = false;
 
     // 毎フレーム再利用するスクラッチ。
     const pos = new Vector3();
@@ -152,6 +160,14 @@ export const createGlobeMarkerManager = (
         const lineHeight = computeOverlayLineHeight(dist);
 
         // ポール: 地心 up 沿い、地表から lineHeight。径は距離スケールでスクリーン定。
+        // 2D（flat）ではポールを描かず、アイコン/ラベルを地表へアンカーする (#395)。
+        if (flat) {
+            if (node.iconText) {
+                node.iconText.mesh.scaling.set(distScale, distScale, distScale);
+                node.iconText.mesh.position.copyFrom(pos);
+            }
+            return;
+        }
         orientYToUpToRef(up, quat);
         node.lineMesh.rotationQuaternion!.copyFrom(quat);
         const diameter = node.poleBaseDiameter * distScale;
@@ -242,7 +258,8 @@ export const createGlobeMarkerManager = (
         };
         // 初期配置（camEcef なし）。update が走る前の原点 (0,0,0) 表示チラつきを防ぐ。
         placeNode(node);
-        lineMesh.setEnabled(enabled);
+        // 2D（flat）中はポールを描かない (#395)。
+        lineMesh.setEnabled(enabled && !flat);
         iconText?.mesh.setEnabled(enabled);
         nodes.set(id, node);
         return id;
@@ -273,8 +290,19 @@ export const createGlobeMarkerManager = (
         const node = nodes.get(id);
         if (!node) throw new Error(`GlobeMarkerManager.setEnabled: id "${id}" not found`);
         node.enabled = enabled;
-        node.lineMesh.setEnabled(enabled);
+        node.lineMesh.setEnabled(enabled && !flat);
         node.iconText?.mesh.setEnabled(enabled);
+    };
+
+    const setFlatten = (next: boolean): void => {
+        if (disposed) throw new Error("GlobeMarkerManager.setFlatten: called after dispose");
+        if (next === flat) return;
+        flat = next;
+        // ポールの有効可否は flat と node.enabled で決まる。アイコン/ラベルの位置は次回 update
+        // （placeNode）が flat を参照して地表/ポール先端へ再アンカーする。
+        for (const node of nodes.values()) {
+            node.lineMesh.setEnabled(node.enabled && !flat);
+        }
     };
 
     const update = (camEcef: Vector3): void => {
@@ -293,5 +321,5 @@ export const createGlobeMarkerManager = (
         for (const id of [...nodes.keys()]) remove(id);
     };
 
-    return { add, remove, setEnabled, update, dispose };
+    return { add, remove, setEnabled, setFlatten, update, dispose };
 };

--- a/src/terrain/geo/globeMarkerManager.ts
+++ b/src/terrain/geo/globeMarkerManager.ts
@@ -156,7 +156,15 @@ export const createGlobeMarkerManager = (
         // 距離は 1 回だけ算出し、スケールと線高さで再利用（sqrt の二重計算を避ける）。
         // camEcef なし（初期配置）は基準距離で仮置き。
         const dist = camEcef ? Vector3.Distance(camEcef, pos) : OVERLAY_REF_DISTANCE_M;
-        const distScale = computeOverlayDistanceScaleFromDistance(dist);
+        // 2D（flat）正射では下限スケール（MIN_SCALE）を外す。下限が残ると最大ズーム時に
+        // ワールドサイズが下限固定され、ortho フラスタム（radius 比例）だけが縮小して
+        // アイコンが不自然に大きく見える。下限なし（0）で全ズーム画面上一定にする。
+        // 3D 透視は近接時の過小化を防ぐ既定の下限を維持する。
+        const distScale = computeOverlayDistanceScaleFromDistance(
+            dist,
+            undefined,
+            flat ? 0 : undefined,
+        );
         const lineHeight = computeOverlayLineHeight(dist);
 
         // ポール: 地心 up 沿い、地表から lineHeight。径は距離スケールでスクリーン定。

--- a/src/terrain/geo/globePolygonManager.ts
+++ b/src/terrain/geo/globePolygonManager.ts
@@ -926,11 +926,14 @@ export const createGlobePolygonManager = (
             altitude: p.altitude,
         }));
         // node.id は内部 id（createLabelMesh の命名に使う）。
-        if (content.labels) {
+        // labels / edgeLabels は「キーの有無」で判定する。`{ labels: undefined }` のように
+        // 明示クリアしたいケースを反映するため `if (content.labels)`（truthy）ではなくキー存在で判定し、
+        // `content.labels?.[i]` の undefined を reconcileLabel がクリアとして扱う。
+        if ("labels" in content) {
             for (let i = 0; i < node.pointLabels.length; i++) {
                 node.pointLabels[i] = reconcileLabel(
                     node.pointLabels[i],
-                    content.labels[i],
+                    content.labels?.[i],
                     node.style,
                     node.id,
                     i,
@@ -938,11 +941,11 @@ export const createGlobePolygonManager = (
                 );
             }
         }
-        if (content.edgeLabels) {
+        if ("edgeLabels" in content) {
             for (let i = 0; i < node.edgeLabels.length; i++) {
                 node.edgeLabels[i] = reconcileLabel(
                     node.edgeLabels[i],
-                    content.edgeLabels[i],
+                    content.edgeLabels?.[i],
                     node.style,
                     node.id,
                     i,

--- a/src/terrain/geo/globePolygonManager.ts
+++ b/src/terrain/geo/globePolygonManager.ts
@@ -18,6 +18,7 @@ import { Color3 } from "@babylonjs/core/Maths/math.color";
 
 import {
     computeOverlayDistanceScale,
+    computeScreenUpToRef,
     drapedPolygonPathLength,
     writeDrapedPolygonPathsToRef,
     type LatLonPoint,
@@ -43,6 +44,14 @@ const scratchMid = new Vector3();
 const scratchBottomMid = new Vector3();
 const scratchEdgeUp = new Vector3();
 const scratchCentroid = new Vector3();
+// ラベルを画面上方向へ逃がすための screen up と、方向ベクトルを破壊せずスケールするための一時。
+const scratchScreenUp = new Vector3();
+const scratchLabelOffset = new Vector3();
+// floating origin 精度対策: tube/ribbon はパス座標を頂点バッファへ焼き込むため、真の ECEF
+// （~6.4e6）を直接渡すと float32 で精度が落ち、最大ズーム付近で線/円が揺れ・退化して消える。
+// 原点（node.top[0]）を引いたローカル座標で形状を作り、原点は mesh.position へ載せて floating
+// origin にリベースさせる（点スフィア/ラベルが mesh.position で精度を保つのと同じ仕組み）。
+const scratchOrigin = new Vector3();
 
 interface GlobePolygonPoint extends LatLonPoint {
     altitude?: number;
@@ -125,6 +134,11 @@ interface LabelEntry {
     texture: DynamicTexture;
     widthWorld: number;
     heightWorld: number;
+    /** 現在描画中のテキスト（in-place 再描画の要否判定用）。 */
+    text: string;
+    /** texture の実ピクセル寸法（in-place 再描画が収まるかの判定用）。 */
+    dtWidth: number;
+    dtHeight: number;
 }
 
 interface MeshEntry {
@@ -156,6 +170,9 @@ interface GlobePolygonNode {
     wallMat: StandardMaterial;
     top: Vector3[];
     bottom: Vector3[];
+    /** floating origin リベース用、原点（top[0]）相対のローカル座標パス（tube/ribbon 頂点用）。 */
+    relTop: Vector3[];
+    relBottom: Vector3[];
     elevs: number[];
     /** 直近 placeNode で算出した点スフィアのワールド半径 [m]（幾何ピック用, #275 P4）。 */
     pointWorldRadius: number;
@@ -165,8 +182,21 @@ export interface GlobePolygonManager {
     add(opts: GlobePolygonOptions): string;
     remove(id: string): void;
     setEnabled(id: string, enabled: boolean): void;
+    /**
+     * 2D（トップダウン正射）縮退の有効/無効を切り替える (#395)。`true` で全ポリゴンの壁
+     * （カーテン）と垂線を無効化し、接地アウトライン・頂点・ラベルのみを残す。`false` で復元する。
+     */
+    setFlatten(flat: boolean): void;
     /** 毎フレーム: 地形標高へ再ドレープし、距離スケールを更新する。 */
-    update(cameraEcef?: Vector3): void;
+    update(cameraEcef?: Vector3, flatScale?: number): void;
+    /**
+     * 点数・closed 構造を変えずに、頂点座標・点ラベル・辺ラベルのみを in-place 更新する。
+     * 既存の mesh / material / texture を再利用するため、ドラッグ編集中の毎フレーム
+     * remove→add 再構築（ラベルのチラつき要因）を回避できる。ラベルはテキスト不変なら再描画も省略、
+     * 変化時も既存テクスチャ寸法に収まれば再描画（mesh/material/texture 再利用）で更新する。
+     * 点数が一致しない・未存在 id の場合は false を返し、呼び出し側で remove/add へフォールバックする。
+     */
+    setContent(id: string, content: GlobePolygonContentUpdate): boolean;
     /**
      * 現在表示中・ピック可能な頂点（点メッシュ）の真の ECEF 位置と当該フレームの
      * ワールド半径を `out` に書き込み、件数を返す（floating origin 非依存の幾何ピック用, #275 P4）。
@@ -190,6 +220,13 @@ export interface GlobePolygonPickablePoint {
     z: number;
     /** 当該フレームの点スフィアのワールド半径 [m]（画面ほぼ定サイズ）。 */
     radius: number;
+}
+
+/** {@link GlobePolygonManager.setContent} の入力。点数・closed 構造は変えない前提。 */
+export interface GlobePolygonContentUpdate {
+    points: readonly { lat: number; lon: number; altitude?: number }[];
+    labels?: ReadonlyArray<string | null | undefined>;
+    edgeLabels?: ReadonlyArray<string | null | undefined>;
 }
 
 const toColor3 = (color: string, fallbackHex: string): Color3 => {
@@ -222,33 +259,36 @@ const labelDpr = (): number =>
         ? Math.max((globalThis as { devicePixelRatio: number }).devicePixelRatio, 1)
         : 1;
 
-const createLabelMesh = (
+// 文字幅計測用 probe テクスチャをシーン単位でキャッシュし、ラベル再描画（ドラッグ中の動的ラベルは
+// テキスト変化のたびに呼ばれる）での DynamicTexture 確保/破棄コストを抑える。シーン dispose 時に
+// テクスチャも破棄されるため WeakMap で保持し、明示破棄は不要。
+const probeTextureByScene = new WeakMap<Scene, DynamicTexture>();
+const getProbeContext = (scene: Scene): ReturnType<DynamicTexture["getContext"]> => {
+    let probe = probeTextureByScene.get(scene);
+    if (!probe) {
+        probe = new DynamicTexture("polygon-label-probe", { width: 16, height: 16 }, scene, false);
+        probeTextureByScene.set(scene, probe);
+    }
+    return probe.getContext();
+};
+
+const computeLabelDims = (
     scene: Scene,
-    id: string,
-    index: number,
     text: string,
     style: ResolvedStyle,
-    prefix: "label" | "edge-label",
-): LabelEntry => {
-    const dpr = labelDpr();
+    dpr: number,
+): { dtWidth: number; dtHeight: number } => {
     const lines = text.split("\n");
     const fontSize = Math.max(style.labelFontSize, 1);
     const padPx = Math.round(fontSize * 0.1);
     const strokePx = Math.max(2, Math.round(fontSize * 0.12));
     const lineHeightPx = fontSize * 1.2;
-    const probe = new DynamicTexture(
-        `${id}-${prefix}-probe-${index}`,
-        { width: 16, height: 16 },
-        scene,
-        false,
-    );
-    const probeCtx = probe.getContext();
+    const probeCtx = getProbeContext(scene);
     probeCtx.font = `${fontSize}px sans-serif`;
     let maxLineWidth = 0;
     for (const line of lines) {
         maxLineWidth = Math.max(maxLineWidth, probeCtx.measureText(line || " ").width);
     }
-    probe.dispose();
 
     const innerPad = padPx + strokePx;
     const innerW = maxLineWidth + innerPad * 2;
@@ -261,15 +301,28 @@ const createLabelMesh = (
         LABEL_MIN_DT_SIZE,
         Math.min(LABEL_MAX_DT_SIZE, Math.ceil(innerH * dpr)),
     );
-    const texture = new DynamicTexture(
-        `${id}-${prefix}-${index}`,
-        { width: dtWidth, height: dtHeight },
-        scene,
-        false,
-    );
-    texture.hasAlpha = true;
-    texture.vScale = -1;
-    texture.vOffset = 1;
+    return { dtWidth, dtHeight };
+};
+
+/**
+ * 既存テクスチャへラベル文字列を（再）描画する。texture の寸法（dtWidth/dtHeight）は
+ * 呼び出し側が決め、本関数はその範囲に中央寄せで描画する。mesh / material / texture を
+ * すべて再利用するため、GPU エフェクトの再コンパイルが起きず 1 フレームの空白（チラつき）を生まない。
+ */
+const paintLabel = (
+    texture: DynamicTexture,
+    text: string,
+    style: ResolvedStyle,
+    dtWidth: number,
+    dtHeight: number,
+    dpr: number,
+): void => {
+    const lines = text.split("\n");
+    const fontSize = Math.max(style.labelFontSize, 1);
+    const padPx = Math.round(fontSize * 0.1);
+    const strokePx = Math.max(2, Math.round(fontSize * 0.12));
+    const lineHeightPx = fontSize * 1.2;
+    const innerPad = padPx + strokePx;
     const ctx = texture.getContext() as unknown as CanvasRenderingContext2D;
     ctx.clearRect(0, 0, dtWidth, dtHeight);
     if (style.labelBackgroundColor && style.labelBackgroundColor !== "transparent") {
@@ -293,6 +346,28 @@ const createLabelMesh = (
         ctx.fillText(lines[i], centerX, startY + i * lineHeightPx * dpr);
     }
     texture.update(false);
+};
+
+const createLabelMesh = (
+    scene: Scene,
+    id: string,
+    index: number,
+    text: string,
+    style: ResolvedStyle,
+    prefix: "label" | "edge-label",
+): LabelEntry => {
+    const dpr = labelDpr();
+    const { dtWidth, dtHeight } = computeLabelDims(scene, text, style, dpr);
+    const texture = new DynamicTexture(
+        `${id}-${prefix}-${index}`,
+        { width: dtWidth, height: dtHeight },
+        scene,
+        false,
+    );
+    texture.hasAlpha = true;
+    texture.vScale = -1;
+    texture.vOffset = 1;
+    paintLabel(texture, text, style, dtWidth, dtHeight, dpr);
 
     const widthWorld = dtWidth / dpr;
     const heightWorld = dtHeight / dpr;
@@ -314,7 +389,32 @@ const createLabelMesh = (
     material.emissiveColor = Color3.White();
     material.diffuseTexture = texture;
     mesh.material = material;
-    return { mesh, material, texture, widthWorld, heightWorld };
+    return { mesh, material, texture, widthWorld, heightWorld, text, dtWidth, dtHeight };
+};
+
+/**
+ * 既存ラベルのテキストを in-place で更新する。新テキストが現テクスチャ寸法に収まる場合のみ
+ * 再描画して true を返す（mesh/material/texture を再利用＝チラつき無し）。収まらない場合は
+ * false を返し、呼び出し側で作り直す。
+ *
+ * 注: テキストが短くなっても texture / 平面（widthWorld/heightWorld）は縮小しない（最大寸法を維持）。
+ * 縮小には texture・平面の作り直しが必要で、それは本関数が回避したい 1 フレームの空白（チラつき）を
+ * 再発させるため、意図的に許容する。固定幅の点ラベル（lat/lon）では寸法は実質一定で影響はない。
+ * 辺ラベル（距離/高低差）で桁数が減ると外周マージンが僅かに大きく見えるのみ（位置ずれではない）。
+ */
+const redrawLabel = (
+    scene: Scene,
+    entry: LabelEntry,
+    text: string,
+    style: ResolvedStyle,
+): boolean => {
+    if (entry.text === text) return true;
+    const dpr = labelDpr();
+    const { dtWidth, dtHeight } = computeLabelDims(scene, text, style, dpr);
+    if (dtWidth > entry.dtWidth || dtHeight > entry.dtHeight) return false;
+    paintLabel(entry.texture, text, style, entry.dtWidth, entry.dtHeight, dpr);
+    entry.text = text;
+    return true;
 };
 
 const edgeCount = (pointCount: number, closed: boolean): number =>
@@ -334,10 +434,29 @@ export const createGlobePolygonManager = (
     const nodes = new Map<string, GlobePolygonNode>();
     let seq = 0;
     let disposed = false;
+    // 2D（トップダウン正射）縮退フラグ (#395)。true の間は壁（カーテン）と垂線を無効化し、
+    // 接地アウトライン・頂点・ラベルのみを残す。3D 復帰（false）で元の表示へ戻る。
+    let flat = false;
+    // 直近フレームの距離スケール基準（add 時に新規ポリゴンを即座に正しいスケールで配置するため）。
+    // add は placeNode を distScale 既定値（=1）で実行するため、これを使わないと再構築直後の
+    // 1 フレームだけ点/ライン/ラベルが誤サイズ（特に 2D は flatScale 比で大きく乖離）で描画され、
+    // ドラッグ中の毎フレーム再構築でチラつく。update のたびに最新値をキャッシュする。
+    let lastCameraEcef: Vector3 | undefined;
+    let lastFlatScale: number | undefined;
 
     const buildPaths = (node: GlobePolygonNode): boolean => {
         let resolved = true;
-        if (node.topAltitudeMeters != null) {
+        if (flat) {
+            // 2D（トップダウン正射）では物体高度を無効化し、必ず地形標高へ接地する（マーカー parity）。
+            // 高度を残すとカメラ距離が radius-高度となり、ズームインで near クリップ面を割って
+            // オブジェクトが消える／ドラッグ時にチラつく。altitude / topAltitudeMeters は 2D では使わない。
+            // terrain 未解決の点は前回値（初期 0=海面）を保持し、非表示にはしない（マーカーと同じ）。
+            for (let i = 0; i < node.points.length; i++) {
+                const p = node.points[i];
+                const terrain = terrainElevAt(p.lat, p.lon);
+                if (terrain !== null) node.elevs[i] = terrain;
+            }
+        } else if (node.topAltitudeMeters != null) {
             for (let i = 0; i < node.elevs.length; i++) node.elevs[i] = node.topAltitudeMeters;
         } else if (node.altitudeMode === "absolute") {
             for (let i = 0; i < node.points.length; i++) {
@@ -378,7 +497,7 @@ export const createGlobePolygonManager = (
             if (entry) entry.mesh.setEnabled(visible && node.pointsEnabled);
         }
         for (const entry of node.dropMeshes) {
-            if (entry) entry.mesh.setEnabled(visible && node.verticalsEnabled);
+            if (entry) entry.mesh.setEnabled(visible && node.verticalsEnabled && !flat);
         }
         for (const entry of node.pointLabels) {
             if (entry) entry.mesh.setEnabled(visible && node.labelsEnabled);
@@ -387,10 +506,14 @@ export const createGlobePolygonManager = (
             if (entry) entry.mesh.setEnabled(visible && node.labelsEnabled && hasEdges);
         }
         node.lineMesh.setEnabled(visible && hasEdges && node.lineEnabled);
-        node.wallMesh.setEnabled(visible && hasEdges && node.wallsEnabled);
+        node.wallMesh.setEnabled(visible && hasEdges && node.wallsEnabled && !flat);
     };
 
-    const placeNode = (node: GlobePolygonNode, cameraEcef?: Vector3): void => {
+    const placeNode = (
+        node: GlobePolygonNode,
+        cameraEcef?: Vector3,
+        flatScale?: number,
+    ): void => {
         if (!buildPaths(node)) {
             applyVisibility(node);
             return;
@@ -399,17 +522,45 @@ export const createGlobePolygonManager = (
         // 先頭頂点基準だと大きなポリゴンやカメラが先頭頂点から離れたケースで
         // スケールが不自然に変化するため。closed の重複点（top[points.length]）は除外する。
         let distScale = 1;
-        if (cameraEcef) {
+        if (flat && flatScale != null) {
+            // 2D 正射（flat）では、距離由来スケールを使わず radius 比例の固定スケールを直接採用する。
+            // 距離由来だと頂点高度（top の海抜）ぶんカメラ距離が変わり、ズーム時に見かけ大きさが
+            // ばらつく（高度が「生きている」状態）。radius 比例なら ortho フラスタムと相殺し、
+            // 高度・パンに依らず全ズームで画面上サイズが一定（マーカー同等）になる。
+            distScale = flatScale;
+        } else if (cameraEcef) {
             const n = node.points.length;
             scratchCentroid.setAll(0);
             for (let i = 0; i < n; i++) scratchCentroid.addInPlace(node.top[i]);
             if (n > 0) scratchCentroid.scaleInPlace(1 / n);
-            distScale = computeOverlayDistanceScale(cameraEcef, scratchCentroid);
+            // 2D 正射（flat）では下限スケールを外し、全ズームで画面上サイズを一定に保つ
+            // （ortho フラスタムが radius 比例のため、距離比例スケールと相殺してマーカー同等になる）。
+            // 3D 透視は近接時の過小化を防ぐ既定の下限を維持する。
+            distScale = computeOverlayDistanceScale(
+                cameraEcef,
+                scratchCentroid,
+                undefined,
+                flat ? 0 : undefined,
+            );
         }
-        const pointDiameter = Math.max(node.style.pointDiameter, 0.001);
-        const pointRadius = pointDiameter * distScale * 0.5;
+        // 点（頂点マーカー）のワールド直径。マーカーと同様、distScale（= 距離比例）を掛けて
+        // ズームに依らず画面上の見かけ大きさを一定に保つ（line/label も同様にスケールするため
+        // 相対比が保たれ、ズームインで点がラインに埋もれない）。
+        const pointWorldDiameter = Math.max(node.style.pointDiameter, 0.001) * distScale;
+        const pointRadius = pointWorldDiameter * 0.5;
         node.pointWorldRadius = pointRadius;
         const labelGap = node.style.labelFontSize * distScale * LABEL_GAP_FONT_RATIO;
+        // floating origin 精度対策: tube/ribbon（line/wall/drop）の頂点は原点相対のローカル座標で
+        // 作り、原点を mesh.position に載せてリベースさせる。原点は top[0]（真の ECEF）。
+        // 差分は JS float64 で計算してから float32 頂点バッファへ落とすため、最大ズームでも精度を保つ。
+        scratchOrigin.copyFrom(node.top[0]);
+        for (let i = 0; i < node.top.length; i++) {
+            node.top[i].subtractToRef(scratchOrigin, node.relTop[i]);
+            node.bottom[i].subtractToRef(scratchOrigin, node.relBottom[i]);
+        }
+        // カメラ（render 空間）。ラベルを画面上方向へ逃がして点／線に重ねないために使う。
+        const camPos = scene.activeCamera?.globalPosition;
+        const camUp = scene.activeCamera?.upVector;
         for (let i = 0; i < node.points.length; i++) {
             const top = node.top[i];
             const bottom = node.bottom[i];
@@ -420,32 +571,40 @@ export const createGlobePolygonManager = (
             const point = node.pointMeshes[i];
             if (point) {
                 point.mesh.position.copyFrom(top);
-                point.mesh.scaling.setAll(pointDiameter * distScale);
+                point.mesh.scaling.setAll(pointWorldDiameter);
             }
 
             const drop = node.dropMeshes[i];
-            if (node.verticalsEnabled && drop) {
+            // flat（2D）では垂線は applyVisibility で常に非表示のため、非表示メッシュの
+            // 毎フレーム再生成（instance 更新）を省く（無駄な更新コスト削減）。
+            if (node.verticalsEnabled && drop && !flat) {
                 drop.mesh = CreateTube(
                     `${node.id}-drop-${i}`,
                     {
-                        path: [top, bottom],
-                        radius: Math.max(node.style.dropLineWidth, 0.001),
+                        path: [node.relTop[i], node.relBottom[i]],
+                        // 垂線も distScale を掛けて画面上の太さを一定に保つ。
+                        radius: Math.max(node.style.dropLineWidth, 0.001) * distScale,
                         instance: drop.mesh,
                     },
                     scene,
                 );
+                drop.mesh.position.copyFrom(scratchOrigin);
             }
 
             const label = node.pointLabels[i];
             if (label) {
                 label.mesh.scaling.setAll(distScale);
+                // ラベルは点を覆い隠さないよう「画面上方向」へオフセットする（平面版と同手法）。
+                // 2D トップダウン（視線=地心 up）では地心 up オフセットだと点に重なるため screen up を使う。
+                // screen up が特異な場合のみ地心 up（scratchUp）へフォールバックする。
+                const dir =
+                    camPos && camUp && computeScreenUpToRef(camPos, camUp, top, scratchScreenUp)
+                        ? scratchScreenUp
+                        : scratchUp;
+                const offset = pointRadius + label.heightWorld * distScale * 0.5 + labelGap;
                 label.mesh.position
                     .copyFrom(top)
-                    .addInPlace(
-                        scratchUp.scaleInPlace(
-                            pointRadius + label.heightWorld * distScale * 0.5 + labelGap,
-                        ),
-                    );
+                    .addInPlace(scratchLabelOffset.copyFrom(dir).scaleInPlace(offset));
             }
         }
 
@@ -454,18 +613,22 @@ export const createGlobePolygonManager = (
             node.lineMesh = CreateTube(
                 `${node.id}-outline`,
                 {
-                    path: node.top,
-                    radius: Math.max(node.style.lineWidth, 0.001),
+                    path: node.relTop,
+                    // ラインも distScale を掛けて画面上の太さを一定に保つ（マーカーの pole と同様）。
+                    radius: Math.max(node.style.lineWidth, 0.001) * distScale,
                     instance: node.lineMesh,
                 },
                 scene,
             );
-            if (node.wallsEnabled) {
+            node.lineMesh.position.copyFrom(scratchOrigin);
+            // flat（2D）では壁は applyVisibility で常に非表示のため再生成を省く。
+            if (node.wallsEnabled && !flat) {
                 node.wallMesh = CreateRibbon(
                     `${node.id}-wall`,
-                    { pathArray: [node.top, node.bottom], instance: node.wallMesh },
+                    { pathArray: [node.relTop, node.relBottom], instance: node.wallMesh },
                     scene,
                 );
+                node.wallMesh.position.copyFrom(scratchOrigin);
             }
             const count = edgeCount(node.points.length, node.closed);
             for (let i = 0; i < count; i++) {
@@ -485,15 +648,20 @@ export const createGlobePolygonManager = (
                     scratchMid.normalizeToRef(scratchEdgeUp);
                 else scratchEdgeUp.normalize();
                 label.mesh.scaling.setAll(distScale);
+                // 辺ラベルも線に重ねないよう画面上方向へ逃がす（特異時は地心 up へフォールバック）。
+                const edgeDir =
+                    camPos &&
+                    camUp &&
+                    computeScreenUpToRef(camPos, camUp, scratchMid, scratchScreenUp)
+                        ? scratchScreenUp
+                        : scratchEdgeUp;
+                const edgeOffset =
+                    Math.max(node.style.lineWidth, 0.001) * distScale +
+                    label.heightWorld * distScale * 0.5 +
+                    labelGap;
                 label.mesh.position
                     .copyFrom(scratchMid)
-                    .addInPlace(
-                        scratchEdgeUp.scaleInPlace(
-                            Math.max(node.style.lineWidth, 0.001) +
-                                label.heightWorld * distScale * 0.5 +
-                                labelGap,
-                        ),
-                    );
+                    .addInPlace(scratchLabelOffset.copyFrom(edgeDir).scaleInPlace(edgeOffset));
             }
         }
         applyVisibility(node);
@@ -640,11 +808,13 @@ export const createGlobePolygonManager = (
             wallMat,
             top: Array.from({ length: pathLen }, () => new Vector3()),
             bottom: Array.from({ length: pathLen }, () => new Vector3()),
+            relTop: Array.from({ length: pathLen }, () => new Vector3()),
+            relBottom: Array.from({ length: pathLen }, () => new Vector3()),
             elevs: opts.points.map(() => 0),
             pointWorldRadius: Math.max(style.pointDiameter, 0.001) * 0.5,
         };
         nodes.set(id, node);
-        placeNode(node);
+        placeNode(node, lastCameraEcef, lastFlatScale);
         return id;
     };
 
@@ -691,12 +861,93 @@ export const createGlobePolygonManager = (
         applyVisibility(node);
     };
 
-    const update = (cameraEcef?: Vector3): void => {
+    const setFlatten = (next: boolean): void => {
+        if (disposed) throw new Error("GlobePolygonManager.setFlatten: called after dispose");
+        if (next === flat) return;
+        flat = next;
+        // 壁/垂線の有効可否は applyVisibility が flat を参照して決めるため、全ノードへ再適用する。
+        for (const node of nodes.values()) applyVisibility(node);
+    };
+
+    const update = (cameraEcef?: Vector3, flatScale?: number): void => {
         if (disposed) throw new Error("GlobePolygonManager.update: called after dispose");
+        lastCameraEcef = cameraEcef;
+        lastFlatScale = flatScale;
         for (const node of nodes.values()) {
             if (!node.enabled) continue;
-            placeNode(node, cameraEcef);
+            placeNode(node, cameraEcef, flatScale);
         }
+    };
+
+    // ラベルを希望テキストへ合わせる。不変なら再利用、変化時も既存テクスチャに収まれば in-place 再描画
+    // （mesh/material/texture 再利用＝チラつき無し）、収まらない場合のみ作り直す。null/undefined で削除。
+    const reconcileLabel = (
+        entry: LabelEntry | null,
+        desiredText: string | null | undefined,
+        style: ResolvedStyle,
+        id: string,
+        index: number,
+        prefix: "label" | "edge-label",
+    ): LabelEntry | null => {
+        const desired = desiredText ?? null;
+        if (desired == null) {
+            if (entry) {
+                entry.texture.dispose();
+                entry.material.dispose();
+                entry.mesh.dispose();
+            }
+            return null;
+        }
+        if (entry) {
+            if (redrawLabel(scene, entry, desired, style)) return entry;
+            // 新テキストが既存テクスチャに収まらない（幅拡大）場合のみ作り直す。
+            entry.texture.dispose();
+            entry.material.dispose();
+            entry.mesh.dispose();
+        }
+        return createLabelMesh(scene, id, index, desired, style, prefix);
+    };
+
+    const setContent = (id: string, content: GlobePolygonContentUpdate): boolean => {
+        if (disposed) throw new Error("GlobePolygonManager.setContent: called after dispose");
+        const node = nodes.get(id);
+        if (!node) return false;
+        // 点数（＝辺数の前提）が変わる場合は in-place 不可。呼び出し側で remove/add する。
+        if (content.points.length !== node.points.length) return false;
+        node.points = content.points.map((p) => ({
+            lat: p.lat,
+            lon: p.lon,
+            altitude: p.altitude,
+        }));
+        // node.id は内部 id（createLabelMesh の命名に使う）。
+        if (content.labels) {
+            for (let i = 0; i < node.pointLabels.length; i++) {
+                node.pointLabels[i] = reconcileLabel(
+                    node.pointLabels[i],
+                    content.labels[i],
+                    node.style,
+                    node.id,
+                    i,
+                    "label",
+                );
+            }
+        }
+        if (content.edgeLabels) {
+            for (let i = 0; i < node.edgeLabels.length; i++) {
+                node.edgeLabels[i] = reconcileLabel(
+                    node.edgeLabels[i],
+                    content.edgeLabels[i],
+                    node.style,
+                    node.id,
+                    i,
+                    "edge-label",
+                );
+            }
+        }
+        // buildPaths が node.points から top/bottom・標高を再計算し、placeNode が
+        // tube/ribbon を instance 更新・点/ラベルを再配置する（メッシュ破棄なし）。
+        placeNode(node, lastCameraEcef, lastFlatScale);
+        return true;
     };
 
     const getPickablePoints = (out: GlobePolygonPickablePoint[]): number => {
@@ -738,5 +989,5 @@ export const createGlobePolygonManager = (
         for (const id of [...nodes.keys()]) remove(id);
     };
 
-    return { add, remove, setEnabled, update, getPickablePoints, dispose };
+    return { add, remove, setEnabled, setFlatten, update, setContent, getPickablePoints, dispose };
 };

--- a/src/terrain/geo/globePolygonManager.ts
+++ b/src/terrain/geo/globePolygonManager.ts
@@ -31,6 +31,12 @@ import {
 
 const RENDERING_GROUP_ID = 1;
 const SUBTERRAIN_RENDERING_GROUP_ID = 0;
+/**
+ * ラベルは専用の上位グループで描画する。レンダリンググループ間は既定で深度バッファが
+ * クリアされるため、ラベルが線（`RENDERING_GROUP_ID`）の背後に回り込んでも文字が常に
+ * 手前へ描かれ、可読性を保てる（2D/3D 共通）。
+ */
+const LABEL_RENDERING_GROUP_ID = 2;
 const LABEL_MAX_DT_SIZE = 1024;
 const LABEL_MIN_DT_SIZE = 32;
 
@@ -377,7 +383,7 @@ const createLabelMesh = (
         scene,
     );
     mesh.billboardMode = AbstractMesh.BILLBOARDMODE_ALL;
-    mesh.renderingGroupId = RENDERING_GROUP_ID;
+    mesh.renderingGroupId = LABEL_RENDERING_GROUP_ID;
     mesh.isPickable = false;
     const material = new StandardMaterial(
         `${id}-${prefix}-mat-${index}`,

--- a/src/terrain/geo/globePolygonManager.ts
+++ b/src/terrain/geo/globePolygonManager.ts
@@ -2,7 +2,11 @@
  * グローブ用ポリゴンマネージャ (Issue #275 Phase 4 Slice 2b-1)。
  *
  * 公開 PolygonManager 互換アダプタから渡される解決済みオプションを、ECEF 上の
- * 点・線・垂線・ラベル・壁として描画する。編集はアダプタ側の add-then-remove 再生成で扱う。
+ * 点・線・垂線・ラベル・壁として描画する。構造変化を伴う編集（点数・closed・各種フラグ・
+ * style 変更）はアダプタ側の add-then-remove 再生成で扱う。一方、点座標／ラベルのみの更新は
+ * `setContent` による in-place 更新（メッシュ破棄なしの instance 更新／ラベル再描画）で扱い、
+ * ドラッグ編集中のチラつきを防ぐ。点数不一致など in-place 不可の場合は false を返し、
+ * アダプタが再生成へフォールバックする。
  */
 import type { Scene } from "@babylonjs/core/scene";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
@@ -871,6 +875,19 @@ export const createGlobePolygonManager = (
         if (disposed) throw new Error("GlobePolygonManager.setFlatten: called after dispose");
         if (next === flat) return;
         flat = next;
+        if (flat) {
+            // 3D→2D 切替の瞬間に elevs を terrain 基準へ正規化する。これをしないと、3D で
+            // absolute / topAltitudeMeters を使っていたポリゴンの elevs（=絶対高度）が残り、
+            // 切替直後に terrainElevAt が未解決（null）だと buildPaths の flat 分岐が前回値を
+            // 保持するため 2D でも高度が生きてしまう（ズームインで near クリップを割る原因）。
+            // terrain 解決済みなら接地高度、未解決なら 0（海面）へ揃える（offset/絶対高度を除去）。
+            for (const node of nodes.values()) {
+                for (let i = 0; i < node.points.length; i++) {
+                    const p = node.points[i];
+                    node.elevs[i] = terrainElevAt(p.lat, p.lon) ?? 0;
+                }
+            }
+        }
         // 壁/垂線の有効可否は applyVisibility が flat を参照して決めるため、全ノードへ再適用する。
         for (const node of nodes.values()) applyVisibility(node);
     };

--- a/src/terrain/geo/overlayPlacement.ts
+++ b/src/terrain/geo/overlayPlacement.ts
@@ -57,23 +57,30 @@ export const computeOverlayDistanceScale = (
     cameraEcef: Vector3,
     posEcef: Vector3,
     refDistanceM: number = OVERLAY_REF_DISTANCE_M,
+    minScale: number = MIN_SCALE,
 ): number =>
     computeOverlayDistanceScaleFromDistance(
         Vector3.Distance(cameraEcef, posEcef),
         refDistanceM,
+        minScale,
     );
 
 /**
  * 既に算出済みの距離 [m] からスクリーン定スケール係数を計算する（下限あり）。
  * 距離を別途使う呼び出し側で `Vector3.Distance` の二重計算（sqrt）を避けるための入口。
+ *
+ * `minScale` は下限値。3D 透視では近接時に過小化（消失）しないよう既定 {@link MIN_SCALE}。
+ * 2D 正射ではフラスタムが radius に比例するため、下限なし（0）にすると全ズームで画面上の
+ * 見かけサイズが一定になる（マーカー同等の挙動）。
  */
 export const computeOverlayDistanceScaleFromDistance = (
     distanceM: number,
     refDistanceM: number = OVERLAY_REF_DISTANCE_M,
+    minScale: number = MIN_SCALE,
 ): number => {
     // 0 以下の基準距離は不正（Infinity/-Infinity を防ぐ）。既定値へフォールバックする。
     const ref = refDistanceM > 0 ? refDistanceM : OVERLAY_REF_DISTANCE_M;
-    return Math.max(distanceM / ref, MIN_SCALE);
+    return Math.max(distanceM / ref, minScale);
 };
 
 /**
@@ -83,6 +90,42 @@ export const computeOverlayDistanceScaleFromDistance = (
 export const computeOverlayLineHeight = (distanceM: number): number => {
     const h = distanceM * 0.1;
     return Math.min(LINE_HEIGHT_MAX, Math.max(LINE_HEIGHT_MIN, h));
+};
+
+// computeScreenUpToRef のスクラッチ（毎フレーム・点数ぶん呼ばれるため割り当て回避）。
+const _suToCam = new Vector3();
+const _suRight = new Vector3();
+
+/**
+ * ワールド点 `point` におけるカメラ視点の「画面上方向（screen up）」を `ref` に書き込む（純関数）。
+ *
+ * ラベルを点の上（画面上）へオフセットして点を覆い隠さないために使う（平面版 polygon と同手法）。
+ * カメラ上方向 `camUp` を、点→カメラ方向（`toCam`）に直交する成分へ Gram-Schmidt 射影して
+ * 正規化する。これにより 2D トップダウン（視線=地心 up）でもラベルが点に重ならない。
+ *
+ * @returns 計算できたら true（`ref` に screen up）。点とカメラが一致／`camUp` が視線と平行などの
+ *   特異時は false（`ref` は不変。呼び出し側は地心 up 等へフォールバックする）。
+ */
+export const computeScreenUpToRef = (
+    camPos: Vector3,
+    camUp: Vector3,
+    point: Vector3,
+    ref: Vector3,
+): boolean => {
+    camPos.subtractToRef(point, _suToCam);
+    const tlen = _suToCam.length();
+    if (tlen <= 1e-6) return false;
+    _suToCam.scaleInPlace(1 / tlen);
+    // right = camUp × toCam
+    Vector3.CrossToRef(camUp, _suToCam, _suRight);
+    if (_suRight.lengthSquared() < 1e-12) return false; // camUp ∥ toCam
+    _suRight.normalize();
+    // screenUp = toCam × right
+    Vector3.CrossToRef(_suToCam, _suRight, ref);
+    const slen = ref.length();
+    if (slen <= 1e-6) return false;
+    ref.scaleInPlace(1 / slen);
+    return true;
 };
 
 // surfaceOrientationToRef のスクラッチ（毎フレーム・モデル数ぶん呼ばれるため割り当て回避）。

--- a/src/terrain/polygon.ts
+++ b/src/terrain/polygon.ts
@@ -38,10 +38,15 @@ const RENDERING_GROUP_ID = 1;
 /**
  * 垂線 / 壁は地表メッシュ（既定グループ 0）と同グループで
  * 描画し、地表の深度バッファで地中部分をオクルードさせる (#186)。
- * 頂点球 / ポリライン / ラベルは引き続き `RENDERING_GROUP_ID` にて
- * 地表より手前に描画される。
+ * 頂点球 / ポリラインは `RENDERING_GROUP_ID` にて地表より手前に描画される。
  */
 const SUBTERRAIN_RENDERING_GROUP_ID = 0;
+/**
+ * ラベルは専用の上位グループで描画する。Babylon はレンダリンググループ間で
+ * 既定で深度バッファをクリアするため、ラベルが線（`RENDERING_GROUP_ID`）の
+ * 背後に回り込んでも文字が常に手前へ描かれ、可読性を保てる（2D/3D 共通）。
+ */
+const LABEL_RENDERING_GROUP_ID = 2;
 const LABEL_MAX_DT_SIZE = 1024;
 // テキストにフィットさせるため MIN は小さくし、余白は innerPad のみで表現する。
 const LABEL_MIN_DT_SIZE = 32;
@@ -309,7 +314,7 @@ const createLabelMesh = (
         scene,
     );
     mesh.billboardMode = AbstractMesh.BILLBOARDMODE_ALL;
-    mesh.renderingGroupId = RENDERING_GROUP_ID;
+    mesh.renderingGroupId = LABEL_RENDERING_GROUP_ID;
     mesh.isPickable = false;
     mesh.parent = parent;
 

--- a/src/terrain/polygonManager.ts
+++ b/src/terrain/polygonManager.ts
@@ -196,18 +196,19 @@ export const createPolygonManager = (ctx: OverlayContext): PolygonManager => {
             // material 再コンパイル起因のラベルのチラつきが無いため、再構築（dispose→再生成）で
             // 十分かつ単純。id は維持する。
             const current = prev.getHandle();
+            // labels / edgeLabels / style は「キーの有無」で判定する。`{ labels: undefined }` の
+            // ように明示的にラベルを削除（クリア）したいケースを正しく反映するため、`?? / !== undefined`
+            // ではなく `"key" in partial` を使う（Partial 型の undefined と「未指定」を区別する）。
             const merged: PolygonOptions = {
                 points: (partial.points ?? current.points).map((p) => ({ ...p })),
                 closed: partial.closed ?? current.closed,
                 altitudeMode: partial.altitudeMode ?? current.altitudeMode,
-                labels: (partial.labels !== undefined
+                labels: ("labels" in partial
                     ? partial.labels
                     : current.labels) as PolygonOptions["labels"],
                 edgeLabels:
-                    partial.edgeLabels !== undefined
-                        ? partial.edgeLabels
-                        : current.edgeLabels,
-                style: partial.style !== undefined ? partial.style : current.style,
+                    "edgeLabels" in partial ? partial.edgeLabels : current.edgeLabels,
+                style: "style" in partial ? partial.style : current.style,
                 enabled: partial.enabled ?? current.enabled,
                 verticalsEnabled:
                     partial.verticalsEnabled ?? current.verticalsEnabled,

--- a/src/terrain/polygonManager.ts
+++ b/src/terrain/polygonManager.ts
@@ -35,8 +35,9 @@ export interface PolygonManager {
     add(id: string, options: PolygonOptions): PolygonHandle;
     get(id: string): PolygonHandle | null;
     /**
-     * 部分更新。`#170` では `JpmapTerrain` 公開 API として露出しない（#173 で公開）。
-     * 内部実装としてのみ提供する。
+     * 部分更新。`partial` を現在状態へマージしてポリゴンを再構築する（id は維持）。
+     * planar は material 再コンパイル起因のチラつきが無いため再構築方式で十分。
+     * globe アダプタは点数等が不変なら in-place 更新する（`globeSceneController`）。
      */
     update(id: string, partial: PolygonUpdate): PolygonHandle;
     remove(id: string): void;
@@ -187,14 +188,40 @@ export const createPolygonManager = (ctx: OverlayContext): PolygonManager => {
             return node ? node.getHandle() : null;
         },
         update(id: string, partial: PolygonUpdate): PolygonHandle {
-            // #170 では公開しない。#173 で実装。
-            // 引数は #173 実装時に使用するため、シグネチャ維持の目的で void で
-            // 参照しておく（@typescript-eslint/no-unused-vars 対策）。
-            void id;
-            void partial;
-            throw new Error(
-                "PolygonManager.update is not implemented yet (Issue #173)",
-            );
+            if (disposed) {
+                throw new Error("PolygonManager has been disposed");
+            }
+            const prev = requireNode(id);
+            // 現在状態へ partial をマージして全再構築する。planar は globe と異なり
+            // material 再コンパイル起因のラベルのチラつきが無いため、再構築（dispose→再生成）で
+            // 十分かつ単純。id は維持する。
+            const current = prev.getHandle();
+            const merged: PolygonOptions = {
+                points: (partial.points ?? current.points).map((p) => ({ ...p })),
+                closed: partial.closed ?? current.closed,
+                altitudeMode: partial.altitudeMode ?? current.altitudeMode,
+                labels: (partial.labels !== undefined
+                    ? partial.labels
+                    : current.labels) as PolygonOptions["labels"],
+                edgeLabels:
+                    partial.edgeLabels !== undefined
+                        ? partial.edgeLabels
+                        : current.edgeLabels,
+                style: partial.style !== undefined ? partial.style : current.style,
+                enabled: partial.enabled ?? current.enabled,
+                verticalsEnabled:
+                    partial.verticalsEnabled ?? current.verticalsEnabled,
+                labelsEnabled: partial.labelsEnabled ?? current.labelsEnabled,
+                wallsEnabled: partial.wallsEnabled ?? current.wallsEnabled,
+            };
+            validateOptions(merged);
+            // 先に新ノードを生成し、成功後に旧ノードを破棄して差し替える
+            // （生成が throw した場合は旧ノード・旧状態を保持して不整合を残さない）。
+            const node = createPolygonNode(ctx.scene, id, merged);
+            prev.dispose();
+            nodes.set(id, node);
+            tickPolygon(node);
+            return node.getHandle();
         },
         remove(id: string): void {
             const node = nodes.get(id);

--- a/tests/geoOverlayPlacement.unit.spec.ts
+++ b/tests/geoOverlayPlacement.unit.spec.ts
@@ -16,6 +16,7 @@ import {
     computeOverlayDistanceScale,
     computeOverlayDistanceScaleFromDistance,
     computeOverlayLineHeight,
+    computeScreenUpToRef,
     buildDrapedPolygonPaths,
     generateGeodesicRing,
     surfaceOrientationToRef,
@@ -92,6 +93,20 @@ describe("computeOverlayDistanceScaleFromDistance", () => {
     });
     it("refDistanceM<=0 は既定値フォールバック", () => {
         expect(computeOverlayDistanceScaleFromDistance(OVERLAY_REF_DISTANCE_M, 0)).toBeCloseTo(1, 9);
+    });
+    it("minScale=0（2D 正射用）は下限なしで純比例（埋もれ・成長を防ぐ）", () => {
+        // 既定（minScale=0.1）では下限に張り付くが、0 指定では距離に純比例する。
+        expect(computeOverlayDistanceScaleFromDistance(1)).toBe(0.1);
+        expect(
+            computeOverlayDistanceScaleFromDistance(1, OVERLAY_REF_DISTANCE_M, 0),
+        ).toBeCloseTo(1 / OVERLAY_REF_DISTANCE_M, 12);
+        // computeOverlayDistanceScale 経由でも minScale が伝播する。
+        const cam = new Vector3(0, 0, 0);
+        const pos = new Vector3(50, 0, 0); // 50m（既定なら下限 0.1 に張り付く近距離）
+        expect(computeOverlayDistanceScale(cam, pos)).toBe(0.1);
+        expect(
+            computeOverlayDistanceScale(cam, pos, OVERLAY_REF_DISTANCE_M, 0),
+        ).toBeCloseTo(50 / OVERLAY_REF_DISTANCE_M, 12);
     });
 });
 
@@ -207,5 +222,38 @@ describe("surfaceOrientationToRef", () => {
         const pos = geodeticToEcef(90, 0, 0);
         const q = new Quaternion();
         expect(surfaceOrientationToRef(pos, 0, q)).toBe(false);
+    });
+});
+
+describe("computeScreenUpToRef", () => {
+    it("トップダウン（視線=地心 up）でも視線に直交する screen up を返す", () => {
+        const point = new Vector3(0, 0, 0);
+        // カメラは真上（+Y）から見下ろす。camUp は水平（例: +Z）。
+        const camPos = new Vector3(0, 100, 0);
+        const camUp = new Vector3(0, 0, 1);
+        const ref = new Vector3();
+        const ok = computeScreenUpToRef(camPos, camUp, point, ref);
+        expect(ok).toBe(true);
+        expect(ref.length()).toBeCloseTo(1, 9);
+        // 視線（point→cam = +Y）に直交。
+        const toCam = camPos.subtract(point).normalize();
+        expect(Vector3.Dot(ref, toCam)).toBeCloseTo(0, 6);
+    });
+
+    it("点とカメラが一致するときは false（ref 不変）", () => {
+        const p = new Vector3(1, 2, 3);
+        const ref = new Vector3(9, 9, 9);
+        expect(computeScreenUpToRef(p.clone(), new Vector3(0, 1, 0), p, ref)).toBe(
+            false,
+        );
+        expect(ref.x).toBe(9);
+    });
+
+    it("camUp が視線と平行のときは false（right が定義できない）", () => {
+        const point = new Vector3(0, 0, 0);
+        const camPos = new Vector3(0, 100, 0); // 視線 = +Y
+        const camUp = new Vector3(0, 1, 0); // camUp ∥ 視線
+        const ref = new Vector3();
+        expect(computeScreenUpToRef(camPos, camUp, point, ref)).toBe(false);
     });
 });

--- a/tests/globeCircleManager.unit.spec.ts
+++ b/tests/globeCircleManager.unit.spec.ts
@@ -20,6 +20,7 @@ interface AddCall {
 const addCalls: AddCall[] = [];
 const removeCalls: string[] = [];
 const setEnabledCalls: [string, boolean][] = [];
+const setFlattenCalls: boolean[] = [];
 let updateCount = 0;
 let disposeCount = 0;
 
@@ -31,6 +32,7 @@ jest.unstable_mockModule("../src/terrain/geo/globePolygonManager", () => ({
         },
         remove: (id: string) => removeCalls.push(id),
         setEnabled: (id: string, e: boolean) => setEnabledCalls.push([id, e]),
+        setFlatten: (flat: boolean) => setFlattenCalls.push(flat),
         update: () => {
             updateCount++;
         },
@@ -52,6 +54,7 @@ beforeEach(() => {
     addCalls.length = 0;
     removeCalls.length = 0;
     setEnabledCalls.length = 0;
+    setFlattenCalls.length = 0;
     updateCount = 0;
     disposeCount = 0;
 });
@@ -125,5 +128,13 @@ describe("委譲（remove/setEnabled/update/dispose）", () => {
         expect(updateCount).toBe(1);
         expect(removeCalls).toEqual(["globe-polygon-0", "globe-polygon-1"]);
         expect(disposeCount).toBe(1);
+    });
+
+    it("setFlatten は内部ポリゴンマネージャへ委譲する (#395)", () => {
+        const mgr = makeManager();
+        mgr.add({ centerLat: 35, centerLon: 139, radiusMeters: 5000 });
+        mgr.setFlatten(true);
+        mgr.setFlatten(false);
+        expect(setFlattenCalls).toEqual([true, false]);
     });
 });

--- a/tests/globeMarkerManager.unit.spec.ts
+++ b/tests/globeMarkerManager.unit.spec.ts
@@ -74,7 +74,10 @@ const validateIconUrl = jest.fn((url: string) => {
     }
 });
 
-const createdIconTexts: { mesh: { enabled: boolean; isPickable: boolean }; disposed: boolean }[] = [];
+const createdIconTexts: {
+    mesh: { enabled: boolean; isPickable: boolean; position: Vector3; scaling: Vector3 };
+    disposed: boolean;
+}[] = [];
 jest.unstable_mockModule("../src/terrain/marker", () => ({
     RENDERING_GROUP_ID: 1,
     validateIconUrl,
@@ -220,6 +223,60 @@ describe("update", () => {
         expect(Vector3.Distance(createdCylinders[0].position, after5000)).toBeLessThan(1);
         // 5000m 接地は楕円体面(elev=0)より地心距離が大きいことの傍証として十分大きい。
         expect(createdCylinders[0].position.length()).toBeGreaterThan(6_300_000);
+    });
+});
+
+describe("setFlatten (#395)", () => {
+    it("setFlatten(true) でポールを無効化し、アイコンを地表へアンカーする", () => {
+        const { mgr } = makeManager();
+        mgr.add({ lat: 35, lon: 139, text: { value: "A" } });
+        const camEcef = new Vector3(7_000_000, 0, 0);
+        // 3D（既定）配置: ポール有効・アイコンはポール先端（地表 + up*lineHeight）。
+        mgr.update(camEcef);
+        const groundLen = createdCylinders[0].position.length(); // ポール中点 ≈ 地表 + up*h/2
+        const icon3dLen = createdIconTexts[0].mesh.position.length();
+        expect(createdCylinders[0].enabled).toBe(true);
+
+        // 2D: ポール無効・アイコンは地表（ポール先端より地心距離が小さい）。
+        mgr.setFlatten(true);
+        mgr.update(camEcef);
+        expect(createdCylinders[0].enabled).toBe(false);
+        expect(createdIconTexts[0].mesh.enabled).toBe(true);
+        const icon2dLen = createdIconTexts[0].mesh.position.length();
+        expect(icon2dLen).toBeLessThan(icon3dLen);
+        expect(icon2dLen).toBeGreaterThan(0);
+        // 念のため: 地表アンカー（ポール中点より下＝地心距離が小さい）。
+        expect(icon2dLen).toBeLessThanOrEqual(groundLen + 1);
+    });
+
+    it("setFlatten(false) でポール表示を復元する", () => {
+        const { mgr } = makeManager();
+        const id = mgr.add({ lat: 35, lon: 139, text: { value: "A" } });
+        const camEcef = new Vector3(7_000_000, 0, 0);
+        mgr.setFlatten(true);
+        mgr.update(camEcef);
+        expect(createdCylinders[0].enabled).toBe(false);
+        mgr.setFlatten(false);
+        mgr.update(camEcef);
+        expect(createdCylinders[0].enabled).toBe(true);
+        // setEnabled(false) のマーカーは flat 解除後もポール非表示のまま。
+        mgr.setEnabled(id, false);
+        mgr.setFlatten(true);
+        mgr.setFlatten(false);
+        expect(createdCylinders[0].enabled).toBe(false);
+    });
+
+    it("flat 中に add したマーカーのポールも無効で生成される", () => {
+        const { mgr } = makeManager();
+        mgr.setFlatten(true);
+        mgr.add({ lat: 35, lon: 139, text: { value: "A" } });
+        expect(createdCylinders[0].enabled).toBe(false);
+    });
+
+    it("dispose 後の setFlatten は throw する", () => {
+        const { mgr } = makeManager();
+        mgr.dispose();
+        expect(() => mgr.setFlatten(true)).toThrow(/after dispose/);
     });
 });
 

--- a/tests/globePolygonManager.unit.spec.ts
+++ b/tests/globePolygonManager.unit.spec.ts
@@ -494,6 +494,30 @@ describe("setContent（in-place 更新, ラベルチラつき対策）", () => {
         expect(createdPlanes.filter((p) => p.disposeCount > 0).length).toBe(1);
     });
 
+    it("labels に明示 undefined を渡すと点ラベルをクリア（dispose）し edgeLabels は維持する (#395 / PR #407)", () => {
+        const { mgr } = makeManager();
+        const id = mgr.add({
+            points: pts3,
+            closed: true,
+            labels: ["A", "B", "C"],
+            edgeLabels: ["x", "y", "z"],
+        });
+        const pointLabelPlanes = createdPlanes.filter(
+            (p) => p.name.includes("-label-") && !p.name.includes("-edge-label-"),
+        );
+        const edgeLabelPlanes = createdPlanes.filter((p) =>
+            p.name.includes("-edge-label-"),
+        );
+        expect(pointLabelPlanes.length).toBe(3);
+        expect(edgeLabelPlanes.length).toBe(3);
+
+        // labels キーを明示 undefined で渡す → 点ラベルをクリア。edgeLabels はキー無し → 維持。
+        const ok = mgr.setContent(id, { points: pts3, labels: undefined });
+        expect(ok).toBe(true);
+        expect(pointLabelPlanes.every((p) => p.disposeCount > 0)).toBe(true);
+        expect(edgeLabelPlanes.every((p) => p.disposeCount === 0)).toBe(true);
+    });
+
     it("点数が変わる場合は false を返す（呼び出し側で再構築）", () => {
         const { mgr } = makeManager();
         const id = mgr.add({ points: pts3 });

--- a/tests/globePolygonManager.unit.spec.ts
+++ b/tests/globePolygonManager.unit.spec.ts
@@ -171,6 +171,7 @@ jest.unstable_mockModule("@babylonjs/core/Meshes/mesh", () => ({
 const { createGlobePolygonManager } = await import(
     "../src/terrain/geo/globePolygonManager"
 );
+const { geodeticToEcef } = await import("../src/terrain/geo/ecef");
 const { describe, it, expect, beforeEach } = await import("@jest/globals");
 
 const pts3 = [
@@ -375,6 +376,45 @@ describe("setFlatten (#395)", () => {
         const { mgr } = makeManager();
         mgr.dispose();
         expect(() => mgr.setFlatten(true)).toThrow(/after dispose/);
+    });
+
+    it("setFlatten(true) は flat 進入時に全頂点の terrainElevAt を引いて elevs を terrain 基準へ正規化する (#395 / PR #407)", () => {
+        // 3D で absolute 高度を使っていたポリゴンの elevs(=絶対高度) を 2D へ持ち越さないことを担保する。
+        const terrainElevAt = jest.fn<(lat: number, lon: number) => number | null>(
+            () => null,
+        );
+        const mgr = createGlobePolygonManager({
+            scene: {} as never,
+            terrainElevAt,
+        });
+        mgr.add({
+            points: pts3.map((p) => ({ ...p, altitude: 1000 })),
+            altitudeMode: "absolute",
+        });
+        terrainElevAt.mockClear();
+        mgr.setFlatten(true);
+        // flat 進入時に頂点ごとへ terrainElevAt を発行して正規化する（前回の絶対高度を保持しない）。
+        expect(terrainElevAt).toHaveBeenCalledTimes(pts3.length);
+        // terrain 未解決(null)時は接地基準 0(海面) へ揃え、ピック点が絶対高度 1000 ではなく
+        // 楕円体表面(elev=0) へ正規化されることを確認する（near クリップ割れ・チラつきの回避）。
+        mgr.update(undefined, 1);
+        const picks: {
+            polygonId: string;
+            index: number;
+            x: number;
+            y: number;
+            z: number;
+            radius: number;
+        }[] = [];
+        const n = mgr.getPickablePoints(picks);
+        expect(n).toBe(pts3.length);
+        for (let i = 0; i < n; i++) {
+            const expected = geodeticToEcef(pts3[i].lat, pts3[i].lon, 0);
+            const dx = picks[i].x - expected.x;
+            const dy = picks[i].y - expected.y;
+            const dz = picks[i].z - expected.z;
+            expect(Math.sqrt(dx * dx + dy * dy + dz * dz)).toBeLessThan(1);
+        }
     });
 });
 

--- a/tests/globePolygonManager.unit.spec.ts
+++ b/tests/globePolygonManager.unit.spec.ts
@@ -214,6 +214,9 @@ describe("add / CRUD", () => {
         expect(createdLines[0].renderingGroupId).toBe(1);
         expect(createdRibbons[0].isPickable).toBe(false);
         expect(createdRibbons[0].renderingGroupId).toBe(0);
+        // ラベル（平面）は線より上位グループ(2)で描画し、常に読めるようにする。
+        expect(createdPlanes.length).toBeGreaterThan(0);
+        expect(createdPlanes.every((p) => p.renderingGroupId === 2)).toBe(true);
     });
 
     it("1 点のみも許容し、線・壁は非表示", () => {

--- a/tests/globePolygonManager.unit.spec.ts
+++ b/tests/globePolygonManager.unit.spec.ts
@@ -17,6 +17,7 @@ interface StubMesh {
     disposeCount: number;
     position: { length: () => number; copyFrom: (v: unknown) => unknown; addInPlace: (v: unknown) => unknown };
     scaling: { setAll: (v: number) => void };
+    lastScale?: number;
     billboardMode?: number;
     setEnabled: (v: boolean) => void;
     dispose: () => void;
@@ -50,7 +51,11 @@ const stub = (name: string, bucket: StubMesh[]): StubMesh => {
                 return this;
             },
         },
-        scaling: { setAll() {} },
+        scaling: {
+            setAll(v: number) {
+                m.lastScale = v;
+            },
+        },
         setEnabled(v: boolean) {
             this.enabled = v;
         },
@@ -327,6 +332,103 @@ describe("topAltitudeMeters（固定高度）", () => {
     });
 });
 
+describe("setFlatten (#395)", () => {
+    it("setFlatten(true) で壁・垂線を無効化し、接地アウトライン/点は残す", () => {
+        const { mgr } = makeManager();
+        mgr.add({ points: pts3, wallsEnabled: true });
+        // 既定（3D）: 壁・垂線・アウトライン・点すべて有効。
+        expect(createdRibbons[0].enabled).toBe(true);
+        expect(createdDrops.every((d) => d.enabled)).toBe(true);
+        expect(createdLines[0].enabled).toBe(true);
+        // 2D: 壁・垂線が無効。接地アウトライン・点は維持。
+        mgr.setFlatten(true);
+        expect(createdRibbons[0].enabled).toBe(false);
+        expect(createdDrops.every((d) => d.enabled === false)).toBe(true);
+        expect(createdLines[0].enabled).toBe(true);
+        expect(createdPoints.every((p) => p.enabled)).toBe(true);
+    });
+
+    it("setFlatten(false) で壁・垂線を復元する", () => {
+        const { mgr } = makeManager();
+        mgr.add({ points: pts3, wallsEnabled: true });
+        mgr.setFlatten(true);
+        mgr.setFlatten(false);
+        expect(createdRibbons[0].enabled).toBe(true);
+        expect(createdDrops.every((d) => d.enabled)).toBe(true);
+    });
+
+    it("flat 中の update でも壁・垂線は無効のまま", () => {
+        const { mgr } = makeManager();
+        mgr.add({ points: pts3, wallsEnabled: true });
+        mgr.setFlatten(true);
+        mgr.update();
+        expect(createdRibbons[0].enabled).toBe(false);
+        expect(createdDrops.every((d) => d.enabled === false)).toBe(true);
+        // アウトラインは update 後も維持。
+        expect(createdLines[0].enabled).toBe(true);
+    });
+
+    it("dispose 後の setFlatten は throw する", () => {
+        const { mgr } = makeManager();
+        mgr.dispose();
+        expect(() => mgr.setFlatten(true)).toThrow(/after dispose/);
+    });
+});
+
+describe("flat + flatScale サイズ一定（#395 Task3 続き）", () => {
+    it("flat 時は点サイズが高度に依らず pointDiameter*flatScale になる", () => {
+        const { mgr } = makeManager();
+        mgr.setFlatten(true);
+        const flatScale = 4;
+        // 低高度ポリゴン。
+        mgr.add({
+            points: pts3.map((p) => ({ ...p, altitude: 500 })),
+            altitudeMode: "absolute",
+            style: { pointDiameter: 10 },
+        });
+        mgr.update(undefined, flatScale);
+        expect(createdPoints.length).toBe(3);
+        expect(createdPoints.every((p) => p.lastScale === 40)).toBe(true);
+
+        // 高度を 10 倍にしても flat スケールは不変（高度が「生きない」）。
+        createdPoints.length = 0;
+        mgr.add({
+            points: pts3.map((p) => ({ ...p, lat: p.lat + 0.01, altitude: 5000 })),
+            altitudeMode: "absolute",
+            style: { pointDiameter: 10 },
+        });
+        mgr.update(undefined, flatScale);
+        expect(createdPoints.every((p) => p.lastScale === 40)).toBe(true);
+    });
+
+    it("再 add 直後も直近 update の flatScale で配置される（再構築チラつき防止）", () => {
+        const { mgr } = makeManager();
+        mgr.setFlatten(true);
+        mgr.add({ points: pts3, style: { pointDiameter: 10 } });
+        mgr.update(undefined, 4);
+        // 再構築（remove→add 相当）。次の update を待たずに add 時点で flatScale=4 が適用される。
+        createdPoints.length = 0;
+        mgr.add({
+            points: pts3.map((p) => ({ ...p, lon: p.lon + 0.01 })),
+            style: { pointDiameter: 10 },
+        });
+        expect(createdPoints.every((p) => p.lastScale === 40)).toBe(true);
+    });
+
+    it("flat 時は absolute 高度を無視して地形へ接地する（near クリップ回避）", () => {
+        const { mgr, terrainElevAt } = makeManager();
+        mgr.setFlatten(true);
+        mgr.add({
+            points: pts3.map((p) => ({ ...p, altitude: 1500 })),
+            altitudeMode: "absolute",
+        });
+        mgr.update(undefined, 4);
+        // 3D の absolute は terrainElevAt を呼ばないが、2D（flat）では高度を捨てて
+        // 地形標高へ接地するため terrainElevAt が呼ばれる。
+        expect(terrainElevAt).toHaveBeenCalled();
+    });
+});
+
 describe("dispose 後ガード", () => {
     it("dispose 後の add/setEnabled/update は throw、二重 dispose は安全", () => {
         const { mgr } = makeManager();
@@ -345,5 +447,64 @@ describe("色フォールバック", () => {
         expect(() =>
             mgr.add({ points: pts3, outlineColor: "red", wallColor: "blue" }),
         ).not.toThrow();
+    });
+});
+
+describe("setContent（in-place 更新, ラベルチラつき対策）", () => {
+    it("同じ点数・同幅ラベルなら mesh/texture を再利用し再生成しない（true）", () => {
+        const { mgr } = makeManager();
+        const id = mgr.add({
+            points: pts3,
+            closed: true,
+            labels: ["AA", "BB", "CC"],
+            edgeLabels: ["xx", "yy", "zz"],
+        });
+        const planesAfterAdd = createdPlanes.length;
+        const ok = mgr.setContent(id, {
+            points: [
+                { lat: 35.31, lon: 138.71 },
+                { lat: 35.41, lon: 138.81 },
+                { lat: 35.31, lon: 138.91 },
+            ],
+            // 同じ文字数 → 既存テクスチャ寸法に収まり in-place 再描画。
+            labels: ["DD", "EE", "FF"],
+            edgeLabels: ["pp", "qq", "rr"],
+        });
+        expect(ok).toBe(true);
+        // 新規 plane（ラベル/点）は作られない＝メッシュ再構築なし。
+        expect(createdPlanes.length).toBe(planesAfterAdd);
+        // 既存ラベル plane は dispose されない。
+        expect(createdPlanes.every((p) => p.disposeCount === 0)).toBe(true);
+    });
+
+    it("ラベルが既存テクスチャに収まらない場合のみ当該ラベルを作り直す", () => {
+        const { mgr } = makeManager();
+        const id = mgr.add({ points: pts3, closed: true, labels: ["A", "B", "C"] });
+        const planesAfterAdd = createdPlanes.length;
+        const ok = mgr.setContent(id, {
+            points: pts3,
+            // 1 つだけ大幅に長い → 既存幅を超えるため作り直し（+1 plane, 旧 1 つ dispose）。
+            labels: ["AAAAAAAAAAAAAAAAAAAA", "B", "C"],
+        });
+        expect(ok).toBe(true);
+        expect(createdPlanes.length).toBe(planesAfterAdd + 1);
+        expect(createdPlanes.filter((p) => p.disposeCount > 0).length).toBe(1);
+    });
+
+    it("点数が変わる場合は false を返す（呼び出し側で再構築）", () => {
+        const { mgr } = makeManager();
+        const id = mgr.add({ points: pts3 });
+        const ok = mgr.setContent(id, {
+            points: [
+                { lat: 35.3, lon: 138.7 },
+                { lat: 35.4, lon: 138.8 },
+            ],
+        });
+        expect(ok).toBe(false);
+    });
+
+    it("未存在 id は false を返す", () => {
+        const { mgr } = makeManager();
+        expect(mgr.setContent("missing", { points: pts3 })).toBe(false);
     });
 });

--- a/tests/globeSceneController.unit.spec.ts
+++ b/tests/globeSceneController.unit.spec.ts
@@ -86,6 +86,9 @@ const makeStub = (
     const dragStartListeners: GlobePolygonPointDragListener[] = [];
     const dragListeners: GlobePolygonPointDragListener[] = [];
     const dragEndListeners: GlobePolygonPointDragListener[] = [];
+    // viewMode 切替の最小スタブ（#395）。adapter は gc へ委譲するだけなので、
+    // ここでは可変の currentViewMode を保持し getZoomLevel を 2D 時のみ数値で返す。
+    let mockViewMode: import("../src/lib/types").ViewMode = "3d";
     const makeSub =
         <T>(arr: T[]) =>
         (listener: T) => {
@@ -132,6 +135,11 @@ const makeStub = (
         subscribePolygonPointDragStart: makeSub(dragStartListeners),
         subscribePolygonPointDrag: makeSub(dragListeners),
         subscribePolygonPointDragEnd: makeSub(dragEndListeners),
+        getViewMode: () => mockViewMode,
+        setViewMode: (m: import("../src/lib/types").ViewMode) => {
+            mockViewMode = m;
+        },
+        getZoomLevel: () => (mockViewMode === "2d" ? 14.5 : undefined),
         dispose: () => {
             disposedFlag = true;
         },
@@ -207,9 +215,18 @@ describe("createGlobeSceneController (P4-0 globe backend adapter)", () => {
         expect(c.getTilt()).toBeCloseTo(60, 4);
     });
 
-    it("getViewMode は常に 3d、getZoomLevel は undefined", () => {
+    it("viewMode は gc へ委譲する（3d→2d で getZoomLevel が数値、3d は undefined）", () => {
         const { gc } = makeStub(35, 139, 1000, 0, 0);
         const c = createGlobeSceneController(gc, "std");
+        // 既定は 3d。2D 概念を持たないため getZoomLevel は undefined。
+        expect(c.getViewMode()).toBe("3d");
+        expect(c.getZoomLevel()).toBeUndefined();
+        // 2D へ切替えると委譲先 gc が "2d" を返し、getZoomLevel が数値になる (#395)。
+        c.setViewMode("2d");
+        expect(c.getViewMode()).toBe("2d");
+        expect(typeof c.getZoomLevel()).toBe("number");
+        // 3D へ戻すと再び undefined。
+        c.setViewMode("3d");
         expect(c.getViewMode()).toBe("3d");
         expect(c.getZoomLevel()).toBeUndefined();
     });
@@ -590,6 +607,8 @@ const makeGlobePolygonStub = (): {
     added: { id: string; opts: GlobePolygonOptions }[];
     removed: string[];
     enabledCalls: { id: string; enabled: boolean }[];
+    contentCalls: { id: string; content: unknown }[];
+    setContentResult: { value: boolean };
     disposed: () => boolean;
 } => {
     let seq = 0;
@@ -597,6 +616,8 @@ const makeGlobePolygonStub = (): {
     const added: { id: string; opts: GlobePolygonOptions }[] = [];
     const removed: string[] = [];
     const enabledCalls: { id: string; enabled: boolean }[] = [];
+    const contentCalls: { id: string; content: unknown }[] = [];
+    const setContentResult = { value: false };
     const mgr = {
         add: (opts: GlobePolygonOptions): string => {
             const id = `gp${seq++}`;
@@ -610,11 +631,23 @@ const makeGlobePolygonStub = (): {
             enabledCalls.push({ id, enabled });
         },
         update: (): void => {},
+        setContent: (id: string, content: unknown): boolean => {
+            contentCalls.push({ id, content });
+            return setContentResult.value;
+        },
         dispose: (): void => {
             disposedFlag = true;
         },
     } as unknown as GlobePolygonManager;
-    return { mgr, added, removed, enabledCalls, disposed: () => disposedFlag };
+    return {
+        mgr,
+        added,
+        removed,
+        enabledCalls,
+        contentCalls,
+        setContentResult,
+        disposed: () => disposedFlag,
+    };
 };
 
 describe("createGlobeMarkerManagerAdapter (P4-0 Slice 2a marker overlay)", () => {
@@ -823,6 +856,46 @@ describe("createGlobeMarkerManagerAdapter (P4-0 Slice 2a marker overlay)", () =>
                 m.setWallsEnabled("poly", false);
                 expect(stub.removed).toEqual(["gp0", "gp1"]);
                 expect(m.get("poly")?.wallsEnabled).toBe(false);
+            });
+
+            it("update は構造不変（点座標/ラベルのみ）なら setContent で in-place 更新し再構築しない", () => {
+                const stub = makeGlobePolygonStub();
+                stub.setContentResult.value = true; // in-place 成功を模擬
+                const m = createGlobePolygonManagerAdapter(stub.mgr, () => 1);
+                m.add("poly", { points: PTS, labels: ["a", "b"] });
+                expect(stub.added).toHaveLength(1);
+                const h = m.update("poly", {
+                    points: [
+                        { lat: 35.37, lon: 138.73 },
+                        { lat: 35.38, lon: 138.74 },
+                    ],
+                    labels: ["a2", "b2"],
+                });
+                // in-place: 再 add / remove は発生しない。
+                expect(stub.added).toHaveLength(1);
+                expect(stub.removed).toEqual([]);
+                expect(stub.contentCalls).toHaveLength(1);
+                expect(stub.contentCalls[0].id).toBe("gp0");
+                expect(h.points[0].lat).toBeCloseTo(35.37);
+                expect(h.labels?.[0]).toBe("a2");
+            });
+
+            it("update は setContent が false（点数不一致など）なら従来どおり再構築へフォールバックする", () => {
+                const stub = makeGlobePolygonStub();
+                stub.setContentResult.value = false; // in-place 不可を模擬
+                const m = createGlobePolygonManagerAdapter(stub.mgr, () => 1);
+                m.add("poly", { points: PTS });
+                const h = m.update("poly", {
+                    points: [
+                        { lat: 35.37, lon: 138.73 },
+                        { lat: 35.38, lon: 138.74 },
+                    ],
+                });
+                expect(stub.contentCalls).toHaveLength(1);
+                // フォールバックで新規 add + 旧 remove。
+                expect(stub.added).toHaveLength(2);
+                expect(stub.removed).toEqual(["gp0"]);
+                expect(h.points[1].lat).toBeCloseTo(35.38);
             });
 
             it("setEnabled は委譲し、点編集 API はハンドルを再構築する", () => {

--- a/tests/globeSceneController.unit.spec.ts
+++ b/tests/globeSceneController.unit.spec.ts
@@ -880,6 +880,24 @@ describe("createGlobeMarkerManagerAdapter (P4-0 Slice 2a marker overlay)", () =>
                 expect(h.labels?.[0]).toBe("a2");
             });
 
+            it("update に labels:undefined を渡すと既存ラベルをクリアし setContent へ undefined を渡す (#395 / PR #407)", () => {
+                const stub = makeGlobePolygonStub();
+                stub.setContentResult.value = true; // in-place 成功を模擬
+                const m = createGlobePolygonManagerAdapter(stub.mgr, () => 1);
+                m.add("poly", { points: PTS, labels: ["a", "b"] });
+                // labels キーを明示 undefined で渡す → 構造不変なので in-place 更新。
+                const h = m.update("poly", { points: PTS, labels: undefined });
+                expect(stub.added).toHaveLength(1);
+                expect(stub.removed).toEqual([]);
+                expect(stub.contentCalls).toHaveLength(1);
+                // ラベルはクリアされ、ハンドルには labels が露出しない。
+                expect(h.labels).toBeUndefined();
+                const content = stub.contentCalls[0].content as {
+                    labels?: unknown;
+                };
+                expect(content.labels).toBeUndefined();
+            });
+
             it("update は setContent が false（点数不一致など）なら従来どおり再構築へフォールバックする", () => {
                 const stub = makeGlobePolygonStub();
                 stub.setContentResult.value = false; // in-place 不可を模擬

--- a/tests/globeSceneControllerUi.unit.spec.ts
+++ b/tests/globeSceneControllerUi.unit.spec.ts
@@ -55,6 +55,8 @@ const makeGcWithScene = (
 } => {
     const onBeforeRender = makeObservable<() => void>();
     let disposedFlag = false;
+    // viewMode 切替の最小スタブ（#395）。UI は gc.getViewMode/setViewMode を参照する。
+    let mockViewMode: import("../src/lib/types").ViewMode = "3d";
     const gc = {
         camera,
         scene: {
@@ -66,6 +68,11 @@ const makeGcWithScene = (
             terrainElevAt: () => null,
             setMapType: jest.fn(),
         },
+        getViewMode: () => mockViewMode,
+        setViewMode: (m: import("../src/lib/types").ViewMode) => {
+            mockViewMode = m;
+        },
+        getZoomLevel: () => (mockViewMode === "2d" ? 14.5 : undefined),
         dispose: () => {
             disposedFlag = true;
         },
@@ -237,6 +244,52 @@ describe("globe UI コントロールパネル配線 (#275 P4-1)", () => {
         expect(camera.center).toEqual(centerBefore);
         // error コールバックも例外なく早期 return する。
         expect(() => errorCb!({ message: "denied" })).not.toThrow();
+    });
+});
+
+describe("globe 視点切替ボタン 2D/3D (#395 / #349)", () => {
+    it("ボタンは表示され、初期ラベルは現在モード（3d）に対し '2D' を示す", () => {
+        const camera = makeCamera();
+        const { gc } = makeGcWithScene(camera);
+        createGlobeSceneController(gc, "std", undefined, makeCanvas());
+        const btn = document.querySelector(
+            '[aria-label="視点切替: 2D に変更"]',
+        ) as HTMLButtonElement;
+        expect(btn).not.toBeNull();
+        // 旧実装の display:none で隠す挙動を撤去したことを担保する。
+        expect(btn.style.display).not.toBe("none");
+        expect(btn.textContent).toBe("2D");
+    });
+
+    it("クリックで gc.setViewMode を逆モードで呼び、ラベルを更新する", () => {
+        const camera = makeCamera();
+        const { gc } = makeGcWithScene(camera);
+        createGlobeSceneController(gc, "std", undefined, makeCanvas());
+        const btn = document.querySelector(
+            '[aria-label="視点切替: 2D に変更"]',
+        ) as HTMLButtonElement;
+        // 3d → クリック → 2d。ラベルは次の切替先 '3D' になる。
+        btn.click();
+        expect(gc.getViewMode()).toBe("2d");
+        expect(btn.textContent).toBe("3D");
+        expect(btn.getAttribute("aria-label")).toBe("視点切替: 3D に変更");
+        // 2d → クリック → 3d。ラベルは '2D' に戻る。
+        btn.click();
+        expect(gc.getViewMode()).toBe("3d");
+        expect(btn.textContent).toBe("2D");
+    });
+
+    it("外部 API setViewMode はラベルも同期する", () => {
+        const camera = makeCamera();
+        const { gc } = makeGcWithScene(camera);
+        const c = createGlobeSceneController(gc, "std", undefined, makeCanvas());
+        const btn = document.querySelector(
+            '[aria-label="視点切替: 2D に変更"]',
+        ) as HTMLButtonElement;
+        c.setViewMode("2d");
+        expect(gc.getViewMode()).toBe("2d");
+        expect(btn.textContent).toBe("3D");
+        expect(c.getViewMode()).toBe("2d");
     });
 });
 

--- a/tests/globeSceneControllerUi.unit.spec.ts
+++ b/tests/globeSceneControllerUi.unit.spec.ts
@@ -8,6 +8,8 @@
  * - dispose 後はズーム/コンパスのアニメーション（rAF）が camera を更新せず再スケジュールしない
  */
 import { jest } from "@jest/globals";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { Color3 } from "@babylonjs/core/Maths/math.color";
 
 import { createGlobeSceneController } from "../src/scenes/globeSceneController";
 import type { GlobeSceneController } from "../src/scenes/globe";
@@ -44,6 +46,8 @@ const makeCamera = () => ({
     yaw: 0,
     pitch: 0,
     fov: 0.8,
+    // placeSunMesh が太陽距離クランプに参照する far クリップ。
+    maxZ: 1_000_000,
 });
 
 const makeGcWithScene = (
@@ -69,9 +73,16 @@ const makeGcWithScene = (
             setMapType: jest.fn(),
         },
         getViewMode: () => mockViewMode,
-        sunLight: { setEnabled: jest.fn() },
+        // applyViewModeLighting / applyGlobeSunState（2D→3D 復帰時に呼ばれる）が参照する
+        // 最小スタブ。direction/position は in-place 更新されるため実体（Vector3/Color3）を渡す。
+        sunLight: { setEnabled: jest.fn(), intensity: 0, direction: new Vector3() },
         hemiLight: { intensity: 0 },
-        sunMesh: { setEnabled: jest.fn() },
+        sunMesh: {
+            setEnabled: jest.fn(),
+            position: new Vector3(),
+            scaling: { set: () => {} },
+        },
+        skyBaseColor: new Color3(),
         setViewMode: (m: import("../src/lib/types").ViewMode) => {
             mockViewMode = m;
         },
@@ -302,8 +313,14 @@ describe("globe 視点切替ボタン 2D/3D (#395 / #349)", () => {
             .sunLight;
         const hemiLight = (gc as unknown as { hemiLight: { intensity: number } })
             .hemiLight;
-        const sunMesh = (gc as unknown as { sunMesh: { setEnabled: jest.Mock } })
-            .sunMesh;
+        const sunMesh = (
+            gc as unknown as {
+                sunMesh: { setEnabled: jest.Mock; position: { x: number } };
+            }
+        ).sunMesh;
+        const sunLightFull = (
+            gc as unknown as { sunLight: { direction: { length: () => number } } }
+        ).sunLight;
         createGlobeSceneController(gc, "std", undefined, makeCanvas());
 
         // 3D（初期）: 太陽光は有効、半球光は通常強度。
@@ -318,11 +335,14 @@ describe("globe 視点切替ボタン 2D/3D (#395 / #349)", () => {
         expect(sunMesh.setEnabled).toHaveBeenLastCalledWith(false);
         expect(hemiLight.intensity).toBeCloseTo(1.0, 6);
 
-        // 3D へ戻すと太陽光が再び有効化される。
+        // 3D へ戻すと太陽光が再有効化され、太陽状態（方向・メッシュ）が再計算される (#395 / PR #407)。
         gc.setViewMode("3d");
         onBeforeRender.fire();
         expect(sunLight.setEnabled).toHaveBeenLastCalledWith(true);
         expect(hemiLight.intensity).toBeCloseTo(0.35, 6);
+        // 2D→3D 復帰で applyGlobeSunState が走り、太陽メッシュを再表示し方向を再計算する。
+        expect(sunMesh.setEnabled).toHaveBeenLastCalledWith(true);
+        expect(sunLightFull.direction.length()).toBeGreaterThan(0);
     });
 });
 

--- a/tests/globeSceneControllerUi.unit.spec.ts
+++ b/tests/globeSceneControllerUi.unit.spec.ts
@@ -69,6 +69,9 @@ const makeGcWithScene = (
             setMapType: jest.fn(),
         },
         getViewMode: () => mockViewMode,
+        sunLight: { setEnabled: jest.fn() },
+        hemiLight: { intensity: 0 },
+        sunMesh: { setEnabled: jest.fn() },
         setViewMode: (m: import("../src/lib/types").ViewMode) => {
             mockViewMode = m;
         },
@@ -290,6 +293,36 @@ describe("globe 視点切替ボタン 2D/3D (#395 / #349)", () => {
         expect(gc.getViewMode()).toBe("2d");
         expect(btn.textContent).toBe("3D");
         expect(c.getViewMode()).toBe("2d");
+    });
+
+    it("2D 切替で太陽光・太陽メッシュを無効化し半球光をフラットにする (#395)", () => {
+        const camera = makeCamera();
+        const { gc, onBeforeRender } = makeGcWithScene(camera);
+        const sunLight = (gc as unknown as { sunLight: { setEnabled: jest.Mock } })
+            .sunLight;
+        const hemiLight = (gc as unknown as { hemiLight: { intensity: number } })
+            .hemiLight;
+        const sunMesh = (gc as unknown as { sunMesh: { setEnabled: jest.Mock } })
+            .sunMesh;
+        createGlobeSceneController(gc, "std", undefined, makeCanvas());
+
+        // 3D（初期）: 太陽光は有効、半球光は通常強度。
+        onBeforeRender.fire();
+        expect(sunLight.setEnabled).toHaveBeenLastCalledWith(true);
+        expect(hemiLight.intensity).toBeCloseTo(0.35, 6);
+
+        // 2D へ切替: 太陽光・太陽メッシュを無効化、半球光をフラット強度へ。
+        gc.setViewMode("2d");
+        onBeforeRender.fire();
+        expect(sunLight.setEnabled).toHaveBeenLastCalledWith(false);
+        expect(sunMesh.setEnabled).toHaveBeenLastCalledWith(false);
+        expect(hemiLight.intensity).toBeCloseTo(1.0, 6);
+
+        // 3D へ戻すと太陽光が再び有効化される。
+        gc.setViewMode("3d");
+        onBeforeRender.fire();
+        expect(sunLight.setEnabled).toHaveBeenLastCalledWith(true);
+        expect(hemiLight.intensity).toBeCloseTo(0.35, 6);
     });
 });
 

--- a/tests/globeViewMode.unit.spec.ts
+++ b/tests/globeViewMode.unit.spec.ts
@@ -1,0 +1,180 @@
+/**
+ * @jest-environment jsdom
+ *
+ * globe バックエンドの 2D/3D 視点モード (#395 / #349) 統合テスト。
+ *
+ * NullEngine + jsdom で `GlobeScene.createSceneWithController` を実体構築し、
+ * GeospatialCamera の ORTHOGRAPHIC 切替・pitch=0 トップダウン・ortho フラスタム・
+ * zoomLevel 整合・3D⇄2D 往復での lat/lon/azimuth 保存・onViewModeChange の発火条件・
+ * タイルマネージャ共有（同一インスタンス維持）を検証する。3DCG の見た目は別ゲート（HITL）。
+ */
+import { describe, it, expect, jest } from "@jest/globals";
+import { NullEngine } from "@babylonjs/core/Engines/nullEngine";
+import { Camera } from "@babylonjs/core/Cameras/camera";
+
+import { GlobeScene, type GlobeSceneController } from "../src/scenes/globe";
+import { ecefToGeodetic } from "../src/terrain/geo/ecef";
+import { radiusToZoomLevel, zoomLevelToRadius } from "../src/terrain/urlState";
+
+const RENDER_W = 800;
+const RENDER_H = 600;
+
+const makeEngine = (): NullEngine =>
+    new NullEngine({
+        renderWidth: RENDER_W,
+        renderHeight: RENDER_H,
+        deterministicLockstep: false,
+        lockstepMaxSteps: 1,
+        textureSize: 512,
+    });
+
+interface Built {
+    gc: GlobeSceneController;
+    teardown: () => void;
+}
+
+const build = (
+    options: Parameters<GlobeScene["createSceneWithController"]>[2] = {},
+): Built => {
+    const engine = makeEngine();
+    const canvas = document.createElement("canvas");
+    const gc = new GlobeScene().createSceneWithController(engine, canvas, options);
+    return {
+        gc,
+        teardown: () => {
+            gc.dispose();
+            engine.dispose();
+        },
+    };
+};
+
+describe("globe 視点モード 2D/3D (#395)", () => {
+    it("既定は 3d（perspective）で getZoomLevel は undefined", () => {
+        const { gc, teardown } = build();
+        expect(gc.getViewMode()).toBe("3d");
+        expect(gc.camera.mode).toBe(Camera.PERSPECTIVE_CAMERA);
+        expect(gc.getZoomLevel()).toBeUndefined();
+        teardown();
+    });
+
+    it("setViewMode('2d') で ORTHOGRAPHIC + pitch=0 + ortho フラスタムになる", () => {
+        const { gc, teardown } = build({ lat: 35.36, lon: 138.73, radius: 60000 });
+        gc.setViewMode("2d");
+        expect(gc.getViewMode()).toBe("2d");
+        expect(gc.camera.mode).toBe(Camera.ORTHOGRAPHIC_CAMERA);
+        // GeospatialCamera は pitch を limits.pitchMin（極小値）でクランプする（≈0=トップダウン）。
+        expect(gc.camera.pitch).toBeLessThan(0.01);
+        // ortho フラスタムが radius・アスペクトから設定される。
+        const aspect = RENDER_W / RENDER_H;
+        const halfH = gc.camera.radius * Math.tan(gc.camera.fov / 2);
+        expect(gc.camera.orthoTop).toBeCloseTo(halfH, 3);
+        expect(gc.camera.orthoBottom).toBeCloseTo(-halfH, 3);
+        expect(gc.camera.orthoRight).toBeCloseTo(halfH * aspect, 3);
+        expect(gc.camera.orthoLeft).toBeCloseTo(-halfH * aspect, 3);
+        teardown();
+    });
+
+    it("getZoomLevel は 2D 時のみ radiusToZoomLevel と整合する", () => {
+        const { gc, teardown } = build({ lat: 35.36, lon: 138.73, radius: 60000 });
+        // 3D 時は undefined。
+        expect(gc.getZoomLevel()).toBeUndefined();
+        gc.setViewMode("2d");
+        const g = ecefToGeodetic(gc.camera.center);
+        const expected = radiusToZoomLevel(
+            gc.camera.radius,
+            RENDER_H,
+            g.latDeg,
+            gc.camera.fov,
+        );
+        expect(gc.getZoomLevel()).toBeCloseTo(expected, 6);
+        teardown();
+    });
+
+    it("3D⇄2D 往復で lat/lon/azimuth(yaw) と pitch が保存される", () => {
+        const { gc, teardown } = build({
+            lat: 35.36,
+            lon: 138.73,
+            radius: 60000,
+            azimuth: 30,
+            tilt: 55,
+        });
+        const before = ecefToGeodetic(gc.camera.center);
+        const yawBefore = gc.camera.yaw;
+        const pitchBefore = gc.camera.pitch;
+
+        gc.setViewMode("2d");
+        // 2D 中は yaw（方位）を保持しつつ pitch はトップダウンへ。
+        expect(gc.camera.yaw).toBeCloseTo(yawBefore, 6);
+
+        gc.setViewMode("3d");
+        const after = ecefToGeodetic(gc.camera.center);
+        expect(after.latDeg).toBeCloseTo(before.latDeg, 6);
+        expect(after.lonDeg).toBeCloseTo(before.lonDeg, 6);
+        expect(gc.camera.yaw).toBeCloseTo(yawBefore, 6);
+        // pitch（tilt）は 3D 復帰時に復元される。
+        expect(gc.camera.pitch).toBeCloseTo(pitchBefore, 6);
+        expect(gc.camera.mode).toBe(Camera.PERSPECTIVE_CAMERA);
+        teardown();
+    });
+
+    it("onViewModeChange は実変化時のみ発火する", () => {
+        const onViewModeChange = jest.fn();
+        const { gc, teardown } = build({ onViewModeChange });
+        // 同値（3d→3d）は発火しない。
+        gc.setViewMode("3d");
+        expect(onViewModeChange).not.toHaveBeenCalled();
+        // 3d→2d で 1 回。
+        gc.setViewMode("2d");
+        expect(onViewModeChange).toHaveBeenCalledTimes(1);
+        expect(onViewModeChange).toHaveBeenLastCalledWith("2d");
+        // 2d→2d は発火しない。
+        gc.setViewMode("2d");
+        expect(onViewModeChange).toHaveBeenCalledTimes(1);
+        // 2d→3d で 1 回。
+        gc.setViewMode("3d");
+        expect(onViewModeChange).toHaveBeenCalledTimes(2);
+        expect(onViewModeChange).toHaveBeenLastCalledWith("3d");
+        teardown();
+    });
+
+    it("初期 viewMode='2d' + zoomLevel で radius が zoomLevelToRadius と整合する", () => {
+        const zoomLevel = 14.5;
+        const { gc, teardown } = build({
+            lat: 35.36,
+            lon: 138.73,
+            viewMode: "2d",
+            zoomLevel,
+        });
+        expect(gc.getViewMode()).toBe("2d");
+        expect(gc.camera.mode).toBe(Camera.ORTHOGRAPHIC_CAMERA);
+        const g = ecefToGeodetic(gc.camera.center);
+        const expectedRadius = zoomLevelToRadius(
+            zoomLevel,
+            RENDER_H,
+            g.latDeg,
+            gc.camera.fov,
+        );
+        expect(gc.camera.radius).toBeCloseTo(expectedRadius, 3);
+        // 往復しても zoomLevel が整合する。
+        expect(gc.getZoomLevel()).toBeCloseTo(zoomLevel, 6);
+        teardown();
+    });
+
+    it("初期 viewMode='2d' でも onViewModeChange は初期化では発火しない（silent）", () => {
+        const onViewModeChange = jest.fn();
+        const { gc, teardown } = build({ viewMode: "2d", onViewModeChange });
+        expect(gc.getViewMode()).toBe("2d");
+        expect(onViewModeChange).not.toHaveBeenCalled();
+        teardown();
+    });
+
+    it("タイルマネージャは 2D/3D 切替で同一インスタンスを共有する（再生成しない）", () => {
+        const { gc, teardown } = build({ lat: 35.36, lon: 138.73 });
+        const tm = gc.tileManager;
+        gc.setViewMode("2d");
+        expect(gc.tileManager).toBe(tm);
+        gc.setViewMode("3d");
+        expect(gc.tileManager).toBe(tm);
+        teardown();
+    });
+});

--- a/tests/globeViewMode.unit.spec.ts
+++ b/tests/globeViewMode.unit.spec.ts
@@ -8,12 +8,12 @@
  * zoomLevel 整合・3D⇄2D 往復での lat/lon/azimuth 保存・onViewModeChange の発火条件・
  * タイルマネージャ共有（同一インスタンス維持）を検証する。3DCG の見た目は別ゲート（HITL）。
  */
-import { describe, it, expect, jest } from "@jest/globals";
+import { describe, it, expect, jest, afterEach } from "@jest/globals";
 import { NullEngine } from "@babylonjs/core/Engines/nullEngine";
 import { Camera } from "@babylonjs/core/Cameras/camera";
 
 import { GlobeScene, type GlobeSceneController } from "../src/scenes/globe";
-import { ecefToGeodetic } from "../src/terrain/geo/ecef";
+import { ecefToGeodetic, geodeticToEcef } from "../src/terrain/geo/ecef";
 import { radiusToZoomLevel, zoomLevelToRadius } from "../src/terrain/urlState";
 
 const RENDER_W = 800;
@@ -33,20 +33,31 @@ interface Built {
     teardown: () => void;
 }
 
+// 構築済みインスタンスの teardown を登録し、afterEach で必ず回収する。expect 失敗で個別
+// teardown が呼ばれず例外終了しても Engine/Scene を残さない（テスト間副作用・リーク防止）。
+const activeTeardowns: Array<() => void> = [];
+
 const build = (
     options: Parameters<GlobeScene["createSceneWithController"]>[2] = {},
 ): Built => {
     const engine = makeEngine();
     const canvas = document.createElement("canvas");
     const gc = new GlobeScene().createSceneWithController(engine, canvas, options);
-    return {
-        gc,
-        teardown: () => {
-            gc.dispose();
-            engine.dispose();
-        },
+    // teardown は idempotent。手動呼び出しと afterEach の二重実行でも一度だけ dispose する。
+    let torn = false;
+    const teardown = (): void => {
+        if (torn) return;
+        torn = true;
+        gc.dispose();
+        engine.dispose();
     };
+    activeTeardowns.push(teardown);
+    return { gc, teardown };
 };
+
+afterEach(() => {
+    for (const teardown of activeTeardowns.splice(0)) teardown();
+});
 
 describe("globe 視点モード 2D/3D (#395)", () => {
     it("既定は 3d（perspective）で getZoomLevel は undefined", () => {
@@ -175,6 +186,41 @@ describe("globe 視点モード 2D/3D (#395)", () => {
         expect(gc.tileManager).toBe(tm);
         gc.setViewMode("3d");
         expect(gc.tileManager).toBe(tm);
+        teardown();
+    });
+
+    it("setViewMode('2d') 直後（描画フレーム前）にオーバーレイを再アンカーして接地する (#395 / PR #407)", () => {
+        const { gc, teardown } = build({ lat: 35.36, lon: 138.73, radius: 60000 });
+        const pts = [
+            { lat: 35.36, lon: 138.73 },
+            { lat: 35.37, lon: 138.74 },
+            { lat: 35.36, lon: 138.75 },
+        ];
+        // 3D で absolute 高度 1000m のポリゴンを追加（この時点では elevs=1000）。
+        gc.polygonManager.add({
+            points: pts.map((p) => ({ ...p, altitude: 1000 })),
+            altitudeMode: "absolute",
+        });
+        // 描画フレームを進めずに 2D へ切替。切替直後の再アンカーで pick 点が接地(elev≈0)している
+        // ことを確認する（再アンカーが無いと次フレームまで elev=1000 のままで 1 フレーム不整合）。
+        gc.setViewMode("2d");
+        const picks: {
+            polygonId: string;
+            index: number;
+            x: number;
+            y: number;
+            z: number;
+            radius: number;
+        }[] = [];
+        const n = gc.polygonManager.getPickablePoints(picks);
+        expect(n).toBe(pts.length);
+        for (let i = 0; i < n; i++) {
+            const p = pts[picks[i].index];
+            const e = geodeticToEcef(p.lat, p.lon, 0);
+            const d = Math.hypot(picks[i].x - e.x, picks[i].y - e.y, picks[i].z - e.z);
+            // 接地済みなら elev=0 の楕円体表面とほぼ一致（未接地なら高度 1000m ぶんずれる）。
+            expect(d).toBeLessThan(1);
+        }
         teardown();
     });
 });

--- a/tests/globeViewMode.unit.spec.ts
+++ b/tests/globeViewMode.unit.spec.ts
@@ -166,6 +166,14 @@ describe("globe 視点モード 2D/3D (#395)", () => {
             gc.camera.fov,
         );
         expect(gc.camera.radius).toBeCloseTo(expectedRadius, 3);
+        // radius 更新後に ortho フラスタムが再同期され、新 radius と整合する（初期化直後の
+        // 1 フレーム不整合を防ぐ, PR #407）。
+        const aspect = RENDER_W / RENDER_H;
+        const halfH = expectedRadius * Math.tan(gc.camera.fov / 2);
+        expect(gc.camera.orthoTop).toBeCloseTo(halfH, 3);
+        expect(gc.camera.orthoBottom).toBeCloseTo(-halfH, 3);
+        expect(gc.camera.orthoRight).toBeCloseTo(halfH * aspect, 3);
+        expect(gc.camera.orthoLeft).toBeCloseTo(-halfH * aspect, 3);
         // 往復しても zoomLevel が整合する。
         expect(gc.getZoomLevel()).toBeCloseTo(zoomLevel, 6);
         teardown();

--- a/tests/polygonManager.unit.spec.ts
+++ b/tests/polygonManager.unit.spec.ts
@@ -16,6 +16,7 @@ interface StubNode {
     id: string;
     altitudeMode: "terrain" | "absolute";
     closed: boolean;
+    labels: ReadonlyArray<string> | undefined;
     points: Array<{
         lat: number;
         lon: number;
@@ -51,6 +52,7 @@ jest.unstable_mockModule("../src/terrain/polygon", () => ({
             id,
             altitudeMode,
             closed: options.closed ?? false,
+            labels: options.labels,
             points: options.points.map((p) => ({ ...p })),
             enabled: options.enabled ?? true,
             elevationResolved: altitudeMode === "absolute",
@@ -110,7 +112,7 @@ jest.unstable_mockModule("../src/terrain/polygon", () => ({
                 points: node.points.map((p) => ({ ...p })),
                 closed: node.closed,
                 altitudeMode: node.altitudeMode,
-                labels: undefined,
+                labels: node.labels,
                 style: {} as unknown as Record<string, unknown>,
                 enabled: node.enabled,
                 elevationResolved: node.elevationResolved,
@@ -513,6 +515,18 @@ describe("PolygonManager update (#173/#395)", () => {
         );
         mgr.add("a", { points: validPoints });
         expect(() => mgr.update("a", { points: [] })).toThrow(/at least 1/);
+    });
+
+    it("labels 未指定時は現在値を維持し、明示 undefined はクリアする", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createPolygonManager(ctx);
+        mgr.add("a", { points: validPoints, labels: ["A", "B", "C"] });
+        // labels キーなし → 現在値を維持。
+        const kept = mgr.update("a", { enabled: false });
+        expect(kept.labels).toEqual(["A", "B", "C"]);
+        // labels: undefined（明示）→ クリア（Partial の罠を回避）。
+        const cleared = mgr.update("a", { labels: undefined });
+        expect(cleared.labels).toBeUndefined();
     });
 });
 

--- a/tests/polygonManager.unit.spec.ts
+++ b/tests/polygonManager.unit.spec.ts
@@ -487,14 +487,32 @@ describe("PolygonManager dispose", () => {
     });
 });
 
-describe("PolygonManager update (#170 では未公開)", () => {
-    it("内部 update は throw する（#173 で実装）", () => {
+describe("PolygonManager update (#173/#395)", () => {
+    it("partial をマージして再構築し、更新後のハンドルを返す", () => {
         const { ctx } = buildCtx(0);
         const mgr = createPolygonManager(ctx);
         mgr.add("a", { points: validPoints });
-        expect(() => mgr.update("a", { enabled: false })).toThrow(
-            /not implemented/,
+        const newPoints = [
+            { lat: validPoints[0].lat + 0.001, lon: validPoints[0].lon },
+            { lat: validPoints[1].lat, lon: validPoints[1].lon },
+        ];
+        const handle = mgr.update("a", { points: newPoints, enabled: false });
+        expect(handle.points).toHaveLength(2);
+        expect(handle.points[0].lat).toBeCloseTo(newPoints[0].lat);
+        expect(handle.enabled).toBe(false);
+        // 旧ノードは破棄され新ノードへ差し替わる。
+        expect(created[0].disposed).toBe(true);
+        expect(created[created.length - 1].disposed).toBe(false);
+    });
+
+    it("未存在 id / 不正な points は throw する", () => {
+        const { ctx } = buildCtx(0);
+        const mgr = createPolygonManager(ctx);
+        expect(() => mgr.update("missing", { enabled: false })).toThrow(
+            /not found/,
         );
+        mgr.add("a", { points: validPoints });
+        expect(() => mgr.update("a", { points: [] })).toThrow(/at least 1/);
     });
 });
 


### PR DESCRIPTION
## 概要
globe バックエンドの 2D モードを Web メルカトル相当のトップダウン正射として再実装し、ポリゴン・サークル・マーカーを縮退表示する（#395）。あわせて 2D 表示で残っていたオーバーレイの不具合（消失・微小ドリフト・編集ドラッグ時のラベルのチラつき）を修正する。デモ10個のうち 2D 表示を無効化していたものを本モードに置き換える（#349）。

## 背景
- #395: 2D モードの再定義。高度不使用 / Web メルカトル相当 / 物理・skybox・日照なし / オーバーレイ縮退 / タイルキャッシュは 3D と共有。
- #349: Phase 4 デモ移行に伴う globe 2D 表示の確定。

## 変更内容

### 2D モード（トップダウン正射）
- ortho フラスタムを適用し、2D では skybox / 日照 / 物理を無効化。
- オーバーレイは高度を無効化して地形へ接地（マーカー parity）。
- 点・ライン・ラベルを radius 比例の `flatScale` で画面上サイズをズーム不変に固定。

### 不具合修正
- **ライン/サークルの float32 精度（最大ズーム付近の消失・微小ドリフト）**
  `useFloatingOrigin: true` のシーンで tube/ribbon が絶対 ECEF（~6.4M）を頂点バッファへ焼き込み float32 精度不足になるのが原因。頂点を原点（`top[0]`）相対のローカル座標で生成し、原点を `mesh.position` に載せてリベースさせる方式へ変更（`GlobePolygonNode.relTop/relBottom` 追加）。点/ラベルは従来どおり絶対 position（既に精度良好）。
- **編集ドラッグ中の点ラベルのチラつき**
  距離計測デモが毎フレーム `removePolygon→addPolygon` でポリゴン全体を再生成し、新規 material/texture の GPU エフェクトが初回 1 フレーム未準備になるのが原因。in-place 更新パスを新設して解消。
  - `globePolygonManager.setContent(id, { points, labels?, edgeLabels? })`: 点数不変ならメッシュを破棄せず座標・ラベルを更新（テキスト不変は再描画も省略、変化時も既存テクスチャに収まれば in-place 再描画、収まらない場合のみ当該ラベルのみ作り直し）。
  - アダプタ `update` が構造（点数/closed/各種フラグ/style）不変時に `setContent` へ委譲し、false 時のみ従来の remove/add フォールバック（境界検証は事前に実施）。
  - `JpmapTerrain.updatePolygon(id, partial)` を公開。距離計測デモの `rebuildPolygon` を点数一致時 `updatePolygon`（in-place）化。

### レビュー反映
- ラベル幅計測の probe テクスチャをシーン単位で WeakMap キャッシュ（毎フレームの確保/破棄を削減）。
- flat（2D）で非表示の wall/drop の毎フレーム再生成を `&& !flat` で抑止。

## 影響範囲
- **API 追加**: `JpmapTerrain.updatePolygon(id, partial)`。既存 API の挙動は不変で、in-place 最適化のみ。
- **挙動変更**: globe の `viewMode "2d"` を正式対応（従来は warn して 3D を維持）。`viewModeButton` の常時非表示を撤廃。
- **ドキュメント**: README / spec の viewMode 記述更新を別途検討（フォローアップ）。

## 検証
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run test:unit` ✅ 60 suites / **1361 passed**（setContent の in-place/フォールバック/境界、アダプタ in-place/フォールバック等を追加）
- `npm run test:visuals` ✅ 19 passed（3D/2D 回帰なし）
- セルフレビュー（4層）・セキュリティ点検: 承認（ブロッカーなし）。指摘は反映済み。

## 目視確認（HITL）
- `?terrainEngine=globe` の 2D で、最大ズームまでライン/サークルが消えず位置も安定。
- 距離計測デモの編集ドラッグで点ラベルがチラつかない。
- → ユーザー確認済み（解消）。

## 既知のフォローアップ（本 PR scope 外）
- `assertLatLonInBounds` が NaN をすり抜ける既存挙動（全ポリゴン API 共通）。将来の堅牢性改善として記録。

Closes #395

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>