### PR TITLE
fix(#424): デモのレスポンシブ・タッチパネル対応

### DIFF
--- a/public/artillery.html
+++ b/public/artillery.html
@@ -5,6 +5,7 @@
   <title>jpmap_terrain – Artillery Game</title>
   <meta name="description" content="ターン制対戦 Artillery Game デモ">
   <meta name="author" content="8ga3">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
   <style>
     html, body {
       overflow: hidden;
@@ -315,6 +316,64 @@
     .input-blocker.active {
       display: block;
       pointer-events: auto;
+    }
+
+    @media (max-width: 640px) {
+      #artillery-overlay .back-link {
+        padding: 8px 14px;
+        font-size: 14px;
+      }
+
+      .score-bar {
+        max-width: calc(100vw - 16px);
+        box-sizing: border-box;
+        font-size: 12px;
+      }
+
+      .score-bar .team {
+        padding: 4px 6px;
+      }
+
+      .score-bar .separator {
+        margin: 0 2px;
+      }
+
+      .controls-bar {
+        bottom: 8px;
+        width: calc(100vw - 16px);
+        box-sizing: border-box;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 8px;
+        padding: 8px;
+        font-size: 12px;
+      }
+
+      .controls-bar .ctrl-group {
+        flex: 1 1 130px;
+        min-width: 0;
+      }
+
+      .controls-bar input[type="range"] {
+        flex: 1;
+        min-width: 80px;
+        height: 28px;
+      }
+
+      .controls-bar .divider {
+        display: none;
+      }
+
+      .controls-bar button {
+        min-height: 36px;
+        padding: 8px 12px;
+        font-size: 14px;
+      }
+
+      .controls-bar button.fire-btn {
+        padding: 8px 16px;
+        font-size: 14px;
+      }
     }
   </style>
 </head>

--- a/public/artillery.html
+++ b/public/artillery.html
@@ -325,7 +325,8 @@
       }
 
       .score-bar {
-        max-width: calc(100vw - 16px);
+        /* 上端左右の back-link / コンパスを避けて中央に収める。 */
+        max-width: calc(100vw - 130px);
         box-sizing: border-box;
         font-size: 12px;
       }
@@ -339,7 +340,8 @@
       }
 
       .controls-bar {
-        bottom: 8px;
+        /* 下端隅のズーム/写真ボタンへ被らないよう、ボタン群の上へ持ち上げる。 */
+        bottom: 140px;
         width: calc(100vw - 16px);
         box-sizing: border-box;
         flex-wrap: wrap;

--- a/public/avatar-controller.html
+++ b/public/avatar-controller.html
@@ -113,16 +113,52 @@
       line-height: 1.4;
     }
 
+    /* モバイル用の操作パネル開閉トグル（PC では非表示・パネル常時表示）。 */
+    .panel-toggle-cb,
+    .panel-toggle-btn {
+      display: none;
+    }
+
     @media (max-width: 640px) {
-      #avatar-controls {
+      .panel-toggle-btn {
+        position: absolute;
         top: 56px;
         left: 8px;
-        right: 8px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 40px;
+        height: 40px;
+        pointer-events: auto;
+        color: #fff;
+        font-size: 18px;
+        background: rgba(0, 0, 0, 0.55);
+        border: 1px solid rgba(255, 255, 255, 0.25);
+        border-radius: 8px;
+        cursor: pointer;
+        z-index: 11;
+      }
+
+      #avatar-panel-toggle:checked + .panel-toggle-btn {
+        background: rgba(96, 165, 250, 0.55);
+        border-color: rgba(191, 219, 254, 0.85);
+      }
+
+      #avatar-controls {
+        top: 104px;
+        left: 8px;
+        right: auto;
+        width: min(78vw, 280px);
         min-width: 0;
         max-width: none;
-        max-height: calc(100vh - 72px);
+        max-height: calc(100vh - 160px);
         overflow-y: auto;
-        font-size: 14px;
+        font-size: 13px;
+      }
+
+      /* 既定は折り畳み（閉じた状態）。トグルで開く。 */
+      #avatar-panel-toggle:not(:checked) ~ #avatar-controls {
+        display: none;
       }
 
       #avatar-controls button {
@@ -146,6 +182,8 @@
   <div id="root"></div>
   <div id="avatar-overlay">
     <a class="back-link" href="/">← デモ一覧へ</a>
+    <input type="checkbox" id="avatar-panel-toggle" class="panel-toggle-cb" hidden>
+    <label for="avatar-panel-toggle" class="panel-toggle-btn" aria-label="操作パネルの開閉" title="操作パネル">⚙</label>
     <div id="avatar-controls">
       <strong>アバターアニメーション #02</strong>
       <div class="info-row">

--- a/public/avatar-controller.html
+++ b/public/avatar-controller.html
@@ -5,6 +5,7 @@
   <title>jpmap_terrain – アバターアニメーション #02</title>
   <meta name="description" content="キーボード / Gamepad / Virtual Joystick でアバターを操作するデモ">
   <meta name="author" content="8ga3">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
   <style>
     html, body {
       overflow: hidden;
@@ -110,6 +111,34 @@
       color: #c8cdd6;
       margin-top: 4px;
       line-height: 1.4;
+    }
+
+    @media (max-width: 640px) {
+      #avatar-controls {
+        top: 56px;
+        left: 8px;
+        right: 8px;
+        min-width: 0;
+        max-width: none;
+        max-height: calc(100vh - 72px);
+        overflow-y: auto;
+        font-size: 14px;
+      }
+
+      #avatar-controls button {
+        min-height: 36px;
+        padding: 8px 12px;
+        font-size: 14px;
+      }
+
+      #avatar-controls input[type="range"] {
+        height: 28px;
+      }
+
+      #avatar-overlay .back-link {
+        padding: 8px 14px;
+        font-size: 14px;
+      }
     }
   </style>
 </head>

--- a/public/avatar.html
+++ b/public/avatar.html
@@ -106,16 +106,52 @@
       background: rgba(255, 255, 255, 0.18);
     }
 
+    /* モバイル用の操作パネル開閉トグル（PC では非表示・パネル常時表示）。 */
+    .panel-toggle-cb,
+    .panel-toggle-btn {
+      display: none;
+    }
+
     @media (max-width: 640px) {
-      #avatar-controls {
+      .panel-toggle-btn {
+        position: absolute;
         top: 56px;
         left: 8px;
-        right: 8px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 40px;
+        height: 40px;
+        pointer-events: auto;
+        color: #fff;
+        font-size: 18px;
+        background: rgba(0, 0, 0, 0.55);
+        border: 1px solid rgba(255, 255, 255, 0.25);
+        border-radius: 8px;
+        cursor: pointer;
+        z-index: 11;
+      }
+
+      #avatar-panel-toggle:checked + .panel-toggle-btn {
+        background: rgba(96, 165, 250, 0.55);
+        border-color: rgba(191, 219, 254, 0.85);
+      }
+
+      #avatar-controls {
+        top: 104px;
+        left: 8px;
+        right: auto;
+        width: min(78vw, 280px);
         min-width: 0;
         max-width: none;
-        max-height: calc(100vh - 72px);
+        max-height: calc(100vh - 160px);
         overflow-y: auto;
-        font-size: 14px;
+        font-size: 13px;
+      }
+
+      /* 既定は折り畳み（閉じた状態）。トグルで開く。 */
+      #avatar-panel-toggle:not(:checked) ~ #avatar-controls {
+        display: none;
       }
 
       #avatar-controls button {
@@ -139,6 +175,8 @@
   <div id="root"></div>
   <div id="avatar-overlay">
     <a class="back-link" href="/">← デモ一覧へ</a>
+    <input type="checkbox" id="avatar-panel-toggle" class="panel-toggle-cb" hidden>
+    <label for="avatar-panel-toggle" class="panel-toggle-btn" aria-label="操作パネルの開閉" title="操作パネル">⚙</label>
     <div id="avatar-controls">
       <strong>アバターアニメーション #01</strong>
       <div class="info-row">

--- a/public/avatar.html
+++ b/public/avatar.html
@@ -5,6 +5,7 @@
   <title>jpmap_terrain – アバターアニメーション #01</title>
   <meta name="description" content="3Dアバターが地形に沿って円軌道を移動するアニメーションデモ">
   <meta name="author" content="8ga3">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
   <style>
     html, body {
       overflow: hidden;
@@ -103,6 +104,34 @@
 
     #avatar-controls button:hover {
       background: rgba(255, 255, 255, 0.18);
+    }
+
+    @media (max-width: 640px) {
+      #avatar-controls {
+        top: 56px;
+        left: 8px;
+        right: 8px;
+        min-width: 0;
+        max-width: none;
+        max-height: calc(100vh - 72px);
+        overflow-y: auto;
+        font-size: 14px;
+      }
+
+      #avatar-controls button {
+        min-height: 36px;
+        padding: 8px 12px;
+        font-size: 14px;
+      }
+
+      #avatar-controls input[type="range"] {
+        height: 28px;
+      }
+
+      #avatar-overlay .back-link {
+        padding: 8px 14px;
+        font-size: 14px;
+      }
     }
   </style>
 </head>

--- a/public/boids.html
+++ b/public/boids.html
@@ -5,6 +5,7 @@
   <title>jpmap_terrain – Boids フロッキングデモ</title>
   <meta name="description" content="Boidsアルゴリズムによる群衆シミュレーションデモ">
   <meta name="author" content="8ga3">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
   <style>
     html, body {
       overflow: hidden;
@@ -112,6 +113,34 @@
 
     .btn-row button {
       flex: 1;
+    }
+
+    @media (max-width: 640px) {
+      #boids-controls {
+        top: 56px;
+        left: 8px;
+        right: 8px;
+        min-width: 0;
+        max-width: none;
+        max-height: calc(100vh - 72px);
+        overflow-y: auto;
+        font-size: 14px;
+      }
+
+      #boids-controls button {
+        min-height: 36px;
+        padding: 8px 12px;
+        font-size: 14px;
+      }
+
+      #boids-controls input[type="range"] {
+        height: 28px;
+      }
+
+      #boids-overlay .back-link {
+        padding: 8px 14px;
+        font-size: 14px;
+      }
     }
   </style>
 </head>

--- a/public/boids.html
+++ b/public/boids.html
@@ -115,16 +115,52 @@
       flex: 1;
     }
 
+    /* モバイル用の操作パネル開閉トグル（PC では非表示・パネル常時表示）。 */
+    .panel-toggle-cb,
+    .panel-toggle-btn {
+      display: none;
+    }
+
     @media (max-width: 640px) {
-      #boids-controls {
+      .panel-toggle-btn {
+        position: absolute;
         top: 56px;
         left: 8px;
-        right: 8px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 40px;
+        height: 40px;
+        pointer-events: auto;
+        color: #fff;
+        font-size: 18px;
+        background: rgba(0, 0, 0, 0.55);
+        border: 1px solid rgba(255, 255, 255, 0.25);
+        border-radius: 8px;
+        cursor: pointer;
+        z-index: 11;
+      }
+
+      #boids-panel-toggle:checked + .panel-toggle-btn {
+        background: rgba(96, 165, 250, 0.55);
+        border-color: rgba(191, 219, 254, 0.85);
+      }
+
+      #boids-controls {
+        top: 104px;
+        left: 8px;
+        right: auto;
+        width: min(78vw, 280px);
         min-width: 0;
         max-width: none;
-        max-height: calc(100vh - 72px);
+        max-height: calc(100vh - 160px);
         overflow-y: auto;
-        font-size: 14px;
+        font-size: 13px;
+      }
+
+      /* 既定は折り畳み（閉じた状態）。トグルで開く。 */
+      #boids-panel-toggle:not(:checked) ~ #boids-controls {
+        display: none;
       }
 
       #boids-controls button {
@@ -148,6 +184,8 @@
   <div id="root"></div>
   <div id="boids-overlay">
     <a class="back-link" href="/">← デモ一覧へ</a>
+    <input type="checkbox" id="boids-panel-toggle" class="panel-toggle-cb" hidden>
+    <label for="boids-panel-toggle" class="panel-toggle-btn" aria-label="操作パネルの開閉" title="操作パネル">⚙</label>
     <div id="boids-controls">
       <strong>Boids フロッキングデモ</strong>
       <div class="info-row">

--- a/public/circle.html
+++ b/public/circle.html
@@ -88,16 +88,52 @@
       background: rgba(255, 255, 255, 0.18);
     }
 
+    /* モバイル用の操作パネル開閉トグル（PC では非表示・パネル常時表示）。 */
+    .panel-toggle-cb,
+    .panel-toggle-btn {
+      display: none;
+    }
+
     @media (max-width: 640px) {
-      #circle-controls {
+      .panel-toggle-btn {
+        position: absolute;
         top: 56px;
         left: 8px;
-        right: 8px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 40px;
+        height: 40px;
+        pointer-events: auto;
+        color: #fff;
+        font-size: 18px;
+        background: rgba(0, 0, 0, 0.55);
+        border: 1px solid rgba(255, 255, 255, 0.25);
+        border-radius: 8px;
+        cursor: pointer;
+        z-index: 11;
+      }
+
+      #circle-panel-toggle:checked + .panel-toggle-btn {
+        background: rgba(96, 165, 250, 0.55);
+        border-color: rgba(191, 219, 254, 0.85);
+      }
+
+      #circle-controls {
+        top: 104px;
+        left: 8px;
+        right: auto;
+        width: min(78vw, 280px);
         min-width: 0;
         max-width: none;
-        max-height: calc(100vh - 72px);
+        max-height: calc(100vh - 160px);
         overflow-y: auto;
-        font-size: 14px;
+        font-size: 13px;
+      }
+
+      /* 既定は折り畳み（閉じた状態）。トグルで開く。 */
+      #circle-panel-toggle:not(:checked) ~ #circle-controls {
+        display: none;
       }
 
       #circle-controls button {
@@ -117,6 +153,8 @@
   <div id="root"></div>
   <div id="circle-overlay">
     <a class="back-link" href="/">← デモ一覧へ</a>
+    <input type="checkbox" id="circle-panel-toggle" class="panel-toggle-cb" hidden>
+    <label for="circle-panel-toggle" class="panel-toggle-btn" aria-label="操作パネルの開閉" title="操作パネル">⚙</label>
     <div id="circle-controls">
       <strong>サークルデモ (Issue #201 / #206)</strong>
       <div id="circle-controls-buttons"></div>

--- a/public/circle.html
+++ b/public/circle.html
@@ -156,7 +156,7 @@
     <input type="checkbox" id="circle-panel-toggle" class="panel-toggle-cb" hidden>
     <label for="circle-panel-toggle" class="panel-toggle-btn" aria-label="操作パネルの開閉" title="操作パネル">⚙</label>
     <div id="circle-controls">
-      <strong>サークルデモ (Issue #201 / #206)</strong>
+      <strong>サークルデモ</strong>
       <div id="circle-controls-buttons"></div>
     </div>
   </div>

--- a/public/circle.html
+++ b/public/circle.html
@@ -5,6 +5,7 @@
   <title>jpmap_terrain – サークルデモ</title>
   <meta name="description" content="jpmap_terrain の Circle (CircleManager) 公開 API 動作確認デモ (Issue #201 / #206)">
   <meta name="author" content="8ga3">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
   <style>
     html, body {
       overflow: hidden;
@@ -85,6 +86,30 @@
 
     #circle-controls button:hover {
       background: rgba(255, 255, 255, 0.18);
+    }
+
+    @media (max-width: 640px) {
+      #circle-controls {
+        top: 56px;
+        left: 8px;
+        right: 8px;
+        min-width: 0;
+        max-width: none;
+        max-height: calc(100vh - 72px);
+        overflow-y: auto;
+        font-size: 14px;
+      }
+
+      #circle-controls button {
+        min-height: 36px;
+        padding: 8px 12px;
+        font-size: 14px;
+      }
+
+      #circle-overlay .back-link {
+        padding: 8px 14px;
+        font-size: 14px;
+      }
     }
   </style>
 </head>

--- a/public/distance.html
+++ b/public/distance.html
@@ -107,16 +107,52 @@
       white-space: pre-line;
     }
 
+    /* モバイル用の操作パネル開閉トグル（PC では非表示・パネル常時表示）。 */
+    .panel-toggle-cb,
+    .panel-toggle-btn {
+      display: none;
+    }
+
     @media (max-width: 640px) {
-      #distance-controls {
+      .panel-toggle-btn {
+        position: absolute;
         top: 56px;
         left: 8px;
-        right: 8px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 40px;
+        height: 40px;
+        pointer-events: auto;
+        color: #fff;
+        font-size: 18px;
+        background: rgba(0, 0, 0, 0.55);
+        border: 1px solid rgba(255, 255, 255, 0.25);
+        border-radius: 8px;
+        cursor: pointer;
+        z-index: 11;
+      }
+
+      #distance-panel-toggle:checked + .panel-toggle-btn {
+        background: rgba(96, 165, 250, 0.55);
+        border-color: rgba(191, 219, 254, 0.85);
+      }
+
+      #distance-controls {
+        top: 104px;
+        left: 8px;
+        right: auto;
+        width: min(78vw, 280px);
         min-width: 0;
         max-width: none;
-        max-height: calc(100vh - 72px);
+        max-height: calc(100vh - 160px);
         overflow-y: auto;
-        font-size: 14px;
+        font-size: 13px;
+      }
+
+      /* 既定は折り畳み（閉じた状態）。トグルで開く。 */
+      #distance-panel-toggle:not(:checked) ~ #distance-controls {
+        display: none;
       }
 
       #distance-controls button {
@@ -136,6 +172,8 @@
   <div id="root"></div>
   <div id="distance-overlay">
     <a class="back-link" href="/">← デモ一覧へ</a>
+    <input type="checkbox" id="distance-panel-toggle" class="panel-toggle-cb" hidden>
+    <label for="distance-panel-toggle" class="panel-toggle-btn" aria-label="操作パネルの開閉" title="操作パネル">⚙</label>
     <div id="distance-controls">
       <strong>距離計測デモ (#186)</strong>
       <div id="distance-toolbar-buttons"></div>

--- a/public/distance.html
+++ b/public/distance.html
@@ -175,7 +175,7 @@
     <input type="checkbox" id="distance-panel-toggle" class="panel-toggle-cb" hidden>
     <label for="distance-panel-toggle" class="panel-toggle-btn" aria-label="操作パネルの開閉" title="操作パネル">⚙</label>
     <div id="distance-controls">
-      <strong>距離計測デモ (#186)</strong>
+      <strong>距離計測デモ</strong>
       <div id="distance-toolbar-buttons"></div>
       <div id="distance-status"></div>
     </div>

--- a/public/distance.html
+++ b/public/distance.html
@@ -5,6 +5,7 @@
   <title>jpmap_terrain – 距離計測デモ</title>
   <meta name="description" content="jpmap_terrain の距離計測デモ (#186)。クリックで点を追加し、辺ごとに水平距離・高低差を表示する">
   <meta name="author" content="8ga3">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
   <style>
     html, body {
       overflow: hidden;
@@ -104,6 +105,30 @@
       line-height: 1.4;
       color: #e2e8f0;
       white-space: pre-line;
+    }
+
+    @media (max-width: 640px) {
+      #distance-controls {
+        top: 56px;
+        left: 8px;
+        right: 8px;
+        min-width: 0;
+        max-width: none;
+        max-height: calc(100vh - 72px);
+        overflow-y: auto;
+        font-size: 14px;
+      }
+
+      #distance-controls button {
+        min-height: 36px;
+        padding: 8px 12px;
+        font-size: 14px;
+      }
+
+      #distance-overlay .back-link {
+        padding: 8px 14px;
+        font-size: 14px;
+      }
     }
   </style>
 </head>

--- a/public/distance.html
+++ b/public/distance.html
@@ -100,6 +100,15 @@
       border-color: rgba(191, 219, 254, 0.85);
     }
 
+    #distance-controls button:disabled {
+      opacity: 0.4;
+      cursor: default;
+    }
+
+    #distance-controls button:disabled:hover {
+      background: rgba(255, 255, 255, 0.08);
+    }
+
     #distance-status {
       font-size: 11px;
       line-height: 1.4;

--- a/public/flight.html
+++ b/public/flight.html
@@ -281,12 +281,14 @@
         top: 104px;
         left: 8px;
         right: auto;
-        width: min(78vw, 280px);
+        width: min(72vw, 240px);
         min-width: 0;
         max-width: none;
-        max-height: calc(100vh - 160px);
+        max-height: calc(100vh - 180px);
         overflow-y: auto;
-        font-size: 13px;
+        padding: 8px 10px;
+        gap: 4px;
+        font-size: 12px;
       }
 
       /* 既定は折り畳み（閉じた状態）。トグルで開く。 */
@@ -295,13 +297,14 @@
       }
 
       #flight-controls button {
-        min-height: 36px;
-        padding: 8px 12px;
-        font-size: 14px;
+        min-height: 32px;
+        padding: 6px 8px;
+        font-size: 12px;
       }
 
       #flight-controls input[type="range"] {
-        height: 28px;
+        height: 22px;
+        margin: 2px 0;
       }
 
       #flight-overlay .back-link {

