### PR TITLE
fix(distance): scene.pick の Ray 副作用モジュールを import (#428)

### DIFF
--- a/src/demos/distance/index.ts
+++ b/src/demos/distance/index.ts
@@ -15,6 +15,8 @@
  * ポイント上 hover は API 既定動作でカーソル `pointer` に切り替わる。
  * 編集中はカメラ操作が API 側で抑制される。
  */
+// `scene.pick` は Ray の副作用モジュールに依存するため明示的に import する。
+import "@babylonjs/core/Culling/ray";
 import { JpmapTerrain } from "../../lib/jpmapTerrain";
 import type {
     JpmapTerrainOptions,


### PR DESCRIPTION
## 概要

距離計測デモで `scene.pick` 呼び出し時に発生していたランタイムエラーを修正する。

> Ray needs to be imported before as it contains a side-effect required by your code.

Closes #428

## 原因

`src/demos/distance/index.ts` の `scene.pick()`（頂点 hover 判定）は Babylon.js の Ray 副作用モジュールに依存するが、当該モジュールが未 import だった。ツリーシェイキングによりレイキャスト実装が注入されずエラーになっていた。`src/lib` 配下にもグローバルな ray import は無く、`src/demos/artillery/index.ts` のみが import 済みだった。

## 変更内容

`src/demos/distance/index.ts` の先頭に副作用 import を追加（artillery と同一パターン）。

```ts
import "@babylonjs/core/Culling/ray";
```

## 影響範囲

- 画面: 距離計測デモのみ
- API / 型変更: なし

## 検証

- [x] `npm run lint` → No issues found
- [x] `npm run typecheck` → 成功
- [x] `npm run dev` で距離計測デモを開きコンソールエラーが出ないこと（目視確認）

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>