### PR TITLE
docs(demos): geospatial を低レベル診断デモへ役割再定義 (#411)

### DIFF
--- a/spec/demos.md
+++ b/spec/demos.md
@@ -20,10 +20,12 @@
 | Boids フロッキング | `/boids.html` | `src/demos/boids/index.ts` | Boids アルゴリズム（分離・整列・結合）による群衆シミュレーション。高尾山山頂付近の矩形リージョン内で複数のアバターが自律的に歩き回る。アバター数スライダー・一時停止・リスタート。Model API + Polygon API (#251) の動作確認 |
 | フライトデモ | `/flight.html` | `src/demos/flight/index.ts` | 飛行機（`plane.glb`）が上空を円軌道で旋回し、Follow カメラで追跡するデモ。外部カメラ frustum API による地形タイル更新。3D/2D/Follow のカメラモード切替。Model API + 外部カメラ連携 API (#245) の動作確認 |
 | Artillery Game | `/artillery.html` | `src/demos/artillery/index.ts` | ターン制対戦ゲーム（紅 vs 青）。仰角・方位・火力を設定して砲弾を発射し相手に命中させる。Havok 物理で砲弾の重力・地形バウンドを再現 (#259) |
+| Geospatial Globe（低レベル診断） | `/geospatial.html` | `src/demos/geospatial/index.ts` | グローブ地形コア `GlobeScene`（GeospatialCamera + ECEF + floating origin）を `JpmapTerrain` を介さず直接起動する開発者向け診断デモ。floatingOrigin/LOD/タイル数の表示・`?snap=off` 比較・`window.scene`/`window.camera` 露出で内部状態を実機確認する (#275 / #349 P4-5 / #411) |
 
 ## 設計方針
 
 - **公開ライブラリ層 (`src/lib/**`) は変更しない**。デモ層 (`src/demos/**`) は `JpmapTerrain` の公開 API 経由で機能を組み立てる。
+  - 例外: `geospatial` デモのみ、グローブ地形コア `scenes/globe.ts` の `GlobeScene` を直接起動する低レベル診断デモであり、公開 API では露出しない内部状態（floatingOrigin / LOD / タイル数）の確認を目的とする。同じ `GlobeScene` は `JpmapTerrain`（`terrainEngine=globe`）も `GlobeSceneAdapter` 経由で利用するため、エンジン実装の重複はない。
 - 各デモは独立した Vite エントリ。`public/<name>.html` を追加し、`vite.config.ts` の `HTML_ENTRIES` に登録すればビルド対象になる（エントリ HTML は `root` = `public/` に集約）。
 - デモ間で共通する Babylon.js 部分は `manualChunks` の `babylonBundle` / `webgpu-shaders` / `webgl-shaders` 等に分割され、複数デモで共有される。
 - ポータルは Babylon.js を読み込まない軽量ページ。バンドルサイズ最小化のため `JpmapTerrain` を import しない。

--- a/src/demos/geospatial/index.ts
+++ b/src/demos/geospatial/index.ts
@@ -1,9 +1,16 @@
 /**
- * グローブ地形デモエントリ (Issue #275 Phase 2)。
+ * グローブ地形 低レベル診断/参照デモエントリ (Issue #275 / #349 P4-5 / #411)。
  *
- * 平面ワールドの各デモと併存する **並行スタック**。`scenes/globe.ts`（`GeospatialCamera` +
- * ECEF 楕円体 + floating origin）の地形エンジンを `/geospatial` で起動し、旧（平面）と
- * 新（グローブ）を一時併存させて実機比較できるようにする。
+ * `scenes/globe.ts` の共有コア `GlobeScene`（`GeospatialCamera` + ECEF 楕円体 +
+ * floating origin）を **`JpmapTerrain` を介さず直接起動** する開発者向けの診断デモ。
+ * 同じ `GlobeScene` を公開 API 経路（`JpmapTerrain` の `terrainEngine=globe` →
+ * `GlobeSceneAdapter`）も利用しており、エンジン重複はない（Phase 3 で統合済み）。
+ *
+ * 本デモの固有の役割は、公開 API では露出しない内部状態の実機確認:
+ * - `floatingOrigin` モード / LOD ズーム範囲 / 選択・読込タイル数の表示
+ * - `?snap=off` によるクロスレベル標高スナップの ON/OFF 比較
+ * - `window.scene` / `window.camera`（非公開）でのデバッグ
+ * `terrainEngine` の既定が `planar` のうちは、グローブ描画の最短比較経路としても機能する。
  *
  * URL（既存共有形式と後方互換, Issue #275 Phase 2 / #64 / #254）:
  * - パス/ハッシュ `@lat,lon,altitude,azimuth,tilt`（3D 共有形式。altitude ⇄ radius）
@@ -179,7 +186,7 @@ const start = async (): Promise<void> => {
                 });
             }
             updateInfo(
-                `Geospatial Globe (#275 Phase 2)\n` +
+                `Geospatial Globe (低レベル診断デモ)\n` +
                     `左ドラッグ=パン / 右ドラッグ=回転 / ホイール=ズーム / WASD=パン\n` +
                     `engine: ${engine.constructor.name} / floatingOrigin: ${floatingOrigin}\n` +
                     `fps: ${engine.getFps().toFixed(0)}\n` +
@@ -277,6 +284,6 @@ if (
 ) {
     start().catch((err) => {
         console.error("[geospatial] failed to start:", err);
-        updateInfo(`Geospatial Globe (#275 Phase 2)\n起動に失敗しました: ${String(err)}`);
+        updateInfo(`Geospatial Globe (低レベル診断デモ)\n起動に失敗しました: ${String(err)}`);
     });
 }

--- a/src/demos/portal/index.ts
+++ b/src/demos/portal/index.ts
@@ -91,9 +91,9 @@ const DEMO_LIST: readonly DemoEntry[] = [
         href: "artillery",
     },
     {
-        title: "Geospatial Globe（実験的・#275 Phase 1）",
+        title: "Geospatial Globe（低レベル診断・開発者向け）",
         description:
-            "Babylon.js 9.x の GeospatialCamera + ECEF 楕円体 + floating origin によるグローブ地形。平面ビューアと併存する移行中の新スタックです。右ドラッグ=回転 / ホイール=ズーム。",
+            "GeospatialCamera + ECEF 楕円体 + floating origin のグローブ地形コア（GlobeScene）を JpmapTerrain を介さず直接起動する診断デモ。floatingOrigin/LOD/タイル数の表示や ?snap=off 比較など内部状態の実機確認に使います。右ドラッグ=回転 / ホイール=ズーム。",
         href: "geospatial",
     },
 ];


### PR DESCRIPTION
Closes #411

## 概要
geospatial デモを「globe 低レベル診断/参照デモ」へ役割再定義（最小差分・runtime ロジック不変）。

## 背景
`GlobeScene`（scenes/globe.ts）は `JpmapTerrain` の `GlobeSceneAdapter` と geospatial デモ双方が利用する共有コアで、エンジン重複は Phase 3 で解消済み。撤去せず役割を明確化する。

## 変更
- src/demos/geospatial/index.ts: ヘッダ doc 再定義＋info ラベル更新
- src/demos/portal/index.ts: ナビ表記を診断/参照デモへ更新
- spec/demos.md: デモ一覧に geospatial 行追加＋設計方針に例外明記

## 検証
- lint / typecheck 緑
- test:unit 1368 passed
- visual regression: 対象ルート外＋描画不変のため無影響

関連: #349 P4-5 / #275 Phase 5