### PR TITLE
chore: bump version v0.1.0 → v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 - 目的: 標高タイルを使った地形可視化の実装と検証
 - 技術スタック: TypeScript / Babylon.js / Vite（デモ）/ tsup（ライブラリ）/ Playwright / Jest
-- バージョン: 0.1.0
+- バージョン: 0.2.0
 
 ## npm パッケージとしての利用
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jpmap-terrain",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jpmap-terrain",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ammo.js": "github:kripken/ammo.js",
@@ -23,7 +23,7 @@
         "@types/jest": "^30.0.0",
         "@types/node": "^26.0.1",
         "@typescript-eslint/eslint-plugin": "^8.62.0",
-        "@typescript-eslint/parser": "^8.59",
+        "@typescript-eslint/parser": "^8.62",
         "cross-env": "^10.1.0",
         "eslint": "^10.6.0",
         "husky": "^9.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jpmap-terrain",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Terrain creation from elevation tiles of the Geospatial Information Authority of Japan.",
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## 概要

Issue #422 対応。フェーズ3完了に伴うバージョン更新。

## 変更内容

| ファイル | 変更箇所 | 変更内容 |
|---|---|---|
| `package.json` | `version` フィールド | `0.1.0` → `0.2.0` |
| `README.md` | バージョン表記 | `0.1.0` → `0.2.0` |
| `package-lock.json` | `version` エントリ | `npm install` で自動同期 |

## 影響範囲

ロジック変更なし。型・ビルド・テストへの影響なし。

## AIレビュー結果

- 型・静的品質: 変更は文字列置換のみ。any 導入なし、未使用import なし。
- lint / typecheck: 通過済み。
- 指摘: なし。

## マージ後の作業

`v0.2.0` タグ付けを実施すること。

closes #422