### PR TITLE
feat(portal): デモトップ画面に出典を明記 (#417)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -86,6 +86,34 @@
     footer a {
       color: #8ab4ff;
     }
+
+    footer .attribution {
+      padding-top: 24px;
+      border-top: 1px solid rgba(255, 255, 255, 0.08);
+    }
+
+    footer .attribution h2 {
+      margin: 0 0 8px;
+      font-size: 13px;
+      font-weight: 600;
+      color: #b8c2d6;
+    }
+
+    footer .attribution ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+
+    footer .attribution li {
+      margin: 0 0 6px;
+      line-height: 1.6;
+      word-break: break-word;
+    }
+
+    footer .source {
+      margin: 16px 0 0;
+    }
   </style>
 </head>
 <body>

--- a/public/index.html
+++ b/public/index.html
@@ -108,7 +108,7 @@
     footer .attribution li {
       margin: 0 0 6px;
       line-height: 1.6;
-      word-break: break-word;
+      overflow-wrap: anywhere;
     }
 
     footer .source {

--- a/src/demos/portal/index.ts
+++ b/src/demos/portal/index.ts
@@ -117,15 +117,53 @@ const renderCard = (demo: DemoEntry): string =>
         demo.title,
     )}</h2><p>${escapeHtml(demo.description)}</p></a></li>`;
 
+/**
+ * 国土地理院タイル等の出典表記（Issue #417）。
+ * 各項目はプレーンテキストとして `escapeHtml` を通して出力し、
+ * URL は明示的にリンク化する。
+ */
+const ATTRIBUTIONS: readonly string[] = [
+    "国土地理院発行 2.5万分1地形図",
+    "The bathymetric contours are derived from those contained within the GEBCO Digital Atlas, published by the BODC on behalf of IOC and IHO (2003) (https://www.gebco.net) 海上保安庁許可第292502号（水路業務法第25条に基づく類似刊行物）",
+    'Shoreline data is derived from: United States. National Imagery and Mapping Agency. "Vector Map Level 0 (VMAP0)." Bethesda, MD: Denver, CO: The Agency; USGS Information Services, 1997.',
+];
+
+/**
+ * テキストを `escapeHtml` した上で、含まれる http(s) URL を `<a>` リンクへ変換する。
+ * リンク化対象の URL は属性値としても安全になるよう、エスケープ後の文字列に対して処理する。
+ */
+const linkifyAttribution = (text: string): string => {
+    const escaped = escapeHtml(text);
+    // URL に続く末尾の閉じ括弧・句読点（`)` `.` `,`）はリンクへ含めない。
+    return escaped.replace(
+        /https?:\/\/[^\s<>"')]+/g,
+        (url) => `<a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>`,
+    );
+};
+
+const renderAttributions = (attributions: readonly string[]): string =>
+    [
+        '<section class="attribution" aria-label="出典">',
+        "<h2>出典</h2>",
+        `<ul>${attributions
+            .map((text) => `<li>${linkifyAttribution(text)}</li>`)
+            .join("")}</ul>`,
+        "</section>",
+    ].join("");
+
 /** ポータル本体 HTML を組み立てる純粋関数（テスト用に export）。 */
 export const buildPortalHtml = (
     demos: readonly DemoEntry[] = DEMO_LIST,
+    attributions: readonly string[] = ATTRIBUTIONS,
 ): string =>
     [
         '<h1>jpmap_terrain デモ</h1>',
         '<p class="lead">地理院タイルの標高データを使った 3D 地形可視化のデモ集です。今後デモを順次追加していきます。</p>',
         `<ul class="demos">${demos.map(renderCard).join("")}</ul>`,
-        '<footer>Source: <a href="https://github.com/8ga3/jpmap_terrain">github.com/8ga3/jpmap_terrain</a></footer>',
+        '<footer>',
+        renderAttributions(attributions),
+        '<p class="source">Source: <a href="https://github.com/8ga3/jpmap_terrain">github.com/8ga3/jpmap_terrain</a></p>',
+        '</footer>',
     ].join("");
 
 const start = (): void => {

--- a/src/demos/portal/index.ts
+++ b/src/demos/portal/index.ts
@@ -134,11 +134,14 @@ const ATTRIBUTIONS: readonly string[] = [
  */
 const linkifyAttribution = (text: string): string => {
     const escaped = escapeHtml(text);
-    // URL に続く末尾の閉じ括弧・句読点（`)` `.` `,`）はリンクへ含めない。
-    return escaped.replace(
-        /https?:\/\/[^\s<>"')]+/g,
-        (url) => `<a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>`,
-    );
+    // URL 本体を貪欲にマッチさせた後、末尾の括弧・句読点（半角/全角）は
+    // リンクへ含めず後続テキストとして戻す。
+    return escaped.replace(/https?:\/\/[^\s<>"']+/g, (match) => {
+        const trailing = match.match(/[).,）、。]+$/);
+        const url = trailing ? match.slice(0, match.length - trailing[0].length) : match;
+        const suffix = trailing ? trailing[0] : "";
+        return `<a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>${suffix}`;
+    });
 };
 
 const renderAttributions = (attributions: readonly string[]): string =>

--- a/src/demos/portal/index.ts
+++ b/src/demos/portal/index.ts
@@ -129,19 +129,34 @@ const ATTRIBUTIONS: readonly string[] = [
 ];
 
 /**
- * テキストを `escapeHtml` した上で、含まれる http(s) URL を `<a>` リンクへ変換する。
- * リンク化対象の URL は属性値としても安全になるよう、エスケープ後の文字列に対して処理する。
+ * 出典テキスト中の http(s) URL を `<a>` リンクへ変換する。
+ *
+ * URL の抽出は **エスケープ前の生テキスト** に対して行い、出力時に
+ * 「非 URL 部分」「URL 本体」「末尾記号」をそれぞれ `escapeHtml` してから組み立てる。
+ * これにより、URL の直後に `<` 等が続くケースでも境界が崩れない
+ * （例: `https://example.com/<b>` の `<b>` を URL に取り込まない）。
+ * URL 直後の括弧・句読点（半角/全角: `)` `.` `,` `）` `、` `。`）はリンク外へ戻す。
  */
 const linkifyAttribution = (text: string): string => {
-    const escaped = escapeHtml(text);
-    // URL 本体を貪欲にマッチさせた後、末尾の括弧・句読点（半角/全角）は
-    // リンクへ含めず後続テキストとして戻す。
-    return escaped.replace(/https?:\/\/[^\s<>"']+/g, (match) => {
-        const trailing = match.match(/[).,）、。]+$/);
-        const url = trailing ? match.slice(0, match.length - trailing[0].length) : match;
+    const urlPattern = /https?:\/\/[^\s<>"']+/g;
+    let result = "";
+    let lastIndex = 0;
+
+    for (let match = urlPattern.exec(text); match !== null; match = urlPattern.exec(text)) {
+        const raw = match[0];
+        const trailing = raw.match(/[).,）、。]+$/);
+        const url = trailing ? raw.slice(0, raw.length - trailing[0].length) : raw;
         const suffix = trailing ? trailing[0] : "";
-        return `<a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>${suffix}`;
-    });
+
+        result += escapeHtml(text.slice(lastIndex, match.index));
+        const safeUrl = escapeHtml(url);
+        result += `<a href="${safeUrl}" target="_blank" rel="noopener noreferrer">${safeUrl}</a>`;
+        result += escapeHtml(suffix);
+        lastIndex = match.index + raw.length;
+    }
+
+    result += escapeHtml(text.slice(lastIndex));
+    return result;
 };
 
 const renderAttributions = (attributions: readonly string[]): string =>

