### PR TITLE
fix(terrain,scenes): 水平チルト・山岳地帯でのズーム終了時の画面ずれを修正

### DIFF
--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -43,6 +43,7 @@ import {
     clampRadiusForGroundClearance,
     rayEllipsoidNearHitToRef,
     resolveTerrainClickElevationToRef,
+    resolveRecalcCenterSource,
 } from "../terrain/geo/cameraMapping";
 import { createGlobeTileManager, type GlobeTileManager, type GlobeTileSyncStats } from "../terrain/geo/globeTileManager";
 import { createGlobeMarkerManager, type GlobeMarkerManager } from "../terrain/geo/globeMarkerManager";
@@ -164,6 +165,16 @@ const TERRAIN_CLICK_MAX_COARSE_STEPS = 300;
 
 /** 同上。粗い探索で見つけた区間を絞り込む二分探索の反復数。 */
 const TERRAIN_CLICK_REFINE_ITERATIONS = 6;
+
+/**
+ * ズーム中の毎フレーム向き補正で、レイマーチングの地表検出が稜線境界付近でちらついて失敗した
+ * フレームでも、直近に採用した実在の地表点を再利用してよい最大経過時間 [ms]。山岳地帯を水平
+ * チルトでズームすると true/false が数フレーム断続的に切り替わり、補正が停止する間にネイティブ
+ * ズームのフレーム結合誤差が蓄積して終了間際にスナップする。数フレーム相当（60fps で ~6 フレーム）
+ * の間は直近の成功点で補正を継続し、それを超えて失敗が続く場合は保持を破棄して補正を止める
+ * （古い点の再利用でカメラが的外れな向きへ寄るのを防ぐ）。
+ */
+const RECALC_CENTER_HOLD_MS = 100;
 
 /**
  * 地球楕円体スフィア（背景＋地平線リファレンス）を海面より沈める量 [m]。
@@ -1120,9 +1131,21 @@ export class GlobeScene {
         //     ほぼ不変＝カーソル下の画素が固定される）。
         // これによりネイティブ _recalculateCenter（_checkInputs から毎フレーム呼ばれ、確定時のみ発火）は
         // 残るが、本補正で既に整っているため実質 no-op となり整合する。
+        //
+        // ちらつき対策: 山岳地帯を水平に近いチルトでズームすると、lookAt レイが稜線をわずかに超えて
+        // 空を指す状態（pickAlongVector が null＝地表未検出）と山を捉える状態が数フレームにわたり
+        // 断続的に切り替わる。失敗フレームでは補正が停止し、その間ネイティブズームのフレーム結合誤差が
+        // 無補正で蓄積 → 次に成功したフレームで一括補正され、ズーム終了間際に画面が急に動く。そこで
+        // 同一ズームジェスチャ内で直近に採用した実在の地表点を短時間だけ保持し、失敗フレームでは
+        // それを再利用して補正を連続させる（遠方の仮想点は捏造しない＝水平チルトでの暴走は再発させない）。
         const recalcLookAt = new Vector3();
         const recalcCenterToOrigin = new Vector3();
         const recalcYawPitch = new Vector2();
+        // 直近に採用した center（実在の地表点）と、その採用時刻。ズームジェスチャ間で古い点を
+        // 持ち越さないよう、保持時刻が古くなれば resolveRecalcCenterSource が破棄する。
+        const recalcLastValidCenter = new Vector3();
+        let recalcLastValidTimeMs = Number.NEGATIVE_INFINITY;
+        let recalcHasLastValid = false;
         const recalculateCenterPublic = (): void => {
             ComputeLookAtFromYawPitchToRef(
                 camera.yaw,
@@ -1132,16 +1155,32 @@ export class GlobeScene {
                 recalcLookAt,
                 movement.calculateUpVectorFromPointToRef,
             );
-            const newCenter = movement.pickAlongVector(recalcLookAt);
-            if (!newCenter?.pickedPoint) return;
+            const nowMs = performance.now();
+            const picked = movement.pickAlongVector(recalcLookAt);
+            const source = resolveRecalcCenterSource(
+                !!picked?.pickedPoint,
+                recalcHasLastValid,
+                nowMs - recalcLastValidTimeMs,
+                RECALC_CENTER_HOLD_MS,
+            );
+            // 補正に使う center。今フレーム成功なら pick 結果、失敗でも保持が新しければ直近の実在点を
+            // 再利用、いずれも無ければ補正しない。
+            let centerForRecalc: Vector3;
+            if (source === "current" && picked?.pickedPoint) {
+                centerForRecalc = picked.pickedPoint;
+            } else if (source === "held") {
+                centerForRecalc = recalcLastValidCenter;
+            } else {
+                return;
+            }
             // 地球の裏側の center を採らないよう、center→原点方向が lookAt とおおむね一致する場合のみ更新。
-            recalcCenterToOrigin.copyFrom(newCenter.pickedPoint).negateInPlace().normalize();
+            recalcCenterToOrigin.copyFrom(centerForRecalc).negateInPlace().normalize();
             if (Vector3.Dot(recalcLookAt, recalcCenterToOrigin) <= 0) return;
-            const newRadius = Vector3.Distance(computeCameraEcef(), newCenter.pickedPoint);
+            const newRadius = Vector3.Distance(computeCameraEcef(), centerForRecalc);
             if (newRadius <= 1e-6) return;
             ComputeYawPitchFromLookAtToRef(
                 recalcLookAt,
-                newCenter.pickedPoint,
+                centerForRecalc,
                 scene.useRightHandedSystem,
                 camera.yaw,
                 recalcYawPitch,
@@ -1149,10 +1188,17 @@ export class GlobeScene {
             );
             // center→yaw→pitch→radius の順で公開セッタへ反映（各セッタが _setOrientation を呼び、
             // 最終呼び出しが (newYaw, newPitch, newRadius, newCenter) 等価になる）。
-            camera.center = newCenter.pickedPoint;
+            camera.center = centerForRecalc;
             camera.yaw = recalcYawPitch.x;
             camera.pitch = recalcYawPitch.y;
             camera.radius = newRadius;
+            // 今フレーム成功した実在点のみを保持点として更新する（Dot ガード等を通過して実際に
+            // 採用できた点だけを次の失敗フレームの再利用対象にする）。
+            if (source === "current") {
+                recalcLastValidCenter.copyFrom(centerForRecalc);
+                recalcLastValidTimeMs = nowMs;
+                recalcHasLastValid = true;
+            }
         };
         const origZoomToPoint = camera.zoomToPoint.bind(camera);
         camera.zoomToPoint = (targetPoint, distance): void => {

--- a/src/terrain/geo/cameraMapping.ts
+++ b/src/terrain/geo/cameraMapping.ts
@@ -520,3 +520,46 @@ export const clampRadiusForGroundClearance = (
     const next = radius + deficit / dAltPerRadius;
     return Number.isFinite(next) ? next : radius;
 };
+
+/**
+ * ズーム中の毎フレーム向き補正（center 再スナップ）で、レイマーチングの地表検出（true/false）が
+ * 境界付近でちらついても補正を連続させるための「使用する center の選び方」を決める純関数。
+ *
+ * 背景: 山岳地帯でチルトを水平に近づけると、視線レイが稜線をわずかに超えて空を指す状態
+ * （地表未検出＝pick 失敗）と、山を捉える状態（pick 成功）の境界付近になりやすい。ズーム中は
+ * カメラ位置が毎フレーム動くため、この境界を数フレームにわたり断続的にまたぐ。向き補正は失敗
+ * フレームで完全に停止するため、その間ネイティブズームのフレーム結合誤差が無補正で蓄積し、次に
+ * 成功したフレームで一括補正されて画面が急に動く（ズーム終了間際のスナップ）。
+ *
+ * 対策として、pick が失敗しても「同一ズームジェスチャ内で直近に成功した実在の地表点」がまだ新しい
+ * 間はそれを補正に再利用し、補正の停止（＝誤差の一括蓄積→スナップ）を避ける。再利用するのは
+ * あくまで直近フレームで実際に検出した実在の近傍地表点であり、遠方の仮想点を捏造しない
+ * （水平チルトで遠方点へ暴走する既知不具合を再発させない）ことがこの設計の要点。
+ *
+ * @param pickSucceeded 今フレームのレイマーチングが地表交点を採用できたか。
+ * @param hasLastValid 同一ズームジェスチャ内で過去に採用できた地表点を保持しているか。
+ * @param frameGapMs 直近の成功フレームから今フレームまでの経過時間 [ms]（保持点の鮮度）。
+ * @param maxHoldMs 保持点を再利用してよい最大経過時間 [ms]。これを超えたら保持を破棄して補正を
+ *        止める（古すぎる点の再利用でカメラが的外れな向きへ寄るのを防ぐ）。0 以上の有限数。
+ * @returns "current" = 今フレームの成功結果を使う / "held" = 保持している直近の成功結果を再利用する /
+ *          "skip" = 使える center が無いので補正しない。
+ */
+export const resolveRecalcCenterSource = (
+    pickSucceeded: boolean,
+    hasLastValid: boolean,
+    frameGapMs: number,
+    maxHoldMs: number,
+): "current" | "held" | "skip" => {
+    if (pickSucceeded) return "current";
+    if (
+        hasLastValid &&
+        Number.isFinite(frameGapMs) &&
+        frameGapMs >= 0 &&
+        Number.isFinite(maxHoldMs) &&
+        maxHoldMs >= 0 &&
+        frameGapMs <= maxHoldMs
+    ) {
+        return "held";
+    }
+    return "skip";
+};