--- a/public/flight.html
+++ b/public/flight.html
@@ -5,6 +5,7 @@
   <title>jpmap_terrain – フライトデモ</title>
   <meta name="description" content="飛行機が上空を旋回し、FollowCameraで追跡するデモ">
   <meta name="author" content="8ga3">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
   <style>
     html, body {
       overflow: hidden;
@@ -243,6 +244,34 @@
       text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
       pointer-events: none;
       z-index: 2;
+    }
+
+    @media (max-width: 640px) {
+      #flight-controls {
+        top: 56px;
+        left: 8px;
+        right: 8px;
+        min-width: 0;
+        max-width: none;
+        max-height: calc(100vh - 72px);
+        overflow-y: auto;
+        font-size: 14px;
+      }
+
+      #flight-controls button {
+        min-height: 36px;
+        padding: 8px 12px;
+        font-size: 14px;
+      }
+
+      #flight-controls input[type="range"] {
+        height: 28px;
+      }
+
+      #flight-overlay .back-link {
+        padding: 8px 14px;
+        font-size: 14px;
+      }
     }
   </style>
 </head>

--- a/public/flight.html
+++ b/public/flight.html
@@ -342,11 +342,11 @@
         <input type="range" id="altitude-slider" min="100" max="10000" value="500" step="50">
       </div>
       <div class="btn-row">
-        <button id="toggle-animation">⏸停止</button>
-        <button id="fly-to-center">移動</button>
-        <button id="camera-3d" class="active">3D</button>
-        <button id="camera-2d">2D</button>
-        <button id="camera-follow">Follow</button>
+        <button type="button" id="toggle-animation">⏸停止</button>
+        <button type="button" id="fly-to-center">移動</button>
+        <button type="button" id="camera-3d" class="active">3D</button>
+        <button type="button" id="camera-2d">2D</button>
+        <button type="button" id="camera-follow">Follow</button>
       </div>
       <div id="follow-cam-info" style="display:none; border-top: 1px solid rgba(255,255,255,0.15); padding-top: 6px; margin-top: 2px;">
         <div class="inline-row" style="margin-bottom: 4px;">
@@ -366,9 +366,9 @@
       <div style="border-top: 1px solid rgba(255,255,255,0.15); padding-top: 6px; margin-top: 2px; display: flex; flex-direction: column; gap: 4px;">
         <strong style="font-size: 11px;">表示切替</strong>
         <div class="btn-row">
-          <button id="waypoint-toggle" class="active" title="ウェイポイント">WP</button>
-          <button id="ribbon-toggle" class="active" title="リボン (飛行経路)">経路</button>
-          <button id="afterburner-toggle" class="active" title="アフターバーナー">噴射</button>
+          <button type="button" id="waypoint-toggle" class="active" title="ウェイポイント" aria-label="ウェイポイント表示切替">WP</button>
+          <button type="button" id="ribbon-toggle" class="active" title="リボン (飛行経路)" aria-label="リボン (飛行経路) 表示切替">経路</button>
+          <button type="button" id="afterburner-toggle" class="active" title="アフターバーナー" aria-label="アフターバーナー表示切替">噴射</button>
         </div>
       </div>
     </div>

--- a/public/flight.html
+++ b/public/flight.html
@@ -92,16 +92,16 @@
       top: 12px;
       right: 64px;
       pointer-events: auto;
-      padding: 10px 12px;
-      font-size: 13px;
+      padding: 8px 10px;
+      font-size: 12px;
       color: #fff;
       background: rgba(0, 0, 0, 0.5);
       border: 1px solid rgba(255, 255, 255, 0.2);
       border-radius: 8px;
       display: flex;
       flex-direction: column;
-      gap: 6px;
-      min-width: 200px;
+      gap: 5px;
+      min-width: 176px;
     }
 
     #flight-controls .btn-row {
@@ -111,6 +111,8 @@
 
     #flight-controls .btn-row button {
       flex: 1;
+      padding: 6px 4px;
+      white-space: nowrap;
     }
 
     #flight-controls .inline-row {
@@ -172,15 +174,6 @@
     #flight-controls button.active {
       background: rgba(59, 130, 246, 0.5);
       border-color: rgba(59, 130, 246, 0.8);
-    }
-
-    #flight-controls .camera-buttons {
-      display: flex;
-      gap: 4px;
-    }
-
-    #flight-controls .camera-buttons button {
-      flex: 1;
     }
 
     /* PIP overlay */
@@ -349,11 +342,8 @@
         <input type="range" id="altitude-slider" min="100" max="10000" value="500" step="50">
       </div>
       <div class="btn-row">
-        <button id="toggle-animation">⏸ 停止</button>
+        <button id="toggle-animation">⏸停止</button>
         <button id="fly-to-center">移動</button>
-      </div>
-      <div style="font-size: 11px; color: #e0e4ea;">カメラモード</div>
-      <div class="camera-buttons">
         <button id="camera-3d" class="active">3D</button>
         <button id="camera-2d">2D</button>
         <button id="camera-follow">Follow</button>
@@ -375,18 +365,11 @@
       </div>
       <div style="border-top: 1px solid rgba(255,255,255,0.15); padding-top: 6px; margin-top: 2px; display: flex; flex-direction: column; gap: 4px;">
         <strong style="font-size: 11px;">表示切替</strong>
-        <label style="display: flex; align-items: center; gap: 6px; font-size: 12px; cursor: pointer;">
-          <input type="checkbox" id="waypoint-toggle" checked style="cursor: pointer;">
-          ウェイポイント
-        </label>
-        <label style="display: flex; align-items: center; gap: 6px; font-size: 12px; cursor: pointer;">
-          <input type="checkbox" id="ribbon-toggle" checked style="cursor: pointer;">
-          リボン (飛行経路)
-        </label>
-        <label style="display: flex; align-items: center; gap: 6px; font-size: 12px; cursor: pointer;">
-          <input type="checkbox" id="afterburner-toggle" checked style="cursor: pointer;">
-          アフターバーナー
-        </label>
+        <div class="btn-row">
+          <button id="waypoint-toggle" class="active" title="ウェイポイント">WP</button>
+          <button id="ribbon-toggle" class="active" title="リボン (飛行経路)">経路</button>
+          <button id="afterburner-toggle" class="active" title="アフターバーナー">噴射</button>
+        </div>
       </div>
     </div>
     <div id="pip-frame">

--- a/public/flight.html
+++ b/public/flight.html
@@ -246,16 +246,52 @@
       z-index: 2;
     }
 
+    /* モバイル用の操作パネル開閉トグル（PC では非表示・パネル常時表示）。 */
+    .panel-toggle-cb,
+    .panel-toggle-btn {
+      display: none;
+    }
+
     @media (max-width: 640px) {
-      #flight-controls {
+      .panel-toggle-btn {
+        position: absolute;
         top: 56px;
         left: 8px;
-        right: 8px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 40px;
+        height: 40px;
+        pointer-events: auto;
+        color: #fff;
+        font-size: 18px;
+        background: rgba(0, 0, 0, 0.55);
+        border: 1px solid rgba(255, 255, 255, 0.25);
+        border-radius: 8px;
+        cursor: pointer;
+        z-index: 11;
+      }
+
+      #flight-panel-toggle:checked + .panel-toggle-btn {
+        background: rgba(96, 165, 250, 0.55);
+        border-color: rgba(191, 219, 254, 0.85);
+      }
+
+      #flight-controls {
+        top: 104px;
+        left: 8px;
+        right: auto;
+        width: min(78vw, 280px);
         min-width: 0;
         max-width: none;
-        max-height: calc(100vh - 72px);
+        max-height: calc(100vh - 160px);
         overflow-y: auto;
-        font-size: 14px;
+        font-size: 13px;
+      }
+
+      /* 既定は折り畳み（閉じた状態）。トグルで開く。 */
+      #flight-panel-toggle:not(:checked) ~ #flight-controls {
+        display: none;
       }
 
       #flight-controls button {
@@ -280,6 +316,8 @@
   <div id="wp-shockwave"></div>
   <div id="flight-overlay">
     <a class="back-link" href="/">← デモ一覧へ</a>
+    <input type="checkbox" id="flight-panel-toggle" class="panel-toggle-cb" hidden>
+    <label for="flight-panel-toggle" class="panel-toggle-btn" aria-label="操作パネルの開閉" title="操作パネル">⚙</label>
     <div id="flight-controls">
       <strong>フライトデモ</strong>
       <div class="inline-row">

--- a/public/geospatial.html
+++ b/public/geospatial.html
@@ -6,6 +6,7 @@
   <title>jpmap_terrain – Geospatial (Globe / #275)</title>
   <meta name="description" content="Babylon.js 9.x Geospatial(GeospatialCamera + ECEF + Floating Origin) によるグローブ地形">
   <meta name="author" content="8ga3">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
     <style>
       html,
       body {
@@ -34,6 +35,15 @@
         border-radius: 6px;
         pointer-events: none;
         white-space: pre-line;
+      }
+
+      @media (max-width: 640px) {
+        #globe-info {
+          max-width: calc(100vw - 16px);
+          box-sizing: border-box;
+          font-size: 12px;
+          line-height: 1.45;
+        }
       }
     </style>
   </head>

--- a/public/geospatial.html
+++ b/public/geospatial.html
@@ -39,7 +39,8 @@
 
       @media (max-width: 640px) {
         #globe-info {
-          max-width: calc(100vw - 16px);
+          /* 右上のコンパスボタン用に右側 56px 程度を空ける。 */
+          max-width: calc(100vw - 64px);
           box-sizing: border-box;
           font-size: 12px;
           line-height: 1.45;

--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,7 @@
 <html lang="ja">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>jpmap_terrain – デモポータル</title>
   <meta name="description" content="jpmap_terrain のデモ一覧ポータル">
   <meta name="author" content="8ga3">

--- a/public/model.html
+++ b/public/model.html
@@ -5,6 +5,7 @@
   <title>jpmap_terrain – 3Dモデルデモ</title>
   <meta name="description" content="jpmap_terrain の 3Dモデル (ModelManager) 公開 API 動作確認デモ">
   <meta name="author" content="8ga3">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
   <style>
     html, body {
       overflow: hidden;
@@ -103,6 +104,34 @@
 
     #model-controls button:hover {
       background: rgba(255, 255, 255, 0.18);
+    }
+
+    @media (max-width: 640px) {
+      #model-controls {
+        top: 56px;
+        left: 8px;
+        right: 8px;
+        min-width: 0;
+        max-width: none;
+        max-height: calc(100vh - 72px);
+        overflow-y: auto;
+        font-size: 14px;
+      }
+
+      #model-controls button {
+        min-height: 36px;
+        padding: 8px 12px;
+        font-size: 14px;
+      }
+
+      #model-controls input[type="range"] {
+        height: 28px;
+      }
+
+      #model-overlay .back-link {
+        padding: 8px 14px;
+        font-size: 14px;
+      }
     }
   </style>
 </head>

--- a/public/model.html
+++ b/public/model.html
@@ -106,19 +106,56 @@
       background: rgba(255, 255, 255, 0.18);
     }
 
+    /* モバイル用の操作パネル開閉トグル（PC では非表示・パネル常時表示）。 */
+    .panel-toggle-cb,
+    .panel-toggle-btn {
+      display: none;
+    }
+
     @media (max-width: 640px) {
-      #model-controls {
+      .panel-toggle-btn {
+        position: absolute;
         top: 56px;
         left: 8px;
-        right: 8px;
-        min-width: 0;
-        max-width: none;
-        max-height: calc(100vh - 72px);
-        overflow-y: auto;
-        font-size: 14px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 40px;
+        height: 40px;
+        pointer-events: auto;
+        color: #fff;
+        font-size: 18px;
+        background: rgba(0, 0, 0, 0.55);
+        border: 1px solid rgba(255, 255, 255, 0.25);
+        border-radius: 8px;
+        cursor: pointer;
+        z-index: 11;
       }
 
-      #model-controls button {
+      #model-panel-toggle:checked + .panel-toggle-btn {
+        background: rgba(96, 165, 250, 0.55);
+        border-color: rgba(191, 219, 254, 0.85);
+      }
+
+      #model-controls {
+        top: 104px;
+        left: 8px;
+        right: auto;
+        width: min(78vw, 280px);
+        min-width: 0;
+        max-width: none;
+        max-height: calc(100vh - 160px);
+        overflow-y: auto;
+        font-size: 13px;
+      }
+
+      /* 既定は折り畳み（閉じた状態）。トグルで開く。 */
+      #model-panel-toggle:not(:checked) ~ #model-controls {
+        display: none;
+      }
+
+      #model-controls button,
+      #model-controls select {
         min-height: 36px;
         padding: 8px 12px;
         font-size: 14px;
@@ -139,6 +176,8 @@
   <div id="root"></div>
   <div id="model-overlay">
     <a class="back-link" href="/">← デモ一覧へ</a>
+    <input type="checkbox" id="model-panel-toggle" class="panel-toggle-cb" hidden>
+    <label for="model-panel-toggle" class="panel-toggle-btn" aria-label="操作パネルの開閉" title="操作パネル">⚙</label>
     <div id="model-controls">
       <strong>3Dモデルデモ</strong>
       <div class="info-row">

--- a/public/plan.html
+++ b/public/plan.html
@@ -144,16 +144,52 @@
       text-align: center;
     }
 
+    /* モバイル用の操作パネル開閉トグル（PC では非表示・パネル常時表示）。 */
+    .panel-toggle-cb,
+    .panel-toggle-btn {
+      display: none;
+    }
+
     @media (max-width: 640px) {
-      #plan-controls {
+      .panel-toggle-btn {
+        position: absolute;
         top: 56px;
         left: 8px;
-        right: 8px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 40px;
+        height: 40px;
+        pointer-events: auto;
+        color: #fff;
+        font-size: 18px;
+        background: rgba(0, 0, 0, 0.55);
+        border: 1px solid rgba(255, 255, 255, 0.25);
+        border-radius: 8px;
+        cursor: pointer;
+        z-index: 11;
+      }
+
+      #plan-panel-toggle:checked + .panel-toggle-btn {
+        background: rgba(96, 165, 250, 0.55);
+        border-color: rgba(191, 219, 254, 0.85);
+      }
+
+      #plan-controls {
+        top: 104px;
+        left: 8px;
+        right: auto;
+        width: min(78vw, 280px);
         min-width: 0;
         max-width: none;
-        max-height: calc(100vh - 72px);
+        max-height: calc(100vh - 160px);
         overflow-y: auto;
-        font-size: 14px;
+        font-size: 13px;
+      }
+
+      /* 既定は折り畳み（閉じた状態）。トグルで開く。 */
+      #plan-panel-toggle:not(:checked) ~ #plan-controls {
+        display: none;
       }
 
       #plan-controls button {
@@ -180,6 +216,8 @@
   <div id="root"></div>
   <div id="plan-overlay">
     <a class="back-link" href="/">← デモ一覧へ</a>
+    <input type="checkbox" id="plan-panel-toggle" class="panel-toggle-cb" hidden>
+    <label for="plan-panel-toggle" class="panel-toggle-btn" aria-label="操作パネルの開閉" title="操作パネル">⚙</label>
     <div id="plan-controls">
       <strong>Plan Viewer</strong>
       <div id="plan-layer-buttons">

--- a/public/plan.html
+++ b/public/plan.html
@@ -5,6 +5,7 @@
   <title>jpmap_terrain – Plan Viewer</title>
   <meta name="description" content="QGroundControl Plan ファイルをドラッグ&ドロップでマップ上に表示するデモ">
   <meta name="author" content="8ga3">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
   <style>
     html, body {
       overflow: hidden;
@@ -141,6 +142,37 @@
       border: 3px dashed rgba(255, 255, 255, 0.6);
       border-radius: 16px;
       text-align: center;
+    }
+
+    @media (max-width: 640px) {
+      #plan-controls {
+        top: 56px;
+        left: 8px;
+        right: 8px;
+        min-width: 0;
+        max-width: none;
+        max-height: calc(100vh - 72px);
+        overflow-y: auto;
+        font-size: 14px;
+      }
+
+      #plan-controls button {
+        min-height: 36px;
+        padding: 8px 12px;
+        font-size: 14px;
+      }
+
+      #plan-overlay .back-link {
+        padding: 8px 14px;
+        font-size: 14px;
+      }
+
+      #plan-drop-zone .drop-label {
+        max-width: calc(100vw - 32px);
+        box-sizing: border-box;
+        padding: 24px 28px;
+        font-size: 16px;
+      }
     }
   </style>
 </head>

--- a/public/polygon.html
+++ b/public/polygon.html
@@ -88,16 +88,52 @@
       background: rgba(255, 255, 255, 0.18);
     }
 
+    /* モバイル用の操作パネル開閉トグル（PC では非表示・パネル常時表示）。 */
+    .panel-toggle-cb,
+    .panel-toggle-btn {
+      display: none;
+    }
+
     @media (max-width: 640px) {
-      #polygon-controls {
+      .panel-toggle-btn {
+        position: absolute;
         top: 56px;
         left: 8px;
-        right: 8px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 40px;
+        height: 40px;
+        pointer-events: auto;
+        color: #fff;
+        font-size: 18px;
+        background: rgba(0, 0, 0, 0.55);
+        border: 1px solid rgba(255, 255, 255, 0.25);
+        border-radius: 8px;
+        cursor: pointer;
+        z-index: 11;
+      }
+
+      #polygon-panel-toggle:checked + .panel-toggle-btn {
+        background: rgba(96, 165, 250, 0.55);
+        border-color: rgba(191, 219, 254, 0.85);
+      }
+
+      #polygon-controls {
+        top: 104px;
+        left: 8px;
+        right: auto;
+        width: min(78vw, 280px);
         min-width: 0;
         max-width: none;
-        max-height: calc(100vh - 72px);
+        max-height: calc(100vh - 160px);
         overflow-y: auto;
-        font-size: 14px;
+        font-size: 13px;
+      }
+
+      /* 既定は折り畳み（閉じた状態）。トグルで開く。 */
+      #polygon-panel-toggle:not(:checked) ~ #polygon-controls {
+        display: none;
       }
 
       #polygon-controls button {
@@ -117,6 +153,8 @@
   <div id="root"></div>
   <div id="polygon-overlay">
     <a class="back-link" href="/">← デモ一覧へ</a>
+    <input type="checkbox" id="polygon-panel-toggle" class="panel-toggle-cb" hidden>
+    <label for="polygon-panel-toggle" class="panel-toggle-btn" aria-label="操作パネルの開閉" title="操作パネル">⚙</label>
     <div id="polygon-controls">
       <strong>ポリゴンデモ (Issue #170)</strong>
       <div id="polygon-controls-buttons"></div>

--- a/public/polygon.html
+++ b/public/polygon.html
@@ -5,6 +5,7 @@
   <title>jpmap_terrain – ポリゴンデモ</title>
   <meta name="description" content="jpmap_terrain のポリゴン (PolygonManager) 公開 API 動作確認デモ (Issue #170)">
   <meta name="author" content="8ga3">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
   <style>
     html, body {
       overflow: hidden;
@@ -85,6 +86,30 @@
 
     #polygon-controls button:hover {
       background: rgba(255, 255, 255, 0.18);
+    }
+
+    @media (max-width: 640px) {
+      #polygon-controls {
+        top: 56px;
+        left: 8px;
+        right: 8px;
+        min-width: 0;
+        max-width: none;
+        max-height: calc(100vh - 72px);
+        overflow-y: auto;
+        font-size: 14px;
+      }
+
+      #polygon-controls button {
+        min-height: 36px;
+        padding: 8px 12px;
+        font-size: 14px;
+      }
+
+      #polygon-overlay .back-link {
+        padding: 8px 14px;
+        font-size: 14px;
+      }
     }
   </style>
 </head>

--- a/public/polygon.html
+++ b/public/polygon.html
@@ -156,7 +156,7 @@
     <input type="checkbox" id="polygon-panel-toggle" class="panel-toggle-cb" hidden>
     <label for="polygon-panel-toggle" class="panel-toggle-btn" aria-label="操作パネルの開閉" title="操作パネル">⚙</label>
     <div id="polygon-controls">
-      <strong>ポリゴンデモ (Issue #170)</strong>
+      <strong>ポリゴンデモ</strong>
       <div id="polygon-controls-buttons"></div>
     </div>
   </div>

--- a/public/timelapse.html
+++ b/public/timelapse.html
@@ -5,6 +5,7 @@
   <title>jpmap_terrain – タイムラプスデモ</title>
   <meta name="description" content="24時間を1分にタイムラプスして太陽の動きと陰影をアニメーション表示する jpmap_terrain デモ">
   <meta name="author" content="8ga3">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
   <style>
     html, body {
       overflow: hidden;
@@ -78,6 +79,29 @@
       border-radius: 4px;
       letter-spacing: 0.02em;
       text-align: center;
+    }
+
+    @media (max-width: 640px) {
+      #timelapse-overlay .back-link {
+        padding: 8px 14px;
+        font-size: 14px;
+      }
+
+      #timelapse-clock-area {
+        max-width: 90vw;
+        bottom: 12px;
+      }
+
+      #timelapse-clock {
+        width: clamp(96px, 34vw, 140px);
+        height: clamp(96px, 34vw, 140px);
+      }
+
+      #timelapse-clock-label {
+        max-width: 90vw;
+        box-sizing: border-box;
+        font-size: 11px;
+      }
     }
   </style>
 </head>

--- a/public/viewer.html
+++ b/public/viewer.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="ja">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">

--- a/public/viewer.html
+++ b/public/viewer.html
@@ -15,6 +15,10 @@
         height: 100%;
         margin: 0;
         padding: 0;
