### PR TITLE
chore: Vite標準化に伴う互換記述の整理＋内部globeマネージャの旧API別名削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ npm start
 
 | デモ | URL | 説明 |
 |---|---|---|
-| 3D 地形ビューア | `/viewer.html` | 既存の地理院タイル 3D ビューア。緯度経度・カメラ向き・地図種別を URL で指定可能。 |
-| タイムラプス | `/timelapse.html` | 24 時間を 1 分に圧縮し、太陽位置・陰影をアニメーション表示（アナログ時計オーバーレイ付き）。 |
+| 3D 地形ビューア | `/viewer` | 既存の地理院タイル 3D ビューア。緯度経度・カメラ向き・地図種別を URL で指定可能。 |
+| タイムラプス | `/timelapse` | 24 時間を 1 分に圧縮し、太陽位置・陰影をアニメーション表示（アナログ時計オーバーレイ付き）。 |
 
 デモ追加方針は [spec/demos.md](spec/demos.md) を参照してください。
 
@@ -85,8 +85,8 @@ npm start
 
 `engine` クエリパラメータでエンジンを切り替えられます。
 
-- WebGPU: `http://localhost:8080/viewer.html?scene=default&engine=webgpu`
-- WebGL2: `http://localhost:8080/viewer.html?scene=default&engine=webgl2`
+- WebGPU: `http://localhost:8080/viewer?scene=default&engine=webgpu`
+- WebGL2: `http://localhost:8080/viewer?scene=default&engine=webgl2`
 
 `webgpu` 指定時に未対応ブラウザの場合は WebGL2 にフォールバックします。
 
@@ -127,10 +127,10 @@ npm start
 
 **例:**
 
-- `http://localhost:8080/viewer.html/@35.681236,139.767125?engine=webgpu`（東京駅・3D・WebGPU）
-- `http://localhost:8080/viewer.html/@35.3606,138.7274?engine=webgl2`（富士山・3D・WebGL2）
-- `http://localhost:8080/viewer.html/@35.681236,139.767125?engine=webgpu&mapType=photo`（東京駅・3D・航空写真）
-- `http://localhost:8080/viewer.html/@35.3606,138.7274,14.50z?viewMode=2d`（富士山・2D・ズームレベル 14.5）
+- `http://localhost:8080/viewer/@35.681236,139.767125?engine=webgpu`（東京駅・3D・WebGPU）
+- `http://localhost:8080/viewer/@35.3606,138.7274?engine=webgl2`（富士山・3D・WebGL2）
+- `http://localhost:8080/viewer/@35.681236,139.767125?engine=webgpu&mapType=photo`（東京駅・3D・航空写真）
+- `http://localhost:8080/viewer/@35.3606,138.7274,14.50z?viewMode=2d`（富士山・2D・ズームレベル 14.5）
 
 ### `engine` パラメータ
 
@@ -163,7 +163,7 @@ npm start
 - パス形式 `/@<lat>,<lon>` の代わりに、`?lat=<lat>&lon=<lon>` クエリでも初期カメラ位置を指定できます
 - パス形式（`/@...`）が存在する場合はそちらが優先されます
 - altitude / azimuth / tilt は既定値で補完されます（クエリでは指定不可）
-- 例: `http://localhost:8080/viewer.html?lat=35.681236&lon=139.767125`
+- 例: `http://localhost:8080/viewer?lat=35.681236&lon=139.767125`
 
 実装の詳細は `src/demos/viewer/index.ts` および `src/terrain/urlState.ts` を参照してください。
 