--- a/tests/geoCameraMapping.unit.spec.ts
+++ b/tests/geoCameraMapping.unit.spec.ts
@@ -23,6 +23,7 @@ import {
     clampRadiusForGroundClearance,
     rayEllipsoidNearHitToRef,
     resolveTerrainClickElevationToRef,
+    resolveRecalcCenterSource,
 } from "../src/terrain/geo/cameraMapping";
 
 describe("uiToYawPitch / yawPitchToUi", () => {
@@ -556,5 +557,37 @@ describe("polePanSpeedMultiplier", () => {
             expect(Number.isNaN(m)).toBe(false);
             expect(m).toBe(1);
         }
+    });
+});
+
+describe("resolveRecalcCenterSource", () => {
+    it("今フレームで地表を検出できたら常に current を使う（保持の有無・鮮度に依らない）", () => {
+        expect(resolveRecalcCenterSource(true, false, 0, 100)).toBe("current");
+        expect(resolveRecalcCenterSource(true, true, 0, 100)).toBe("current");
+        // 保持が古くても成功フレームは current 優先。
+        expect(resolveRecalcCenterSource(true, true, 9999, 100)).toBe("current");
+    });
+
+    it("検出失敗でも保持点が新しければ held を使い、補正の停止（＝一括スナップ）を避ける", () => {
+        expect(resolveRecalcCenterSource(false, true, 0, 100)).toBe("held");
+        expect(resolveRecalcCenterSource(false, true, 50, 100)).toBe("held");
+        // 境界（経過時間 == 上限）は再利用可。
+        expect(resolveRecalcCenterSource(false, true, 100, 100)).toBe("held");
+    });
+
+    it("検出失敗で保持が古すぎる/存在しない場合は skip（補正しない）", () => {
+        // 保持なし。
+        expect(resolveRecalcCenterSource(false, false, 0, 100)).toBe("skip");
+        // 保持が上限超過（数フレームを超えて失敗が継続）。古い点の再利用でカメラが的外れに寄るのを防ぐ。
+        expect(resolveRecalcCenterSource(false, true, 101, 100)).toBe("skip");
+        expect(resolveRecalcCenterSource(false, true, 9999, 100)).toBe("skip");
+    });
+
+    it("経過時間・上限が非有限/負なら held を採らず skip（NaN の rest 混入で誤って再利用しない）", () => {
+        expect(resolveRecalcCenterSource(false, true, NaN, 100)).toBe("skip");
+        expect(resolveRecalcCenterSource(false, true, Infinity, 100)).toBe("skip");
+        expect(resolveRecalcCenterSource(false, true, -1, 100)).toBe("skip");
+        expect(resolveRecalcCenterSource(false, true, 50, NaN)).toBe("skip");
+        expect(resolveRecalcCenterSource(false, true, 50, -1)).toBe("skip");
     });
 });