+        /* モバイルでの2本指スクロール/オーバースクロール（自動スクロール）やダブルタップ
+           ズーム等のブラウザ既定ジェスチャを抑止する（Issue #424）。 */
+        touch-action: none;
+        overscroll-behavior: none;
       }
 
       #root {

--- a/public/viewer.html
+++ b/public/viewer.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
 
   <title>jpmap_terrain – 3D地形ビューア</title>
   <meta name="description" content="地理院タイルの標高データから3D地形を表示するWebアプリ">

--- a/spec/demos.md
+++ b/spec/demos.md
@@ -30,7 +30,7 @@
 - デモ間で共通する Babylon.js 部分は `manualChunks` の `babylonBundle` / `webgpu-shaders` / `webgl-shaders` 等に分割され、複数デモで共有される。
 - ポータルは Babylon.js を読み込まない軽量ページ。バンドルサイズ最小化のため `JpmapTerrain` を import しない。
 
-### レスポンシブ / タッチ操作対応（Issue #424）
+### レスポンシブ / タッチ操作対応
 
 - 全デモの HTML（`public/*.html`）に `<meta name="viewport" content="width=device-width, ...">` を付与し、モバイルでの等倍表示を保証する（viewer は `viewport-fit=cover`、`maximum-scale=1`）。
 - 操作 UI（`src/terrain/controlPanel.ts`）は固定 px で生成するが、`@media (pointer: coarse)` のスタイルを注入し、**タッチ端末でのみ** タップ領域（最小 44px）・文字サイズ・配置余白を拡大する。マウス/トラックパッド（fine pointer）では従来の見た目を維持するため、ビジュアル回帰テスト（`tests/validation.spec.ts`）への影響はない。
@@ -40,7 +40,7 @@
   - 間隔が広い（`>= TWO_FINGER_TILT_SPREAD_PX`）→ 平行移動で pan、指のひねり（twist）で方位回転（yaw）。
   - 間隔が狭い（`< TWO_FINGER_TILT_SPREAD_PX`）→ 縦移動で tilt（pitch、`limits` でクランプ）。
   - モードは最初の 2 本指 move 時に間隔で確定し、指を離す（2 本未満になる）まで維持する。途中で間隔がしきい値を跨いでもモードを切り替えない（誤切替防止）。
-  - 感度・しきい値は `TWO_FINGER_TILT_SPREAD_PX` / `TWO_FINGER_TILT_SENS` / `TWO_FINGER_YAW_SENS` で調整可能。動作確認は iOS Safari / Android Chrome 実機で行う（Issue #424 の完了定義）。
+  - 感度・しきい値は `TWO_FINGER_TILT_SPREAD_PX` / `TWO_FINGER_TILT_SENS` / `TWO_FINGER_YAW_SENS` で調整可能。動作確認は iOS Safari / Android Chrome 実機で行う。
 - 残課題: タッチパッドの 2 本指スクロール→パンのマッピングは、マウスホイールズームとの判別がハードウェア依存のため未実装。実機（Mac トラックパッド）での挙動確認を経て方針決定する。
 - **ブラウザ既定ジェスチャの抑止**: 操作ボタン（`.cp-btn` / `.cp-compass`）に `touch-action: manipulation` を付与し、iOS Safari のダブルタップズームを抑止する（タップは従来どおり機能）。viewer ページ（`public/viewer.html`）の `html, body` に `touch-action: none; overscroll-behavior: none;` を付与する。さらに、`touch-action` だけでは Android Chrome 等のオーバースクロール（2 本指スワイプによる自動スクロール）や画面端スワイプの戻る/進むナビゲーションが残るため、地図キャンバスの `touchmove` を `{ passive: false }` で捕捉し `preventDefault()` する（`src/lib/jpmapTerrain.ts`。Babylon はポインタイベントで操作を処理するためジェスチャ実装には影響しない）。
 - **現在地（Geolocation）**: `navigator.geolocation.getCurrentPosition` はセキュアコンテキスト（HTTPS、または `localhost`）でのみ動作する。LAN の IP に対する `http://` の dev サーバではブラウザがブロックするため、スマホ実機では取得できない（本番/`localhost` では動作）。仕様であり実装上の不具合ではない。

--- a/spec/demos.md
+++ b/spec/demos.md
@@ -39,6 +39,7 @@
   - ピンチイン/アウト（間隔変化）→ ズーム（GeospatialCamera 側で処理）。
   - 間隔が広い（`>= TWO_FINGER_TILT_SPREAD_PX`）→ 平行移動で pan、指のひねり（twist）で方位回転（yaw）。
   - 間隔が狭い（`< TWO_FINGER_TILT_SPREAD_PX`）→ 縦移動で tilt（pitch、`limits` でクランプ）。
+  - モードは最初の 2 本指 move 時に間隔で確定し、指を離す（2 本未満になる）まで維持する。途中で間隔がしきい値を跨いでもモードを切り替えない（誤切替防止）。
   - 感度・しきい値は `TWO_FINGER_TILT_SPREAD_PX` / `TWO_FINGER_TILT_SENS` / `TWO_FINGER_YAW_SENS` で調整可能。動作確認は iOS Safari / Android Chrome 実機で行う（Issue #424 の完了定義）。
 - 残課題: タッチパッドの 2 本指スクロール→パンのマッピングは、マウスホイールズームとの判別がハードウェア依存のため未実装。実機（Mac トラックパッド）での挙動確認を経て方針決定する。
 

--- a/spec/demos.md
+++ b/spec/demos.md
@@ -32,7 +32,7 @@
 
 ### レスポンシブ / タッチ操作対応
 
-- 全デモの HTML（`public/*.html`）に `<meta name="viewport" content="width=device-width, ...">` を付与し、モバイルでの等倍表示を保証する。Babylon.js を読み込むデモ（viewer を含むポータル `index.html` 以外のすべて）には `viewport-fit=cover`・`maximum-scale=1` を付与する（ポータル `index.html` は軽量ページのため `initial-scale=1` のみ）。
+- 全デモの HTML（`public/*.html`）に `<meta name="viewport" content="width=device-width, ...">` を付与し、モバイルでの等倍表示を保証する。すべてのページに `viewport-fit=cover` を付与し、Babylon.js を読み込むデモ（ポータル `index.html` 以外のすべて）にはさらに `maximum-scale=1` を付与する（ポータル `index.html` は軽量ページのため `maximum-scale=1` を付与せず、ページズームを許可する）。
   - **注意（アクセシビリティ）**: `maximum-scale=1` はユーザーのページズーム（ピンチズーム）を無効化するため、低視力ユーザー等のアクセシビリティに影響する。地図/3D キャンバス自体のピンチズーム（地形・モデルの拡大縮小）とブラウザのページズームが競合するのを避けるための意図的な指定だが、将来 UI 文字サイズの調整等で見直す際は、この制約（ページズーム不可）を踏まえて判断すること。
 - 操作 UI（`src/terrain/controlPanel.ts`）は固定 px で生成するが、`@media (pointer: coarse)` のスタイルを注入し、**タッチ端末でのみ** タップ領域（最小 44px）・文字サイズ・配置余白を拡大する。マウス/トラックパッド（fine pointer）では従来の見た目を維持するため、ビジュアル回帰テスト（`tests/validation.spec.ts`）への影響はない。
 - タッチパネルのパン（`src/scenes/globe.ts` の独自シングルタッチパン）は、接地中のタッチポインタ位置（`touchPoints`）で 2 本指以上を検出し、ピンチ中はシングルタッチパンを無効化する。これにより `GeospatialCamera` のピンチズームとシングルタッチパンの同時発火を防ぐ（マウス操作は従来どおり）。

--- a/spec/demos.md
+++ b/spec/demos.md
@@ -42,7 +42,7 @@
   - モードは最初の 2 本指 move 時に間隔で確定し、指を離す（2 本未満になる）まで維持する。途中で間隔がしきい値を跨いでもモードを切り替えない（誤切替防止）。
   - 感度・しきい値は `TWO_FINGER_TILT_SPREAD_PX` / `TWO_FINGER_TILT_SENS` / `TWO_FINGER_YAW_SENS` で調整可能。動作確認は iOS Safari / Android Chrome 実機で行う（Issue #424 の完了定義）。
 - 残課題: タッチパッドの 2 本指スクロール→パンのマッピングは、マウスホイールズームとの判別がハードウェア依存のため未実装。実機（Mac トラックパッド）での挙動確認を経て方針決定する。
-- **ブラウザ既定ジェスチャの抑止**: 操作ボタン（`.cp-btn` / `.cp-compass`）に `touch-action: manipulation` を付与し、iOS Safari のダブルタップズームを抑止する（タップは従来どおり機能）。viewer ページ（`public/viewer.html`）の `html, body` に `touch-action: none; overscroll-behavior: none;` を付与し、Android Chrome 等での 2 本指スクロール/オーバースクロール（自動スクロール）を抑止する。地図キャンバスは従来どおり `touch-action: none`（`src/lib/jpmapTerrain.ts`）。
+- **ブラウザ既定ジェスチャの抑止**: 操作ボタン（`.cp-btn` / `.cp-compass`）に `touch-action: manipulation` を付与し、iOS Safari のダブルタップズームを抑止する（タップは従来どおり機能）。viewer ページ（`public/viewer.html`）の `html, body` に `touch-action: none; overscroll-behavior: none;` を付与する。さらに、`touch-action` だけでは Android Chrome 等のオーバースクロール（2 本指スワイプによる自動スクロール）や画面端スワイプの戻る/進むナビゲーションが残るため、地図キャンバスの `touchmove` を `{ passive: false }` で捕捉し `preventDefault()` する（`src/lib/jpmapTerrain.ts`。Babylon はポインタイベントで操作を処理するためジェスチャ実装には影響しない）。
 - **現在地（Geolocation）**: `navigator.geolocation.getCurrentPosition` はセキュアコンテキスト（HTTPS、または `localhost`）でのみ動作する。LAN の IP に対する `http://` の dev サーバではブラウザがブロックするため、スマホ実機では取得できない（本番/`localhost` では動作）。仕様であり実装上の不具合ではない。
 
 

--- a/spec/demos.md
+++ b/spec/demos.md
@@ -44,6 +44,8 @@
 - 残課題: タッチパッドの 2 本指スクロール→パンのマッピングは、マウスホイールズームとの判別がハードウェア依存のため未実装。実機（Mac トラックパッド）での挙動確認を経て方針決定する。
 - **ブラウザ既定ジェスチャの抑止**: 操作ボタン（`.cp-btn` / `.cp-compass`）に `touch-action: manipulation` を付与し、iOS Safari のダブルタップズームを抑止する（タップは従来どおり機能）。viewer ページ（`public/viewer.html`）の `html, body` に `touch-action: none; overscroll-behavior: none;` を付与する。さらに、`touch-action` だけでは Android Chrome 等のオーバースクロール（2 本指スワイプによる自動スクロール）や画面端スワイプの戻る/進むナビゲーションが残るため、地図キャンバスの `touchmove` を `{ passive: false }` で捕捉し `preventDefault()` する（`src/lib/jpmapTerrain.ts`。Babylon はポインタイベントで操作を処理するためジェスチャ実装には影響しない）。
 - **現在地（Geolocation）**: `navigator.geolocation.getCurrentPosition` はセキュアコンテキスト（HTTPS、または `localhost`）でのみ動作する。LAN の IP に対する `http://` の dev サーバではブラウザがブロックするため、スマホ実機では取得できない（本番/`localhost` では動作）。仕様であり実装上の不具合ではない。
+- **スケールバー幅の上限制御**: スケールバーは右下に右寄せ配置され、`snapScale` が常に切り上げるためバー幅が基準（100px）の最大 2.5 倍程度まで広がりうる。狭い画面ではバーが左へ伸びて左下の地図切替ボタン（写真/標準）へ被るため、`pickScaleWithin(metersPerPx, basePx, maxBarPx)`（`src/terrain/controlPanel.ts`）で画面幅から求めた `maxBarPx` を超えない範囲のきれいな値を選ぶ（超える場合は 1 段階小さいスケールへ下げる）。`maxBarPx` は「行の右端 − 地図切替ボタンの右端 − 安全マージン − バー以外の固定要素幅（地理院タイル＋ラベル＋gap）」として `src/scenes/globeSceneController.ts` で算出する。広い画面では従来の `snapScale` と同一値となり、デスクトップ表示は不変。
+- **言語宣言**: 各デモの `<html lang="ja">` を宣言し、Chrome の自動翻訳プロンプトを抑止する（中身が日本語のため）。将来的な多言語切り替え（UI テキストの i18n / `locale` オプション）は別課題。
 
 
 ## URL 規約

--- a/spec/demos.md
+++ b/spec/demos.md
@@ -32,8 +32,8 @@
 
 ### レスポンシブ / タッチ操作対応
 
-- 全デモの HTML（`public/*.html`）に `<meta name="viewport" content="width=device-width, ...">` を付与し、モバイルでの等倍表示を保証する（viewer は `viewport-fit=cover`、`maximum-scale=1`）。
-  - **注意（アクセシビリティ）**: `maximum-scale=1` はユーザーのページズーム（ピンチズーム）を無効化するため、低視力ユーザー等のアクセシビリティに影響する。viewer は地図キャンバス自体のピンチズーム（地形の拡大縮小）とブラウザのページズームが競合するのを避けるための意図的な指定だが、将来 UI 文字サイズの調整等で見直す際は、この制約（ページズーム不可）を踏まえて判断すること。
+- 全デモの HTML（`public/*.html`）に `<meta name="viewport" content="width=device-width, ...">` を付与し、モバイルでの等倍表示を保証する。Babylon.js を読み込むデモ（viewer を含むポータル `index.html` 以外のすべて）には `viewport-fit=cover`・`maximum-scale=1` を付与する（ポータル `index.html` は軽量ページのため `initial-scale=1` のみ）。
+  - **注意（アクセシビリティ）**: `maximum-scale=1` はユーザーのページズーム（ピンチズーム）を無効化するため、低視力ユーザー等のアクセシビリティに影響する。地図/3D キャンバス自体のピンチズーム（地形・モデルの拡大縮小）とブラウザのページズームが競合するのを避けるための意図的な指定だが、将来 UI 文字サイズの調整等で見直す際は、この制約（ページズーム不可）を踏まえて判断すること。
 - 操作 UI（`src/terrain/controlPanel.ts`）は固定 px で生成するが、`@media (pointer: coarse)` のスタイルを注入し、**タッチ端末でのみ** タップ領域（最小 44px）・文字サイズ・配置余白を拡大する。マウス/トラックパッド（fine pointer）では従来の見た目を維持するため、ビジュアル回帰テスト（`tests/validation.spec.ts`）への影響はない。
 - タッチパネルのパン（`src/scenes/globe.ts` の独自シングルタッチパン）は、接地中のタッチポインタ位置（`touchPoints`）で 2 本指以上を検出し、ピンチ中はシングルタッチパンを無効化する。これにより `GeospatialCamera` のピンチズームとシングルタッチパンの同時発火を防ぐ（マウス操作は従来どおり）。
 - **2 本指ジェスチャ（`src/scenes/globe.ts`）**: GeospatialCamera 組み込みの multi-touch パン（= 2 本指ドラッグでの tilt 回転）を無効化（`multiTouchPanning=false`／`multiTouchPanAndZoom=false`、`pinchZoom` は温存）し、独自のジェスチャ処理に置き換える。割り当ては指の間隔（spread）で切り替える:

--- a/spec/demos.md
+++ b/spec/demos.md
@@ -30,6 +30,14 @@
 - デモ間で共通する Babylon.js 部分は `manualChunks` の `babylonBundle` / `webgpu-shaders` / `webgl-shaders` 等に分割され、複数デモで共有される。
 - ポータルは Babylon.js を読み込まない軽量ページ。バンドルサイズ最小化のため `JpmapTerrain` を import しない。
 
+### レスポンシブ / タッチ操作対応（Issue #424）
+
+- 全デモの HTML（`public/*.html`）に `<meta name="viewport" content="width=device-width, ...">` を付与し、モバイルでの等倍表示を保証する（viewer は `viewport-fit=cover`、`maximum-scale=1`）。
+- 操作 UI（`src/terrain/controlPanel.ts`）は固定 px で生成するが、`@media (pointer: coarse)` のスタイルを注入し、**タッチ端末でのみ** タップ領域（最小 44px）・文字サイズ・配置余白を拡大する。マウス/トラックパッド（fine pointer）では従来の見た目を維持するため、ビジュアル回帰テスト（`tests/validation.spec.ts`）への影響はない。
+- タッチパネルのパン（`src/scenes/globe.ts` の独自シングルタッチパン）は、接地中のタッチポインタ集合（`activeTouchPointers`）で 2 本指以上を検出し、ピンチ中はパンを無効化する。これにより `GeospatialCamera` のピンチズームとシングルタッチパンの同時発火を防ぐ（マウス操作は従来どおり）。
+- 残課題: タッチパッドの 2 本指スクロール→パンのマッピングは、マウスホイールズームとの判別がハードウェア依存のため未実装。実機（Mac トラックパッド）での挙動確認を経て方針決定する。動作確認は iOS Safari / Android Chrome 実機で行う（Issue #424 の完了定義）。
+
+
 ## URL 規約
 
 ### 共通

--- a/spec/demos.md
+++ b/spec/demos.md
@@ -33,6 +33,7 @@
 ### レスポンシブ / タッチ操作対応
 
 - 全デモの HTML（`public/*.html`）に `<meta name="viewport" content="width=device-width, ...">` を付与し、モバイルでの等倍表示を保証する（viewer は `viewport-fit=cover`、`maximum-scale=1`）。
+  - **注意（アクセシビリティ）**: `maximum-scale=1` はユーザーのページズーム（ピンチズーム）を無効化するため、低視力ユーザー等のアクセシビリティに影響する。viewer は地図キャンバス自体のピンチズーム（地形の拡大縮小）とブラウザのページズームが競合するのを避けるための意図的な指定だが、将来 UI 文字サイズの調整等で見直す際は、この制約（ページズーム不可）を踏まえて判断すること。
 - 操作 UI（`src/terrain/controlPanel.ts`）は固定 px で生成するが、`@media (pointer: coarse)` のスタイルを注入し、**タッチ端末でのみ** タップ領域（最小 44px）・文字サイズ・配置余白を拡大する。マウス/トラックパッド（fine pointer）では従来の見た目を維持するため、ビジュアル回帰テスト（`tests/validation.spec.ts`）への影響はない。
 - タッチパネルのパン（`src/scenes/globe.ts` の独自シングルタッチパン）は、接地中のタッチポインタ位置（`touchPoints`）で 2 本指以上を検出し、ピンチ中はシングルタッチパンを無効化する。これにより `GeospatialCamera` のピンチズームとシングルタッチパンの同時発火を防ぐ（マウス操作は従来どおり）。
 - **2 本指ジェスチャ（`src/scenes/globe.ts`）**: GeospatialCamera 組み込みの multi-touch パン（= 2 本指ドラッグでの tilt 回転）を無効化（`multiTouchPanning=false`／`multiTouchPanAndZoom=false`、`pinchZoom` は温存）し、独自のジェスチャ処理に置き換える。割り当ては指の間隔（spread）で切り替える:

--- a/spec/demos.md
+++ b/spec/demos.md
@@ -34,8 +34,13 @@
 
 - 全デモの HTML（`public/*.html`）に `<meta name="viewport" content="width=device-width, ...">` を付与し、モバイルでの等倍表示を保証する（viewer は `viewport-fit=cover`、`maximum-scale=1`）。
 - 操作 UI（`src/terrain/controlPanel.ts`）は固定 px で生成するが、`@media (pointer: coarse)` のスタイルを注入し、**タッチ端末でのみ** タップ領域（最小 44px）・文字サイズ・配置余白を拡大する。マウス/トラックパッド（fine pointer）では従来の見た目を維持するため、ビジュアル回帰テスト（`tests/validation.spec.ts`）への影響はない。
-- タッチパネルのパン（`src/scenes/globe.ts` の独自シングルタッチパン）は、接地中のタッチポインタ集合（`activeTouchPointers`）で 2 本指以上を検出し、ピンチ中はパンを無効化する。これにより `GeospatialCamera` のピンチズームとシングルタッチパンの同時発火を防ぐ（マウス操作は従来どおり）。
-- 残課題: タッチパッドの 2 本指スクロール→パンのマッピングは、マウスホイールズームとの判別がハードウェア依存のため未実装。実機（Mac トラックパッド）での挙動確認を経て方針決定する。動作確認は iOS Safari / Android Chrome 実機で行う（Issue #424 の完了定義）。
+- タッチパネルのパン（`src/scenes/globe.ts` の独自シングルタッチパン）は、接地中のタッチポインタ位置（`touchPoints`）で 2 本指以上を検出し、ピンチ中はシングルタッチパンを無効化する。これにより `GeospatialCamera` のピンチズームとシングルタッチパンの同時発火を防ぐ（マウス操作は従来どおり）。
+- **2 本指ジェスチャ（`src/scenes/globe.ts`）**: GeospatialCamera 組み込みの multi-touch パン（= 2 本指ドラッグでの tilt 回転）を無効化（`multiTouchPanning=false`／`multiTouchPanAndZoom=false`、`pinchZoom` は温存）し、独自のジェスチャ処理に置き換える。割り当ては指の間隔（spread）で切り替える:
+  - ピンチイン/アウト（間隔変化）→ ズーム（GeospatialCamera 側で処理）。
+  - 間隔が広い（`>= TWO_FINGER_TILT_SPREAD_PX`）→ 平行移動で pan、指のひねり（twist）で方位回転（yaw）。
+  - 間隔が狭い（`< TWO_FINGER_TILT_SPREAD_PX`）→ 縦移動で tilt（pitch、`limits` でクランプ）。
+  - 感度・しきい値は `TWO_FINGER_TILT_SPREAD_PX` / `TWO_FINGER_TILT_SENS` / `TWO_FINGER_YAW_SENS` で調整可能。動作確認は iOS Safari / Android Chrome 実機で行う（Issue #424 の完了定義）。
+- 残課題: タッチパッドの 2 本指スクロール→パンのマッピングは、マウスホイールズームとの判別がハードウェア依存のため未実装。実機（Mac トラックパッド）での挙動確認を経て方針決定する。
 
 
 ## URL 規約