--- a/public/geospatial.html
+++ b/public/geospatial.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
 
   <title>jpmap_terrain – Geospatial (Globe / #275)</title>
-  <meta name="description" content="Babylon.js 9.x Geospatial(GeospatialCamera + ECEF + Floating Origin) によるグローブ地形（段階移行 Phase 1）">
+  <meta name="description" content="Babylon.js 9.x Geospatial(GeospatialCamera + ECEF + Floating Origin) によるグローブ地形">
   <meta name="author" content="8ga3">
     <style>
       html,

--- a/spec/architecture.md
+++ b/spec/architecture.md
@@ -33,7 +33,7 @@ C4Context
 
 jpmap_terrain 内部の主要コンテナ（デプロイ・ビルド単位）を示します。
 
-> デモ 11 本は `splitChunks` でコードを共有するため、独立コンテナではなく  
+> デモ 13 本は `manualChunks`（Vite）でコードを共有するため、独立コンテナではなく  
 > **Demo Apps グループ** としてまとめます。
 
 ```mermaid

--- a/spec/demos.md
+++ b/spec/demos.md
@@ -159,7 +159,7 @@ QGroundControl の `.plan` ファイルをドラッグ&ドロップでマップ�
 ## 互換性メモ
 
 - 既存の VR スナップショット（`tests/validation.spec.ts-snapshots/`）は viewer の URL 変更（`/?scene=default` → `/viewer.html?scene=default`）後も同一の描画結果のため流用可能。
-- `manualChunks`（`vite.config.ts`）のバンドル分割方針は webpack 時代の `splitChunks.cacheGroups` を踏襲している。
+- `manualChunks`（`vite.config.ts`）で共有依存（Babylon.js / シェーダー）を分割している。
 
 ### avatar (`/avatar.html`)
 

--- a/src/demos/geospatial/index.ts
+++ b/src/demos/geospatial/index.ts
@@ -247,8 +247,7 @@ const start = async (): Promise<void> => {
             centerLat: 35.360625,
             centerLon: 138.727363,
             radiusMeters: 8000,
-            outlineColor: "#33aaff",
-            wallColor: "#33aaff",
+            style: { lineColor: "#33aaff", wallColor: "#33aaff" },
             // 富士山頂(3776m)より高く浮かせて山に隠れないようにする（polygon と同じ）。
             topAltitudeMeters: 6000,
         });

--- a/src/demos/model/index.ts
+++ b/src/demos/model/index.ts
@@ -22,7 +22,7 @@ import {
 import humanGlbUrl from "../../../assets/human.glb";
 import humanObjUrl from "../../../assets/human.obj";
 // MTL は OBJ ローダーが rootUrl から自動取得するが、
-// webpack にバンドル対象として認識させるためインポートしておく。
+// Vite にバンドル対象として認識させるためインポートしておく。
 import "../../../assets/human.mtl";
 import humanStlUrl from "../../../assets/human.stl";
 

--- a/src/demos/portal/index.ts
+++ b/src/demos/portal/index.ts
@@ -5,7 +5,7 @@
  * Babylon.js は読み込まないため、ライブラリ側 (`src/lib/**`) の依存は持たない。
  *
  * 追加デモは `DEMO_LIST` に項目を増やすことで一覧へ反映できる。
- * 並びは配列順。`href` は webpack の HtmlWebpackPlugin が出力する HTML ファイル名と一致させる。
+ * 並びは配列順。`href` は Vite が配信する HTML ファイル名（`<name>.html`）と一致させる。
  */
 
 interface DemoEntry {

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -1,9 +1,9 @@
 /**
  * グローブ地形シーン (Issue #275 Phase 1 + Phase 2)。
  *
- * かつての平面ワールド（撤去済み planar 実装）に対する **並行構築** として生まれたグローブ（ECEF 楕円体 +
- * Large World Rendering の floating origin）シーン。`GeospatialCamera` を中核に、
- * `geo/globeTileManager` で動的 LOD タイルを描画し、注視点を地形表面へ追従させる。
+ * ECEF 楕円体 + Large World Rendering の floating origin で構築したグローブ地形シーン。
+ * `GeospatialCamera` を中核に、`geo/globeTileManager` で動的 LOD タイルを描画し、
+ * 注視点を地形表面へ追従させる。
  *
  * Phase 1: 「座標系・メッシュ生成・カメラ基盤・配置・LOD」の地形エンジン（注視点ズーム・
  * seat-on-terrain・地心距離 LOD）。

--- a/src/terrain/geo/globeCircleManager.ts
+++ b/src/terrain/geo/globeCircleManager.ts
@@ -43,13 +43,13 @@ export interface GlobeCircleOptions {
     label?: string | null;
     /** スタイル（polygon と共通のキー）。 */
     style?: PolygonStyleOptions;
-    /** 旧 API 互換。style.lineColor より優先度は低い（ring のアウトライン色）。 */
+    /** `style.lineColor` の別名（ring のアウトライン色。`style.lineColor` より優先度は低い）。 */
     outlineColor?: string;
-    /** 旧 API 互換。style.wallColor より優先度は低い。 */
+    /** `style.wallColor` の別名（`style.wallColor` より優先度は低い）。 */
     wallColor?: string;
-    /** 旧 API 互換。style.wallOpacity より優先度は低い。 */
+    /** `style.wallOpacity` の別名（`style.wallOpacity` より優先度は低い）。 */
     wallOpacity?: number;
-    /** 旧 API 互換。top を固定する楕円体高度[m]（未指定なら地形ドレープ）。 */
+    /** top を固定する楕円体高度[m]（未指定なら地形ドレープ）。 */
     topAltitudeMeters?: number;
     /** 円全体の表示。default true。 */
     enabled?: boolean;
@@ -59,7 +59,7 @@ export interface GlobeCircleOptions {
     lineEnabled?: boolean;
     /** 壁（カーテン）の表示。default true。 */
     wallEnabled?: boolean;
-    /** 旧 API 互換の壁表示フラグ（wallEnabled と同義、指定時は wallEnabled より優先）。 */
+    /** `wallEnabled` の別名（同義、指定時は `wallEnabled` より優先）。 */
     wallsEnabled?: boolean;
     /** 中心ラベルの表示。default true。 */
     labelEnabled?: boolean;

--- a/src/terrain/geo/globeCircleManager.ts
+++ b/src/terrain/geo/globeCircleManager.ts
@@ -43,12 +43,6 @@ export interface GlobeCircleOptions {
     label?: string | null;
     /** スタイル（polygon と共通のキー）。 */
     style?: PolygonStyleOptions;
-    /** `style.lineColor` の別名（ring のアウトライン色。`style.lineColor` より優先度は低い）。 */
-    outlineColor?: string;
-    /** `style.wallColor` の別名（`style.wallColor` より優先度は低い）。 */
-    wallColor?: string;
-    /** `style.wallOpacity` の別名（`style.wallOpacity` より優先度は低い）。 */
-    wallOpacity?: number;
     /** top を固定する楕円体高度[m]（未指定なら地形ドレープ）。 */
     topAltitudeMeters?: number;
     /** 円全体の表示。default true。 */
@@ -59,8 +53,6 @@ export interface GlobeCircleOptions {
     lineEnabled?: boolean;
     /** 壁（カーテン）の表示。default true。 */
     wallEnabled?: boolean;
-    /** `wallEnabled` の別名（同義、指定時は `wallEnabled` より優先）。 */
-    wallsEnabled?: boolean;
     /** 中心ラベルの表示。default true。 */
     labelEnabled?: boolean;
 }
@@ -130,7 +122,7 @@ export const createGlobeCircleManager = (
             );
         }
         const enabled = opts.enabled ?? true;
-        const wallEnabled = opts.wallsEnabled ?? opts.wallEnabled ?? true;
+        const wallEnabled = opts.wallEnabled ?? true;
         const ringPoints = generateGeodesicRing(
             opts.centerLat,
             opts.centerLon,
@@ -145,9 +137,6 @@ export const createGlobeCircleManager = (
             altitudeMode,
             topAltitudeMeters: opts.topAltitudeMeters,
             style: opts.style,
-            outlineColor: opts.outlineColor,
-            wallColor: opts.wallColor,
-            wallOpacity: opts.wallOpacity,
             pointsEnabled: false,
             verticalsEnabled: false,
             labelsEnabled: false,
@@ -164,7 +153,6 @@ export const createGlobeCircleManager = (
             altitudeMode,
             topAltitudeMeters: opts.topAltitudeMeters,
             style: opts.style,
-            outlineColor: opts.outlineColor,
             labels: hasLabel ? [opts.label as string] : undefined,
             pointsEnabled: opts.pointEnabled ?? true,
             verticalsEnabled: false,

--- a/src/terrain/geo/globePolygonManager.ts
+++ b/src/terrain/geo/globePolygonManager.ts
@@ -116,12 +116,6 @@ export interface GlobePolygonOptions {
     labels?: ReadonlyArray<string | undefined>;
     edgeLabels?: ReadonlyArray<string | undefined>;
     style?: PolygonStyleOptions;
-    /** `style.lineColor` の別名（`style.lineColor` より優先度は低い）。 */
-    outlineColor?: string;
-    /** `style.wallColor` の別名（`style.wallColor` より優先度は低い）。 */
-    wallColor?: string;
-    /** `style.wallOpacity` の別名（`style.wallOpacity` より優先度は低い）。 */
-    wallOpacity?: number;
     verticalsEnabled?: boolean;
     labelsEnabled?: boolean;
     wallsEnabled?: boolean;
@@ -688,12 +682,7 @@ export const createGlobePolygonManager = (
             opts.topAltitudeMeters != null
                 ? "absolute"
                 : (opts.altitudeMode ?? POLYGON_DEFAULTS.altitudeMode);
-        const style = resolveStyle({
-            ...opts.style,
-            lineColor: opts.style?.lineColor ?? opts.outlineColor,
-            wallColor: opts.style?.wallColor ?? opts.wallColor,
-            wallOpacity: opts.style?.wallOpacity ?? opts.wallOpacity,
-        });
+        const style = resolveStyle(opts.style);
         const pathLen = Math.max(2, drapedPolygonPathLength(opts.points.length, closed));
         const pointsEnabled = opts.pointsEnabled ?? true;
         const verticalsEnabled =

--- a/src/terrain/geo/globePolygonManager.ts
+++ b/src/terrain/geo/globePolygonManager.ts
@@ -110,17 +110,17 @@ export interface GlobePolygonOptions {
     /** 高度モード。default terrain。 */
     altitudeMode?: AltitudeMode;
     /**
-     * 旧 Phase 3 API 互換。指定時は全頂点をこの楕円体高度に置く（absolute 相当）。
+     * 指定時は全頂点をこの楕円体高度に置く（absolute 相当）。
      */
     topAltitudeMeters?: number;
     labels?: ReadonlyArray<string | undefined>;
     edgeLabels?: ReadonlyArray<string | undefined>;
     style?: PolygonStyleOptions;
-    /** 旧 API 互換。style.lineColor より優先度は低い。 */
+    /** `style.lineColor` の別名（`style.lineColor` より優先度は低い）。 */
     outlineColor?: string;
-    /** 旧 API 互換。style.wallColor より優先度は低い。 */
+    /** `style.wallColor` の別名（`style.wallColor` より優先度は低い）。 */
     wallColor?: string;
-    /** 旧 API 互換。style.wallOpacity より優先度は低い。 */
+    /** `style.wallOpacity` の別名（`style.wallOpacity` より優先度は低い）。 */
     wallOpacity?: number;
     verticalsEnabled?: boolean;
     labelsEnabled?: boolean;

--- a/src/terrain/geo/sunDirectionEcef.ts
+++ b/src/terrain/geo/sunDirectionEcef.ts
@@ -1,8 +1,7 @@
 /**
  * 太陽の地理的見かけ位置（高度・方位角）を、グローブシーンの ECEF 太陽方向ベクトルへ変換する。
  *
- * かつての平面シーン（撤去済み planar 実装）は Babylon 左手系（X=東/Y=上/Z=北）で太陽方向を組んでいたが、
- * グローブシーン（`scenes/globe.ts`）は **右手系 ECEF**（X→経度0 / Y→東経90° / Z→北極、
+ * Babylon の左手系（X=東/Y=上/Z=北）ではなく、グローブシーン（`scenes/globe.ts`）は **右手系 ECEF**（X→経度0 / Y→東経90° / Z→北極、
  * `geo/ecef` と同一規約）で動く。観測点（lat/lon）でのローカル ENU（East-North-Up）基底を
  * ECEF で構成し、地平座標（azimuth/altitude）の太陽方向を ECEF へ写す。
  *

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -143,8 +143,8 @@ const PENDING_RELEASE_TIMEOUT_MS = 5000;
  */
 const EMPTY_NAN_ELEVATION = new Float32Array(TILE_SIZE * TILE_SIZE).fill(NaN);
 
-// 旧 applyElevation はインラインで使われていたが、Web Worker への移行に伴い
-// `elevationCompute.ts` の `applyElevationToPositions` に集約された。
+// 標高反映は Web Worker 化に伴い `elevationCompute.ts` の
+// `applyElevationToPositions` に集約されている。
 
 /**
  * 低zoomテクスチャ使用時のUVパラメータを算出する。

--- a/tests/atPathReload.spec.ts
+++ b/tests/atPathReload.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "./tileCache.fixture";
 
 /**
  * Issue #157: `/viewer/@...` および `/timelapse/@...` のデモ識別子付きパスで
- * 直接アクセス（リロード相当）した際に、HtmlWebpackPlugin が inject する script 等が
+ * 直接アクセス（リロード相当）した際に、HTML が inject する script 等が
  * 相対パスで解決されて 404 になる回帰を防止する E2E テスト。
  *
  * - `/js/` 配下のリクエストが全て成功（response.ok() かつ requestfailed なし）であること

--- a/tests/globeCircleManager.unit.spec.ts
+++ b/tests/globeCircleManager.unit.spec.ts
@@ -10,7 +10,7 @@ import { jest } from "@jest/globals";
 interface AddCall {
     points: { lat: number; lon: number }[];
     closed?: boolean;
-    outlineColor?: string;
+    style?: { lineColor?: string; wallColor?: string; wallOpacity?: number };
     pointsEnabled?: boolean;
     lineEnabled?: boolean;
     wallsEnabled?: boolean;
@@ -88,10 +88,15 @@ describe("add", () => {
         expect(addCalls[1].labels?.[0]).toBe("中心");
     });
 
-    it("旧 API のスタイル（色）を ring へ委譲する", () => {
+    it("スタイル（色）を ring へ委譲する", () => {
         const mgr = makeManager();
-        mgr.add({ centerLat: 35, centerLon: 139, radiusMeters: 5000, outlineColor: "#abcdef" });
-        expect(addCalls[0].outlineColor).toBe("#abcdef");
+        mgr.add({
+            centerLat: 35,
+            centerLon: 139,
+            radiusMeters: 5000,
+            style: { lineColor: "#abcdef" },
+        });
+        expect(addCalls[0].style?.lineColor).toBe("#abcdef");
     });
 
     it("radius <= 0 は throw", () => {

--- a/tests/globePolygonManager.unit.spec.ts
+++ b/tests/globePolygonManager.unit.spec.ts
@@ -485,10 +485,10 @@ describe("dispose 後ガード", () => {
 });
 
 describe("色フォールバック", () => {
-    it("非 hex の outline/wall 色でも throw しない", () => {
+    it("非 hex の line/wall 色でも throw しない", () => {
         const { mgr } = makeManager();
         expect(() =>
-            mgr.add({ points: pts3, outlineColor: "red", wallColor: "blue" }),
+            mgr.add({ points: pts3, style: { lineColor: "red", wallColor: "blue" } }),
         ).not.toThrow();
     });
 });

--- a/tests/timelapseBackLink.spec.ts
+++ b/tests/timelapseBackLink.spec.ts
@@ -4,7 +4,7 @@ import { test, expect } from "./tileCache.fixture";
  * Issue #163: タイムラプスデモの戻るリンクからポータルへ戻れない不具合の回帰防止。
  *
  * Issue #155 で URL が `/timelapse/@lat,lon,...` 形式に書き換えられるようになった結果、
- * 相対パス `href="./"` は `/timelapse/` に解決され、webpack の historyApiFallback rewrite で
+ * 相対パス `href="./"` は `/timelapse/` に解決され、SPA rewrite で
  * 再びタイムラプス HTML へフォールバックされてしまっていた。
  * 戻るリンクは絶対パス `/` を指し、ポータル (`<ul class="demos">`) へ遷移すること。
  */

--- a/tests/validation.spec.ts
+++ b/tests/validation.spec.ts
@@ -306,7 +306,7 @@ for (const engine of engines) {
         page,
     }, testInfo) => {
         // 東京の夜明け（2025-04-25 JST 05:13）に東向きでカメラを構え、太陽メッシュが画面内に映ることを検証する。
-        // パス `/@lat,lon` ではなく `?lat=&lon=` クエリ形式を採用（dev-server の historyApiFallback 互換）。
+        // パス `/@lat,lon` ではなく `?lat=&lon=` クエリ形式を採用（dev サーバの SPA rewrite と両立させる）。
         const sceneUrl = new URL("/viewer.html?scene=default", "http://localhost");
         sceneUrl.searchParams.set("engine", engine.param);
         sceneUrl.searchParams.set("lat", String(SUNRISE_LAT));

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,12 +3,12 @@ import { defineConfig } from "vite";
 import { demoRewritePlugin } from "./vite.rewrites";
 
 /**
- * Vite 設定（Webpack からの移行 / Issue #298）。
+ * Vite 設定（Issue #298）。
  */
 
 /**
  * エントリ HTML を格納するディレクトリ（Vite の `root`）。
- * webpack 時代と同様にリポジトリルートを HTML で散らかさないため `public/` に集約する。
+ * リポジトリルートを HTML で散らかさないため `public/` に集約する。
  * `root` を `public/` にすることで、配信 URL はルート基準（`/`, `/viewer.html` ...）を維持する。
  */
 const PAGES_DIR = "public";
@@ -44,7 +44,7 @@ const input = Object.fromEntries(
     ]),
 );
 
-/** url-loader の inline 閾値（8192B）を踏襲する。 */
+/** アセットを data URI 化する inline 閾値（8192B）。 */
 const ASSET_INLINE_LIMIT = 8192;
 
 export default defineConfig({
@@ -67,7 +67,7 @@ export default defineConfig({
     optimizeDeps: {
         entries: ["*.html"],
     },
-    // webpack-dev-server のデフォルトポート（8080）を踏襲する。
+    // 開発サーバーのポート（8080）。
     server: {
         port: 8080,
         strictPort: true,
@@ -93,7 +93,7 @@ export default defineConfig({
         // outDir が root 外のため明示的に許可する。
         emptyOutDir: true,
         sourcemap: true,
-        // url-loader 互換: 8192B 以下はインライン化（Base64 data URI）する。
+        // 8192B 以下のアセットはインライン化（Base64 data URI）する。
         // ただし OBJ/MTL/STL は OBJ ローダーが mtllib を rootUrl 相対で取得するため、
         // data URI 化すると解決できない。常にファイルとして出力する。
         assetsInlineLimit: (filePath, content) => {
@@ -112,7 +112,7 @@ export default defineConfig({
                     }
                     return "assets/[name]-[hash][extname]";
                 },
-                // webpack splitChunks.cacheGroups を踏襲したチャンク分割 (#298 / #317)。
+                // 共有依存（Babylon.js やシェーダー）を分離するチャンク分割 (#298 / #317)。
                 manualChunks(id) {
                     if (/\/ShadersWGSL\//.test(id)) return "webgpu-shaders";
                     if (/\/Shaders\//.test(id)) return "webgl-shaders";

--- a/vite.rewrites.ts
+++ b/vite.rewrites.ts
@@ -3,12 +3,9 @@ import type { Connect, Plugin } from "vite";
 /**
  * SPA fallback ルーティング定義 (Issue #157 / #298)。
  *
- * webpack-dev-server の `historyApiFallback.rewrites`（旧 `webpack.rewrites.js`）を
- * Vite の `configureServer` ミドルウェアへ移植したもの。dev (`vite.config.ts`) と
- * E2E テスト (`vite.tests.config.ts`) で同一の定義を共有し、両者の乖離を防ぐ。
- *
- * デモ識別子付きパス（/viewer/@..., /timelapse/@...）と、`.html` 付きの
- * 旧形式 URL も許容する（パース側 `src/terrain/urlState.ts` の挙動に合わせる）。
+ * デモ識別子付きパス（/viewer/@..., /timelapse/@...）を該当 HTML へ書き換える
+ * dev サーバーミドルウェア。dev (`vite.config.ts`) と E2E テスト
+ * (`vite.tests.config.ts`) で同一の定義を共有し、両者の乖離を防ぐ。
  */
 export interface DemoRewrite {
     from: RegExp;
@@ -32,10 +29,10 @@ const DEMO_NAMES = [
     "geospatial",
 ];
 
-export const demoAtPathRewrites: DemoRewrite[] = DEMO_NAMES.flatMap((name) => [
-    { from: new RegExp(`^/${name}(?:/@.*)?/?$`), to: `/${name}.html` },
-    { from: new RegExp(`^/${name}\\.html(?:/?@.*)?/?$`), to: `/${name}.html` },
-]);
+export const demoAtPathRewrites: DemoRewrite[] = DEMO_NAMES.map((name) => ({
+    from: new RegExp(`^/${name}(?:/@.*)?/?$`),
+    to: `/${name}.html`,
+}));
 
 /**
  * `demoAtPathRewrites` を Vite dev サーバーのミドルウェアとして適用するプラグイン。

--- a/vite.tests.config.ts
+++ b/vite.tests.config.ts
@@ -5,8 +5,7 @@ import baseConfig from "./vite.config";
  * E2E テスト（Playwright）用の Vite 設定（Issue #298 / #157）。
  *
  * dev 設定（`vite.config.ts`）を継承し、SPA rewrite プラグインを共有することで
- * dev と E2E の挙動の乖離を防ぐ。E2E の安定性のため HMR を無効化する
- * （webpack.tests.js の `hot: false` / `webSocketServer: false` 相当）。
+ * dev と E2E の挙動の乖離を防ぐ。E2E の安定性のため HMR を無効化する。
  */
 export default mergeConfig(baseConfig, {
     // dev (`npm start`) と E2E で依存最適化キャッシュを分離する。


### PR DESCRIPTION
## 概要

Vite を標準とする方針に伴い、旧 webpack 互換記述・`.html` 付き旧形式 URL・旧情報を整理（#423）し、あわせて内部 globe マネージャに残っていた旧API別名オプションを現行APIへ寄せて削除しました。

2 つの関連作業を 1 つの PR にまとめています。

## コミット

### 1. `6d1371f` — Vite標準化に伴う整理 (#423)
- `README.md`: URL 例をクリーン形に統一（`/viewer.html` → `/viewer` 等）
- `vite.config.ts` / `vite.rewrites.ts` / `vite.tests.config.ts`: webpack 由来コメントの言い換え、`.html`/`@` rewrite 規則を削除
- `spec/architecture.md` / `spec/demos.md`: 「デモ11本」→「13本」、`splitChunks` → `manualChunks` 等の旧情報を最新化
- `public/geospatial.html`: 「段階移行 Phase 1」記述を削除
- `src/**`: webpack/planar/旧framing 由来のコメントを簡潔化・言い換え

### 2. `e9a5cac` — 内部globeマネージャの旧API別名削除
- `GlobePolygonOptions` / `GlobeCircleOptions` から別名 `outlineColor` / `wallColor` / `wallOpacity` を削除し、`style` に一本化
- `GlobeCircleOptions` の `wallsEnabled` 別名を削除し、正規の `wallEnabled`（単数）に一本化
- 唯一の利用箇所だった geospatial デモを `style` 形式へ移行
- 関連 unit テストを `style` 形式へ更新
- **挙動は不変**。`topAltitudeMeters`・公開API（`src/lib/types.ts`）・`GlobePolygonOptions.wallsEnabled` は機能として保持

## 影響範囲

- 公開パッケージ API（`@jpmap/terrain` / `JpmapTerrain`）に変更なし。`spec/package.md` の記載（`style.wallColor` / `wallEnabled`）と整合（むしろ実装をドキュメント通りに揃えた）
- 内部マネージャの別名廃止は破壊的変更だが、リポジトリ内の唯一の利用箇所を同時移行済みで完結

## 検証

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test:unit` ✅（1241件）
- `npm run test:visuals` ✅（19件、円・ポリゴンの線/壁色の見た目一致を確認）
- reviewer エージェントによるAIレビュー: 承認（指摘なし）

Closes #423