### PR TITLE
fix(artillery): タイトル表示中に戻るボタンを即時応答させる (#433)

### DIFF
--- a/public/artillery.html
+++ b/public/artillery.html
@@ -151,6 +151,15 @@
       background: rgba(255, 255, 255, 0.18);
     }
 
+    .controls-bar button:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+
+    .controls-bar button:disabled:hover {
+      background: rgba(255, 255, 255, 0.08);
+    }
+
     .controls-bar button.fire-btn {
       background: rgba(220, 50, 50, 0.6);
       border-color: rgba(255, 100, 100, 0.5);
@@ -161,6 +170,10 @@
 
     .controls-bar button.fire-btn:hover {
       background: rgba(220, 50, 50, 0.8);
+    }
+
+    .controls-bar button.fire-btn:disabled:hover {
+      background: rgba(220, 50, 50, 0.6);
     }
 
     .controls-bar .divider {

--- a/src/demos/artillery/index.ts
+++ b/src/demos/artillery/index.ts
@@ -587,7 +587,7 @@ const start = async (): Promise<void> => {
             if (viewer.isTerrainIdle) {
                 fn();
             } else if (performance.now() - startTime >= TIMEOUT_MS) {
-                console.warn("[artillery] 地形ロードのタイムアウト: ベストエフォートで続行します");
+                console.warn("[artillery] terrain load timed out; continuing best-effort");
                 fn();
             } else {
                 setTimeout(tryRun, POLL_INTERVAL_MS);

--- a/src/demos/artillery/index.ts
+++ b/src/demos/artillery/index.ts
@@ -18,6 +18,8 @@ import { TransformNode } from "@babylonjs/core/Meshes/transformNode";
 import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
 import { Color3 } from "@babylonjs/core/Maths/math.color";
 import type { Mesh } from "@babylonjs/core/Meshes/mesh";
+import type { AbstractMesh } from "@babylonjs/core/Meshes/abstractMesh";
+import type { PickingInfo } from "@babylonjs/core/Collisions/pickingInfo";
 
 import { JpmapTerrain } from "../../lib/jpmapTerrain";
 import type { JpmapTerrainOptions } from "../../lib/types";
@@ -34,6 +36,7 @@ import {
 import { powderToSpeed } from "./ballistics";
 import { initPhysics } from "./physics";
 import { createTerrainCollider, type TerrainCollider } from "./terrainCollider";
+import { createInitCancellation } from "./initCancellation";
 import {
     createInitialState,
     nextTurn,
@@ -145,6 +148,24 @@ const start = async (): Promise<void> => {
     const mount = document.getElementById(DEMO_MOUNT_ID);
     if (!mount) return;
 
+    // 初期化（地形ロード・物理エンジン初期化など重い処理）中に「戻る」操作で
+    // ページ離脱した場合、その瞬間にレンダーループ停止・リソース破棄を行って
+    // メインスレッドを即座に解放し、ページ遷移を速やかに進める。
+    // viewer は create 完了後に viewerRef へ格納されるため、abort 時点で未生成なら
+    // 破棄はスキップし、create 完了直後の中断チェック（下記）でフォールバック破棄する。
+    const viewerRef: {
+        current: Awaited<ReturnType<typeof JpmapTerrain.create>> | null;
+    } = { current: null };
+    let viewerDisposed = false;
+    const disposeViewerOnce = (): void => {
+        if (viewerRef.current && !viewerDisposed) {
+            viewerDisposed = true;
+            viewerRef.current.dispose();
+        }
+    };
+    const cancel = createInitCancellation(disposeViewerOnce);
+
+
     const camera = parseCameraStateFromUrl(location.href);
     const mapType = parseMapTypeFromUrl(location.href);
 
@@ -171,6 +192,13 @@ const start = async (): Promise<void> => {
         // サイレントな白画面にせず明示的に送出する。
         console.error("[artillery] globe terrain init failed", err);
         throw err;
+    }
+    // 以降の abort で同期破棄できるよう viewer を共有参照へ格納する。
+    viewerRef.current = viewer;
+    // create 完了前に離脱（戻る操作）していたら、生成済みリソースを破棄して中断する。
+    if (cancel.isAborted()) {
+        disposeViewerOnce();
+        return;
     }
     // 現在地ボタン（GPS）は砲撃ゲームには不要なので非表示にする。
     viewer.showLocateMe = false;
@@ -216,6 +244,12 @@ const start = async (): Promise<void> => {
 
     // --- Havok 物理エンジン初期化（砲弾の生成より前に必須） ---
     await initPhysics(scene, stage.gravity);
+
+    // 物理エンジン初期化中にページ離脱（戻る操作）していたら中断する。
+    if (cancel.isAborted()) {
+        disposeViewerOnce();
+        return;
+    }
 
     // --- 影（砲台・砲弾 → 地形）: 真上からの平行光源 ---
     const shadows = createArtilleryShadows(scene, stage);
@@ -360,6 +394,15 @@ const start = async (): Promise<void> => {
         // 地形メッシュのみを対象にする。globe は `tile-*` / `base-tile-*`
         // （globeTileManager の命名）。
         //
+        // 高速経路: buildCollider 中はプレイエリア近傍タイルだけに絞った候補配列
+        // (terrainPickCandidates) に対して ray.intersectsMesh で最近接ヒットを取る。
+        // scene.pickWithRay は全メッシュ（~177 タイル）を走査するため、候補絞り込みで
+        // ピックコストを大幅に削減する（コリジョン構築の総 CPU 時間を短縮）。
+        if (terrainPickCandidates) {
+            return pickNearestTerrain(terrainRay, terrainPickCandidates);
+        }
+        // フォールバック（候補未収集時）。
+        //
         // 注意: globe タイルは globeTileManager で `isPickable=false`（パン
         // 干渉回避）だが、`pickWithRay` に predicate を渡すと Babylon は
         // isPickable/isVisible/isEnabled の既定フィルタを適用せず predicate のみで
@@ -370,6 +413,54 @@ const start = async (): Promise<void> => {
         // タイルを pickable に戻すとパン干渉が再発するため、ここは predicate
         // 方式を維持すること。
         return scene.pickWithRay(terrainRay, isTerrainMesh);
+    };
+
+    /**
+     * buildCollider 中のレイキャスト高速化用の候補メッシュ。
+     * null の間は scene.pickWithRay（全走査）にフォールバックする。
+     */
+    let terrainPickCandidates: AbstractMesh[] | null = null;
+    const scratchStageCenter = new Vector3();
+
+    /**
+     * 候補配列に対してレイの最近接ヒットを返す。ray.intersectsMesh は
+     * mesh の三角形まで判定する（fastCheck=false）ため精度は pickWithRay と同等。
+     */
+    const pickNearestTerrain = (
+        ray: Ray,
+        candidates: AbstractMesh[],
+    ): PickingInfo | null => {
+        let best: PickingInfo | null = null;
+        for (const mesh of candidates) {
+            const info = ray.intersectsMesh(mesh);
+            if (info.hit && (best === null || info.distance < best.distance)) {
+                best = info;
+            }
+        }
+        return best;
+    };
+
+    /**
+     * プレイエリア近傍の地形タイルメッシュを収集する（buildCollider 前に 1 回）。
+     * ステージ原点ワールド座標から一定半径内（+ メッシュ境界球半径）に中心がある
+     * 地形タイルのみを候補にすることで、レイキャスト対象を ~177 → 数十枚に絞る。
+     */
+    const collectTerrainPickCandidates = (): AbstractMesh[] => {
+        scratchStageCenter.copyFromFloats(0, 0, 0);
+        stage.localToWorld(scratchStageCenter, scratchStageCenter);
+        // 大砲は ±750m、サンプリングは ±~1500m 範囲。余裕を持たせる。
+        const PLAY_AREA_RADIUS = 4000; // m
+        const out: AbstractMesh[] = [];
+        for (const mesh of scene.meshes) {
+            if (!isTerrainMesh(mesh)) continue;
+            mesh.computeWorldMatrix(false);
+            const sphere = mesh.getBoundingInfo().boundingSphere;
+            const dist = Vector3.Distance(sphere.centerWorld, scratchStageCenter);
+            if (dist <= PLAY_AREA_RADIUS + sphere.radiusWorld) {
+                out.push(mesh);
+            }
+        }
+        return out;
     };
 
     /** 地形タイルメッシュ判定（globe の命名規約）。 */
@@ -418,16 +509,31 @@ const start = async (): Promise<void> => {
         typeof window !== "undefined" &&
         (window as unknown as { __ARTILLERY_DEBUG?: boolean }).__ARTILLERY_DEBUG === true;
 
-    /** 地形コリジョンメッシュを現在の地形からサンプリングして構築する */
-    const buildCollider = (): void => {
-        const rate = collider.rebuild((x, z) => {
-            const y = getTerrainY(x, z);
-            return Number.isNaN(y) ? null : y;
-        });
-        if (isDebug()) {
-            console.debug(
-                `[artillery] 地形コリジョン構築: サンプリング成功率 ${(rate * 100).toFixed(0)}%`,
+    /**
+     * 地形コリジョンメッシュを現在の地形からサンプリングして構築する。
+     * サンプリングは重いためフレーム分割で実行し、離脱（戻る操作）時は中断する。
+     * @returns 構築完了したら true。中断された場合は false。
+     */
+    const buildCollider = async (): Promise<boolean> => {
+        // レイキャスト対象をプレイエリア近傍タイルに絞り、ピックコストを削減する。
+        terrainPickCandidates = collectTerrainPickCandidates();
+        try {
+            const rate = await collider.rebuild(
+                (x, z) => {
+                    const y = getTerrainY(x, z);
+                    return Number.isNaN(y) ? null : y;
+                },
+                { shouldAbort: () => cancel.isAborted() },
             );
+            if (rate === null) return false; // 離脱により中断
+            if (isDebug()) {
+                console.debug(
+                    `[artillery] 地形コリジョン構築: サンプリング成功率 ${(rate * 100).toFixed(0)}%`,
+                );
+            }
+            return true;
+        } finally {
+            terrainPickCandidates = null;
         }
     };
 
@@ -437,6 +543,11 @@ const start = async (): Promise<void> => {
         const TIMEOUT_MS = 30_000;
         const startTime = performance.now();
         const tryRun = (): void => {
+            // 地形ロード待機中にページ離脱（戻る操作）していたら、ポーリングを止めて中断する。
+            if (cancel.isAborted()) {
+                disposeViewerOnce();
+                return;
+            }
             if (viewer.isTerrainIdle) {
                 fn();
             } else if (performance.now() - startTime >= TIMEOUT_MS) {
@@ -449,13 +560,25 @@ const start = async (): Promise<void> => {
         setTimeout(tryRun, 500);
     };
 
-    // 地形ロード後に大砲を配置し、地形コリジョンを構築。
-    // 準備完了で中央告知（HAKONE / RED）を爆散させて消す。
+    // 地形ロード後に大砲を配置し、中央告知（HAKONE / RED）を消してゲームを表示する。
+    // 地形コリジョン構築は重いため、タイトルを消した後にフレーム分割で背景構築する
+    // （構築中もページ遷移＝戻る操作を妨げない）。
     waitTerrainIdleThen(() => {
         placeCannons();
-        buildCollider();
         setCannonsEnabled(true);
         announce.dismiss();
+        // コリジョンを背景で構築。完了するまで離脱監視（cancel）は解除しない。
+        void buildCollider()
+            .then((completed) => {
+                if (completed) {
+                    // 初期化が無事完了したので離脱監視を解除する。
+                    cancel.dispose();
+                }
+                // 中断時は onAbort（disposeViewerOnce）で破棄済みのため、ここでは何もしない。
+            })
+            .catch((err: unknown) => {
+                console.error("[artillery] terrain collider build failed", err);
+            });
     });
 
     const updateUI = (): void => {
@@ -608,7 +731,9 @@ const start = async (): Promise<void> => {
         settings.blue = { angle: 45, heading: 0, power: 50 };
         loadSettingsToUI(gameState.turn);
         placeCannons();
-        buildCollider();
+        void buildCollider().catch((err: unknown) => {
+            console.error("[artillery] terrain collider rebuild failed", err);
+        });
         updateUI();
         // リスタート時も先攻（RED）を中央に告知する。
         announce.show({ stage: STAGE_NAME, team: gameState.turn, hold: 1000 });

--- a/src/demos/artillery/index.ts
+++ b/src/demos/artillery/index.ts
@@ -415,7 +415,9 @@ const start = async (): Promise<void> => {
         // (terrainPickCandidates) に対して ray.intersectsMesh で最近接ヒットを取る。
         // scene.pickWithRay は全メッシュ（~177 タイル）を走査するため、候補絞り込みで
         // ピックコストを大幅に削減する（コリジョン構築の総 CPU 時間を短縮）。
-        if (terrainPickCandidates) {
+        // 候補が 0 件（近傍タイル未ロード等）の場合は全走査フォールバックへ回す
+        // （空配列のまま高速経路に入ると常にミスヒットし、コリジョンが平坦化するため）。
+        if (terrainPickCandidates && terrainPickCandidates.length > 0) {
             return pickNearestTerrain(terrainRay, terrainPickCandidates);
         }
         // フォールバック（候補未収集時）。
@@ -532,6 +534,9 @@ const start = async (): Promise<void> => {
      * @returns 構築完了したら true。中断された場合は false。
      */
     const buildCollider = async (): Promise<boolean> => {
+        // 既に離脱が確定していれば、重い前処理（候補収集 = scene.meshes 全走査）に
+        // 入る前に早期 return して戻る操作の即応性を保つ。
+        if (cancel.isAborted()) return false;
         // レイキャスト対象をプレイエリア近傍タイルに絞り、ピックコストを削減する。
         terrainPickCandidates = collectTerrainPickCandidates();
         try {

--- a/src/demos/artillery/index.ts
+++ b/src/demos/artillery/index.ts
@@ -596,18 +596,21 @@ const start = async (): Promise<void> => {
         setTimeout(tryRun, 500);
     };
 
-    // 地形ロード後に大砲を配置し、中央告知（HAKONE / RED）を消してゲームを表示する。
-    // 地形コリジョン構築は重いため、タイトルを消した後にフレーム分割で背景構築する
-    // （構築中もページ遷移＝戻る操作を妨げない）。
+    // 地形ロード後に大砲を配置し、コリジョン構築（=Fire 可能）まではタイトルを
+    // 表示したまま背景で構築する。構築完了時にタイトルを消してゲームを開始する。
+    // 地形コリジョン構築は重いためフレーム分割で実行し、構築中もページ遷移
+    // （戻る操作）を妨げない。
     waitTerrainIdleThen(() => {
         placeCannons();
         setCannonsEnabled(true);
-        announce.dismiss();
-        // コリジョンを背景で構築。構築中は fire/restart を無効化する。
+        // コリジョンを背景で構築。構築中は fire/restart を無効化し、タイトルは
+        // 表示したままにする（Fire 可能になるまで状態を分かりやすくするため）。
         // 完了するまで離脱監視（cancel）は解除しない。
         void rebuildColliderGuarded()
             .then((completed) => {
                 if (completed) {
+                    // 構築完了 = Fire 可能。タイトルを消してゲームを開始する。
+                    announce.dismiss();
                     // 初期化が無事完了したので離脱監視を解除する。
                     cancel.dispose();
                 }

--- a/src/demos/artillery/index.ts
+++ b/src/demos/artillery/index.ts
@@ -270,6 +270,13 @@ const start = async (): Promise<void> => {
     // --- ゲーム状態 ---
     let gameState: GameState = createInitialState(RED_CANNON_POS, BLUE_CANNON_POS);
     let firing = false;
+    /**
+     * 地形コリジョンが構築済みか。構築完了まで fire/restart を無効化する
+     * （未完成のコライダーに砲弾を当てると挙動が破綻するため）。
+     */
+    let colliderReady = false;
+    /** コリジョン構築の多重起動防止フラグ（PhysicsAggregate の競合回避）。 */
+    let colliderBuilding = false;
     /** ターン切替タイマー（命中時にキャンセルするため保持） */
     let turnTimer: ReturnType<typeof setTimeout> | null = null;
     /** 命中時にHIT!表示後へ遅延させる交代告知タイマー（リスタート等でキャンセルするため保持） */
@@ -299,6 +306,16 @@ const start = async (): Promise<void> => {
     const scoreBlueEl = document.getElementById("score-blue")!;
     const turnRedEl = document.getElementById("turn-indicator-red")!;
     const turnBlueEl = document.getElementById("turn-indicator-blue")!;
+    /**
+     * コリジョン構築状態を UI（fire/restart ボタンの有効・無効）へ反映する。
+     * 構築完了まで操作を無効化し、未完成コライダーへの発射や多重再構築を防ぐ。
+     */
+    const setColliderReady = (ready: boolean): void => {
+        colliderReady = ready;
+        (fireBtn as HTMLButtonElement).disabled = !ready;
+        (restartBtn as HTMLButtonElement).disabled = !ready;
+    };
+    setColliderReady(false);
 
     // --- 中央ターン告知（HAKONE / 攻撃ターン表示） ---
     const announce = createAnnounce({
@@ -528,12 +545,31 @@ const start = async (): Promise<void> => {
             if (rate === null) return false; // 離脱により中断
             if (isDebug()) {
                 console.debug(
-                    `[artillery] 地形コリジョン構築: サンプリング成功率 ${(rate * 100).toFixed(0)}%`,
+                    `[artillery] terrain collider build: sampling success rate ${(rate * 100).toFixed(0)}%`,
                 );
             }
             return true;
         } finally {
             terrainPickCandidates = null;
+        }
+    };
+
+    /**
+     * コリジョンを（再）構築する。構築中は fire/restart を無効化し、
+     * 構築完了まで操作をガードする。多重起動（PhysicsAggregate の dispose/
+     * 再生成競合）を防ぐため、実行中の再呼び出しはスキップする。
+     * @returns 構築完了で true。中断・多重起動スキップ時は false。
+     */
+    const rebuildColliderGuarded = async (): Promise<boolean> => {
+        if (colliderBuilding) return false; // 多重起動防止
+        colliderBuilding = true;
+        setColliderReady(false);
+        try {
+            const completed = await buildCollider();
+            if (completed) setColliderReady(true);
+            return completed;
+        } finally {
+            colliderBuilding = false;
         }
     };
 
@@ -567,8 +603,9 @@ const start = async (): Promise<void> => {
         placeCannons();
         setCannonsEnabled(true);
         announce.dismiss();
-        // コリジョンを背景で構築。完了するまで離脱監視（cancel）は解除しない。
-        void buildCollider()
+        // コリジョンを背景で構築。構築中は fire/restart を無効化する。
+        // 完了するまで離脱監視（cancel）は解除しない。
+        void rebuildColliderGuarded()
             .then((completed) => {
                 if (completed) {
                     // 初期化が無事完了したので離脱監視を解除する。
@@ -667,6 +704,7 @@ const start = async (): Promise<void> => {
 
     // --- 発射ロジック ---
     const fire = (): void => {
+        if (!colliderReady) return; // コライダー未構築時は発射しない
         if (firing) return;
         firing = true;
 
@@ -714,6 +752,9 @@ const start = async (): Promise<void> => {
     });
 
     restartBtn.addEventListener("click", () => {
+        // コリジョン構築中は無視する（ボタンも disabled だが二重防御）。
+        // 構築中の再構築は PhysicsAggregate の競合を招くため許可しない。
+        if (!colliderReady || colliderBuilding) return;
         if (turnTimer !== null) {
             clearTimeout(turnTimer);
             turnTimer = null;
@@ -731,7 +772,8 @@ const start = async (): Promise<void> => {
         settings.blue = { angle: 45, heading: 0, power: 50 };
         loadSettingsToUI(gameState.turn);
         placeCannons();
-        void buildCollider().catch((err: unknown) => {
+        // 再構築中は fire/restart を無効化（rebuildColliderGuarded が制御）。
+        void rebuildColliderGuarded().catch((err: unknown) => {
             console.error("[artillery] terrain collider rebuild failed", err);
         });
         updateUI();

--- a/src/demos/artillery/initCancellation.ts
+++ b/src/demos/artillery/initCancellation.ts
@@ -1,0 +1,72 @@
+/**
+ * 初期化中断（キャンセル）ヘルパー
+ *
+ * Artillery Game の初期化は地形ロードや物理エンジン初期化など重い処理を伴い、
+ * その間は描画ループ等でメインスレッドが飽和しやすい。ブラウザの「戻る」操作が
+ * 行われても、メインスレッドが解放されるまでページ遷移が処理されず待たされる。
+ *
+ * そこで `pagehide`（bfcache 含むページ離脱）と `popstate`（履歴移動）を監視し、
+ * 発火した瞬間に同期コールバック（`onAbort`）でレンダーループ停止・リソース破棄を
+ * 行えるようにする。これによりメインスレッドを即座に解放し、遷移を速やかに進める。
+ * `AbortSignal` も内包するため、対応 API へそのまま渡すこともできる。
+ */
+
+/** 初期化中断トークン。 */
+export interface InitCancellation {
+    /** 内包する AbortSignal。対応 API へ渡せる。 */
+    readonly signal: AbortSignal;
+    /** 中断済みなら true。 */
+    isAborted(): boolean;
+    /** 監視を解除する（初期化完了時に呼ぶ）。 */
+    dispose(): void;
+}
+
+/** 離脱検知に使うイベント名。 */
+const ABORT_EVENTS = ["pagehide", "popstate"] as const;
+
+/**
+ * 離脱検知用のキャンセルトークンを生成する。
+ *
+ * @param onAbort 離脱検知時に同期実行するコールバック（描画停止・破棄など）。
+ *   例外は内部で握りつぶし、後続のクリーンアップを妨げない。
+ * @param target 監視対象（既定: `window`）。テスト時に EventTarget を差し替え可能。
+ * @returns 中断状態を参照できる {@link InitCancellation}。
+ */
+export const createInitCancellation = (
+    onAbort?: () => void,
+    target: EventTarget = window,
+): InitCancellation => {
+    const controller = new AbortController();
+
+    const handleAbort = (): void => {
+        const firstAbort = !controller.signal.aborted;
+        if (firstAbort) {
+            controller.abort();
+        }
+        removeListeners();
+        // 戻る操作を即座に反映するため、初回のみ同期でクリーンアップを実行する。
+        if (firstAbort && onAbort) {
+            try {
+                onAbort();
+            } catch (err) {
+                console.error("[artillery] init abort handler failed", err);
+            }
+        }
+    };
+
+    const removeListeners = (): void => {
+        for (const name of ABORT_EVENTS) {
+            target.removeEventListener(name, handleAbort);
+        }
+    };
+
+    for (const name of ABORT_EVENTS) {
+        target.addEventListener(name, handleAbort);
+    }
+
+    return {
+        signal: controller.signal,
+        isAborted: () => controller.signal.aborted,
+        dispose: removeListeners,
+    };
+};

--- a/src/demos/artillery/terrainCollider.ts
+++ b/src/demos/artillery/terrainCollider.ts
@@ -37,10 +37,21 @@ export const DEFAULT_COLLIDER_OPTIONS: TerrainColliderOptions = {
 export interface TerrainCollider {
     /**
      * 地形をサンプリングし直してコリジョンメッシュ＆物理ボディを再構築する。
+     *
+     * サンプリング（頂点ごとのレイキャスト）は重く、グリッド全体を一度に処理すると
+     * メインスレッドを長時間ブロックしてページ遷移（戻る操作）を妨げる。これを避けるため
+     * フレーム時間予算ごとに処理を分割し、各区切りで `setTimeout(0)` により制御を返す。
+     * 区切りごとに `shouldAbort` を確認し、中断要求があれば即座に処理を打ち切る。
+     *
      * @param sampleY ワールド (x, z) の地表 Y を返す。取得不可なら null。
-     * @returns サンプリング成功率 (0–1)。地形未ロード時は低くなる。
+     * @param opts.shouldAbort true を返すと構築を中断する（離脱検知時など）。
+     * @param opts.frameBudgetMs 1 区切りあたりの処理時間予算 [ms]（既定 8）。
+     * @returns サンプリング成功率 (0–1)。中断された場合は null。
      */
-    rebuild(sampleY: (x: number, z: number) => number | null): number;
+    rebuild(
+        sampleY: (x: number, z: number) => number | null,
+        opts?: { shouldAbort?: () => boolean; frameBudgetMs?: number },
+    ): Promise<number | null>;
     dispose(): void;
 }
 
@@ -64,7 +75,11 @@ export const createTerrainCollider = (
 
     let aggregate: PhysicsAggregate | null = null;
 
-    const rebuild = (sampleY: (x: number, z: number) => number | null): number => {
+    const rebuild = async (
+        sampleY: (x: number, z: number) => number | null,
+        opts: { shouldAbort?: () => boolean; frameBudgetMs?: number } = {},
+    ): Promise<number | null> => {
+        const { shouldAbort, frameBudgetMs = 8 } = opts;
         const positions = mesh.getVerticesData(VertexBuffer.PositionKind);
         if (!positions) return 0;
 
@@ -72,6 +87,9 @@ export const createTerrainCollider = (
         const vertexCount = positions.length / 3;
         let lastValidY = 0;
 
+        // サンプリング（レイキャスト）はメインスレッドを長時間占有しうるため、フレーム時間
+        // 予算ごとに setTimeout(0) で制御を返し、ブラウザの遷移・入力処理を妨げない。
+        let chunkStart = performance.now();
         for (let i = 0; i < positions.length; i += 3) {
             const x = positions[i];
             const z = positions[i + 2];
@@ -83,6 +101,12 @@ export const createTerrainCollider = (
             } else {
                 // 未ロード等で取得失敗 → 直近の有効値で穴埋め（穴あきメッシュを避ける）
                 positions[i + 1] = lastValidY;
+            }
+            if (performance.now() - chunkStart >= frameBudgetMs) {
+                if (shouldAbort?.()) return null;
+                await new Promise<void>((resolve) => setTimeout(resolve, 0));
+                if (shouldAbort?.()) return null;
+                chunkStart = performance.now();
             }
         }
 

--- a/src/demos/artillery/terrainCollider.ts
+++ b/src/demos/artillery/terrainCollider.ts
@@ -79,7 +79,12 @@ export const createTerrainCollider = (
         sampleY: (x: number, z: number) => number | null,
         opts: { shouldAbort?: () => boolean; frameBudgetMs?: number } = {},
     ): Promise<number | null> => {
-        const { shouldAbort, frameBudgetMs = 8 } = opts;
+        const { shouldAbort } = opts;
+        // frameBudgetMs に 0 / 負数 / NaN が渡ると区切り条件が常に真になり、頂点ごとに
+        // yield して極端に遅くなる。有限かつ最低 1ms にクランプして事故を防ぐ。
+        const frameBudgetMs = Number.isFinite(opts.frameBudgetMs)
+            ? Math.max(1, opts.frameBudgetMs as number)
+            : 8;
         const positions = mesh.getVerticesData(VertexBuffer.PositionKind);
         if (!positions) return 0;
 

--- a/tests/initCancellation.unit.spec.ts
+++ b/tests/initCancellation.unit.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * Artillery 初期化中断ヘルパー (initCancellation.ts) のユニットテスト。
+ *
+ * pagehide / popstate による中断遷移、onAbort コールバックの同期実行、
+ * dispose 後の監視解除を検証する。
+ */
+import { describe, it, expect, jest } from "@jest/globals";
+import { createInitCancellation } from "../src/demos/artillery/initCancellation";
+
+describe("createInitCancellation", () => {
+    it("初期状態では中断していない", () => {
+        const target = new EventTarget();
+        const cancel = createInitCancellation(undefined, target);
+        expect(cancel.isAborted()).toBe(false);
+        expect(cancel.signal.aborted).toBe(false);
+    });
+
+    it("pagehide で中断状態へ遷移する", () => {
+        const target = new EventTarget();
+        const cancel = createInitCancellation(undefined, target);
+        target.dispatchEvent(new Event("pagehide"));
+        expect(cancel.isAborted()).toBe(true);
+        expect(cancel.signal.aborted).toBe(true);
+    });
+
+    it("popstate で中断状態へ遷移する", () => {
+        const target = new EventTarget();
+        const cancel = createInitCancellation(undefined, target);
+        target.dispatchEvent(new Event("popstate"));
+        expect(cancel.isAborted()).toBe(true);
+    });
+
+    it("中断時に onAbort を同期実行する", () => {
+        const target = new EventTarget();
+        const onAbort = jest.fn();
+        createInitCancellation(onAbort, target);
+        expect(onAbort).not.toHaveBeenCalled();
+        target.dispatchEvent(new Event("popstate"));
+        expect(onAbort).toHaveBeenCalledTimes(1);
+    });
+
+    it("複数イベントが続けて発火しても onAbort は一度だけ実行する", () => {
+        const target = new EventTarget();
+        const onAbort = jest.fn();
+        createInitCancellation(onAbort, target);
+        target.dispatchEvent(new Event("pagehide"));
+        target.dispatchEvent(new Event("popstate"));
+        expect(onAbort).toHaveBeenCalledTimes(1);
+    });
+
+    it("onAbort が例外を投げても中断状態は確定する", () => {
+        const target = new EventTarget();
+        const onAbort = jest.fn(() => {
+            throw new Error("boom");
+        });
+        const cancel = createInitCancellation(onAbort, target);
+        expect(() => target.dispatchEvent(new Event("pagehide"))).not.toThrow();
+        expect(cancel.isAborted()).toBe(true);
+    });
+
+    it("dispose 後はイベントが発火しても中断せず onAbort も呼ばれない", () => {
+        const target = new EventTarget();
+        const onAbort = jest.fn();
+        const cancel = createInitCancellation(onAbort, target);
+        cancel.dispose();
+        target.dispatchEvent(new Event("pagehide"));
+        target.dispatchEvent(new Event("popstate"));
+        expect(cancel.isAborted()).toBe(false);
+        expect(onAbort).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## 概要
Closes #433

Artillery Game の初期化中、タイトル（HAKONE / RED 等）表示中にブラウザの戻るボタンが効かず、初期化完了まで待たされる問題を修正します。

## 原因
地形コリジョン構築 `terrainCollider.rebuild` が、CreateGround(subdivisions=100)=約1万頂点それぞれで `scene.pickWithRay`（全177タイル走査）を実行する **単一同期タスク（約30秒）** としてメインスレッドを占有していました。この間、`pagehide`/`popstate` もブラウザの戻る遷移も処理できませんでした。

## 修正内容
- **非ブロック化**: `rebuild` をフレーム予算（既定8ms）ごとに `setTimeout(0)` で分割する async 方式へ変更。各区切りで中断要求を確認。メインスレッドが解放され、戻る遷移が即時処理されます。
- **中断トークン**: 初期化離脱（`pagehide`/`popstate`）を検知して同期 `dispose()` する `initCancellation` を追加し、`start()` の各フェーズにガードを挿入。
- **ピックコスト削減**: レイキャスト対象をプレイエリア近傍タイル（ステージ原点から半径4000m＋境界球半径内）に絞り込み、`ray.intersectsMesh` の最近接ループへ置換。総CPU時間を短縮（~177枚→数十枚）。精度は `intersectsMesh`（三角形判定）で従来同等。
- **操作ガード**: コリジョン構築完了（=Fire 可能）まで fire/restart を無効化（`colliderReady` + ボタン `disabled` + 関数先頭ガード）。未サンプリングのコライダーへの発射による挙動破綻を防止。
- **多重起動防止**: `colliderBuilding` フラグ + `rebuildColliderGuarded` で再構築中の `collider.rebuild` 並行実行（PhysicsAggregate の dispose/再生成競合）を防止。
- **タイトル表示タイミング**: コリジョン構築完了（=Fire 可能）まではタイトルを表示したままにし、完了時に `announce.dismiss()` でゲーム開始。構築中は「準備中」だと一目で分かるようにする（戻る操作は構築中も即応）。

## 影響範囲
- 画面: Artillery デモ（`src/demos/artillery/`, `public/artillery.html`）のみ。タイトルは Fire 可能になるまで表示され、構築中は fire/restart が無効（`button:disabled` スタイル追加）。
- API/型: `TerrainCollider.rebuild` の戻り値が `number` → `Promise<number | null>` に変更（呼び出し元は本PR内で更新済み）。
- ドキュメント: 変更なし。

## 検証
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run test:unit` ✅（1275 tests / 中断トークンのユニットテスト7件追加）
- 実機（`npm start`）目視確認: タイトル表示中の戻るボタン即時応答 ✅ / 砲弾の地形バウンド ✅ / Fire 可能まではタイトル表示 ✅