--- a/spec/demos.md
+++ b/spec/demos.md
@@ -42,6 +42,8 @@
   - モードは最初の 2 本指 move 時に間隔で確定し、指を離す（2 本未満になる）まで維持する。途中で間隔がしきい値を跨いでもモードを切り替えない（誤切替防止）。
   - 感度・しきい値は `TWO_FINGER_TILT_SPREAD_PX` / `TWO_FINGER_TILT_SENS` / `TWO_FINGER_YAW_SENS` で調整可能。動作確認は iOS Safari / Android Chrome 実機で行う（Issue #424 の完了定義）。
 - 残課題: タッチパッドの 2 本指スクロール→パンのマッピングは、マウスホイールズームとの判別がハードウェア依存のため未実装。実機（Mac トラックパッド）での挙動確認を経て方針決定する。
+- **ブラウザ既定ジェスチャの抑止**: 操作ボタン（`.cp-btn` / `.cp-compass`）に `touch-action: manipulation` を付与し、iOS Safari のダブルタップズームを抑止する（タップは従来どおり機能）。viewer ページ（`public/viewer.html`）の `html, body` に `touch-action: none; overscroll-behavior: none;` を付与し、Android Chrome 等での 2 本指スクロール/オーバースクロール（自動スクロール）を抑止する。地図キャンバスは従来どおり `touch-action: none`（`src/lib/jpmapTerrain.ts`）。
+- **現在地（Geolocation）**: `navigator.geolocation.getCurrentPosition` はセキュアコンテキスト（HTTPS、または `localhost`）でのみ動作する。LAN の IP に対する `http://` の dev サーバではブラウザがブロックするため、スマホ実機では取得できない（本番/`localhost` では動作）。仕様であり実装上の不具合ではない。
 
 
 ## URL 規約

--- a/src/demos/distance/index.ts
+++ b/src/demos/distance/index.ts
@@ -64,7 +64,9 @@ interface DemoState {
     /**
      * 高度編集モード（スティッキー）。スマホなど Shift キーが使えない環境向けに、
      * 「高度」ボタンで ON にするとドラッグが lat/lon ではなく altitude を編集する。
-     * `edit` モードかつ非 2D のときのみ有効。
+     * トグル自体は `edit` モードのときに操作できる。実際の altitude 編集が反映されるのは
+     * 3D（非 2D）表示のときのみで、2D 表示中はドラッグ/カーソル判定側
+     * （`viewer.viewMode !== "2d"`）で無効化される。
      */
     altitudeMode: boolean;
     /**

--- a/src/demos/distance/index.ts
+++ b/src/demos/distance/index.ts
@@ -62,6 +62,12 @@ interface DemoState {
     mode: DistanceDemoMode;
     points: PolygonPointOptions[];
     /**
+     * 高度編集モード（スティッキー）。スマホなど Shift キーが使えない環境向けに、
+     * 「高度」ボタンで ON にするとドラッグが lat/lon ではなく altitude を編集する。
+     * `edit` モードかつ非 2D のときのみ有効。
+     */
+    altitudeMode: boolean;
+    /**
      * Shift+ドラッグ開始時のスナップショット。`pointermove` ごとに altitude を再計算するため、
      * dragStart の `altitude` と `clientY` を保持する。
      */
@@ -151,7 +157,9 @@ const updateStatus = (
                   : `削除モード（点 ${n}）`
               : is2d
                 ? `編集モード（点 ${n}）。ドラッグで移動`
-                : `編集モード（点 ${n}）。ドラッグで移動 / Shift+ドラッグで高度`;
+                : state.altitudeMode
+                  ? `編集モード（点 ${n}）。ドラッグで高度を変更（高度ボタン ON）`
+                  : `編集モード（点 ${n}）。ドラッグで移動 / Shift+ドラッグまたは高度ボタンで高度`;
     statusEl.textContent = `モード: ${state.mode}（点 ${n}）／ ${guide}`;
 };
 
@@ -175,7 +183,28 @@ const buildToolbar = (
                 state.mode === mode ? "true" : "false",
             );
         }
+        // 高度トグルは編集モードのときのみ有効。
+        const altEnabled = state.mode === "edit";
+        altitudeBtn.disabled = !altEnabled;
+        altitudeBtn.dataset.active =
+            altEnabled && state.altitudeMode ? "true" : "false";
+        altitudeBtn.setAttribute(
+            "aria-pressed",
+            altEnabled && state.altitudeMode ? "true" : "false",
+        );
     };
