### PR TITLE
feat: terrainEngine 既定を globe へ切替＋デモ修正 (#413)

### DIFF
--- a/public/circle.html
+++ b/public/circle.html
@@ -52,7 +52,7 @@
     #circle-controls {
       position: absolute;
       top: 12px;
-      right: 12px;
+      right: 64px;
       pointer-events: auto;
       padding: 10px 12px;
       font-size: 13px;

--- a/public/distance.html
+++ b/public/distance.html
@@ -52,7 +52,7 @@
     #distance-controls {
       position: absolute;
       top: 12px;
-      right: 12px;
+      right: 64px;
       pointer-events: auto;
       padding: 10px 12px;
       font-size: 13px;

--- a/public/plan.html
+++ b/public/plan.html
@@ -51,7 +51,7 @@
     #plan-controls {
       position: absolute;
       top: 12px;
-      right: 12px;
+      right: 64px;
       pointer-events: auto;
       padding: 10px 12px;
       font-size: 13px;
@@ -151,7 +151,6 @@
     <div id="plan-controls">
       <strong>Plan Viewer</strong>
       <div id="plan-layer-buttons">
-        <button type="button" id="btn-view-mode" disabled>2D 表示</button>
         <button type="button" id="btn-waypoints" data-active="true" disabled>ウェイポイント</button>
         <button type="button" id="btn-geofence" data-active="true" disabled>ジオフェンス</button>
         <button type="button" id="btn-rally" data-active="true" disabled>ラリーポイント</button>

--- a/public/polygon.html
+++ b/public/polygon.html
@@ -52,7 +52,7 @@
     #polygon-controls {
       position: absolute;
       top: 12px;
-      right: 12px;
+      right: 64px;
       pointer-events: auto;
       padding: 10px 12px;
       font-size: 13px;

--- a/spec/package.md
+++ b/spec/package.md
@@ -45,6 +45,7 @@ const viewer = await JpmapTerrain.create(document.getElementById("map")!, {
 | パラメータ | 型 | デフォルト値 | 説明 |
 |---|---|---|---|
 | `engine` | `"webgpu" \| "webgl2"` | `"webgpu"` | 描画エンジン。WebGPU 非対応時は自動で WebGL2 にフォールバック |
+| `terrainEngine` | `"globe" \| "planar"` | `"globe"` | 地形描画バックエンド（Issue #349 Phase 4 / #413 Phase 5）。既定の `"globe"` は ECEF 楕円体 + GeospatialCamera + floating origin。`"planar"` は従来の平面ワールドで明示指定時のみ使用 |
 | `lat` | `number` | `35.681236` | 緯度（Babylon.js Z 軸に対応） |
 | `lon` | `number` | `139.767125` | 経度（Babylon.js X 軸に対応） |
 | `altitude` | `number` | `2000` | カメラのワールド高度（メートル）。`camera.position.y = target.y + radius·cos(beta)` で算出される値であり、カメラの地表からの距離（radius）とは異なる。Babylon.js Y 軸に対応 |

--- a/src/demos/artillery/index.ts
+++ b/src/demos/artillery/index.ts
@@ -185,7 +185,18 @@ const start = async (): Promise<void> => {
             err,
         );
         terrainEngine = "planar";
-        viewer = await JpmapTerrain.create(mount, { ...opts, terrainEngine });
+        // planar フォールバック時は JAPAN_BOUNDS 基準でカメラを再解決する (#413 review)。
+        // 初回 opts の lat/lon は globe 既定（WORLD_BOUNDS）でパース済みのため、planar の
+        // 被覆域外座標がそのまま採用されると空描画になり得る。planar 基準で再クランプして反映する。
+        const planarCamera = parseCameraStateFromUrl(location.href, {
+            terrainEngine: "planar",
+        });
+        viewer = await JpmapTerrain.create(mount, {
+            ...opts,
+            terrainEngine,
+            lat: planarCamera?.lat ?? STAGE_CENTER.lat,
+            lon: planarCamera?.lon ?? STAGE_CENTER.lon,
+        });
     }
     // 実際に構築されたバックエンド (#413: 未指定は lib 既定 globe)。
     // undefined を旧既定 planar と誤認して globe シーン上に planar の恒等ステージを

--- a/src/demos/artillery/index.ts
+++ b/src/demos/artillery/index.ts
@@ -177,8 +177,9 @@ const start = async (): Promise<void> => {
         viewer = await JpmapTerrain.create(mount, opts);
     } catch (err) {
         // globe 初期化に失敗した場合のみ planar へフォールバックして再試行する
-        // （planar は従来からの安定経路）。planar 自体の失敗はそのまま送出する。
-        if (terrainEngine !== "globe") throw err;
+        // （planar は従来からの安定経路）。明示的に planar を要求していた場合は
+        // そのまま送出する（#413: 未指定は globe 既定なのでフォールバック対象）。
+        if (requestedTerrainEngine === "planar") throw err;
         console.warn(
             "[artillery] globe terrain init failed; falling back to planar",
             err,
@@ -186,6 +187,10 @@ const start = async (): Promise<void> => {
         terrainEngine = "planar";
         viewer = await JpmapTerrain.create(mount, { ...opts, terrainEngine });
     }
+    // 実際に構築されたバックエンド (#413: 未指定は lib 既定 globe)。
+    // undefined を旧既定 planar と誤認して globe シーン上に planar の恒等ステージを
+    // 構築すると、大砲が ECEF 外（原点付近）に配置され表示されない。viewer の実効値に従う。
+    terrainEngine = viewer.terrainEngine;
     // Issue #259: 現在地ボタン（GPS）は砲撃ゲームには不要なので非表示にする。
     viewer.showLocateMe = false;
 
@@ -222,7 +227,7 @@ const start = async (): Promise<void> => {
     // --- ステージ座標フレーム（planar=恒等 / globe=ENU→ECEF stageRoot） ---
     // globe では物理・配置をローカル ENU（= planar と同一規約）で扱い、描画と Havok の
     // floating-origin region 機能で ECEF を float32 安全に解く（#404）。
-    const stage: StageFrame = createStageFrame(scene, terrainEngine ?? "planar", {
+    const stage: StageFrame = createStageFrame(scene, terrainEngine ?? "globe", {
         lat: STAGE_CENTER.lat,
         lon: STAGE_CENTER.lon,
         alt: 0,

--- a/src/demos/artillery/terrainEngine.ts
+++ b/src/demos/artillery/terrainEngine.ts
@@ -15,7 +15,7 @@ import type { TerrainEngine } from "../../lib/types";
 export interface ArtilleryEngineResolution {
     /**
      * `JpmapTerrain.create` に渡す地形バックエンド。
-     * `undefined` は未指定（lib 既定 = planar）。
+     * `undefined` は未指定（lib 既定 = globe, #413）。
      */
     engine: TerrainEngine | undefined;
 }

--- a/src/demos/avatar-controller/index.ts
+++ b/src/demos/avatar-controller/index.ts
@@ -15,7 +15,7 @@
  * - 地面クリックでスポーン地点を変更
  * - 進行方向に自動回転
  * - 地形追従（`altitudeMode: "terrain"`, `gravity: true`）
- * - 地形バックエンド: `?terrainEngine=globe|planar`（既定 planar, #275 Phase 4 / P4-2）
+ * - 地形バックエンド: `?terrainEngine=globe|planar`（既定 globe, #275 Phase 5 #413）
  *   globe では自動スクロール追従はカメラ中心（viewer.lat/lon）駆動で行う
  */
 import { JpmapTerrain } from "../../lib/jpmapTerrain";
@@ -23,7 +23,7 @@ import type { JpmapTerrainOptions, TerrainClickEvent } from "../../lib/types";
 import {
     parseCameraStateFromUrl,
     parseMapTypeFromUrl,
-    resolveTerrainEngine,
+    resolveEffectiveTerrainEngine,
 } from "../../terrain/urlState";
 import { GamepadManager } from "@babylonjs/core/Gamepads/gamepadManager";
 import type { GenericPad } from "@babylonjs/core/Gamepads/gamepad";
@@ -92,7 +92,10 @@ const start = async (): Promise<void> => {
 
     const camera = parseCameraStateFromUrl(location.href);
     const mapType = parseMapTypeFromUrl(location.href);
-    const terrainEngine = resolveTerrainEngine(location.search);
+    // 実効エンジンで解決する（未指定は lib 既定 globe, #413）。undefined を旧既定 planar と
+    // 誤認すると、globe シーン上で planar 用の方位規約（azimuth 符号）・追従ロジックが適用され、
+    // 移動方向がカメラ向きに追従しない（北固定に見える）リグレッションを起こすため。
+    const terrainEngine = resolveEffectiveTerrainEngine(location.search);
     // globe バックエンドでは ArcRotateCamera("terrain-camera") と external frustum
     // 系（detachTileCamera / refreshTerrainWithExternalFrustum）が存在しない（globe では
     // GeospatialCamera ベースでタイルは camera.center 駆動で自動ストリーミングされる）。

--- a/src/demos/avatar/index.ts
+++ b/src/demos/avatar/index.ts
@@ -12,7 +12,7 @@
  * - 地形追従（`altitudeMode: "terrain"`, `gravity: true`）
  * - 半径・速度のスライダー操作
  * - アニメーション開始/停止トグル
- * - 地形バックエンド: `?terrainEngine=globe|planar`（既定 planar, #275 Phase 4 / P4-2）
+ * - 地形バックエンド: `?terrainEngine=globe|planar`（既定 globe, #275 Phase 5 #413）
  */
 import { JpmapTerrain } from "../../lib/jpmapTerrain";
 import type { JpmapTerrainOptions, TerrainClickEvent } from "../../lib/types";

--- a/src/demos/boids/index.ts
+++ b/src/demos/boids/index.ts
@@ -7,7 +7,7 @@
  * - Model API (`addModel` / `updateModel` / `playModelAnimation`) を使用
  * - Polygon API (`addPolygon`, `closed: true`) でリージョン境界を描画
  * - 地形追従 (`altitudeMode: "terrain"`, `gravity: true`)
- * - 地形バックエンド: `?terrainEngine=globe|planar`（既定 planar, #275 Phase 4 / P4-2）
+ * - 地形バックエンド: `?terrainEngine=globe|planar`（既定 globe, #275 Phase 5 #413）
  */
 import { JpmapTerrain } from "../../lib/jpmapTerrain";
 import type { JpmapTerrainOptions } from "../../lib/types";

--- a/src/demos/circle/index.ts
+++ b/src/demos/circle/index.ts
@@ -175,20 +175,7 @@ const buildControls = (
         }),
     );
 
-    // 3D / 2D 視点モード切替
-    {
-        const btn = document.createElement("button");
-        btn.type = "button";
-        const refresh = (): void => {
-            btn.textContent = viewer.viewMode === "3d" ? "2D 表示" : "3D 表示";
-        };
-        btn.addEventListener("click", () => {
-            viewer.viewMode = viewer.viewMode === "3d" ? "2d" : "3d";
-        });
-        viewer.onViewModeChange(() => refresh());
-        refresh();
-        container.appendChild(btn);
-    }
+    // 3D / 2D 視点モード切替はライブラリ内蔵ボタン（コンパス直下）を使用する (Issue #193)。
 
     // updateCircle デモ: 半径を段階的に変更
     const editTargetId = "yomiuri-terrain";
@@ -276,7 +263,6 @@ const start = async (): Promise<void> => {
         ...(terrainEngine ? { terrainEngine } : {}),
         ...(cameraState ?? defaultCamera),
         ...(mapType !== null ? { mapType } : {}),
-        showViewModeButton: false,
     };
 
     const viewer = await JpmapTerrain.create(mount, opts);

--- a/src/demos/distance/index.ts
+++ b/src/demos/distance/index.ts
@@ -257,8 +257,6 @@ const start = async (): Promise<void> => {
         ...(terrainEngine ? { terrainEngine } : {}),
         ...(cameraState ?? defaultCamera),
         ...(mapType !== null ? { mapType } : {}),
-        // ライブラリ内蔵の視点モード切替ボタンは非表示。デモ独自の UI を提供する (Issue #193)。
-        showViewModeButton: false,
     };
 
     const viewer = await JpmapTerrain.create(mount, opts);
@@ -305,24 +303,12 @@ const start = async (): Promise<void> => {
     const toolbar = document.getElementById(TOOLBAR_ID);
     if (toolbar instanceof HTMLElement) {
         buildToolbar(toolbar, state, onStateChange);
-        // 3D / 2D 視点モード切替 (Issue #193)
-        // ライブラリ内蔵ボタンは showViewModeButton:false で非表示。
-        const viewModeBtn = document.createElement("button");
-        viewModeBtn.type = "button";
-        viewModeBtn.dataset.distanceAction = "viewMode";
-        const refreshViewModeBtn = (): void => {
-            viewModeBtn.textContent =
-                viewer.viewMode === "3d" ? "2D 表示" : "3D 表示";
-            // 2D/3D で編集ヒント（高度操作の可否）が変わるため再描画する。
-            updateStatus(state, statusEl, viewer.viewMode === "2d");
-        };
-        viewModeBtn.addEventListener("click", () => {
-            viewer.viewMode = viewer.viewMode === "3d" ? "2d" : "3d";
-        });
-        viewer.onViewModeChange(() => refreshViewModeBtn());
-        refreshViewModeBtn();
-        toolbar.appendChild(viewModeBtn);
     }
+    // 3D / 2D 視点モード切替はライブラリ内蔵ボタン（コンパス直下）を使用する (Issue #193)。
+    // 視点モードで編集ヒント（高度操作の可否）が変わるため、切替時にステータスを再描画する。
+    viewer.onViewModeChange(() => {
+        updateStatus(state, statusEl, viewer.viewMode === "2d");
+    });
 
     // モード別のカーソル表示 (#186)。
     //

--- a/src/demos/flight/index.ts
+++ b/src/demos/flight/index.ts
@@ -26,7 +26,7 @@ import type { JpmapTerrainOptions, TerrainClickEvent } from "../../lib/types";
 import {
     parseCameraStateFromUrl,
     parseMapTypeFromUrl,
-    resolveTerrainEngine,
+    resolveEffectiveTerrainEngine,
 } from "../../terrain/urlState";
 import { circularOrbitPosition, circularOrbitHeading } from "../avatar/orbit";
 import { geodeticToEcefToRef } from "../../terrain/geo/ecef";
@@ -110,10 +110,12 @@ const start = async (): Promise<void> => {
     const mount = document.getElementById(DEMO_MOUNT_ID);
     if (!mount) return;
 
-    const camera = parseCameraStateFromUrl(location.href);
+    // `?terrainEngine=globe|planar`（未指定/不正は lib 既定 globe (#413)）。
+    // 実効エンジンで解決することで、globe シーン上で planar 用の初期高度を選ぶ
+    // 既定化リグレッション（飛行機が見えない）を防ぐ。
+    const terrainEngine = resolveEffectiveTerrainEngine(location.search);
+    const camera = parseCameraStateFromUrl(location.href, { terrainEngine });
     const mapType = parseMapTypeFromUrl(location.href);
-    // `?terrainEngine=globe|planar`（未指定/不正は undefined → lib 既定 planar）。
-    const terrainEngine = resolveTerrainEngine(location.search);
 
     const opts: JpmapTerrainOptions = {
         engine: resolveEngine(location.search),

--- a/src/demos/geospatial/index.ts
+++ b/src/demos/geospatial/index.ts
@@ -10,7 +10,7 @@
  * - `floatingOrigin` モード / LOD ズーム範囲 / 選択・読込タイル数の表示
  * - `?snap=off` によるクロスレベル標高スナップの ON/OFF 比較
  * - `window.scene` / `window.camera`（非公開）でのデバッグ
- * `terrainEngine` の既定が `planar` のうちは、グローブ描画の最短比較経路としても機能する。
+ * 既定が `globe` となった現在（#413）も、`JpmapTerrain` を介さない最短のグローブ診断経路として機能する。
  *
  * URL（既存共有形式と後方互換, Issue #275 Phase 2 / #64 / #254）:
  * - パス/ハッシュ `@lat,lon,altitude,azimuth,tilt`（3D 共有形式。altitude ⇄ radius）

--- a/src/demos/plan/index.ts
+++ b/src/demos/plan/index.ts
@@ -35,7 +35,6 @@ const DROP_ZONE_ID = "plan-drop-zone";
 const BTN_WAYPOINTS_ID = "btn-waypoints";
 const BTN_GEOFENCE_ID = "btn-geofence";
 const BTN_RALLY_ID = "btn-rally";
-const BTN_VIEW_MODE_ID = "btn-view-mode";
 
 // 描画 ID プレフィックス
 const ID_WAYPOINTS = "plan-waypoints";
@@ -293,7 +292,6 @@ const start = async (): Promise<void> => {
         ...(terrainEngine ? { terrainEngine } : {}),
         ...(cameraState ?? defaultCamera),
         ...(mapType !== null ? { mapType } : {}),
-        showViewModeButton: false,
     };
 
     const viewer = await JpmapTerrain.create(mount, opts);
@@ -307,27 +305,11 @@ const start = async (): Promise<void> => {
     const layerVisible = { waypoints: true, geofence: true, rally: true };
 
     // ボタン要素
-    const btnViewMode = document.getElementById(BTN_VIEW_MODE_ID) as HTMLButtonElement | null;
     const btnWaypoints = document.getElementById(BTN_WAYPOINTS_ID) as HTMLButtonElement | null;
     const btnGeofence = document.getElementById(BTN_GEOFENCE_ID) as HTMLButtonElement | null;
     const btnRally = document.getElementById(BTN_RALLY_ID) as HTMLButtonElement | null;
 
-    // 2D/3D 視点モード切替
-    const refreshViewModeBtn = (): void => {
-        if (btnViewMode) {
-            const label = viewer.viewMode === "3d" ? "2D 表示" : "3D 表示";
-            btnViewMode.textContent = label;
-            btnViewMode.setAttribute("aria-label", label);
-        }
-    };
-    if (btnViewMode) {
-        btnViewMode.addEventListener("click", () => {
-            viewer.viewMode = viewer.viewMode === "3d" ? "2d" : "3d";
-        });
-        btnViewMode.disabled = false;
-    }
-    viewer.onViewModeChange(() => refreshViewModeBtn());
-    refreshViewModeBtn();
+    // 2D/3D 視点モード切替はライブラリ内蔵ボタン（コンパス直下）を使用する (Issue #193)。
 
     const refreshButtons = (hasPlan: boolean): void => {
         if (btnWaypoints) {

--- a/src/demos/polygon/index.ts
+++ b/src/demos/polygon/index.ts
@@ -195,22 +195,7 @@ const buildControls = (
         }),
     );
 
-    // 3D / 2D 視点モード切替 (Issue #193)
-    // ライブラリ内蔵ボタンは showViewModeButton:false で非表示にしているため、
-    // ここに同等機能のボタンを置いて API 経由で切替する。
-    {
-        const btn = document.createElement("button");
-        btn.type = "button";
-        const refresh = (): void => {
-            btn.textContent = viewer.viewMode === "3d" ? "2D 表示" : "3D 表示";
-        };
-        btn.addEventListener("click", () => {
-            viewer.viewMode = viewer.viewMode === "3d" ? "2d" : "3d";
-        });
-        viewer.onViewModeChange(() => refresh());
-        refresh();
-        container.appendChild(btn);
-    }
+    // 3D / 2D 視点モード切替はライブラリ内蔵ボタン（コンパス直下）を使用する (Issue #193)。
 
     // 点編集 API デモ (Issue #173)。`yomiuri-closed` を編集対象とする。
     const editTargetId = "yomiuri-closed";
@@ -336,8 +321,6 @@ const start = async (): Promise<void> => {
         ...(terrainEngine ? { terrainEngine } : {}),
         ...(cameraState ?? defaultCamera),
         ...(mapType !== null ? { mapType } : {}),
-        // ライブラリ内蔵の視点モード切替ボタンは非表示。デモ独自の UI を提供する (Issue #193)。
-        showViewModeButton: false,
     };
 
     const viewer = await JpmapTerrain.create(mount, opts);

--- a/src/demos/timelapse/index.ts
+++ b/src/demos/timelapse/index.ts
@@ -7,7 +7,7 @@
  *
  * URL 規約:
  * - `?engine=webgpu|webgl|webgl2`（既存と互換）
- * - `?terrainEngine=globe|planar`（既定 planar, #275 Phase 4 / P4-1。globe では太陽方向が時刻追従する）
+ * - `?terrainEngine=globe|planar`（既定 globe, #275 Phase 5 #413。globe では太陽方向が時刻追従する）
  * - `?lat=`, `?lon=` 等のカメラ初期値（viewer デモと共通の `parseCameraStateFromUrl`）
  * - `?start=<ISO8601>`: シミュレーション開始時刻（タイムゾーン無指定は UTC として解釈。`+09:00` の
  *   ような正オフセットは URL では `%2B09:00` とエンコードするか、`Z` 付き UTC を推奨）
@@ -27,6 +27,7 @@ import {
     parseMapTypeFromUrl,
     createUrlUpdater,
     resolveTerrainEngine,
+    resolveEffectiveTerrainEngine,
 } from "../../terrain/urlState";
 import { longitudeToOffsetMs, mountClock } from "./clockOverlay";
 import {
@@ -134,7 +135,9 @@ const start = async (): Promise<void> => {
     }
 
     const engine = resolveEngine(location.search);
-    const terrainEngine = resolveTerrainEngine(location.search);
+    // 実効エンジンで解決（未指定は lib 既定 globe, #413）。undefined を旧既定 planar と
+    // 誤認すると globe シーンで globe 専用カメラデフォルト（日の出が正面）が適用されない。
+    const terrainEngine = resolveEffectiveTerrainEngine(location.search);
     const cameraInit = resolveCameraInit(location.href);
     const mapType = parseMapTypeFromUrl(location.href);
     const showSunShadows = resolveShowSunShadows(location.search);

--- a/src/demos/viewer/index.ts
+++ b/src/demos/viewer/index.ts
@@ -5,7 +5,7 @@
  * - URL 形式:
  *   - 3D: `/@lat,lon[,altitude,azimuth,tilt]?engine=webgpu|webgl|webgl2`
  *   - 2D: `/@lat,lon,Xz?viewMode=2d` （X はズームレベル, Issue #254）
- *   - 地形バックエンド: `?terrainEngine=globe|planar`（既定 planar, #275 Phase 4 / P4-1）
+ *   - 地形バックエンド: `?terrainEngine=globe|planar`（既定 globe, #275 Phase 5 #413）
  *   （`webgl`/`webgl2` は `webgl2` に正規化、既定: 自動。altitude/azimuth/tilt は省略可、Issue #64）
  * - `#root` 要素にビューアをマウントする。
  * - URL ↔ カメラ同期はパッケージ層から切り離し、デモ層 (本ファイル) で

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -20,10 +20,9 @@ export type MapType = "standard" | "photo";
 export type ViewMode = "3d" | "2d";
 
 /**
- * 地形描画バックエンド (Issue #349 / #275 Phase 4)。
- * - `"planar"` (既定): 従来の平面ワールド（`scenes/default.ts`）。
- * - `"globe"`: ECEF 楕円体 + GeospatialCamera + floating origin（`scenes/globe.ts`）。
- *   P4-0 段階では overlay / UI パネル / 2D / 太陽影 / external frustum は順次対応中。
+ * 地形描画バックエンド (Issue #349 / #275 Phase 4 / Phase 5 #413)。
+ * - `"globe"` (既定): ECEF 楕円体 + GeospatialCamera + floating origin（`scenes/globe.ts`）。
+ * - `"planar"`: 従来の平面ワールド（`scenes/default.ts`）。明示指定時のみ使用する。
  */
 export type TerrainEngine = "planar" | "globe";
 
@@ -35,9 +34,9 @@ export interface JpmapTerrainOptions {
     /** 描画エンジン。WebGPU 非対応時は自動で WebGL2 にフォールバックする */
     engine?: EngineType;
     /**
-     * 地形描画バックエンド (Issue #349 / #275 Phase 4)。
-     * - `"planar"` (既定): 従来の平面ワールド。
-     * - `"globe"`: ECEF 楕円体 + GeospatialCamera（移行中。overlay/UI/2D 等は順次対応）。
+     * 地形描画バックエンド (Issue #349 / #275 Phase 4 / Phase 5 #413)。
+     * - `"globe"` (既定): ECEF 楕円体 + GeospatialCamera + floating origin。
+     * - `"planar"`: 従来の平面ワールド。明示指定時のみ使用する。
      */
     terrainEngine?: TerrainEngine;
     /** 緯度（度） */
@@ -127,7 +126,7 @@ export interface FlyToOptions {
  */
 export const JPMAP_TERRAIN_DEFAULTS = {
     engine: "webgpu" as EngineType,
-    terrainEngine: "planar" as TerrainEngine,
+    terrainEngine: "globe" as TerrainEngine,
     lat: 35.681236,
     lon: 139.767125,
     altitude: 2000,

--- a/src/terrain/controlPanel.ts
+++ b/src/terrain/controlPanel.ts
@@ -397,14 +397,15 @@ export const createControlPanel = (): ControlPanelElements => {
     // 方位磁針（画面右上に独立配置）
     const compass = createCompass();
 
+    // 視点モード切替ボタン（コンパス直下に配置） (Issue #193)。
+    // Tab 順がコンパスの直後になるよう、DOM への追加順をコンパスの直後にする。
+    const viewModeButton = createViewModeToggleButton();
+
     // ズームボタン＋スケールバー（画面右下に独立配置）
     const { locateMe, zoomIn, zoomOut, scaleBar } = createZoomButtons();
 
     // 地図切替ボタン（画面左下に配置）
     const mapToggle = createMapToggleButton();
-
-    // 視点モード切替ボタン（コンパス直下に配置） (Issue #193)
-    const viewModeButton = createViewModeToggleButton();
 
     // スケールバー（ズームボタンコンテナ内に統合済み）
 

--- a/src/terrain/urlState.ts
+++ b/src/terrain/urlState.ts
@@ -17,14 +17,16 @@ export interface LatLon {
 export const WORLD_BOUNDS = { minLat: -90, maxLat: 90, minLon: -180, maxLon: 180 } as const;
 
 /**
- * terrainEngine に応じた緯度経度クランプ範囲を返す (#375)。
- * - `globe` → {@link WORLD_BOUNDS}（全球）
- * - それ以外（planar / 未指定）→ {@link JAPAN_BOUNDS}（日本被覆域）
+ * terrainEngine に応じた緯度経度クランプ範囲を返す (#375 / #413)。
+ * - `planar` → {@link JAPAN_BOUNDS}（日本被覆域）
+ * - それ以外（globe / 未指定）→ {@link WORLD_BOUNDS}（全球）
+ *
+ * 未指定（`undefined`）は lib 既定（`globe`, #413）に従い全球を許容する。
  */
 const resolveLatLonBounds = (
     terrainEngine?: TerrainEngine,
 ): typeof JAPAN_BOUNDS | typeof WORLD_BOUNDS =>
-    terrainEngine === "globe" ? WORLD_BOUNDS : JAPAN_BOUNDS;
+    terrainEngine === "planar" ? JAPAN_BOUNDS : WORLD_BOUNDS;
 
 /** カメラ姿勢を含む URL 状態 (Issue #64) */
 export interface CameraUrlState extends LatLon {
@@ -87,7 +89,7 @@ const ZOOM_LEVEL_PRECISION = 2;
  * 各デモ（viewer / polygon 等）で共通利用するため本モジュールに集約する。
  * - `globe` → `"globe"`（GeospatialCamera + ECEF の地球儀バックエンド）
  * - `planar` → `"planar"`（従来の平面シーン）
- * - 上記以外 / 未指定 → `undefined`（lib 既定の `"planar"` にフォールバック）
+ * - 上記以外 / 未指定 → `undefined`（lib 既定の `"globe"` にフォールバック, #413）
  *
  * @param search `location.search` 等のクエリ文字列（先頭 `?` 任意）
  */
@@ -99,6 +101,20 @@ export const resolveTerrainEngine = (
     if (value === "planar") return "planar";
     return undefined;
 };
+
+/**
+ * URL クエリから「実効的な」地形バックエンドを解決する (#413)。
+ * {@link resolveTerrainEngine} が `undefined`（未指定）の場合は lib 既定
+ * （{@link JPMAP_TERRAIN_DEFAULTS}.terrainEngine = `"globe"`）を返す。
+ *
+ * 各デモが `JpmapTerrain.create` 前にカメラ高度・移動方向・物理ステージなどを
+ * バックエンド別に分岐する際、`undefined` を旧既定 `planar` と誤認して globe シーン上で
+ * planar 用ロジックを適用してしまうリグレッション（#413 既定化）を防ぐために使用する。
+ *
+ * @param search `location.search` 等のクエリ文字列（先頭 `?` 任意）
+ */
+export const resolveEffectiveTerrainEngine = (search: string): TerrainEngine =>
+    resolveTerrainEngine(search) ?? JPMAP_TERRAIN_DEFAULTS.terrainEngine;
 
 /**
  * Web Mercator の赤道上 zoom 0 における 1 ピクセルあたりメートル。
@@ -195,11 +211,11 @@ const pickFinite = (raw: string | undefined, fallback: number): number => {
  * 3 番目のトークンが `z` で終わる場合（例: `14.50z`）は Google Maps 互換の
  * ズームレベルとして解釈し、`zoomLevel` フィールドに格納する (#254)。
  *
- * `options.terrainEngine` が `"globe"` の場合、緯度経度を {@link WORLD_BOUNDS}（全球）で
- * クランプする。未指定 / `"planar"` の場合は従来どおり {@link JAPAN_BOUNDS} でクランプする (#375)。
+ * `options.terrainEngine` が `"planar"` の場合、緯度経度を {@link JAPAN_BOUNDS}（日本被覆域）で
+ * クランプする。`"globe"` / 未指定の場合は {@link WORLD_BOUNDS}（全球）でクランプする (#375 / #413)。
  * `options` 未指定（または `options.terrainEngine` 未指定）時は URL クエリ `?terrainEngine=` を
- * フォールバックとして解決するため、呼び出し側が terrainEngine を渡さなくても globe URL を
- * 1本で正しく復元できる (#375)。
+ * フォールバックとして解決する。URL にも指定が無ければ lib 既定（`globe`, #413）に従い全球で
+ * クランプするため、呼び出し側が terrainEngine を渡さなくても URL 1本で正しく復元できる (#375)。
  */
 export const parseCameraStateFromUrl = (
     url: string,

--- a/tests/index.unit.spec.ts
+++ b/tests/index.unit.spec.ts
@@ -31,7 +31,7 @@ describe("resolveTerrainEngine", () => {
         expect(resolveTerrainEngine("?terrainEngine=planar")).toBe("planar");
     });
 
-    it("未指定 → undefined（lib 既定 planar にフォールバック）", () => {
+    it("未指定 → undefined（lib 既定 globe にフォールバック, #413）", () => {
         expect(resolveTerrainEngine("")).toBeUndefined();
         expect(resolveTerrainEngine("?engine=webgpu")).toBeUndefined();
     });

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -799,7 +799,13 @@ describe("JpmapTerrain (skeleton)", () => {
     type Viewer = Awaited<ReturnType<typeof JpmapTerrain.create>>;
     const createdViewers: Viewer[] = [];
     const create: typeof JpmapTerrain.create = async (mount, opts) => {
-        const viewer = await JpmapTerrain.create(mount, opts);
+        // 本スイートは planar の `scenes/default` のみモックしているため、
+        // 既定が globe へ切り替わった後（#413）も planar 経路を明示して固定する。
+        // globe 経路は globeSceneController.unit.spec.ts が担当する。
+        const viewer = await JpmapTerrain.create(mount, {
+            terrainEngine: "planar",
+            ...opts,
+        });
         createdViewers.push(viewer);
         return viewer;
     };
@@ -1308,7 +1314,7 @@ describe("JpmapTerrain (skeleton)", () => {
             // createBabylonEngine(canvas, preferredEngine, options) のシグネチャ
             const callArgs = createEngineMock.mock.calls[0];
             expect(callArgs[1]).toBe("webgl2");
-            // planar 既定では high precision matrix は不要（globe のみ true）。
+            // planar 経路では high precision matrix は不要（globe のみ true, #413）。
             expect(callArgs[2]).toEqual({ highPrecisionMatrix: false });
         });
 

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -801,10 +801,11 @@ describe("JpmapTerrain (skeleton)", () => {
     const create: typeof JpmapTerrain.create = async (mount, opts) => {
         // 本スイートは planar の `scenes/default` のみモックしているため、
         // 既定が globe へ切り替わった後（#413）も planar 経路を明示して固定する。
+        // 呼び出し側 opts より後に terrainEngine を置き、常に planar を強制する。
         // globe 経路は globeSceneController.unit.spec.ts が担当する。
         const viewer = await JpmapTerrain.create(mount, {
-            terrainEngine: "planar",
             ...opts,
+            terrainEngine: "planar",
         });
         createdViewers.push(viewer);
         return viewer;

--- a/tests/timelapseIndex.unit.spec.ts
+++ b/tests/timelapseIndex.unit.spec.ts
@@ -88,7 +88,7 @@ describe("resolveTerrainEngine (timelapse)", () => {
         expect(resolveTerrainEngine("?terrainEngine=planar")).toBe("planar");
     });
 
-    it("不正値は undefined（lib 既定 planar にフォールバック）", () => {
+    it("不正値は undefined（lib 既定 globe にフォールバック, #413）", () => {
         expect(resolveTerrainEngine("?terrainEngine=foo")).toBeUndefined();
     });
 

--- a/tests/urlState.unit.spec.ts
+++ b/tests/urlState.unit.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, jest } from "@jest/globals";
 import {
     parseLatLonFromUrl,
     parseCameraStateFromUrl,
+    resolveEffectiveTerrainEngine,
     toAtPath,
     createUrlUpdater,
     clampAltitude,
@@ -57,15 +58,26 @@ describe("urlState", () => {
             expect(parseLatLonFromUrl("http://localhost/@abc,def")).toBeNull();
         });
 
-        it("JAPAN_BOUNDS を超える緯度はクランプされる", () => {
-            const result = parseLatLonFromUrl("http://localhost/@50.0,139.0");
+        it("未指定（lib 既定 globe）では JAPAN_BOUNDS でクランプされない (#413)", () => {
+            const result = parseLatLonFromUrl("http://localhost/@50.0,100.0");
+            expect(result).not.toBeNull();
+            expect(result!.lat).toBe(50.0);
+            expect(result!.lon).toBe(100.0);
+        });
+
+        it("planar では JAPAN_BOUNDS を超える緯度はクランプされる (#413)", () => {
+            const result = parseLatLonFromUrl("http://localhost/@50.0,139.0", {
+                terrainEngine: "planar",
+            });
             expect(result).not.toBeNull();
             expect(result!.lat).toBe(46);
             expect(result!.lon).toBe(139.0);
         });
 
-        it("JAPAN_BOUNDS を下回る経度はクランプされる", () => {
-            const result = parseLatLonFromUrl("http://localhost/@35.0,100.0");
+        it("planar では JAPAN_BOUNDS を下回る経度はクランプされる (#413)", () => {
+            const result = parseLatLonFromUrl("http://localhost/@35.0,100.0", {
+                terrainEngine: "planar",
+            });
             expect(result).not.toBeNull();
             expect(result!.lon).toBe(122);
         });
@@ -89,6 +101,31 @@ describe("urlState", () => {
         it("ハッシュ内の @lat,lon をパースできる", () => {
             const result = parseLatLonFromUrl("http://localhost/#/@35.681236,139.767125");
             expect(result).toEqual({ lat: 35.681236, lon: 139.767125 });
+        });
+    });
+
+    describe("resolveEffectiveTerrainEngine (#413)", () => {
+        it("?terrainEngine=globe → 'globe'", () => {
+            expect(resolveEffectiveTerrainEngine("?terrainEngine=globe")).toBe(
+                "globe",
+            );
+        });
+
+        it("?terrainEngine=planar → 'planar'（明示指定は尊重）", () => {
+            expect(resolveEffectiveTerrainEngine("?terrainEngine=planar")).toBe(
+                "planar",
+            );
+        });
+
+        it("未指定 → lib 既定 'globe' を返す（undefined にしない）", () => {
+            expect(resolveEffectiveTerrainEngine("")).toBe("globe");
+            expect(resolveEffectiveTerrainEngine("?engine=webgpu")).toBe("globe");
+        });
+
+        it("不正値 → lib 既定 'globe' を返す", () => {
+            expect(resolveEffectiveTerrainEngine("?terrainEngine=sphere")).toBe(
+                "globe",
+            );
         });
     });
 
@@ -444,7 +481,7 @@ describe("urlState", () => {
             expect(result!.lon).toBe(180);
         });
 
-        it("terrainEngine=planar / 未指定では従来どおり JAPAN_BOUNDS でクランプする (#375)", () => {
+        it("terrainEngine=planar では従来どおり JAPAN_BOUNDS でクランプする (#375 / #413)", () => {
             const planar = parseCameraStateFromUrl(
                 "http://localhost/viewer/@17.316969,38.639148",
                 { terrainEngine: "planar" }
@@ -452,13 +489,15 @@ describe("urlState", () => {
             expect(planar).not.toBeNull();
             expect(planar!.lat).toBe(20);
             expect(planar!.lon).toBe(122);
+        });
 
+        it("未指定（lib 既定 globe）では WORLD_BOUNDS でクランプする (#413)", () => {
             const noEngine = parseCameraStateFromUrl(
                 "http://localhost/viewer/@17.316969,38.639148"
             );
             expect(noEngine).not.toBeNull();
-            expect(noEngine!.lat).toBe(20);
-            expect(noEngine!.lon).toBe(122);
+            expect(noEngine!.lat).toBeCloseTo(17.316969, 6);
+            expect(noEngine!.lon).toBeCloseTo(38.639148, 6);
         });
 
         // #375: options 未指定でも URL クエリ ?terrainEngine=globe をフォールバック解決する。


### PR DESCRIPTION
## 概要

Issue #275 Phase 5 の残作業として、地形バックエンドの既定値を **`planar` → `globe`** に切り替え、全デモ・URL・テストの既定経路を globe に統一する（#413）。あわせて、既定切替で顕在化したデモのリグレッションを修正し、視点モード(2D/3D)UI を整理する。

Closes #413

## 変更内容

### 1. globe 既定化 (#413)
- `JPMAP_TERRAIN_DEFAULTS.terrainEngine` を `"planar"` → `"globe"`（`src/lib/types.ts`、JSDoc 更新）
- `src/terrain/urlState.ts`: `resolveEffectiveTerrainEngine` を追加（`?terrainEngine=` 未指定時にライブラリ既定へ解決）
- `resolveLatLonBounds` の既定を「planar のみ `JAPAN_BOUNDS`、それ以外 `WORLD_BOUNDS`」に整合
- `spec/package.md` に `terrainEngine`（既定 globe）を追記

### 2. デモのリグレッション修正
既定が planar 前提だったデモが、未指定 = `undefined` を planar と誤判定していた問題を修正。
- **flight**: 実効エンジンを解決し、初期高度／カメラ境界を globe 既定に整合（機体が見えない問題を解消）
- **avatar-controller**: `isGlobe` 判定を実効エンジンで補正（移動方向がカメラに追従）
- **artillery**: 明示 `planar` のみ再送出し、生成後に `viewer.terrainEngine` で実効値を同期（砲台が表示されない問題を解消）
- **timelapse**: globe 既定のカメラ初期値を実効エンジンで解決

### 3. 視点モード UI 整理
- `controlPanel.ts`: 視点モードボタンをコンパス直後に配置し **Tab 順を自然化**
- **polygon / distance / circle / plan**: パネル内の独自 2D ボタンを廃止し、ライブラリ内蔵 2D/3D ボタンに統一
  - distance は編集ヒントの再描画副作用を `onViewModeChange` で温存
- 各 HTML パネルを `right: 64px` に移動し、右上ボタン（コンパス／視点モード）との重なりを回避

## 影響範囲
- **挙動**: 既定の地形バックエンドが globe になる（URL で `?terrainEngine=planar` を明示すれば従来挙動を維持）
- **画面**: 4デモのパネル位置・2Dボタンの提供元、全デモの Tab 順
- **ドキュメント**: `spec/package.md`

## 検証
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run test:unit` ✅ **1374 passed**（60 suites）
- 3DCG 目視確認 ✅（flight / artillery / avatar-controller / timelapse + 4デモの Tab 順・パネル配置）
- セルフレビュー（Coding Rules 観点）✅ / セキュリティ点検 ✅ 重大な懸念なし

## 補足
- VR スナップショット（`tests/validation.spec.ts-snapshots/`）は `.gitignore` 済み（ローカル生成）。globe 既定化に伴う再ベースラインはローカルで `npm run test:visuals:update` ＋目視ゲートが本質。
- planar バックエンドの撤去は本 PR の範囲外。後続トラッキングとして **#414**（Phase 6: planar 撤去）を起票済み。
- 関連: #275（親）, #411（Phase 5 先行分）, #392（README）。
