### PR TITLE
fix(flight): フライトデモ「デモ一覧へ」遷移時のエラー解消 (#429)

### DIFF
--- a/src/demos/flight/index.ts
+++ b/src/demos/flight/index.ts
@@ -1132,7 +1132,7 @@ const start = async (): Promise<void> => {
         if (pipViewer) {
             pipViewer.dispose();
         }
-    });
+    }, { once: true });
 };
 
 start().catch((err) => {

--- a/src/demos/flight/index.ts
+++ b/src/demos/flight/index.ts
@@ -1110,10 +1110,7 @@ const start = async (): Promise<void> => {
     // ページ離脱時にアニメーションフレームをキャンセル + Viewer/PIP クリーンアップ
     window.addEventListener("beforeunload", () => {
         cancelAnimationFrame(rafId);
-        // メインエンジンのレンダーループを先に停止する。PIP（第2エンジン）の dispose と
-        // メインエンジンの描画が競合すると Babylon 内部の UniformBuffer override が壊れ、
-        // `_updateMatrixForUniformOverride is not a function` が発生するため。
-        viewer.__debugScene?.getEngine().stopRenderLoop();
+        // メインシーンに紐づくリソースを先に解放する（シーン破棄前）。
         if (routeLine) {
             routeLine.dispose();
         }
@@ -1126,12 +1123,15 @@ const start = async (): Promise<void> => {
         if (afterburner) {
             afterburner.dispose();
         }
+        // メイン Viewer を PIP（第2エンジン）より先に dispose してレンダーループを止める。
+        // メインエンジンの描画と PIP の dispose が競合すると Babylon 内部の
+        // UniformBuffer override が壊れ、`_updateMatrixForUniformOverride is not a
+        // function` が発生するため、この順序を守る。
+        viewer.dispose();
         pipCleanups.forEach((fn) => fn());
         if (pipViewer) {
             pipViewer.dispose();
         }
-        // メイン Viewer（Scene/Engine）も解放する。
-        viewer.dispose();
     });
 };
 

--- a/src/demos/flight/index.ts
+++ b/src/demos/flight/index.ts
@@ -1124,9 +1124,10 @@ const start = async (): Promise<void> => {
             afterburner.dispose();
         }
         // メイン Viewer を PIP（第2エンジン）より先に dispose してレンダーループを止める。
-        // メインエンジンの描画と PIP の dispose が競合すると Babylon 内部の
-        // UniformBuffer override が壊れ、`_updateMatrixForUniformOverride is not a
-        // function` が発生するため、この順序を守る。
+        // メインエンジンの描画と PIP の dispose が競合すると Babylon 内部の UniformBuffer
+        // override が壊れる。
+        // 例: `TypeError: this._updateMatrixForUniformOverride is not a function`
+        // これを避けるため、この順序を守る。
         viewer.dispose();
         pipCleanups.forEach((fn) => fn());
         if (pipViewer) {

--- a/src/demos/flight/index.ts
+++ b/src/demos/flight/index.ts
@@ -1107,9 +1107,13 @@ const start = async (): Promise<void> => {
     };
     rafId = requestAnimationFrame(tick);
 
-    // ページ離脱時にアニメーションフレームをキャンセル + PIP クリーンアップ
+    // ページ離脱時にアニメーションフレームをキャンセル + Viewer/PIP クリーンアップ
     window.addEventListener("beforeunload", () => {
         cancelAnimationFrame(rafId);
+        // メインエンジンのレンダーループを先に停止する。PIP（第2エンジン）の dispose と
+        // メインエンジンの描画が競合すると Babylon 内部の UniformBuffer override が壊れ、
+        // `_updateMatrixForUniformOverride is not a function` が発生するため。
+        viewer.__debugScene?.getEngine().stopRenderLoop();
         if (routeLine) {
             routeLine.dispose();
         }
@@ -1126,6 +1130,8 @@ const start = async (): Promise<void> => {
         if (pipViewer) {
             pipViewer.dispose();
         }
+        // メイン Viewer（Scene/Engine）も解放する。
+        viewer.dispose();
     });
 };
 


### PR DESCRIPTION
Closes #429

## 概要
フライトデモで「デモ一覧へ」リンク押下（ページ遷移）時にコンソールへ `TypeError: this._updateMatrixForUniformOverride is not a function` が出力される不具合を修正する。

## 根本原因
フライトデモはメイン viewer と PIP viewer の 2 つの Babylon Engine を生成する。`beforeunload` では PIP や付随リソースを dispose する一方、**メイン viewer を dispose していなかった**ため、離脱時にメインエンジンの描画継続と PIP（第2エンジン）の dispose が競合し、Babylon 内部の UniformBuffer override 状態が壊れてエラーが発生していた。

## 変更内容
`src/demos/flight/index.ts` の `beforeunload` ハンドラを修正:
- メインシーンに紐づくリソース（routeLine / waypointManager / flightAudio / afterburner）を先に解放
- 続いて **メイン `viewer.dispose()` を PIP dispose より前に実行**。`JpmapTerrain.dispose()` 内部でメインエンジンが dispose されレンダーループが停止するため、PIP（第2エンジン）破棄との競合を回避する
- 最後に PIP のクリーンアップ（`pipCleanups` / `pipViewer.dispose()`）を実行
- ハンドラに `{ once: true }` を指定し、複数回発火時の二重 dispose を防止

## 影響範囲
- 画面: フライトデモのページ離脱処理のみ（描画挙動への副作用なし）
- API/型: 変更なし

## 確認
- [x] `npm run typecheck` 成功
- [x] `npm run lint` 成功
- [x] `npm run test:unit` 成功（1241件）
- [x] 目視確認: 「デモ一覧へ」押下時に当該エラーが出力されないこと（報告者確認済み）