### PR DESCRIPTION
## 概要

チルト角が水平に近い状態で山岳地帯をズームアップすると、ズーム終了あたりで画面が意図せずずれる不具合を修正する（#440 の修正作業中に発見・切り出された残存バグ）。

## 原因

`src/scenes/globe.ts` の `recalculateCenterPublic` は、ズームフレーム毎に地表交点をレイマーチング（`resolveTerrainClickElevationToRef`）で取得し、視線方向を保ったまま center/yaw/pitch/radius を再計算してネイティブズームのフレーム結合誤差を打ち消している。

水平に近いチルトで山岳地帯を見ていると、視線レイが稜線をわずかに超えて空を指す状態（地表未検出）と山を捉える状態の境界付近になりやすい。ズーム中はカメラ位置が毎フレーム動くため、この境界を数フレームにわたり断続的にまたぐ。地表検出に失敗したフレームでは補正が完全停止していたため、その間ネイティブズームの誤差が無補正で蓄積し、次に成功したフレームで一括補正されて画面が急に動いていた（ズーム終了間際のスナップ）。

## 修正内容

- `src/terrain/geo/cameraMapping.ts`: 補正に使う center の選び方（今フレーム成功 / 直近成功の保持点を再利用 / 補正しない）を決める純関数 `resolveRecalcCenterSource` を追加。
- `src/scenes/globe.ts`: `recalculateCenterPublic` を改修し、地表検出に失敗しても直近に採用した実在の地表点を短時間（100ms）だけ再利用して補正を連続させる。遠方の仮想点は捏造しないため、#440 で導入した「地表検出できない場合に暴走させない」安全策は維持している。
- `tests/geoCameraMapping.unit.spec.ts`: `resolveRecalcCenterSource` の単体テストを追加。

## 影響範囲

- 挙動: グローブカメラのズーム・地形クリック処理（`GlobeScene`）。API/型の変更なし。
- 目視確認: 山岳地帯・水平チルトでズームアップし、終了間際の画面ずれが解消していることをユーザーが確認済み。

## テスト

- `npm run lint`: pass
- `npm run typecheck`: pass
- `npm run test:unit`: pass（1299 tests）

Closes #442