+    // 高度編集トグル（スマホ向け。Shift キーの代替）。
+    const altitudeBtn = document.createElement("button");
+    altitudeBtn.type = "button";
+    altitudeBtn.textContent = "高度";
+    altitudeBtn.dataset.distanceAction = "altitude";
+    altitudeBtn.title = "ドラッグで高度を編集（編集モード時）";
+    altitudeBtn.addEventListener("click", () => {
+        if (state.mode !== "edit") return;
+        state.altitudeMode = !state.altitudeMode;
+        refresh();
+        onChange();
+    });
     for (const m of modes) {
         const btn = document.createElement("button");
         btn.type = "button";
@@ -183,12 +212,17 @@ const buildToolbar = (
         btn.dataset.distanceMode = m.value;
         btn.addEventListener("click", () => {
             state.mode = m.value;
+            // 編集モード以外へ移ると高度トグルは無効化する。
+            if (m.value !== "edit") {
+                state.altitudeMode = false;
+            }
             refresh();
             onChange();
         });
         buttons.set(m.value, btn);
         container.appendChild(btn);
     }
+    container.appendChild(altitudeBtn);
     refresh();
 
     // クリア（全頂点削除）
@@ -263,6 +297,7 @@ const start = async (): Promise<void> => {
     const state: DemoState = {
         mode: DEFAULT_DISTANCE_DEMO_MODE,
         points: [],
+        altitudeMode: false,
         altitudeDragStart: null,
     };
 
@@ -364,7 +399,8 @@ const start = async (): Promise<void> => {
         }
         if (state.mode === "edit" && hovering) {
             // 2D ではドラッグの高度変更を無効化しているため ns-resize は出さない。
-            const altitudeEditable = shiftPressed && viewer.viewMode !== "2d";
+            const altitudeEditable =
+                (shiftPressed || state.altitudeMode) && viewer.viewMode !== "2d";
             renderCanvas.style.cursor = altitudeEditable ? "ns-resize" : "move";
         }
     };
@@ -423,15 +459,19 @@ const start = async (): Promise<void> => {
         if (e.polygonId !== POLYGON_ID) return;
         const current = state.points[e.index];
         if (!current) return;
-        if (e.pointerEvent.shiftKey && viewer.viewMode !== "2d") {
-            // 高度モード: 開始 altitude / clientY / 地表標高を保持。
-            // 2D（トップダウン）では高度変化が見えないため無効化し、通常の lat/lon 移動にする。
-            state.altitudeDragStart = {
-                index: e.index,
-                altitude: current.altitude ?? 0,
-                clientY: e.pointerEvent.clientY,
-                groundAltitude: e.groundAltitude ?? 0,
-            };
+        if (e.pointerEvent.shiftKey || state.altitudeMode) {
+            if (viewer.viewMode !== "2d") {
+                // 高度モード: 開始 altitude / clientY / 地表標高を保持。
+                // 2D（トップダウン）では高度変化が見えないため無効化し、通常の lat/lon 移動にする。
+                state.altitudeDragStart = {
+                    index: e.index,
+                    altitude: current.altitude ?? 0,
+                    clientY: e.pointerEvent.clientY,
+                    groundAltitude: e.groundAltitude ?? 0,
+                };
+            } else {
+                state.altitudeDragStart = null;
+            }
         } else {
             state.altitudeDragStart = null;
         }

--- a/src/demos/flight/globeAfterburner.ts
+++ b/src/demos/flight/globeAfterburner.ts
@@ -263,9 +263,13 @@ export const createGlobeAfterburner = (scene: Scene): Afterburner => {
             history.push(new Vector3());
         }
         const pathArray = [left, right];
+        // sideOrientation は既定 (FRONTSIDE)。両面表示は material.backFaceCulling = false で
+        // 実現する。DOUBLESIDE は頂点を複製して総頂点数を 2 倍にするため、固定長の頂点カラー
+        // バッファ (SAMPLE_COUNT * 2 頂点ぶん) と齟齬が生じ、複製側が未着色（白）のまま
+        // additive 合成され、炎が白飛びして正しく表示されない。
         const mesh = CreateRibbon(
             name,
-            { pathArray, updatable: true, sideOrientation: Mesh.DOUBLESIDE },
+            { pathArray, updatable: true },
             scene,
         );
         mesh.material = material;

--- a/src/demos/flight/index.ts
+++ b/src/demos/flight/index.ts
@@ -754,13 +754,14 @@ const start = async (): Promise<void> => {
         });
     }
 
-    // ウェイポイント / リボン 表示切替チェックボックス
-    const waypointToggle = document.getElementById("waypoint-toggle") as HTMLInputElement | null;
-    const ribbonToggle = document.getElementById("ribbon-toggle") as HTMLInputElement | null;
+    // ウェイポイント / リボン 表示切替ボタン
+    const waypointToggle = document.getElementById("waypoint-toggle") as HTMLButtonElement | null;
+    const ribbonToggle = document.getElementById("ribbon-toggle") as HTMLButtonElement | null;
     if (waypointToggle) {
-        waypointToggle.checked = showWaypoints;
-        waypointToggle.addEventListener("change", () => {
-            showWaypoints = waypointToggle.checked;
+        waypointToggle.classList.toggle("active", showWaypoints);
+        waypointToggle.addEventListener("click", () => {
+            showWaypoints = !showWaypoints;
+            waypointToggle.classList.toggle("active", showWaypoints);
             if (!showWaypoints && waypointManager) {
                 waypointManager.dispose();
                 waypointManager = null;
@@ -768,21 +769,23 @@ const start = async (): Promise<void> => {
         });
     }
     if (ribbonToggle) {
-        ribbonToggle.checked = showRibbon;
-        ribbonToggle.addEventListener("change", () => {
-            showRibbon = ribbonToggle.checked;
+        ribbonToggle.classList.toggle("active", showRibbon);
+        ribbonToggle.addEventListener("click", () => {
+            showRibbon = !showRibbon;
+            ribbonToggle.classList.toggle("active", showRibbon);
             if (routeLine) {
                 routeLine.setVisible(showRibbon);
             }
         });
     }
 
-    // アフターバーナー表示切替チェックボックス
-    const afterburnerToggle = document.getElementById("afterburner-toggle") as HTMLInputElement | null;
+    // アフターバーナー表示切替ボタン
+    const afterburnerToggle = document.getElementById("afterburner-toggle") as HTMLButtonElement | null;
     if (afterburnerToggle) {
-        afterburnerToggle.checked = showAfterburner;
-        afterburnerToggle.addEventListener("change", () => {
-            showAfterburner = afterburnerToggle.checked;
+        afterburnerToggle.classList.toggle("active", showAfterburner);
+        afterburnerToggle.addEventListener("click", () => {
+            showAfterburner = !showAfterburner;
+            afterburnerToggle.classList.toggle("active", showAfterburner);
             if (afterburner) {
                 afterburner.setVisible(showAfterburner);
             }

--- a/src/demos/flight/index.ts
+++ b/src/demos/flight/index.ts
@@ -91,6 +91,8 @@ const FOLLOW_CAMERA_HEIGHT_OFFSET_MAX_MAG = 3;
 const DRAG_ROT_DEG_PER_PX = 0.5;
 const DRAG_HEIGHT_M_PER_PX = 0.5;
 const WHEEL_RADIUS_M_PER_DELTA = 0.5;
+/** 2本指ピンチの間隔変化[px] → radius[m] 係数（広げる=ズームイン=radius 減） */
+const PINCH_RADIUS_M_PER_PX = 0.5;
 
 type CameraMode = "3d" | "2d" | "follow";
 
@@ -247,7 +249,9 @@ const start = async (): Promise<void> => {
             'button[aria-label^="地図切替"]',
         );
         if (mapToggleBtn) {
-            mapToggleBtn.style.left = `${12 + pixelWidth + 8}px`;
+            // coarse-pointer 端末ではライブラリの `.cp-maptoggle { left:16px !important }`
+            // が inline style を上書きして PIP と重なるため、!important で確実に右隣へ移す。
+            mapToggleBtn.style.setProperty("left", `${12 + pixelWidth + 8}px`, "important");
         }
     };
 
@@ -417,15 +421,83 @@ const start = async (): Promise<void> => {
     let followDragging = false;
     let followLastX = 0;
     let followLastY = 0;
+    // タッチの2本指ジェスチャ（ピンチ=ズーム / 重心移動=回転・高度）の状態。
+    const followTouches = new Map<number, { x: number; y: number }>();
+    let followPinchPrevDist = 0;
+    let followPinchPrevCx = 0;
+    let followPinchPrevCy = 0;
+
+    /** followTouches から先頭2点でピンチ基準（間隔・重心）を取り直す */
+    const recomputeFollowPinchRef = (): void => {
+        const it = followTouches.values();
+        const a = it.next().value as { x: number; y: number } | undefined;
+        const b = it.next().value as { x: number; y: number } | undefined;
+        if (!a || !b) return;
+        followPinchPrevDist = Math.hypot(a.x - b.x, a.y - b.y);
+        followPinchPrevCx = (a.x + b.x) / 2;
+        followPinchPrevCy = (a.y + b.y) / 2;
+    };
+
+    /** 2本指ジェスチャ1ステップ: ピンチ→radius、重心左右→回転、重心上下→高度。 */
+    const handleFollowPinch = (): void => {
+        const it = followTouches.values();
+        const a = it.next().value as { x: number; y: number } | undefined;
+        const b = it.next().value as { x: number; y: number } | undefined;
+        if (!a || !b) return;
+        const dist = Math.hypot(a.x - b.x, a.y - b.y);
+        const cx = (a.x + b.x) / 2;
+        const cy = (a.y + b.y) / 2;
+
+        // ピンチ: 指を広げる（間隔増）= ズームイン = radius 減。
+        const dDist = dist - followPinchPrevDist;
+        if (dDist !== 0) {
+            followCamRadius = Math.max(1, followCamRadius - dDist * PINCH_RADIUS_M_PER_PX);
+        }
+        // 重心の左右移動 → 水平回転、上下移動 → 高度オフセット。
+        const dCx = cx - followPinchPrevCx;
+        const dCy = cy - followPinchPrevCy;
+        if (dCx !== 0) {
+            followCamRotationOffset = ((followCamRotationOffset + dCx * DRAG_ROT_DEG_PER_PX) % 360 + 360) % 360;
+        }
+        const maxOffset = followCamRadius * FOLLOW_CAMERA_HEIGHT_OFFSET_MAX_MAG;
+        followCamHeightOffset = Math.max(
+            1,
+            Math.min(maxOffset, followCamHeightOffset + dCy * DRAG_HEIGHT_M_PER_PX),
+        );
+
+        followPinchPrevDist = dist;
+        followPinchPrevCx = cx;
+        followPinchPrevCy = cy;
+        updateFollowCamDisplay();
+    };
 
     const onFollowPointerDown = (e: PointerEvent): void => {
+        if (e.pointerType === "touch") {
+            followTouches.set(e.pointerId, { x: e.clientX, y: e.clientY });
+            if (followTouches.size >= 2) {
+                // 2本指開始: 単指ドラッグを止め、ピンチ基準を初期化する。
+                followDragging = false;
+                recomputeFollowPinchRef();
+                e.stopImmediatePropagation();
+                return;
+            }
+        }
         followDragging = true;
         followLastX = e.clientX;
         followLastY = e.clientY;
         e.stopImmediatePropagation();
     };
     const onFollowPointerMove = (e: PointerEvent): void => {
-        if (!followDragging || !followCamera) return;
+        if (!followCamera) return;
+        if (e.pointerType === "touch" && followTouches.has(e.pointerId)) {
+            followTouches.set(e.pointerId, { x: e.clientX, y: e.clientY });
+            if (followTouches.size >= 2) {
+                handleFollowPinch();
+                e.stopImmediatePropagation();
+                return;
+            }
+        }
+        if (!followDragging) return;
         const dx = e.clientX - followLastX;
         const dy = e.clientY - followLastY;
         followLastX = e.clientX;
@@ -442,6 +514,22 @@ const start = async (): Promise<void> => {
         e.stopImmediatePropagation();
     };
     const onFollowPointerUp = (e: PointerEvent): void => {
+        if (e.pointerType === "touch") {
+            followTouches.delete(e.pointerId);
+            if (followTouches.size >= 2) {
+                recomputeFollowPinchRef();
+            } else if (followTouches.size === 1) {
+                // 2本→1本: 残った指でジャンプせず単指ドラッグを継続する。
+                const p = followTouches.values().next().value as { x: number; y: number };
+                followDragging = true;
+                followLastX = p.x;
+                followLastY = p.y;
+            } else {
+                followDragging = false;
+            }
+            e.stopImmediatePropagation();
+            return;
+        }
         followDragging = false;
         e.stopImmediatePropagation();
     };
@@ -463,15 +551,19 @@ const start = async (): Promise<void> => {
         canvas.addEventListener("pointerdown", onFollowPointerDown, { capture: true });
         canvas.addEventListener("pointermove", onFollowPointerMove, { capture: true });
         canvas.addEventListener("pointerup", onFollowPointerUp, { capture: true });
+        canvas.addEventListener("pointercancel", onFollowPointerUp, { capture: true });
         canvas.addEventListener("wheel", onFollowWheel, { capture: true, passive: false });
     };
     const detachFollowPointerHandlers = (): void => {
         const scene = viewer.__debugScene;
         const canvas = scene?.getEngine().getRenderingCanvas();
+        followTouches.clear();
+        followDragging = false;
         if (!canvas) return;
         canvas.removeEventListener("pointerdown", onFollowPointerDown, { capture: true });
         canvas.removeEventListener("pointermove", onFollowPointerMove, { capture: true });
         canvas.removeEventListener("pointerup", onFollowPointerUp, { capture: true });
+        canvas.removeEventListener("pointercancel", onFollowPointerUp, { capture: true });
         canvas.removeEventListener("wheel", onFollowWheel, { capture: true });
     };
 

--- a/src/demos/flight/index.ts
+++ b/src/demos/flight/index.ts
@@ -757,11 +757,16 @@ const start = async (): Promise<void> => {
     // ウェイポイント / リボン 表示切替ボタン
     const waypointToggle = document.getElementById("waypoint-toggle") as HTMLButtonElement | null;
     const ribbonToggle = document.getElementById("ribbon-toggle") as HTMLButtonElement | null;
+    // トグルボタンの ON/OFF を視覚（active クラス）と支援技術（aria-pressed）の両方へ反映する。
+    const setTogglePressed = (btn: HTMLButtonElement, on: boolean): void => {
+        btn.classList.toggle("active", on);
+        btn.setAttribute("aria-pressed", on ? "true" : "false");
+    };
     if (waypointToggle) {
-        waypointToggle.classList.toggle("active", showWaypoints);
+        setTogglePressed(waypointToggle, showWaypoints);
         waypointToggle.addEventListener("click", () => {
             showWaypoints = !showWaypoints;
-            waypointToggle.classList.toggle("active", showWaypoints);
+            setTogglePressed(waypointToggle, showWaypoints);
             if (!showWaypoints && waypointManager) {
                 waypointManager.dispose();
                 waypointManager = null;
@@ -769,10 +774,10 @@ const start = async (): Promise<void> => {
         });
     }
     if (ribbonToggle) {
-        ribbonToggle.classList.toggle("active", showRibbon);
+        setTogglePressed(ribbonToggle, showRibbon);
         ribbonToggle.addEventListener("click", () => {
             showRibbon = !showRibbon;
-            ribbonToggle.classList.toggle("active", showRibbon);
+            setTogglePressed(ribbonToggle, showRibbon);
             if (routeLine) {
                 routeLine.setVisible(showRibbon);
             }
@@ -782,10 +787,10 @@ const start = async (): Promise<void> => {
     // アフターバーナー表示切替ボタン
     const afterburnerToggle = document.getElementById("afterburner-toggle") as HTMLButtonElement | null;
     if (afterburnerToggle) {
-        afterburnerToggle.classList.toggle("active", showAfterburner);
+        setTogglePressed(afterburnerToggle, showAfterburner);
         afterburnerToggle.addEventListener("click", () => {
             showAfterburner = !showAfterburner;
-            afterburnerToggle.classList.toggle("active", showAfterburner);
+            setTogglePressed(afterburnerToggle, showAfterburner);
             if (afterburner) {
                 afterburner.setVisible(showAfterburner);
             }

--- a/src/demos/flight/index.ts
+++ b/src/demos/flight/index.ts
@@ -256,7 +256,12 @@ const start = async (): Promise<void> => {
             if (isMobile) {
                 const pipHeight =
                     pipFrame.getBoundingClientRect().height || (pixelWidth * 3) / 4;
-                // 既定の left に戻し、bottom で PIP の真上へ持ち上げる。
+                // モバイルでは PIP の真上へ持ち上げる（縦位置 = bottom を !important で確定）。
+                // 横位置(left)は PIP 左端に揃える意図だが、ここでは !important を付けず
+                // 既定値(12px)を再設定するに留める。coarse-pointer 端末では
+                // `.cp-maptoggle{left:16px!important}` が優先され実効 16px となるが、
+                // PIP も左端付近にあるため 12/16px いずれでも「PIP の真上」を満たす。
+                // ＝横位置は coarse 補正へ委ね、縦位置のみ明示制御する方針。
                 mapToggleBtn.style.setProperty("left", "12px");
                 mapToggleBtn.style.setProperty("bottom", `${12 + pipHeight + 8}px`, "important");
             } else {

--- a/src/demos/flight/index.ts
+++ b/src/demos/flight/index.ts
@@ -243,15 +243,27 @@ const start = async (): Promise<void> => {
         const pixelWidth = pipWidthFraction * canvas.clientWidth;
         pipFrame.style.width = `${pixelWidth}px`;
         // 高さは CSS の aspect-ratio: 4/3 に任せる
-        // 地図切替ボタン (lib 製) は既定で `bottom:12px; left:12px` に配置されるため
-        // PIP と重なる。PIP の右隣 (= 12 + PIP 幅 + 8px) に移動させる。
+        // 地図切替ボタン (lib 製) は既定で `bottom:12px; left:12px` に配置されるため PIP と重なる。
+        // - デスクトップ: PIP の右隣 (= 12 + PIP 幅 + 8px) へ移す。
+        // - モバイル(<=640px): 横並びだと窮屈なため PIP の真上 (= 12 + PIP 高 + 8px) へ移す。
+        // coarse-pointer 端末ではライブラリの `.cp-maptoggle{left:16px!important;bottom:16px!important}`
+        // が inline style を上書きするため、移動させる軸は !important で指定する。
         const mapToggleBtn = document.querySelector<HTMLButtonElement>(
             'button[aria-label^="地図切替"]',
         );
         if (mapToggleBtn) {
-            // coarse-pointer 端末ではライブラリの `.cp-maptoggle { left:16px !important }`
-            // が inline style を上書きして PIP と重なるため、!important で確実に右隣へ移す。
-            mapToggleBtn.style.setProperty("left", `${12 + pixelWidth + 8}px`, "important");
+            const isMobile = window.matchMedia("(max-width: 640px)").matches;
+            if (isMobile) {
+                const pipHeight =
+                    pipFrame.getBoundingClientRect().height || (pixelWidth * 3) / 4;
+                // 既定の left に戻し、bottom で PIP の真上へ持ち上げる。
+                mapToggleBtn.style.setProperty("left", "12px");
+                mapToggleBtn.style.setProperty("bottom", `${12 + pipHeight + 8}px`, "important");
+            } else {
+                // PIP の右隣へ。bottom はライブラリ既定 (12px) に戻す。
+                mapToggleBtn.style.setProperty("left", `${12 + pixelWidth + 8}px`, "important");
+                mapToggleBtn.style.setProperty("bottom", "12px");
+            }
         }
     };
 

--- a/src/demos/flight/index.ts
+++ b/src/demos/flight/index.ts
@@ -86,6 +86,15 @@ const FOLLOW_CAMERA_HEIGHT_OFFSET = 15;
 const FOLLOW_CAMERA_ROTATION_OFFSET = 180;
 /** heightOffset の最大値 = radius × この倍率 */
 const FOLLOW_CAMERA_HEIGHT_OFFSET_MAX_MAG = 3;
+/** FollowCamera の far clip (m) */
+const FOLLOW_CAMERA_MAX_Z = 400000;
+/**
+ * radius の上限 (m)。カメラ→機体距離は最大で
+ * `radius × hypot(1, HEIGHT_OFFSET_MAX_MAG)`（heightOffset 上限時）まで広がるため、
+ * これが maxZ を超えると機体/地形が far clip で消える。0.9 の安全係数で余裕を持たせる。
+ */
+const FOLLOW_CAMERA_RADIUS_MAX =
+    (FOLLOW_CAMERA_MAX_Z * 0.9) / Math.hypot(1, FOLLOW_CAMERA_HEIGHT_OFFSET_MAX_MAG);
 
 /** マウス操作感度 */
 const DRAG_ROT_DEG_PER_PX = 0.5;
@@ -382,7 +391,7 @@ const start = async (): Promise<void> => {
             scene,
         );
         fc.minZ = 1;
-        fc.maxZ = 400000;
+        fc.maxZ = FOLLOW_CAMERA_MAX_Z;
         // 組み込み入力を無効化（カスタム操作で制御）
         fc.inputs.clear();
 
@@ -455,6 +464,10 @@ const start = async (): Promise<void> => {
         followPinchPrevCy = (a.y + b.y) / 2;
     };
 
+    /** radius を [1, FOLLOW_CAMERA_RADIUS_MAX] にクランプ（far clip 超過で機体が消えるのを防ぐ）。 */
+    const clampFollowCamRadius = (r: number): number =>
+        Math.max(1, Math.min(FOLLOW_CAMERA_RADIUS_MAX, r));
+
     /** 2本指ジェスチャ1ステップ: ピンチ→radius、重心左右→回転、重心上下→高度。 */
     const handleFollowPinch = (): void => {
         const it = followTouches.values();
@@ -468,7 +481,7 @@ const start = async (): Promise<void> => {
         // ピンチ: 指を広げる（間隔増）= ズームイン = radius 減。
         const dDist = dist - followPinchPrevDist;
         if (dDist !== 0) {
-            followCamRadius = Math.max(1, followCamRadius - dDist * PINCH_RADIUS_M_PER_PX);
+            followCamRadius = clampFollowCamRadius(followCamRadius - dDist * PINCH_RADIUS_M_PER_PX);
         }
         // 重心の左右移動 → 水平回転、上下移動 → 高度オフセット。
         const dCx = cx - followPinchPrevCx;
@@ -552,7 +565,7 @@ const start = async (): Promise<void> => {
     };
     const onFollowWheel = (e: WheelEvent): void => {
         if (!followCamera) return;
-        followCamRadius = Math.max(1, followCamRadius + e.deltaY * WHEEL_RADIUS_M_PER_DELTA);
+        followCamRadius = clampFollowCamRadius(followCamRadius + e.deltaY * WHEEL_RADIUS_M_PER_DELTA);
         // radius 変更時に heightOffset が上限を超えないようクランプ
         const maxOffset = followCamRadius * FOLLOW_CAMERA_HEIGHT_OFFSET_MAX_MAG;
         followCamHeightOffset = Math.min(followCamHeightOffset, maxOffset);

--- a/src/demos/flight/routeLine.ts
+++ b/src/demos/flight/routeLine.ts
@@ -132,9 +132,12 @@ export const createRouteLine = (scene: Scene): RouteLine => {
 
     const pathArray = initPath();
 
+    // sideOrientation は既定 (FRONTSIDE)。両面表示は material.backFaceCulling = false で
+    // 実現する。DOUBLESIDE は頂点を複製して総頂点数を 2 倍にするため、固定長の頂点カラー
+    // バッファ (SAMPLE_COUNT * 2 頂点ぶん) と齟齬が生じ、複製側が未着色のまま白く描画されてしまう。
     const ribbon: Mesh = CreateRibbon(
         "flightRouteRibbon",
-        { pathArray, updatable: true, sideOrientation: Mesh.DOUBLESIDE },
+        { pathArray, updatable: true },
         scene,
     );
     ribbon.material = material;

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -100,6 +100,13 @@ export class JpmapTerrain {
     private _scene: Scene | null = null;
     private _onWindowResize: (() => void) | null = null;
     private _resizeObserver: ResizeObserver | null = null;
+    /**
+     * canvas に登録した `touchmove` ハンドラ。
+     * `touch-action: none` だけでは Android Chrome 等のオーバースクロール
+     * （2 本指スワイプによる自動スクロール）や画面端スワイプの戻る/進む
+     * ナビゲーションが抑止できないため、`preventDefault` で明示的に止める。
+     */
+    private _onCanvasTouchMove: ((ev: TouchEvent) => void) | null = null;
     private _disposed = false;
     private _controller: DefaultSceneController | null = null;
     /** 進行中の flyTo をキャンセルするためのトークン */
@@ -210,6 +217,22 @@ export class JpmapTerrain {
         canvas.style.visibility = "hidden";
         this.mountElement.appendChild(canvas);
         this._canvas = canvas;
+
+        // Android Chrome 等では `touch-action: none` だけではブラウザ既定の
+        // オーバースクロール（2 本指スワイプによる自動スクロール）や画面端
+        // スワイプによる戻る/進むナビゲーションが残ることがある。canvas 上の
+        // touchmove を passive:false で握って preventDefault し、これらを抑止する。
+        // Babylon はポインタイベントで操作を処理するため、touch のキャンセルは
+        // ジェスチャ実装に影響しない。
+        const onCanvasTouchMove = (ev: TouchEvent): void => {
+            if (ev.cancelable) {
+                ev.preventDefault();
+            }
+        };
+        canvas.addEventListener("touchmove", onCanvasTouchMove, {
+            passive: false,
+        });
+        this._onCanvasTouchMove = onCanvasTouchMove;
 
         try {
             const engine = await createBabylonEngine(
@@ -362,6 +385,10 @@ export class JpmapTerrain {
             }
             if (canvas.parentElement === this.mountElement) {
                 this.mountElement.removeChild(canvas);
+            }
+            if (this._onCanvasTouchMove) {
+                canvas.removeEventListener("touchmove", this._onCanvasTouchMove);
+                this._onCanvasTouchMove = null;
             }
             this._canvas = null;
             throw error;
@@ -1430,6 +1457,10 @@ export class JpmapTerrain {
         if (this._canvas && this._canvas.parentElement === this.mountElement) {
             this.mountElement.removeChild(this._canvas);
         }
+        if (this._canvas && this._onCanvasTouchMove) {
+            this._canvas.removeEventListener("touchmove", this._onCanvasTouchMove);
+        }
+        this._onCanvasTouchMove = null;
         this._canvas = null;
     }
 

--- a/src/lib/jpmapTerrain.ts
+++ b/src/lib/jpmapTerrain.ts
@@ -107,6 +107,13 @@ export class JpmapTerrain {
      * ナビゲーションが抑止できないため、`preventDefault` で明示的に止める。
      */
     private _onCanvasTouchMove: ((ev: TouchEvent) => void) | null = null;
+    /**
+     * canvas に登録した `wheel` ハンドラ。
+     * タッチパッドのピンチ操作は `ctrlKey=true` の wheel イベントとして届き、
+     * 既定では PC ブラウザ（Chrome 等）のページズームを引き起こす。地図側の
+     * ズームと衝突するため、`ctrlKey` の wheel を `preventDefault` で抑止する。
+     */
+    private _onCanvasWheel: ((ev: WheelEvent) => void) | null = null;
     private _disposed = false;
     private _controller: DefaultSceneController | null = null;
     /** 進行中の flyTo をキャンセルするためのトークン */
@@ -233,6 +240,19 @@ export class JpmapTerrain {
             passive: false,
         });
         this._onCanvasTouchMove = onCanvasTouchMove;
+
+        // タッチパッドのピンチは ctrlKey=true の wheel として届き、既定では PC
+        // ブラウザのページズーム（Ctrl+ホイール相当）を発火させる。地図のズームと
+        // 衝突するため preventDefault で抑止する。地図ズームは Babylon が wheel を
+        // 直接読むため、既定動作のキャンセルでは妨げられない。通常スクロール用の
+        // wheel（ctrlKey=false）には干渉しない。
+        const onCanvasWheel = (ev: WheelEvent): void => {
+            if (ev.ctrlKey && ev.cancelable) {
+                ev.preventDefault();
+            }
+        };
+        canvas.addEventListener("wheel", onCanvasWheel, { passive: false });
+        this._onCanvasWheel = onCanvasWheel;
 
         try {
             const engine = await createBabylonEngine(
@@ -389,6 +409,10 @@ export class JpmapTerrain {
             if (this._onCanvasTouchMove) {
                 canvas.removeEventListener("touchmove", this._onCanvasTouchMove);
                 this._onCanvasTouchMove = null;
+            }
+            if (this._onCanvasWheel) {
+                canvas.removeEventListener("wheel", this._onCanvasWheel);
+                this._onCanvasWheel = null;
             }
             this._canvas = null;
             throw error;
@@ -1461,6 +1485,10 @@ export class JpmapTerrain {
             this._canvas.removeEventListener("touchmove", this._onCanvasTouchMove);
         }
         this._onCanvasTouchMove = null;
+        if (this._canvas && this._onCanvasWheel) {
+            this._canvas.removeEventListener("wheel", this._onCanvasWheel);
+        }
+        this._onCanvasWheel = null;
         this._canvas = null;
     }
 

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -1984,7 +1984,7 @@ export class GlobeScene {
             document.removeEventListener("visibilitychange", onVisibilityChange);
             canvas.removeEventListener("pointerdown", onPointerDown);
             canvas.removeEventListener("pointerup", onPointerUp);
-            canvas.removeEventListener("pointercancel", endDrag);
+            canvas.removeEventListener("pointercancel", onPointerCancel);
             canvas.removeEventListener("pointermove", onPointerMove);
             detachClickHandlers();
             terrainClickListeners.length = 0;

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -617,7 +617,7 @@ export class GlobeScene {
             } else {
                 // 離れている: 平行移動 ＋ 回転（ひねり）。
                 if (panEnabled) panByPixels(dCx, dCy);
-                if (dAng !== 0) camera.yaw = camera.yaw + dAng * TWO_FINGER_YAW_SENS;
+                if (dAng !== 0) camera.yaw = camera.yaw - dAng * TWO_FINGER_YAW_SENS;
             }
         };
 

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -526,10 +526,27 @@ export class GlobeScene {
         const endDrag = (): void => {
             dragging = false;
         };
+        // touchPoints の先頭要素（残り1本指の現在位置）を返す。
+        const firstTouchPoint = (): { x: number; y: number } | undefined => {
+            const it = touchPoints.values().next();
+            return it.done ? undefined : it.value;
+        };
         const onPointerUp = (e: PointerEvent): void => {
             if (e.pointerType === "touch") {
                 touchPoints.delete(e.pointerId);
                 if (touchPoints.size < 2) twoFingerMode = null;
+                // 2本→1本: 残った指は接地済みで pointerdown が来ないため、ここで
+                // シングルタッチパンを残指の現在位置から継続できるよう再初期化する
+                // （しないと全指を離すまでパン不可になる）。
+                if (touchPoints.size === 1) {
+                    const remaining = firstTouchPoint();
+                    if (remaining) {
+                        dragging = true;
+                        lastX = remaining.x;
+                        lastY = remaining.y;
+                    }
+                    return;
+                }
             }
             if (e.button === 0) endDrag();
         };
@@ -537,6 +554,16 @@ export class GlobeScene {
             if (e.pointerType === "touch") {
                 touchPoints.delete(e.pointerId);
                 if (touchPoints.size < 2) twoFingerMode = null;
+                // onPointerUp と同契約: 2本→1本になったら残指でパンを継続する。
+                if (touchPoints.size === 1) {
+                    const remaining = firstTouchPoint();
+                    if (remaining) {
+                        dragging = true;
+                        lastX = remaining.x;
+                        lastY = remaining.y;
+                    }
+                    return;
+                }
             }
             endDrag();
         };

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -410,6 +410,20 @@ export class GlobeScene {
         camera.addBehavior(new GeospatialClippingBehavior());
         camera.attachControl(true);
 
+        // 2本指タッチジェスチャは独自実装（ひねり=yaw / 平行移動=pan / 近接時=tilt。後述の
+        // pointer handler）に置き換えるため、GeospatialCamera 組み込みの multi-touch パン
+        // （= 2本指ドラッグでの tilt 回転）を無効化する。ピンチによるズームは温存する（pinchZoom）。
+        for (const name of Object.keys(camera.inputs.attached)) {
+            const input = camera.inputs.attached[name] as unknown as {
+                multiTouchPanning?: boolean;
+                multiTouchPanAndZoom?: boolean;
+            };
+            if (typeof input.multiTouchPanning === "boolean") {
+                input.multiTouchPanning = false;
+                input.multiTouchPanAndZoom = false;
+            }
+        }
+
         // zoom-to-cursor（カーソル下の地点へ寄るズーム）を有効化する。ネイティブ実装は
         // ホイール毎に scene.pick でカーソル下の点を取り直すが、floating origin 下では
         // レンダリング座標と真の ECEF メッシュ位置がずれてピックが毎回ブレ、ズームが揺れる。
@@ -471,9 +485,9 @@ export class GlobeScene {
         let dragging = false;
         let lastX = 0;
         let lastY = 0;
-        // アクティブなタッチポインタ集合（ピンチ等のマルチタッチ検出用）。2本指以上が接地している
-        // 間は独自のシングルタッチパンを無効化し、GeospatialCamera のピンチズームと競合させない。
-        const activeTouchPointers = new Set<number>();
+        // アクティブなタッチポインタの現在位置（clientX/Y）。2本指ジェスチャ（ピンチ/ひねり/平行移動）
+        // と、2本指以上の間のシングルタッチパン抑止に使う。キー = pointerId。
+        const touchPoints = new Map<number, { x: number; y: number }>();
         // ---- ポリゴン頂点インタラクション状態 ----
         // パン handler（onPointerDown/Move）から参照するため早期に宣言する。実体の購読 API・
         // 幾何ピック・ドラッグハンドラはカメラ/レイ補助関数（後述）の後で定義・遅延登録する。
@@ -492,10 +506,10 @@ export class GlobeScene {
         const onPointerDown = (e: PointerEvent): void => {
             canvas.focus(); // WASD のためにフォーカスを確保（右/左/中ボタンいずれでも）
             if (e.pointerType === "touch") {
-                activeTouchPointers.add(e.pointerId);
-                // 2本指以上はピンチ等のマルチタッチジェスチャ。進行中の独自パンを打ち切り、
-                // 以降の pointermove ではパンしない（ピンチズームと同時発火させない）。
-                if (activeTouchPointers.size >= 2) {
+                touchPoints.set(e.pointerId, { x: e.clientX, y: e.clientY });
+                // 2本指以上はマルチタッチジェスチャ（ピンチ/ひねり/平行移動）。進行中の独自シングル
+                // タッチパンを打ち切り、以降は 2本指ハンドラに委ねる。
+                if (touchPoints.size >= 2) {
                     dragging = false;
                     return;
                 }
@@ -510,11 +524,11 @@ export class GlobeScene {
             dragging = false;
         };
         const onPointerUp = (e: PointerEvent): void => {
-            if (e.pointerType === "touch") activeTouchPointers.delete(e.pointerId);
+            if (e.pointerType === "touch") touchPoints.delete(e.pointerId);
             if (e.button === 0) endDrag();
         };
         const onPointerCancel = (e: PointerEvent): void => {
-            if (e.pointerType === "touch") activeTouchPointers.delete(e.pointerId);
+            if (e.pointerType === "touch") touchPoints.delete(e.pointerId);
             endDrag();
         };
         // パン用の再利用バッファ（毎フレーム/毎 move 呼び出しでの割当を避ける）。
@@ -524,24 +538,12 @@ export class GlobeScene {
         const tangent = new Vector3();
         const panned = new Vector3();
 
-        const onPointerMove = (e: PointerEvent): void => {
-            // ポリゴン頂点ジェスチャ進行中はパンしない。ドラッグ処理は専用 handler が行う。
-            if (
-                polygonPointGesture &&
-                polygonPointGesture.pointerId === e.pointerId
-            ) {
-                return;
-            }
-            if (!dragging) return;
-            if (!panEnabled) return;
-            // 2本指以上のタッチ（ピンチ等）進行中はパンしない。GeospatialCamera のピンチズームに委ねる。
-            if (activeTouchPointers.size >= 2) return;
-            const dx = e.clientX - lastX;
-            const dy = e.clientY - lastY;
-            lastX = e.clientX;
-            lastY = e.clientY;
+        /**
+         * 画面上の (dx, dy) [px] 分だけ「マップを掴んで引く」パンを行う（center を地表接線方向へ移動）。
+         * シングルタッチ／マウスドラッグと、2本指の平行移動の双方から共用する。
+         */
+        const panByPixels = (dx: number, dy: number): void => {
             if (dx === 0 && dy === 0) return;
-
             // カメラ→center 方向(lookAt)から地表接線の右・前方向を作る。
             ComputeLookAtFromYawPitchToRef(
                 camera.yaw,
@@ -562,6 +564,88 @@ export class GlobeScene {
             // 極付近の高速回転を抑える。極では東西の一定メートル移動が経度の巨大変化に対応する。
             tangent.scaleInPlace(polePanSpeedMultiplier(camera.center, camera.radius));
             camera.center = panCenterOnSphereToRef(camera.center, tangent, panned);
+        };
+
+        // ---- 2本指ジェスチャ（タッチ）パラメータ（Issue #424）----
+        // 指の間隔がこの値[px]未満なら「近い」とみなしチルト、以上なら移動＋回転に切り替える。
+        const TWO_FINGER_TILT_SPREAD_PX = 160;
+        // 重心の縦移動[px] → pitch[rad] 係数（チルト感度）。
+        const TWO_FINGER_TILT_SENS = 0.005;
+        // 指の「ひねり」角[rad] → yaw[rad] 係数（回転感度）。
+        const TWO_FINGER_YAW_SENS = 1.0;
+        const MIN_PITCH_RAD = 0;
+        const MAX_PITCH_RAD = MAX_TILT_DEG * DEG2RAD;
+
+        /**
+         * 2本指タッチの 1 ステップ分のジェスチャを適用する。
+         * - 指の間隔が近い（< TWO_FINGER_TILT_SPREAD_PX）: 重心の縦移動でチルト（pitch）。
+         * - 指の間隔が離れている: 重心移動で平行移動（pan）＋ 指のひねりで方位回転（yaw）。
+         * ピンチ（間隔変化）によるズームは GeospatialCamera 側が別途処理する。
+         */
+        const handleTwoFingerMove = (
+            movedId: number,
+            prev: { x: number; y: number },
+            now: { x: number; y: number },
+        ): void => {
+            let other: { x: number; y: number } | undefined;
+            for (const [id, p] of touchPoints) {
+                if (id !== movedId) {
+                    other = p;
+                    break;
+                }
+            }
+            if (!other) return;
+
+            // 指のひねり角の差分（前フレーム→現フレーム）。
+            const angPrev = Math.atan2(prev.y - other.y, prev.x - other.x);
+            const angNow = Math.atan2(now.y - other.y, now.x - other.x);
+            let dAng = angNow - angPrev;
+            if (dAng > Math.PI) dAng -= 2 * Math.PI;
+            else if (dAng < -Math.PI) dAng += 2 * Math.PI;
+
+            // 現在の指の間隔。
+            const spread = Math.hypot(now.x - other.x, now.y - other.y);
+
+            // 2本指の重心移動（前フレーム→現フレーム）。動いたのは movedId の指のみ。
+            const dCx = (now.x - prev.x) / 2;
+            const dCy = (now.y - prev.y) / 2;
+
+            if (spread < TWO_FINGER_TILT_SPREAD_PX) {
+                // 近い: チルト。上方向ドラッグ（dCy<0）でチルトアップ（pitch 増）。limits 範囲にクランプ。
+                const next = camera.pitch - dCy * TWO_FINGER_TILT_SENS;
+                camera.pitch = Math.min(MAX_PITCH_RAD, Math.max(MIN_PITCH_RAD, next));
+            } else {
+                // 離れている: 平行移動 ＋ 回転（ひねり）。
+                if (panEnabled) panByPixels(dCx, dCy);
+                if (dAng !== 0) camera.yaw = camera.yaw + dAng * TWO_FINGER_YAW_SENS;
+            }
+        };
+
+        const onPointerMove = (e: PointerEvent): void => {
+            // ポリゴン頂点ジェスチャ進行中はパンしない。ドラッグ処理は専用 handler が行う。
+            if (
+                polygonPointGesture &&
+                polygonPointGesture.pointerId === e.pointerId
+            ) {
+                return;
+            }
+            // タッチの位置追跡を更新し、2本指以上なら 2本指ハンドラへ委譲（シングルパンはしない）。
+            if (e.pointerType === "touch" && touchPoints.has(e.pointerId)) {
+                const prev = touchPoints.get(e.pointerId)!;
+                const now = { x: e.clientX, y: e.clientY };
+                touchPoints.set(e.pointerId, now);
+                if (touchPoints.size >= 2) {
+                    handleTwoFingerMove(e.pointerId, prev, now);
+                    return;
+                }
+            }
+            if (!dragging) return;
+            if (!panEnabled) return;
+            const dx = e.clientX - lastX;
+            const dy = e.clientY - lastY;
+            lastX = e.clientX;
+            lastY = e.clientY;
+            panByPixels(dx, dy);
         };
         canvas.addEventListener("pointerdown", onPointerDown);
         canvas.addEventListener("pointerup", onPointerUp);

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -488,6 +488,9 @@ export class GlobeScene {
         // アクティブなタッチポインタの現在位置（clientX/Y）。2本指ジェスチャ（ピンチ/ひねり/平行移動）
         // と、2本指以上の間のシングルタッチパン抑止に使う。キー = pointerId。
         const touchPoints = new Map<number, { x: number; y: number }>();
+        // 2本指ジェスチャのモード。最初の2本指 move 時に指の間隔で確定し、指を離す（2本未満に
+        // なる）まで維持する。途中で間隔がしきい値を跨いでもモードを切り替えない（誤切替防止）。
+        let twoFingerMode: "tilt" | "panRotate" | null = null;
         // ---- ポリゴン頂点インタラクション状態 ----
         // パン handler（onPointerDown/Move）から参照するため早期に宣言する。実体の購読 API・
         // 幾何ピック・ドラッグハンドラはカメラ/レイ補助関数（後述）の後で定義・遅延登録する。
@@ -524,11 +527,17 @@ export class GlobeScene {
             dragging = false;
         };
         const onPointerUp = (e: PointerEvent): void => {
-            if (e.pointerType === "touch") touchPoints.delete(e.pointerId);
+            if (e.pointerType === "touch") {
+                touchPoints.delete(e.pointerId);
+                if (touchPoints.size < 2) twoFingerMode = null;
+            }
             if (e.button === 0) endDrag();
         };
         const onPointerCancel = (e: PointerEvent): void => {
-            if (e.pointerType === "touch") touchPoints.delete(e.pointerId);
+            if (e.pointerType === "touch") {
+                touchPoints.delete(e.pointerId);
+                if (touchPoints.size < 2) twoFingerMode = null;
+            }
             endDrag();
         };
         // パン用の再利用バッファ（毎フレーム/毎 move 呼び出しでの割当を避ける）。
@@ -606,16 +615,21 @@ export class GlobeScene {
             // 現在の指の間隔。
             const spread = Math.hypot(now.x - other.x, now.y - other.y);
 
+            // モードは最初の2本指 move 時に確定し、指を離すまで維持（しきい値の跨ぎで切替えない）。
+            if (twoFingerMode === null) {
+                twoFingerMode = spread < TWO_FINGER_TILT_SPREAD_PX ? "tilt" : "panRotate";
+            }
+
             // 2本指の重心移動（前フレーム→現フレーム）。動いたのは movedId の指のみ。
             const dCx = (now.x - prev.x) / 2;
             const dCy = (now.y - prev.y) / 2;
 
-            if (spread < TWO_FINGER_TILT_SPREAD_PX) {
-                // 近い: チルト。上方向ドラッグ（dCy<0）でチルトアップ（pitch 増）。limits 範囲にクランプ。
+            if (twoFingerMode === "tilt") {
+                // チルト。上方向ドラッグ（dCy<0）でチルトアップ（pitch 増）。limits 範囲にクランプ。
                 const next = camera.pitch - dCy * TWO_FINGER_TILT_SENS;
                 camera.pitch = Math.min(MAX_PITCH_RAD, Math.max(MIN_PITCH_RAD, next));
             } else {
-                // 離れている: 平行移動 ＋ 回転（ひねり）。
+                // 平行移動 ＋ 回転（ひねり）。
                 if (panEnabled) panByPixels(dCx, dCy);
                 if (dAng !== 0) camera.yaw = camera.yaw - dAng * TWO_FINGER_YAW_SENS;
             }

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -471,6 +471,9 @@ export class GlobeScene {
         let dragging = false;
         let lastX = 0;
         let lastY = 0;
+        // アクティブなタッチポインタ集合（ピンチ等のマルチタッチ検出用）。2本指以上が接地している
+        // 間は独自のシングルタッチパンを無効化し、GeospatialCamera のピンチズームと競合させない。
+        const activeTouchPointers = new Set<number>();
         // ---- ポリゴン頂点インタラクション状態 ----
         // パン handler（onPointerDown/Move）から参照するため早期に宣言する。実体の購読 API・
         // 幾何ピック・ドラッグハンドラはカメラ/レイ補助関数（後述）の後で定義・遅延登録する。
@@ -488,6 +491,15 @@ export class GlobeScene {
         } | null = null;
         const onPointerDown = (e: PointerEvent): void => {
             canvas.focus(); // WASD のためにフォーカスを確保（右/左/中ボタンいずれでも）
+            if (e.pointerType === "touch") {
+                activeTouchPointers.add(e.pointerId);
+                // 2本指以上はピンチ等のマルチタッチジェスチャ。進行中の独自パンを打ち切り、
+                // 以降の pointermove ではパンしない（ピンチズームと同時発火させない）。
+                if (activeTouchPointers.size >= 2) {
+                    dragging = false;
+                    return;
+                }
+            }
             if (e.button !== 0) return;
             dragging = true;
             lastX = e.clientX;
@@ -498,7 +510,12 @@ export class GlobeScene {
             dragging = false;
         };
         const onPointerUp = (e: PointerEvent): void => {
+            if (e.pointerType === "touch") activeTouchPointers.delete(e.pointerId);
             if (e.button === 0) endDrag();
+        };
+        const onPointerCancel = (e: PointerEvent): void => {
+            if (e.pointerType === "touch") activeTouchPointers.delete(e.pointerId);
+            endDrag();
         };
         // パン用の再利用バッファ（毎フレーム/毎 move 呼び出しでの割当を避ける）。
         const dragRight = new Vector3();
@@ -517,6 +534,8 @@ export class GlobeScene {
             }
             if (!dragging) return;
             if (!panEnabled) return;
+            // 2本指以上のタッチ（ピンチ等）進行中はパンしない。GeospatialCamera のピンチズームに委ねる。
+            if (activeTouchPointers.size >= 2) return;
             const dx = e.clientX - lastX;
             const dy = e.clientY - lastY;
             lastX = e.clientX;
@@ -546,7 +565,7 @@ export class GlobeScene {
         };
         canvas.addEventListener("pointerdown", onPointerDown);
         canvas.addEventListener("pointerup", onPointerUp);
-        canvas.addEventListener("pointercancel", endDrag);
+        canvas.addEventListener("pointercancel", onPointerCancel);
         canvas.addEventListener("pointermove", onPointerMove);
 
         /**

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -1691,7 +1691,8 @@ export const createGlobeSceneController = (
         // computeMaxScaleBarPx は getBoundingClientRect / offsetWidth を読むため
         // レイアウト再計算（reflow）を伴う。毎フレーム実行すると重いので結果を
         // キャッシュし、(1) ビューポート/キャンバスのリサイズ時 (2) スケールラベル
-        // 文字列が変化して固定部の幅が変わったとき のみ再計算する。
+        // 文字列が変化して固定部の幅が変わったとき (3) 地図切替ボタンの位置
+        // (style/class) が外部 JS で変更されたとき のみ再計算する。
         let cachedMaxBarPx = SCALE_BAR_BASE_PX;
         let maxBarPxDirty = true;
         const getMaxScaleBarPx = (): number => {
@@ -1706,6 +1707,17 @@ export const createGlobeSceneController = (
         };
         if (typeof window !== "undefined") {
             window.addEventListener("resize", markMaxBarPxDirty);
+        }
+        // 地図切替ボタンはデモ側 JS で後から移動されうる（例: flight の PIP レイアウト
+        // 調整で left/bottom を書き換える）。その場合も上限幅を再計算するため、
+        // ボタンの属性変更を監視して dirty 化する。
+        let mapToggleObserver: MutationObserver | null = null;
+        if (typeof MutationObserver !== "undefined") {
+            mapToggleObserver = new MutationObserver(markMaxBarPxDirty);
+            mapToggleObserver.observe(ui.mapToggle, {
+                attributes: true,
+                attributeFilter: ["style", "class"],
+            });
         }
         const updateOverlayUi = (): void => {
             // コンパス: 外部指定があればその値を優先し、なければ北矢印が実際の北を
@@ -1867,6 +1879,7 @@ export const createGlobeSceneController = (
             if (typeof window !== "undefined") {
                 window.removeEventListener("resize", markMaxBarPxDirty);
             }
+            mapToggleObserver?.disconnect();
             removeFromParent(ui.compass);
             removeFromParent(ui.mapToggle);
             removeFromParent(ui.viewModeButton);

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -30,7 +30,7 @@ import { assertLatLonInBounds } from "../terrain/overlayCoords";
 import { resolveIcon, resolveText } from "../terrain/marker";
 import {
     createControlPanel,
-    snapScale,
+    pickScaleWithin,
     formatScale,
     showToast,
 } from "../terrain/controlPanel";
@@ -1657,9 +1657,37 @@ export const createGlobeSceneController = (
 
         // コンパス回転 + スケールバーをフレーム毎に更新する（変化時のみ DOM を書く）。
         const SCALE_BAR_BASE_PX = 100;
+        const SCALE_BAR_MIN_PX = 20;
+        // 地図切替ボタンとスケール行の間に確保する安全マージン（px）。
+        const SCALE_BAR_SAFETY_PX = 8;
         let prevCompassDeg = Number.NaN;
         let prevScaleText = "";
         let prevBarPx = Number.NaN;
+        // スケールバーの最大許容幅（px）を画面幅から求める。スケール行は右下に
+        // 右寄せ配置され、左へ伸びるほど左下の地図切替ボタンへ近づく。バー以外の
+        // 固定要素（地理院タイル / ラベル / gap）と、ボタン右端＋マージンを差し引いた
+        // 残り幅をバーに割り当てる。レイアウト未確定時は基準幅にフォールバックする。
+        const computeMaxScaleBarPx = (): number => {
+            const viewportWidth =
+                (typeof window !== "undefined" ? window.innerWidth : 0) ||
+                canvas.clientWidth;
+            if (!(viewportWidth > 0)) return SCALE_BAR_BASE_PX;
+            const toggleRect = ui.mapToggle.getBoundingClientRect();
+            const containerRect = ui.scaleBar.container.getBoundingClientRect();
+            // 行の右端（= 右下基準位置）。未測定時は右インセット 12px 相当で代替。
+            const rowRight =
+                containerRect.width > 0 ? containerRect.right : viewportWidth - 12;
+            // 地図切替ボタンの右端。未測定時は left:12 + width:48 で代替。
+            const toggleRight = toggleRect.width > 0 ? toggleRect.right : 60;
+            // バー以外（地理院タイル + ラベル + gap 2 つ）の現在幅。
+            const fixedPart =
+                ui.scaleBar.attribution.offsetWidth +
+                ui.scaleBar.label.offsetWidth +
+                8;
+            const available =
+                rowRight - toggleRight - SCALE_BAR_SAFETY_PX - fixedPart;
+            return Math.max(SCALE_BAR_MIN_PX, available);
+        };
         const updateOverlayUi = (): void => {
             // コンパス: 外部指定があればその値を優先し、なければ北矢印が実際の北を
             // 指すよう azimuth の逆回転を適用する。
@@ -1679,10 +1707,15 @@ export const createGlobeSceneController = (
             if (h > 0) {
                 const metersPerPx =
                     (2 * camera.radius * Math.tan(camera.fov / 2)) / h;
-                const rawMeters = metersPerPx * SCALE_BAR_BASE_PX;
-                if (Number.isFinite(rawMeters) && rawMeters > 0) {
-                    const snapped = snapScale(rawMeters);
-                    const barPx = Math.round(snapped / metersPerPx);
+                if (Number.isFinite(metersPerPx) && metersPerPx > 0) {
+                    // 画面幅に対するバーの最大許容幅を求め、行（地理院タイル + ラベル
+                    // + バー）が左下の地図切替ボタンへ被らないようにする。
+                    const maxBarPx = computeMaxScaleBarPx();
+                    const { meters: snapped, barPx } = pickScaleWithin(
+                        metersPerPx,
+                        SCALE_BAR_BASE_PX,
+                        maxBarPx,
+                    );
                     const text = formatScale(snapped);
                     if (text !== prevScaleText) {
                         ui.scaleBar.label.textContent = text;

--- a/src/scenes/globeSceneController.ts
+++ b/src/scenes/globeSceneController.ts
@@ -1688,6 +1688,25 @@ export const createGlobeSceneController = (
                 rowRight - toggleRight - SCALE_BAR_SAFETY_PX - fixedPart;
             return Math.max(SCALE_BAR_MIN_PX, available);
         };
+        // computeMaxScaleBarPx は getBoundingClientRect / offsetWidth を読むため
+        // レイアウト再計算（reflow）を伴う。毎フレーム実行すると重いので結果を
+        // キャッシュし、(1) ビューポート/キャンバスのリサイズ時 (2) スケールラベル
+        // 文字列が変化して固定部の幅が変わったとき のみ再計算する。
+        let cachedMaxBarPx = SCALE_BAR_BASE_PX;
+        let maxBarPxDirty = true;
+        const getMaxScaleBarPx = (): number => {
+            if (maxBarPxDirty) {
+                cachedMaxBarPx = computeMaxScaleBarPx();
+                maxBarPxDirty = false;
+            }
+            return cachedMaxBarPx;
+        };
+        const markMaxBarPxDirty = (): void => {
+            maxBarPxDirty = true;
+        };
+        if (typeof window !== "undefined") {
+            window.addEventListener("resize", markMaxBarPxDirty);
+        }
         const updateOverlayUi = (): void => {
             // コンパス: 外部指定があればその値を優先し、なければ北矢印が実際の北を
             // 指すよう azimuth の逆回転を適用する。
@@ -1710,7 +1729,7 @@ export const createGlobeSceneController = (
                 if (Number.isFinite(metersPerPx) && metersPerPx > 0) {
                     // 画面幅に対するバーの最大許容幅を求め、行（地理院タイル + ラベル
                     // + バー）が左下の地図切替ボタンへ被らないようにする。
-                    const maxBarPx = computeMaxScaleBarPx();
+                    const maxBarPx = getMaxScaleBarPx();
                     const { meters: snapped, barPx } = pickScaleWithin(
                         metersPerPx,
                         SCALE_BAR_BASE_PX,
@@ -1720,6 +1739,9 @@ export const createGlobeSceneController = (
                     if (text !== prevScaleText) {
                         ui.scaleBar.label.textContent = text;
                         prevScaleText = text;
+                        // ラベル幅が変わると固定部の幅も変わるため、次フレームで
+                        // 最大バー幅を再計算する。
+                        markMaxBarPxDirty();
                     }
                     // ラベル同様、幅も変化時のみ更新して不要なレイアウトを避ける。
                     if (barPx !== prevBarPx) {
@@ -1842,6 +1864,9 @@ export const createGlobeSceneController = (
         uiDispose = (): void => {
             uiDisposed = true;
             gc.scene.onBeforeRenderObservable.remove(overlayObserver);
+            if (typeof window !== "undefined") {
+                window.removeEventListener("resize", markMaxBarPxDirty);
+            }
             removeFromParent(ui.compass);
             removeFromParent(ui.mapToggle);
             removeFromParent(ui.viewModeButton);

--- a/src/terrain/controlPanel.ts
+++ b/src/terrain/controlPanel.ts
@@ -103,7 +103,9 @@ const createCompass = (): HTMLDivElement => {
         const style = document.createElement("style");
         style.id = "cp-focus-style";
         style.textContent = [
-            ".cp-compass, .cp-btn { outline: none; }",
+            // touch-action: manipulation で iOS Safari のダブルタップズーム等のブラウザ既定
+            // ジェスチャを抑止しつつ、タップ（クリック）は従来どおり機能させる（Issue #424）。
+            ".cp-compass, .cp-btn { outline: none; touch-action: manipulation; }",
             ".cp-compass:focus, .cp-btn:focus { box-shadow: 0 0 0 2px #90caf9; }",
             ".cp-compass:focus:not(:focus-visible), .cp-btn:focus:not(:focus-visible) { box-shadow: none; }",
         ].join("\n");

--- a/src/terrain/controlPanel.ts
+++ b/src/terrain/controlPanel.ts
@@ -371,7 +371,9 @@ export const pickScaleWithin = (
     let idx = SCALE_STEPS.findIndex((s) => s >= rawMeters);
     if (idx === -1) idx = SCALE_STEPS.length - 1;
     // maxBarPx を超える間は 1 段階ずつ小さいスケールへ下げる（最小ステップまで）。
-    while (idx > 0 && SCALE_STEPS[idx] / metersPerPx > maxBarPx) {
+    // 判定は実際の描画幅と一致させるため round 後の barPx で行う（小数では max 以下
+    // でも round で +1px されて上限を超えるケースを防ぐ）。
+    while (idx > 0 && Math.round(SCALE_STEPS[idx] / metersPerPx) > maxBarPx) {
         idx--;
     }
     const meters = SCALE_STEPS[idx];

--- a/src/terrain/controlPanel.ts
+++ b/src/terrain/controlPanel.ts
@@ -347,6 +347,38 @@ export const snapScale = (meters: number): number => {
     return SCALE_STEPS[SCALE_STEPS.length - 1];
 };
 
+/**
+ * スケールバーの「きれいな数値」を、表示幅の上限（maxBarPx）を超えない範囲で選ぶ。
+ *
+ * `snapScale` は常に切り上げるため、バー幅は基準（basePx）の最大 2.5 倍程度まで
+ * 広がりうる。狭い画面ではバーが横に伸びて左下の地図切替ボタン等に被るため、
+ * `maxBarPx` を超える場合は 1 段階ずつ小さいスケールへ下げてバー幅を収める。
+ *
+ * @param metersPerPx 画面 1px あたりのメートル数（>0）
+ * @param basePx スケールバーの目標幅（px）。この近傍のきれいな値を選ぶ起点。
+ * @param maxBarPx 許容する最大バー幅（px）。これを超えないスケールを選ぶ。
+ * @returns 選んだスケール（meters）と対応するバー幅（barPx）
+ */
+export const pickScaleWithin = (
+    metersPerPx: number,
+    basePx: number,
+    maxBarPx: number,
+): { meters: number; barPx: number } => {
+    if (!(metersPerPx > 0) || !Number.isFinite(metersPerPx)) {
+        return { meters: SCALE_STEPS[0], barPx: 0 };
+    }
+    const rawMeters = metersPerPx * basePx;
+    let idx = SCALE_STEPS.findIndex((s) => s >= rawMeters);
+    if (idx === -1) idx = SCALE_STEPS.length - 1;
+    // maxBarPx を超える間は 1 段階ずつ小さいスケールへ下げる（最小ステップまで）。
+    while (idx > 0 && SCALE_STEPS[idx] / metersPerPx > maxBarPx) {
+        idx--;
+    }
+    const meters = SCALE_STEPS[idx];
+    const barPx = Math.round(meters / metersPerPx);
+    return { meters, barPx };
+};
+
 export const formatScale = (meters: number): string => {
     if (meters >= 1000) return `${meters / 1000} km`;
     return `${meters} m`;

--- a/src/terrain/controlPanel.ts
+++ b/src/terrain/controlPanel.ts
@@ -21,6 +21,33 @@ const css = (el: HTMLElement, styles: Partial<CSSStyleDeclaration>): void => {
     Object.assign(el.style, styles);
 };
 
+/**
+ * タッチ端末（coarse pointer）向けのレスポンシブ補正スタイルを一度だけ注入する。
+ *
+ * 操作 UI は固定 px のインラインスタイルで生成されるため、ここでは `@media (pointer: coarse)`
+ * + `!important` でインライン値を上書きし、スマートフォン/タブレットでのみタップ領域・文字を
+ * 拡大する。マウス/トラックパッド（fine pointer）では何も変えないため、PC の見た目とビジュアル
+ * 回帰テストには影響しない。
+ */
+const injectResponsiveStyle = (): void => {
+    if (document.getElementById("cp-responsive-style")) return;
+    const style = document.createElement("style");
+    style.id = "cp-responsive-style";
+    style.textContent = [
+        "@media (pointer: coarse) {",
+        "  .cp-compass { width: 48px !important; height: 48px !important; top: 16px !important; right: 16px !important; }",
+        "  .cp-compass svg { width: 34px; height: 34px; }",
+        "  .cp-viewmode { width: 48px !important; height: 48px !important; top: 72px !important; right: 16px !important; font-size: 15px !important; }",
+        "  .cp-btn { min-width: 44px; min-height: 44px; }",
+        "  .cp-zoombtn { width: 44px !important; height: 44px !important; font-size: 22px !important; }",
+        "  .cp-zoombtn svg { width: 22px; height: 22px; }",
+        "  .cp-maptoggle { width: 56px !important; height: 44px !important; left: 16px !important; bottom: 16px !important; font-size: 13px !important; }",
+        "  .cp-scale-text { font-size: 12px !important; }",
+        "}",
+    ].join("\n");
+    document.head.appendChild(style);
+};
+
 const createCompass = (): HTMLDivElement => {
     const container = document.createElement("div");
     css(container, {
@@ -131,6 +158,7 @@ const createZoomButtons = (): {
             pointerEvents: "auto",
         });
         btn.classList.add("cp-btn");
+        btn.classList.add("cp-zoombtn");
         return btn;
     };
 
@@ -175,6 +203,7 @@ const createZoomButtons = (): {
             "-1px -1px 0 #fff, 1px -1px 0 #fff, -1px 1px 0 #fff, 1px 1px 0 #fff",
     });
     scaleLabel.textContent = "";
+    scaleLabel.classList.add("cp-scale-text");
 
     const scaleBar = document.createElement("div");
     css(scaleBar, {
@@ -192,6 +221,7 @@ const createZoomButtons = (): {
     attribution.target = "_blank";
     attribution.rel = "noopener noreferrer";
     attribution.textContent = "地理院タイル";
+    attribution.classList.add("cp-scale-text");
     css(attribution, {
         color: "#222",
         fontSize: "10px",
@@ -257,6 +287,7 @@ const createMapToggleButton = (): HTMLButtonElement => {
         zIndex: "10",
     });
     btn.classList.add("cp-btn");
+    btn.classList.add("cp-maptoggle");
     document.body.appendChild(btn);
     return btn;
 };
@@ -296,6 +327,7 @@ const createViewModeToggleButton = (): HTMLButtonElement => {
         zIndex: "10",
     });
     btn.classList.add("cp-btn");
+    btn.classList.add("cp-viewmode");
     document.body.appendChild(btn);
     return btn;
 };
@@ -394,6 +426,9 @@ export const showToast = (message: string, durationMs = 3000): void => {
 };
 
 export const createControlPanel = (): ControlPanelElements => {
+    // タッチ端末向けのレスポンシブ補正スタイルを注入（fine pointer では無効）。
+    injectResponsiveStyle();
+
     // 方位磁針（画面右上に独立配置）
     const compass = createCompass();
 

--- a/tests/controlPanel.unit.spec.ts
+++ b/tests/controlPanel.unit.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import { jest } from "@jest/globals";
-import { snapScale, formatScale, SCALE_STEPS, createControlPanel, showToast } from "../src/terrain/controlPanel";
+import { snapScale, pickScaleWithin, formatScale, SCALE_STEPS, createControlPanel, showToast } from "../src/terrain/controlPanel";
 
 function cleanupDOM(): void {
     document.body.innerHTML = "";
@@ -170,6 +170,47 @@ describe("snapScale", () => {
     it("全ステップが昇順である", () => {
         for (let i = 1; i < SCALE_STEPS.length; i++) {
             expect(SCALE_STEPS[i]).toBeGreaterThan(SCALE_STEPS[i - 1]);
+        }
+    });
+});
+
+describe("pickScaleWithin", () => {
+    it("maxBarPx が十分大きいときは snapScale と同じきれいな値を選ぶ", () => {
+        // metersPerPx=2, basePx=100 → rawMeters=200 → snapped=200, barPx=100
+        const r = pickScaleWithin(2, 100, 10_000);
+        expect(r.meters).toBe(200);
+        expect(r.barPx).toBe(100);
+    });
+
+    it("切り上げでバーが広がるケースでも上限内に収める（段階を下げる）", () => {
+        // metersPerPx=2.01, basePx=100 → rawMeters≈201 → snapped=500 → barPx≈249
+        const wide = pickScaleWithin(2.01, 100, 10_000);
+        expect(wide.meters).toBe(500);
+        expect(wide.barPx).toBeGreaterThan(200);
+        // 上限 120px を与えると 1 段階下げて 200m（barPx≈100）に収まる
+        const capped = pickScaleWithin(2.01, 100, 120);
+        expect(capped.meters).toBe(200);
+        expect(capped.barPx).toBeLessThanOrEqual(120);
+    });
+
+    it("最小ステップでも上限を超える場合は最小ステップを返す", () => {
+        // metersPerPx=1, smallest step=1 → barPx=1。maxBarPx=0.5 でも 1m を返す
+        const r = pickScaleWithin(1, 100, 0.5);
+        expect(r.meters).toBe(SCALE_STEPS[0]);
+    });
+
+    it("metersPerPx が不正（0/NaN）なら barPx 0 を返す", () => {
+        expect(pickScaleWithin(0, 100, 100).barPx).toBe(0);
+        expect(pickScaleWithin(Number.NaN, 100, 100).barPx).toBe(0);
+    });
+
+    it("選んだバー幅は可能な限り maxBarPx 以下に収まる", () => {
+        for (const mpp of [0.3, 1, 3.7, 50, 1234]) {
+            const r = pickScaleWithin(mpp, 100, 90);
+            // 最小ステップで超過する場合を除き上限以下
+            if (r.meters !== SCALE_STEPS[0]) {
+                expect(r.barPx).toBeLessThanOrEqual(90);
+            }
         }
     });
 });

--- a/tests/controlPanel.unit.spec.ts
+++ b/tests/controlPanel.unit.spec.ts
@@ -199,6 +199,16 @@ describe("pickScaleWithin", () => {
         expect(r.meters).toBe(SCALE_STEPS[0]);
     });
 
+    it("round 後のバー幅が maxBarPx を超えないよう段階を下げる", () => {
+        // 100m / mpp ≈ 100.55px。Math.round で 101px となり、上限 100.6px を
+        // 超えてしまう（小数判定だけでは見逃すケース）。round 後の幅で判定し、
+        // 1 段下げて上限以下に収まることを検証する。
+        const mpp = 100 / 100.55;
+        const max = 100.6;
+        const r = pickScaleWithin(mpp, 100, max);
+        expect(r.barPx).toBeLessThanOrEqual(max);
+    });
+
     it("metersPerPx が不正（0/NaN）なら barPx 0 を返す", () => {
         expect(pickScaleWithin(0, 100, 100).barPx).toBe(0);
         expect(pickScaleWithin(Number.NaN, 100, 100).barPx).toBe(0);

--- a/tests/controlPanel.unit.spec.ts
+++ b/tests/controlPanel.unit.spec.ts
@@ -129,6 +129,13 @@ describe("createControlPanel レスポンシブ対応 (#424)", () => {
         expect(panel.viewModeButton.classList.contains("cp-viewmode")).toBe(true);
     });
 
+    it("ボタンに touch-action: manipulation が適用される（ダブルタップズーム抑止）", () => {
+        createControlPanel();
+        const style = document.getElementById("cp-focus-style");
+        expect(style).not.toBeNull();
+        expect(style!.textContent).toContain("touch-action: manipulation");
+    });
+
     it("スケールバーのテキスト要素に cp-scale-text クラスが付与される", () => {
         const panel = createControlPanel();
         expect(panel.scaleBar.label.classList.contains("cp-scale-text")).toBe(true);

--- a/tests/controlPanel.unit.spec.ts
+++ b/tests/controlPanel.unit.spec.ts
@@ -7,6 +7,7 @@ import { snapScale, formatScale, SCALE_STEPS, createControlPanel, showToast } fr
 function cleanupDOM(): void {
     document.body.innerHTML = "";
     document.head.querySelectorAll("#cp-focus-style").forEach((el) => el.remove());
+    document.head.querySelectorAll("#cp-responsive-style").forEach((el) => el.remove());
 }
 
 describe("createControlPanel locateMe ボタン", () => {
@@ -92,6 +93,46 @@ describe("createControlPanel pointerEvents 透過", () => {
     it("locateMe ボタンに pointerEvents: auto が設定されている", () => {
         const panel = createControlPanel();
         expect(panel.locateMe.style.pointerEvents).toBe("auto");
+    });
+});
+
+describe("createControlPanel レスポンシブ対応 (#424)", () => {
+    afterEach(cleanupDOM);
+
+    it("coarse pointer 用のレスポンシブスタイルが head に注入される", () => {
+        createControlPanel();
+        const style = document.getElementById("cp-responsive-style");
+        expect(style).not.toBeNull();
+        expect(style!.tagName).toBe("STYLE");
+        expect(style!.textContent).toContain("(pointer: coarse)");
+    });
+
+    it("レスポンシブスタイルは複数回呼んでも 1 つだけ注入される", () => {
+        createControlPanel();
+        cleanupDOM();
+        createControlPanel();
+        createControlPanel();
+        const styles = document.head.querySelectorAll("#cp-responsive-style");
+        expect(styles.length).toBe(1);
+    });
+
+    it("ズームボタンに cp-zoombtn クラスが付与される（タップ領域拡大対象）", () => {
+        const panel = createControlPanel();
+        expect(panel.zoomIn.classList.contains("cp-zoombtn")).toBe(true);
+        expect(panel.zoomOut.classList.contains("cp-zoombtn")).toBe(true);
+        expect(panel.locateMe.classList.contains("cp-zoombtn")).toBe(true);
+    });
+
+    it("地図切替/視点切替ボタンに識別クラスが付与される", () => {
+        const panel = createControlPanel();
+        expect(panel.mapToggle.classList.contains("cp-maptoggle")).toBe(true);
+        expect(panel.viewModeButton.classList.contains("cp-viewmode")).toBe(true);
+    });
+
+    it("スケールバーのテキスト要素に cp-scale-text クラスが付与される", () => {
+        const panel = createControlPanel();
+        expect(panel.scaleBar.label.classList.contains("cp-scale-text")).toBe(true);
+        expect(panel.scaleBar.attribution.classList.contains("cp-scale-text")).toBe(true);
     });
 });
 

--- a/tests/globeAfterburnerRibbon.unit.spec.ts
+++ b/tests/globeAfterburnerRibbon.unit.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * `src/demos/flight/globeAfterburner.ts` の統合 unit test（実 NullEngine 使用）。
+ *
+ * 回帰防止: アフターバーナーのトレイル mesh（左右）の総頂点数と頂点カラーバッファ長が
+ * 一致していること（= sideOrientation の DOUBLESIDE による頂点倍化が起きていないこと）を
+ * 検証する。倍化すると複製側が未着色（白）のまま additive 合成され、炎が白飛びする。
+ *
+ * 純関数テストは globeAfterburner.unit.spec.ts が Babylon をモックして担当するため、
+ * 実描画モジュールを使うこのテストは別ファイルに分離する。
+ */
+import { describe, it, expect, afterEach } from "@jest/globals";
+
+import { NullEngine } from "@babylonjs/core/Engines/nullEngine";
+import { Scene } from "@babylonjs/core/scene";
+import { VertexBuffer } from "@babylonjs/core/Buffers/buffer";
+
+import { createGlobeAfterburner } from "../src/demos/flight/globeAfterburner";
+
+const makeEngine = (): NullEngine =>
+    new NullEngine({
+        renderWidth: 800,
+        renderHeight: 600,
+        deterministicLockstep: false,
+        lockstepMaxSteps: 1,
+        textureSize: 512,
+    });
+
+const teardowns: Array<() => void> = [];
+afterEach(() => {
+    while (teardowns.length) teardowns.pop()!();
+});
+
+describe("globeAfterburner - トレイルの頂点カラーバッファ整合性", () => {
+    it("左右トレイル mesh の総頂点数と color バッファ長が一致し、全頂点が着色される", () => {
+        const engine = makeEngine();
+        const scene = new Scene(engine);
+        const ab = createGlobeAfterburner(scene);
+        teardowns.push(() => {
+            ab.dispose();
+            scene.dispose();
+            engine.dispose();
+        });
+
+        ab.start();
+        const ctx = {
+            centerLat: 35.681,
+            centerLon: 139.767,
+            radiusM: 2000,
+            altitudeM: 500,
+            angleDeg: 30,
+        };
+        // 初回は履歴初期化のみ、2回目で色バッファをアップロードする。
+        ab.update(ctx);
+        ab.update({ ...ctx, angleDeg: 33 });
+
+        for (const name of ["globe-afterburner-left", "globe-afterburner-right"]) {
+            const mesh = scene.getMeshByName(name);
+            expect(mesh).not.toBeNull();
+            const totalVertices = mesh!.getTotalVertices();
+            const colors = mesh!.getVerticesData(VertexBuffer.ColorKind);
+            expect(colors).not.toBeNull();
+            expect(colors!.length).toBe(totalVertices * 4);
+            // 先端付近（バッファ末尾）に色が書き込まれていること。
+            const tail = colors!.slice(colors!.length - 8);
+            expect(tail.some((v) => v !== 0)).toBe(true);
+        }
+    });
+});

--- a/tests/globePinchPan.unit.spec.ts
+++ b/tests/globePinchPan.unit.spec.ts
@@ -1,14 +1,17 @@
 /**
  * @jest-environment jsdom
  *
- * タッチ操作のピンチ／シングルタッチ競合ガードの統合テスト（Issue #424）。
+ * タッチ操作の2本指ジェスチャ統合テスト（Issue #424）。
  *
  * NullEngine + jsdom で `GlobeScene.createSceneWithController` を実体構築し、canvas へ
  * PointerEvent 相当を dispatch して以下を検証する:
- *   - 1本指タッチのドラッグでは center が動く（従来のパン挙動）。
- *   - 2本指タッチ（ピンチ）進行中は独自シングルタッチパンが発火せず center が動かない。
+ *   - 1本指タッチのドラッグでは center が動く（パン）。
+ *   - 2本指（間隔が広い）で平行移動すると center が動き、ひねりで yaw が変わる（移動＋回転）。
+ *   - 2本指（間隔が狭い）で縦移動すると pitch が変わり center は動かない（チルト）。
+ *   - 2本指中はシングルタッチパン（dragging 経路）が暴発しない。
  *   - マウス（fine pointer）のドラッグは従来どおりパンする。
- * ピンチズーム自体（GeospatialCamera 側）は対象外。3DCG の見た目は別ゲート（HITL）。
+ * ピンチズーム自体（GeospatialCamera 側）は scene.pick 依存のため本テスト対象外。
+ * 3DCG の見た目は別ゲート（HITL）。
  */
 import { describe, it, expect, afterEach } from "@jest/globals";
 import { NullEngine } from "@babylonjs/core/Engines/nullEngine";
@@ -86,7 +89,7 @@ const dispatchPointer = (
 
 const centerOf = (gc: GlobeSceneController): Vector3 => gc.camera.center.clone();
 
-describe("globe タッチ ピンチ/シングルタッチ競合ガード (#424)", () => {
+describe("globe タッチ 2本指ジェスチャ (#424)", () => {
     it("1本指タッチのドラッグで center が動く", () => {
         const { gc, canvas, teardown } = build();
         const before = centerOf(gc);
@@ -97,17 +100,53 @@ describe("globe タッチ ピンチ/シングルタッチ競合ガード (#424)"
         teardown();
     });
 
-    it("2本指タッチ（ピンチ）進行中は center が動かない", () => {
+    it("2本指（間隔が広い）平行移動で center が動く（移動）", () => {
         const { gc, canvas, teardown } = build();
-        // 1本目を接地（この時点ではまだドラッグ可能）。
-        dispatchPointer(canvas, "pointerdown", { pointerId: 1, clientX: 100, clientY: 100 });
-        // 2本目を接地 → マルチタッチ判定。以降パンは無効化されるべき。
-        dispatchPointer(canvas, "pointerdown", { pointerId: 2, clientX: 300, clientY: 300 });
+        // 間隔を広く（spread ≈ 300px > 160）取って 2本指接地。
+        dispatchPointer(canvas, "pointerdown", { pointerId: 1, clientX: 100, clientY: 200 });
+        dispatchPointer(canvas, "pointerdown", { pointerId: 2, clientX: 400, clientY: 200 });
         const before = centerOf(gc);
-        // 1本目を動かしてもパンしない。
-        dispatchPointer(canvas, "pointermove", { pointerId: 1, clientX: 180, clientY: 160 });
+        // 1本目を縦に動かす → 重心が移動し pan が発火する。
+        dispatchPointer(canvas, "pointermove", { pointerId: 1, clientX: 100, clientY: 260 });
         const moved = Vector3.Distance(before, gc.camera.center);
-        expect(moved).toBe(0);
+        expect(moved).toBeGreaterThan(0);
+        teardown();
+    });
+
+    it("2本指（間隔が広い）ひねりで yaw が変わる（回転）", () => {
+        const { gc, canvas, teardown } = build();
+        dispatchPointer(canvas, "pointerdown", { pointerId: 1, clientX: 100, clientY: 200 });
+        dispatchPointer(canvas, "pointerdown", { pointerId: 2, clientX: 400, clientY: 200 });
+        const yawBefore = gc.camera.yaw;
+        // 1本目を回り込ませる（ペアの角度が変化）→ yaw が変わる。
+        dispatchPointer(canvas, "pointermove", { pointerId: 1, clientX: 130, clientY: 280 });
+        expect(gc.camera.yaw).not.toBe(yawBefore);
+        teardown();
+    });
+
+    it("2本指（間隔が狭い）縦移動で pitch が変わり center は動かない（チルト）", () => {
+        const { gc, canvas, teardown } = build();
+        // 間隔を狭く（spread ≈ 60px < 160）取って 2本指接地。
+        dispatchPointer(canvas, "pointerdown", { pointerId: 1, clientX: 200, clientY: 200 });
+        dispatchPointer(canvas, "pointerdown", { pointerId: 2, clientX: 260, clientY: 200 });
+        const pitchBefore = gc.camera.pitch;
+        const centerBefore = centerOf(gc);
+        // 1本目を縦に動かす → チルト（pitch 変化）、center は不変。
+        dispatchPointer(canvas, "pointermove", { pointerId: 1, clientX: 200, clientY: 150 });
+        expect(gc.camera.pitch).not.toBe(pitchBefore);
+        expect(Vector3.Distance(centerBefore, gc.camera.center)).toBe(0);
+        teardown();
+    });
+
+    it("2本指中はシングルタッチパン（dragging 経路）が暴発しない", () => {
+        const { gc, canvas, teardown } = build();
+        // 間隔を狭く取り、チルトモードにする。1本目移動で pan（center 移動）は起きないこと。
+        dispatchPointer(canvas, "pointerdown", { pointerId: 1, clientX: 200, clientY: 200 });
+        dispatchPointer(canvas, "pointerdown", { pointerId: 2, clientX: 250, clientY: 200 });
+        const before = centerOf(gc);
+        dispatchPointer(canvas, "pointermove", { pointerId: 1, clientX: 200, clientY: 160 });
+        // チルトのみで center は動かない（シングルパンが暴発していない）。
+        expect(Vector3.Distance(before, gc.camera.center)).toBe(0);
         teardown();
     });
 

--- a/tests/globePinchPan.unit.spec.ts
+++ b/tests/globePinchPan.unit.spec.ts
@@ -207,4 +207,49 @@ describe("globe タッチ 2本指ジェスチャ (#424)", () => {
         expect(moved).toBeGreaterThan(0);
         teardown();
     });
+
+    it("dispose で canvas に登録した全リスナが解除される（pointercancel 等の解除漏れ防止）", () => {
+        const engine = makeEngine();
+        const canvas = document.createElement("canvas");
+        document.body.appendChild(canvas);
+        // (type, handler) ペアの追加/解除を記録し、対称性を検証する。
+        const added = new Set<string>();
+        const removed = new Set<string>();
+        const key = (type: string, h: EventListenerOrEventListenerObject): string =>
+            `${type}::${(h as { name?: string }).name ?? String(h)}`;
+        const origAdd = canvas.addEventListener.bind(canvas);
+        const origRemove = canvas.removeEventListener.bind(canvas);
+        canvas.addEventListener = ((
+            type: string,
+            h: EventListenerOrEventListenerObject,
+            opts?: boolean | AddEventListenerOptions,
+        ): void => {
+            added.add(key(type, h));
+            origAdd(type, h, opts);
+        }) as typeof canvas.addEventListener;
+        canvas.removeEventListener = ((
+            type: string,
+            h: EventListenerOrEventListenerObject,
+            opts?: boolean | EventListenerOptions,
+        ): void => {
+            removed.add(key(type, h));
+            origRemove(type, h, opts);
+        }) as typeof canvas.removeEventListener;
+
+        const gc = new GlobeScene().createSceneWithController(engine, canvas, {
+            lat: 35.36,
+            lon: 138.73,
+            radius: 60000,
+            tilt: 60,
+        });
+        expect(added.has("pointercancel::onPointerCancel")).toBe(true);
+        gc.dispose();
+
+        // 追加された全ペアが解除されていること。
+        const notRemoved = [...added].filter((k) => !removed.has(k));
+        expect(notRemoved).toEqual([]);
+
+        engine.dispose();
+        canvas.remove();
+    });
 });

--- a/tests/globePinchPan.unit.spec.ts
+++ b/tests/globePinchPan.unit.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * @jest-environment jsdom
+ *
+ * タッチ操作のピンチ／シングルタッチ競合ガードの統合テスト（Issue #424）。
+ *
+ * NullEngine + jsdom で `GlobeScene.createSceneWithController` を実体構築し、canvas へ
+ * PointerEvent 相当を dispatch して以下を検証する:
+ *   - 1本指タッチのドラッグでは center が動く（従来のパン挙動）。
+ *   - 2本指タッチ（ピンチ）進行中は独自シングルタッチパンが発火せず center が動かない。
+ *   - マウス（fine pointer）のドラッグは従来どおりパンする。
+ * ピンチズーム自体（GeospatialCamera 側）は対象外。3DCG の見た目は別ゲート（HITL）。
+ */
+import { describe, it, expect, afterEach } from "@jest/globals";
+import { NullEngine } from "@babylonjs/core/Engines/nullEngine";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+
+import { GlobeScene, type GlobeSceneController } from "../src/scenes/globe";
+
+const makeEngine = (): NullEngine =>
+    new NullEngine({
+        renderWidth: 800,
+        renderHeight: 600,
+        deterministicLockstep: false,
+        lockstepMaxSteps: 1,
+        textureSize: 512,
+    });
+
+interface Built {
+    gc: GlobeSceneController;
+    canvas: HTMLCanvasElement;
+    teardown: () => void;
+}
+
+const activeTeardowns: Array<() => void> = [];
+
+const build = (): Built => {
+    const engine = makeEngine();
+    const canvas = document.createElement("canvas");
+    document.body.appendChild(canvas);
+    const gc = new GlobeScene().createSceneWithController(engine, canvas, {
+        lat: 35.36,
+        lon: 138.73,
+        radius: 60000,
+        tilt: 60,
+    });
+    let torn = false;
+    const teardown = (): void => {
+        if (torn) return;
+        torn = true;
+        gc.dispose();
+        engine.dispose();
+        canvas.remove();
+    };
+    activeTeardowns.push(teardown);
+    return { gc, canvas, teardown };
+};
+
+afterEach(() => {
+    for (const teardown of activeTeardowns.splice(0)) teardown();
+});
+
+interface PointerProps {
+    pointerType?: string;
+    pointerId?: number;
+    button?: number;
+    clientX?: number;
+    clientY?: number;
+}
+
+const dispatchPointer = (
+    canvas: HTMLCanvasElement,
+    type: string,
+    props: PointerProps,
+): void => {
+    const ev = new Event(type, { bubbles: true, cancelable: true });
+    Object.assign(ev, {
+        pointerType: "touch",
+        pointerId: 1,
+        button: 0,
+        clientX: 0,
+        clientY: 0,
+        ...props,
+    });
+    canvas.dispatchEvent(ev);
+};
+
+const centerOf = (gc: GlobeSceneController): Vector3 => gc.camera.center.clone();
+
+describe("globe タッチ ピンチ/シングルタッチ競合ガード (#424)", () => {
+    it("1本指タッチのドラッグで center が動く", () => {
+        const { gc, canvas, teardown } = build();
+        const before = centerOf(gc);
+        dispatchPointer(canvas, "pointerdown", { pointerId: 1, clientX: 100, clientY: 100 });
+        dispatchPointer(canvas, "pointermove", { pointerId: 1, clientX: 180, clientY: 160 });
+        const moved = Vector3.Distance(before, gc.camera.center);
+        expect(moved).toBeGreaterThan(0);
+        teardown();
+    });
+
+    it("2本指タッチ（ピンチ）進行中は center が動かない", () => {
+        const { gc, canvas, teardown } = build();
+        // 1本目を接地（この時点ではまだドラッグ可能）。
+        dispatchPointer(canvas, "pointerdown", { pointerId: 1, clientX: 100, clientY: 100 });
+        // 2本目を接地 → マルチタッチ判定。以降パンは無効化されるべき。
+        dispatchPointer(canvas, "pointerdown", { pointerId: 2, clientX: 300, clientY: 300 });
+        const before = centerOf(gc);
+        // 1本目を動かしてもパンしない。
+        dispatchPointer(canvas, "pointermove", { pointerId: 1, clientX: 180, clientY: 160 });
+        const moved = Vector3.Distance(before, gc.camera.center);
+        expect(moved).toBe(0);
+        teardown();
+    });
+
+    it("ピンチ後に全指を離すと次の1本指で再びパンできる", () => {
+        const { gc, canvas, teardown } = build();
+        dispatchPointer(canvas, "pointerdown", { pointerId: 1, clientX: 100, clientY: 100 });
+        dispatchPointer(canvas, "pointerdown", { pointerId: 2, clientX: 300, clientY: 300 });
+        dispatchPointer(canvas, "pointerup", { pointerId: 2, clientX: 300, clientY: 300 });
+        dispatchPointer(canvas, "pointerup", { pointerId: 1, clientX: 100, clientY: 100 });
+        const before = centerOf(gc);
+        dispatchPointer(canvas, "pointerdown", { pointerId: 3, clientX: 100, clientY: 100 });
+        dispatchPointer(canvas, "pointermove", { pointerId: 3, clientX: 180, clientY: 160 });
+        const moved = Vector3.Distance(before, gc.camera.center);
+        expect(moved).toBeGreaterThan(0);
+        teardown();
+    });
+
+    it("マウス（fine pointer）のドラッグは従来どおりパンする", () => {
+        const { gc, canvas, teardown } = build();
+        const before = centerOf(gc);
+        dispatchPointer(canvas, "pointerdown", { pointerType: "mouse", pointerId: 1, clientX: 100, clientY: 100 });
+        dispatchPointer(canvas, "pointermove", { pointerType: "mouse", pointerId: 1, clientX: 180, clientY: 160 });
+        const moved = Vector3.Distance(before, gc.camera.center);
+        expect(moved).toBeGreaterThan(0);
+        teardown();
+    });
+});

--- a/tests/globePinchPan.unit.spec.ts
+++ b/tests/globePinchPan.unit.spec.ts
@@ -150,6 +150,40 @@ describe("globe タッチ 2本指ジェスチャ (#424)", () => {
         teardown();
     });
 
+    it("移動+回転で開始したら、間隔がしきい値未満になってもモードを維持する", () => {
+        const { gc, canvas, teardown } = build();
+        // 広い間隔（spread=300 > 160）で開始 → panRotate モードに確定。
+        dispatchPointer(canvas, "pointerdown", { pointerId: 1, clientX: 100, clientY: 200 });
+        dispatchPointer(canvas, "pointerdown", { pointerId: 2, clientX: 400, clientY: 200 });
+        dispatchPointer(canvas, "pointermove", { pointerId: 1, clientX: 120, clientY: 210 });
+        // 指を近づけて間隔をしきい値未満（spread≈40 < 160）にする。
+        dispatchPointer(canvas, "pointermove", { pointerId: 1, clientX: 360, clientY: 200 });
+        const pitchBefore = gc.camera.pitch;
+        const before = centerOf(gc);
+        // この状態で縦移動してもチルトせず、移動（center 変化）が続く。
+        dispatchPointer(canvas, "pointermove", { pointerId: 1, clientX: 360, clientY: 240 });
+        expect(gc.camera.pitch).toBe(pitchBefore);
+        expect(Vector3.Distance(before, gc.camera.center)).toBeGreaterThan(0);
+        teardown();
+    });
+
+    it("チルトで開始したら、間隔がしきい値以上になってもモードを維持する", () => {
+        const { gc, canvas, teardown } = build();
+        // 狭い間隔（spread=60 < 160）で開始 → tilt モードに確定。
+        dispatchPointer(canvas, "pointerdown", { pointerId: 1, clientX: 200, clientY: 200 });
+        dispatchPointer(canvas, "pointerdown", { pointerId: 2, clientX: 260, clientY: 200 });
+        dispatchPointer(canvas, "pointermove", { pointerId: 1, clientX: 200, clientY: 190 });
+        // 指を広げて間隔をしきい値以上（spread≈300 > 160）にする。
+        dispatchPointer(canvas, "pointermove", { pointerId: 1, clientX: -40, clientY: 190 });
+        const before = centerOf(gc);
+        const pitchBefore = gc.camera.pitch;
+        // この状態で縦移動しても移動せず、チルト（pitch 変化）が続く。
+        dispatchPointer(canvas, "pointermove", { pointerId: 1, clientX: -40, clientY: 150 });
+        expect(Vector3.Distance(before, gc.camera.center)).toBe(0);
+        expect(gc.camera.pitch).not.toBe(pitchBefore);
+        teardown();
+    });
+
     it("ピンチ後に全指を離すと次の1本指で再びパンできる", () => {
         const { gc, canvas, teardown } = build();
         dispatchPointer(canvas, "pointerdown", { pointerId: 1, clientX: 100, clientY: 100 });

--- a/tests/globePinchPan.unit.spec.ts
+++ b/tests/globePinchPan.unit.spec.ts
@@ -198,6 +198,21 @@ describe("globe タッチ 2本指ジェスチャ (#424)", () => {
         teardown();
     });
 
+    it("2本指から1本離した直後、残った指でそのままパンを継続できる", () => {
+        const { gc, canvas, teardown } = build();
+        // 2本指接地（広い間隔）。
+        dispatchPointer(canvas, "pointerdown", { pointerId: 1, clientX: 100, clientY: 200 });
+        dispatchPointer(canvas, "pointerdown", { pointerId: 2, clientX: 400, clientY: 200 });
+        // 1本目を離す → 残る pointerId:2 でパン継続できる状態になるはず。
+        dispatchPointer(canvas, "pointerup", { pointerId: 1, clientX: 100, clientY: 200 });
+        const before = centerOf(gc);
+        // 残った指（pointerId:2）を動かすと center が動く（pointerdown を挟まずに）。
+        dispatchPointer(canvas, "pointermove", { pointerId: 2, clientX: 480, clientY: 260 });
+        const moved = Vector3.Distance(before, gc.camera.center);
+        expect(moved).toBeGreaterThan(0);
+        teardown();
+    });
+
     it("マウス（fine pointer）のドラッグは従来どおりパンする", () => {
         const { gc, canvas, teardown } = build();
         const before = centerOf(gc);

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -1369,6 +1369,23 @@ describe("JpmapTerrain (skeleton)", () => {
             expect(ev.defaultPrevented).toBe(true);
         });
 
+        it("canvas 上の ctrl+wheel（トラックパッドのピンチ）で preventDefault される", async () => {
+            const mount = createMountElement();
+            await create(mount);
+
+            const canvas = mount.querySelector("canvas")!;
+            const pinch = new Event("wheel", { bubbles: true, cancelable: true });
+            Object.assign(pinch, { ctrlKey: true, deltaY: -10 });
+            canvas.dispatchEvent(pinch);
+            expect(pinch.defaultPrevented).toBe(true);
+
+            // ctrlKey なしの通常 wheel には干渉しない（地図ズーム/スクロール用）。
+            const normal = new Event("wheel", { bubbles: true, cancelable: true });
+            Object.assign(normal, { ctrlKey: false, deltaY: -10 });
+            canvas.dispatchEvent(normal);
+            expect(normal.defaultPrevented).toBe(false);
+        });
+
         it("同一ページで複数インスタンスを共存できる", async () => {
             const mountA = createMountElement();
             const mountB = createMountElement();

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -1358,6 +1358,17 @@ describe("JpmapTerrain (skeleton)", () => {
             expect(canvas.id).toBe("");
         });
 
+        it("canvas 上の touchmove で preventDefault される（ブラウザ既定スクロール抑止）", async () => {
+            const mount = createMountElement();
+            await create(mount);
+
+            const canvas = mount.querySelector("canvas")!;
+            const ev = new Event("touchmove", { bubbles: true, cancelable: true });
+            canvas.dispatchEvent(ev);
+
+            expect(ev.defaultPrevented).toBe(true);
+        });
+
         it("同一ページで複数インスタンスを共存できる", async () => {
             const mountA = createMountElement();
             const mountB = createMountElement();

--- a/tests/routeLine.unit.spec.ts
+++ b/tests/routeLine.unit.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * `src/demos/flight/routeLine.ts` の unit test。
+ *
+ * 回帰防止: リボン mesh の総頂点数と、毎フレーム流し込む頂点カラーバッファの長さが
+ * 一致していること（= sideOrientation の DOUBLESIDE による頂点倍化が起きていないこと）を
+ * 検証する。倍化すると複製側が未着色のまま白く描画され、リボンが正しく表示されなくなる。
+ */
+import { describe, it, expect, afterEach } from "@jest/globals";
+
+import { NullEngine } from "@babylonjs/core/Engines/nullEngine";
+import { Scene } from "@babylonjs/core/scene";
+import { VertexBuffer } from "@babylonjs/core/Buffers/buffer";
+
+import { createRouteLine } from "../src/demos/flight/routeLine";
+
+const makeEngine = (): NullEngine =>
+    new NullEngine({
+        renderWidth: 800,
+        renderHeight: 600,
+        deterministicLockstep: false,
+        lockstepMaxSteps: 1,
+        textureSize: 512,
+    });
+
+const teardowns: Array<() => void> = [];
+afterEach(() => {
+    while (teardowns.length) teardowns.pop()!();
+});
+
+describe("routeLine - ribbon の頂点カラーバッファ整合性", () => {
+    it("ribbon の総頂点数と color バッファ長が一致し、全頂点が着色される", () => {
+        const engine = makeEngine();
+        const scene = new Scene(engine);
+        const route = createRouteLine(scene);
+        teardowns.push(() => {
+            route.dispose();
+            scene.dispose();
+            engine.dispose();
+        });
+
+        // 1 フレーム更新して頂点・カラーを確定させる。
+        route.update(
+            { angleDeg: 30, centerLat: 35.681, centerLon: 139.767, radiusM: 2000, altitudeM: 500 },
+            1000,
+        );
+
+        const ribbon = scene.getMeshByName("flightRouteRibbon");
+        expect(ribbon).not.toBeNull();
+
+        const totalVertices = ribbon!.getTotalVertices();
+        const colors = ribbon!.getVerticesData(VertexBuffer.ColorKind);
+        expect(colors).not.toBeNull();
+        // color は 1 頂点あたり 4 要素（RGBA）。総頂点数 × 4 と一致すること。
+        expect(colors!.length).toBe(totalVertices * 4);
+
+        // 末尾付近の頂点にも色（アルファ含む）が書き込まれていること（未着色=全0でない）。
+        const tail = colors!.slice(colors!.length - 8);
+        expect(tail.some((v) => v !== 0)).toBe(true);
+    });
+});


### PR DESCRIPTION
<!-- Copilot Code Review: Follow .github/copilot-instructions.md. -->
<!-- Copilot Code Review: Follow AGENTS.md. -->
<!-- Copilot Code Review: Write all review comments in Japanese. -->

## 概要

各デモページをレスポンシブ／タッチパネル対応にし、実機（Android Chrome / iOS Safari / トラックパッド）でのフィードバックを反映しました。あわせて 3D 地形ビューア・フライトデモの操作系を改善し、表示不具合（リボン／アフターバーナーの白飛び）を修正しています。

## 関連 Issue

Closes #424

## 変更内容

### レスポンシブ / タッチ対応
- 各デモ HTML に `viewport`（`viewport-fit=cover` / `maximum-scale=1`）を付与し、媒体クエリ（`@media (max-width: 640px)`）でレイアウトをモバイル最適化
- モバイルでは各デモの操作パネルを折り畳み式（⚙ トグル）に変更
- `controlPanel` に `@media (pointer: coarse)` 補正を追加し、地図切替/PIP 等のタップ領域を拡大
- スケールバー幅を画面幅で上限制御し、地理院タイル表記が地図切替ボタンへ被る問題を解消
- `viewer.html` ほかの `lang` を `ja` に宣言（Chrome の翻訳プロンプト抑止）

### タッチジェスチャ（globe）
- 2本指ジェスチャを実装：指間隔が近いとき=チルト、離れているとき=移動＋ひねり回転。回転は実機フィードバックに合わせ向きを補正
- ジェスチャ開始後は指を離すまでモードをラッチ（チルト⇔回転の競合を解消）
- ブラウザ既定タッチ（エッジナビ/自動スクロール/ダブルタップズーム）を抑止。トラックパッドの ctrl+wheel による PC ブラウザのページズームも抑止

### フライトデモ
- Follow カメラに2本指ピンチ（距離）＋重心移動（回転/高度）を実装
- リボン（飛行経路）／アフターバーナーの白飛びを修正（`CreateRibbon` の `DOUBLESIDE` 撤去。両面表示は `backFaceCulling=false` で維持）
- 操作パネルをコンパクト化し、停止・移動・3D・2D・Follow を1行に、表示切替（WP/経路/噴射）をトグルボタン化して1行に集約
- モバイルでは写真（地図切替）ボタンを PIP の真上に配置

### 距離計測デモ
- スマホで Shift キーが使えず高度編集ができない問題に対し「高度」トグルボタンを追加（編集モード時のみ有効）

### その他
- ポリゴン/サークル/距離計測デモのパネルタイトルから issue 番号を削除
- 回帰テスト追加（`routeLine` / `globeAfterburnerRibbon` / `globePinchPan` / `controlPanel` / `jpmapTerrain`）

## 動作確認方法

```shell
npm run typecheck
npm run lint
npm run test:unit   # 1265 件
npm run build
```

加えて実機で以下を目視確認:
- 3D 地形ビューア: 2本指ピンチ／ひねり回転／チルト／パン、パネル折り畳み
- フライト: Follow の2本指ピンチ、リボン／アフターバーナー表示、写真ボタンが PIP に被らない
- 距離計測: 編集モード→高度ボタン ON→ドラッグで高度変更

## 確認事項

- [x] Copilot レビューを日本語で実施し、指摘（Nit のみ）を確認した
- [x] `npm run test:visuals:update` は毎回実行していない
- [x] 画面表示の意図した変更がある場合のみ、開発者がスナップショットを更新した

## レビュー所見（AI 4層レビュー）

Blocker / Major なし。Nit のみ（任意対応）:
- 折り畳みパネルが hidden checkbox + label 方式のためキーボード操作に未対応（タッチ端末向け UI のため影響小）
- `handleFollowPinch` は2本指運用前提
- `followCamRadius` の縮小方向に上限なし
