### PR TITLE
feat(globe): sseThreshold を下げ最高ズームタイル表示エリアを拡大 (#420)

### DIFF
--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -68,7 +68,7 @@ export const GLOBE_SCENE_DEFAULTS = {
     /** チルト[deg]（0=直下, 90=水平）→ pitch。 */
     tilt: 60,
     /** SSE 採用しきい値 [px]。 */
-    sseThreshold: 256 * 2.5,
+    sseThreshold: 256 * 2.0,
     /**
      * 同時保持タイル数の上限。#335 の視錐台フルカバー（前景〜地平線、横は水平 FOV 台形）を高 DPI
      * （3x≒render 3240px）かつ高チルトでも欠けなく収めるため拡大（実測最悪 ~329 枚 < 384）。

--- a/tests/globeLod.unit.spec.ts
+++ b/tests/globeLod.unit.spec.ts
@@ -20,6 +20,7 @@ import {
     tileKey,
     type GlobeLodOptions,
 } from "../src/terrain/geo/globeLod";
+import { GLOBE_SCENE_DEFAULTS } from "../src/scenes/globe";
 
 const CENTER_LAT = 35.3606;
 const CENTER_LON = 138.7274;
@@ -37,7 +38,7 @@ const baseOpts = (
     viewportHeight: 1080,
     viewportWidth: 1920,
     verticalFov: 0.8,
-    sseThreshold: 256 * 2.5,
+    sseThreshold: GLOBE_SCENE_DEFAULTS.sseThreshold,
     maxTiles: 200,
     rootSearchRadius: 2,
     maxRootTiles: 256,
@@ -401,7 +402,7 @@ describe("selectGlobeRootTiles", () => {
         viewportHeight: 1080,
         viewportWidth: 1920,
         verticalFov: 0.8,
-        sseThreshold: 256 * 2.5,
+        sseThreshold: GLOBE_SCENE_DEFAULTS.sseThreshold,
         ...overrides,
     });
 


### PR DESCRIPTION
## Summary

- `GLOBE_SCENE_DEFAULTS.sseThreshold` を `256 * 2.5`（640px）→ `256 * 2.0`（512px）に変更
- 高ズームタイルの採用半径が約25%拡大、表示エリアが約1.5倍（~8枚 → ~12枚）

Closes #420

## Test plan

- [ ] グローブシーンで同一視点のz15タイル枚数が増加していること
- [ ] `npm run lint` 通過
- [ ] `npm run test:unit` 通過
- [ ] 遠景・高チルト時に `maxTiles`（384）を超えないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)