--- a/tests/portal.unit.spec.ts
+++ b/tests/portal.unit.spec.ts
@@ -65,6 +65,33 @@ describe("buildPortalHtml", () => {
         );
     });
 
+    it("URL 末尾の括弧・句読点（半角/全角）はリンクへ含めない", () => {
+        const html = buildPortalHtml(undefined, [
+            "a (https://example.com/a).",
+            "b https://example.com/b、",
+            "c https://example.com/c。",
+            "d https://example.com/d,",
+        ]);
+        // 半角閉じ括弧 + ピリオドはリンク外へ戻る。
+        expect(html).toContain(
+            '<a href="https://example.com/a" target="_blank" rel="noopener noreferrer">https://example.com/a</a>).',
+        );
+        // 全角読点・句点もリンク外へ戻る。
+        expect(html).toContain(
+            '<a href="https://example.com/b" target="_blank" rel="noopener noreferrer">https://example.com/b</a>、',
+        );
+        expect(html).toContain(
+            '<a href="https://example.com/c" target="_blank" rel="noopener noreferrer">https://example.com/c</a>。',
+        );
+        // 半角カンマもリンク外へ戻る。
+        expect(html).toContain(
+            '<a href="https://example.com/d" target="_blank" rel="noopener noreferrer">https://example.com/d</a>,',
+        );
+        // href に句読点が混入していないこと。
+        expect(html).not.toContain('href="https://example.com/a).');
+        expect(html).not.toContain('href="https://example.com/d,');
+    });
+
     it("出典文言の HTML 特殊文字をエスケープする", () => {
         const html = buildPortalHtml(undefined, [
             "<b>x</b> & y http://example.com/?a=1&b=2",

--- a/tests/portal.unit.spec.ts
+++ b/tests/portal.unit.spec.ts
@@ -65,6 +65,19 @@ describe("buildPortalHtml", () => {
         );
     });
 
+    it("URL 直後に < が続いても URL 抽出の境界が崩れない", () => {
+        const html = buildPortalHtml(undefined, [
+            "see https://example.com/p<b>bold</b>",
+        ]);
+        // URL は `<` の手前で終わり、後続の <b> はエスケープされる。
+        expect(html).toContain(
+            '<a href="https://example.com/p" target="_blank" rel="noopener noreferrer">https://example.com/p</a>',
+        );
+        expect(html).toContain("&lt;b&gt;bold&lt;/b&gt;");
+        // `&lt;` 以降が href に取り込まれていないこと。
+        expect(html).not.toContain('href="https://example.com/p&lt;');
+    });
+
     it("URL 末尾の括弧・句読点（半角/全角）はリンクへ含めない", () => {
         const html = buildPortalHtml(undefined, [
             "a (https://example.com/a).",

--- a/tests/portal.unit.spec.ts
+++ b/tests/portal.unit.spec.ts
@@ -42,4 +42,39 @@ describe("buildPortalHtml", () => {
         expect(html).toContain("a &amp; b");
         expect(html).toContain("ok.html?x=1&amp;y=2");
     });
+
+    // 出典表記 (Issue #417)
+    it("フッターに出典 3 項目を表示する", () => {
+        const html = buildPortalHtml();
+        expect(html).toContain('<section class="attribution"');
+        expect(html).toContain("出典");
+        expect(html).toContain("国土地理院発行 2.5万分1地形図");
+        expect(html).toContain("GEBCO Digital Atlas");
+        expect(html).toContain("海上保安庁許可第292502号");
+        expect(html).toContain("Vector Map Level 0 (VMAP0)");
+        // 既存の Source リンクも維持される。
+        expect(html).toContain(
+            'href="https://github.com/8ga3/jpmap_terrain"',
+        );
+    });
+
+    it("出典中の URL をリンク化する", () => {
+        const html = buildPortalHtml();
+        expect(html).toContain(
+            '<a href="https://www.gebco.net" target="_blank" rel="noopener noreferrer">https://www.gebco.net</a>',
+        );
+    });
+
+    it("出典文言の HTML 特殊文字をエスケープする", () => {
+        const html = buildPortalHtml(undefined, [
+            "<b>x</b> & y http://example.com/?a=1&b=2",
+        ]);
+        expect(html).not.toContain("<b>x</b>");
+        expect(html).toContain("&lt;b&gt;x&lt;/b&gt;");
+        expect(html).toContain("&amp; y");
+        // URL はリンク化され、クエリの & はエスケープ済み。
+        expect(html).toContain(
+            '<a href="http://example.com/?a=1&amp;b=2" target="_blank" rel="noopener noreferrer">',
+        );
+    });
 });


### PR DESCRIPTION
## 概要
デモポータル（`/`）のフッターに国土地理院タイル等の出典表記を追加する (#417)。

## 変更内容
- `src/demos/portal/index.ts`: `buildPortalHtml` のフッターに出典セクションを追加。
  - 出典3項目（国土地理院 2.5万分1地形図 / GEBCO・海上保安庁 / VMAP0）。
  - URL 抽出は生テキストに対して行い、「非URL部分」「URL本体」「末尾記号」をそれぞれ `escapeHtml` して組み立て（境界崩れ・XSS を防止）。文中の URL のみ `<a>` リンク化し、末尾の括弧・句読点（半角/全角）はリンク外へ戻す。
  - 既存の Source（GitHub）リンクは維持。
- `public/index.html`: フッター出典セクションの CSS（区切り線・小フォント・行間・`overflow-wrap` による折返し）。
- `tests/portal.unit.spec.ts`: 出典表示・URL リンク化・末尾句読点除外・`<` 境界・特殊文字エスケープの unit test を追加。

## 影響範囲
- 画面: デモトップ（ポータル）のフッターのみ。他デモ・公開ライブラリ層への影響なし。

## 確認
- [x] `npm run test:unit`（portal: 8 件 PASS）
- [x] `npm run lint`
- [x] `npm run typecheck`
- [ ] 目視確認（HITL）: `npm run dev` でポータル下部に出典が表示されること

Closes #417