### PR TITLE
fix(terrain): 水平チルト時の地平線タイル消失をreverse-Zで解消

### DIFF
--- a/src/lib/internal/engineFactory.ts
+++ b/src/lib/internal/engineFactory.ts
@@ -86,5 +86,4 @@ export async function createBabylonEngine(
  */
 function enableReverseDepthBuffer(engine: AbstractEngine): void {
     engine.useReverseDepthBuffer = true;
-    console.info("[engineFactory] reverse-Z depth buffer enabled");
 }

--- a/src/lib/internal/engineFactory.ts
+++ b/src/lib/internal/engineFactory.ts
@@ -65,8 +65,26 @@ export async function createBabylonEngine(
                 useHighPrecisionMatrix,
             });
             await engine.initAsync();
+            enableReverseDepthBuffer(engine);
             return engine;
         }
     }
-    return new Engine(canvas, true, { useHighPrecisionMatrix });
+    const engine = new Engine(canvas, true, { useHighPrecisionMatrix });
+    enableReverseDepthBuffer(engine);
+    return engine;
+}
+
+/**
+ * reverse-Z 深度バッファを有効化する。
+ *
+ * 低高度・水平チルト（地平線付近）では minZ:maxZ 比が極端（例: 1m : ~733km）になり、
+ * 24bit 整数深度では遠景の深度分解能が枯渇して地形メッシュとスカイボックスが z-fighting し、
+ * 地平線付近の地形が透けて見える。reverse-Z は投影行列レベルで near/far の深度分布を反転し、
+ * 遠景の深度分解能を大幅に改善する。全メッシュ・全マテリアルへ自動適用されるため
+ * マテリアル毎の設定漏れリスクがなく、追加シェーダーコストもほぼゼロ。
+ * 右手系・ORTHOGRAPHIC(2D) の双方に Babylon 本体が対応済み。
+ */
+function enableReverseDepthBuffer(engine: AbstractEngine): void {
+    engine.useReverseDepthBuffer = true;
+    console.info("[engineFactory] reverse-Z depth buffer enabled");
 }

--- a/tests/engineFactory.unit.spec.ts
+++ b/tests/engineFactory.unit.spec.ts
@@ -21,6 +21,7 @@ let webgpuSupported = true;
 
 class MockWebGPUEngine {
     initAsync = webgpuInitAsync;
+    useReverseDepthBuffer = false;
     constructor(...args: unknown[]) {
         webgpuConstructor(...args);
     }
@@ -30,6 +31,7 @@ class MockWebGPUEngine {
 }
 
 class MockEngine {
+    useReverseDepthBuffer = false;
     constructor(...args: unknown[]) {
         engineConstructor(...args);
     }
@@ -108,5 +110,19 @@ describe("createBabylonEngine", () => {
             | { useHighPrecisionMatrix?: boolean }
             | undefined;
         expect(options?.useHighPrecisionMatrix).toBe(true);
+    });
+
+    it("WebGL2 生成時に reverse-Z 深度バッファを有効化する (地平線 z-fighting 対策)", async () => {
+        const engine = (await createBabylonEngine(canvas(), "webgl2")) as unknown as {
+            useReverseDepthBuffer: boolean;
+        };
+        expect(engine.useReverseDepthBuffer).toBe(true);
+    });
+
+    it("WebGPU 生成時に reverse-Z 深度バッファを有効化する (地平線 z-fighting 対策)", async () => {
+        const engine = (await createBabylonEngine(canvas(), "webgpu")) as unknown as {
+            useReverseDepthBuffer: boolean;
+        };
+        expect(engine.useReverseDepthBuffer).toBe(true);
     });
 });

--- a/tests/globeLod.unit.spec.ts
+++ b/tests/globeLod.unit.spec.ts
@@ -124,6 +124,146 @@ describe("selectGlobeTiles", () => {
         for (const t of tiles) expect(t.tileSizeMeters).toBeGreaterThan(0);
     });
 
+    describe("高チルト（水平気味）でも可視地表を欠けなく被覆する（#446 地平線カリング）", () => {
+        const EARTH_R = 6_371_000;
+        const DEG = Math.PI / 180;
+        const V_FOV = 0.8;
+        const ASPECT = 1920 / 1080;
+
+        /**
+         * 注視点(center)を地表に固定し、方位 az・チルト tilt・視距離 radius から
+         * `globe.ts` と同じ手順（`ComputeLookAtFromYawPitchToRef`）でカメラ ECEF を組む。
+         * tilt は 0=直下、90=水平。
+         */
+        const cameraFor = (
+            tiltDeg: number,
+            radius: number,
+            azDeg = 0,
+        ): Vector3 => {
+            const centerEcef = geodeticToEcef(CENTER_LAT, CENTER_LON, 0);
+            const lookAt = new Vector3();
+            ComputeLookAtFromYawPitchToRef(
+                azDeg * DEG,
+                tiltDeg * DEG,
+                centerEcef,
+                true,
+                lookAt,
+            );
+            return centerEcef.clone().subtract(lookAt.scale(radius));
+        };
+
+        /** 原点 O から単位方向 Dn のレイと地心半径 R の球の最近交点。無交差なら null（＝空を向く）。 */
+        const raySphereHit = (O: Vector3, Dn: Vector3): Vector3 | null => {
+            const b = 2 * Vector3.Dot(O, Dn);
+            const c = Vector3.Dot(O, O) - EARTH_R * EARTH_R;
+            const disc = b * b - 4 * c;
+            if (disc < 0) return null;
+            const t = (-b - Math.sqrt(disc)) / 2;
+            if (t < 0) return null;
+            return O.add(Dn.scale(t));
+        };
+
+        /**
+         * 視錐台がとらえる地表領域を N×N グリッドでレイキャストし、地表に当たる各サンプルが
+         * いずれかの選択タイルに含まれる割合を返す。地平線カリングが可視タイルを取りこぼすと
+         * 100% を下回り、地球ベースレイヤ（フォールバック背景）が露出することを検知できる。
+         */
+        const groundCoverageRatio = (
+            cameraEcef: Vector3,
+            tiles: ReturnType<typeof selectGlobeTiles>,
+        ): number => {
+            const centerEcef = geodeticToEcef(CENTER_LAT, CENTER_LON, 0);
+            const forward = centerEcef.subtract(cameraEcef).normalize();
+            const upApprox = cameraEcef.clone().normalize();
+            const right = Vector3.Cross(forward, upApprox).normalize();
+            const up = Vector3.Cross(right, forward).normalize();
+            const tanY = Math.tan(V_FOV / 2);
+            const tanX = tanY * ASPECT;
+            const isCovered = (lat: number, lon: number): boolean =>
+                tiles.some((t) => {
+                    const c = toTileXY(lat, lon, t.zoom);
+                    return c.x === t.x && c.y === t.y;
+                });
+            let ground = 0;
+            let covered = 0;
+            const N = 12;
+            for (let iy = 0; iy <= N; iy++) {
+                for (let ix = 0; ix <= N; ix++) {
+                    const ny = ((iy / N) * 2 - 1) * tanY;
+                    const nx = ((ix / N) * 2 - 1) * tanX;
+                    const dir = forward
+                        .add(right.scale(nx))
+                        .add(up.scale(ny))
+                        .normalize();
+                    const hit = raySphereHit(cameraEcef, dir);
+                    if (!hit) continue; // 空（地平線より上）を向くサンプルは対象外。
+                    ground++;
+                    const g = ecefToGeodetic(hit);
+                    if (isCovered(g.latDeg, g.lonDeg)) covered++;
+                }
+            }
+            return ground === 0 ? 1 : covered / ground;
+        };
+
+        const highTiltOpts = (
+            tiltDeg: number,
+            radius: number,
+            overrides: Partial<GlobeLodOptions> = {},
+        ): GlobeLodOptions => {
+            const cameraEcef = cameraFor(tiltDeg, radius);
+            const alt = ecefToGeodetic(cameraEcef).altMeters;
+            return baseOpts(alt, {
+                cameraEcef,
+                centerLat: CENTER_LAT,
+                centerLon: CENTER_LON,
+                maxZoom: GLOBE_SCENE_DEFAULTS.maxZoom,
+                sseThreshold: GLOBE_SCENE_DEFAULTS.sseThreshold,
+                maxTiles: GLOBE_SCENE_DEFAULTS.maxTiles,
+                rootSearchRadius: GLOBE_SCENE_DEFAULTS.rootSearchRadius,
+                maxRootTiles: GLOBE_SCENE_DEFAULTS.maxRootTiles,
+                horizonDotThreshold: GLOBE_SCENE_DEFAULTS.horizonDotThreshold,
+                rootZoomFloor: GLOBE_SCENE_DEFAULTS.rootZoomFloor,
+                ...overrides,
+            });
+        };
+
+        // tilt 80〜89°・複数の視距離で視錐台の地表被覆が 100%（ベースレイヤ露出なし）であること。
+        for (const [tilt, radius] of [
+            [80, 60000],
+            [85, 60000],
+            [88, 120000],
+            [89, 60000],
+            [89, 300000],
+        ] as const) {
+            it(`tilt=${tilt}° radius=${radius}m で視錐台の地表を全面被覆する`, () => {
+                const opts = highTiltOpts(tilt, radius);
+                const tiles = selectGlobeTiles(opts);
+                expect(tiles.length).toBeGreaterThan(0);
+                // 地平線付近まで含め、視錐台がとらえる地表がすべてタイルで覆われる。
+                expect(groundCoverageRatio(opts.cameraEcef, tiles)).toBe(1);
+            });
+        }
+
+        it("高標高の注視点（富士山頂相当）でも高チルトで地表を全面被覆する", () => {
+            // 注視点標高を上げると遠景タイルの評価位置がずれるが、被覆は維持されること。
+            const opts = highTiltOpts(89, 60000, { referenceAltitude: 3776 });
+            const tiles = selectGlobeTiles(opts);
+            expect(groundCoverageRatio(opts.cameraEcef, tiles)).toBe(1);
+        });
+
+        it("高チルトでもタイル数が maxTiles 予算を超えない（リクエスト暴発なし）", () => {
+            for (const [tilt, radius] of [
+                [85, 60000],
+                [89, 60000],
+                [89, 300000],
+            ] as const) {
+                const opts = highTiltOpts(tilt, radius);
+                const tiles = selectGlobeTiles(opts);
+                expect(tiles.length).toBeLessThanOrEqual(GLOBE_SCENE_DEFAULTS.maxTiles);
+            }
+        });
+    });
+
     it("全球視点（高高度）は粗タイルで可視キャップ全体を欠けなく被覆する（#335 全球モード）", () => {
         // 高度 15,000km の直下視＝地球の大部分が見える。視線方向に沿う 1 次元帯では 2 次元キャップを
         // 覆い切れないため全球モード（floorZoom 一様種付け＋タイルサイズ考慮の地平線カリング）に切替。

--- a/tests/globeLod.unit.spec.ts
+++ b/tests/globeLod.unit.spec.ts
@@ -11,6 +11,7 @@
 import { describe, it, expect } from "@jest/globals";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { ComputeLookAtFromYawPitchToRef } from "@babylonjs/core/Cameras/geospatialCamera";
+import { Wgs84Ellipsoid } from "@babylonjs/core/Maths/math.geospatial.functions";
 
 import { tileCenterLatLon, toTileXY } from "../src/terrain/gsiTile";
 import { geodeticToEcef, ecefToGeodetic } from "../src/terrain/geo/ecef";
@@ -125,7 +126,10 @@ describe("selectGlobeTiles", () => {
     });
 
     describe("高チルト（水平気味）でも可視地表を欠けなく被覆する（#446 地平線カリング）", () => {
-        const EARTH_R = 6_371_000;
+        // `geodeticToEcef`/`ecefToGeodetic` は WGS84 楕円体（赤道半径 a）基準のため、
+        // 地表判定の球近似も平均半径ではなく a に揃える（レビュー指摘: 半径不整合による
+        // 交点ズレ・被覆率誤判定の防止）。
+        const EARTH_R = Wgs84Ellipsoid.semiMajorAxis;
         const DEG = Math.PI / 180;
         const V_FOV = 0.8;
         const ASPECT = 1920 / 1080;


### PR DESCRIPTION
## 概要

チルト角80°超（水平に近い視点）で地平線付近の地形タイルが徐々に消え、89°でほぼ完全にスカイボックス（大気散乱の背景）が透ける不具合を修正する（#442 のズームスナップ修正確認中に発見・切り出された #446）。

## 原因

Babylon.js 本体の `GeospatialClippingBehavior`（`src/scenes/globe.ts` でカメラにアタッチ）が、標高に応じて毎フレーム `camera.minZ`/`camera.maxZ` を自動更新するが、低高度・水平チルトでは near:far 比が極端（実測例: minZ≈1m, maxZ≈733km、比≈1:733,000）になる。この比率のもとで標準的な深度バッファ（本環境では実質24bit整数深度）を使うと、地平線付近（実距離90km前後）での深度分解能が枯渇し、地形メッシュとスカイボックス（`infiniteDistance=true`、深度テスト・書き込みあり）が z-fighting して地形が負け、透けて見える。

なお当初「ブラウザウィンドウの高さでも症状が変わる」という報告があったが、`camera.fovMode` はデフォルト `FOVMODE_VERTICAL_FIXED` であり、ウィンドウ高さは視錐台・LOD計算（`src/terrain/geo/globeLod.ts`）には影響しない。LOD選択ロジック自体は数値シミュレーション・実描画確認済みで健全であり、原因ではなく「地平線バンドが画面に占める割合」の見え方の違いと判断した。

## 修正内容

- `src/lib/internal/engineFactory.ts`: `engine.useReverseDepthBuffer = true` を有効化（reverse-Z）。投影行列レベルで near/far の深度分布を反転し、遠景の深度分解能を大幅に改善する。Babylon本体が標準サポートしており、右手系・2D(ORTHOGRAPHIC)モードの両方に対応済み。全メッシュ・全マテリアルへ自動適用されるため、マテリアル毎に `useLogarithmicDepth` を設定する代替案より設定漏れリスクが低く、追加シェーダーコストもほぼゼロ。
- `tests/engineFactory.unit.spec.ts`: reverse-Z が有効化されることを検証するテストを追加（WebGL2/WebGPU 両エンジン生成パス）。
- `tests/globeLod.unit.spec.ts`: 高チルト時の地表被覆率を検証する回帰テストを追加（LOD選択ロジック自体が健全であることの記録）。

## 検証結果

以下の環境で修正確認済み（症状解消）:

- iPhone Safari
- Android Chrome
- Windows 11（macOS ARM64上の仮想PC）Edge / Chrome
- macOS Safari / Firefox
- macOS Chrome（WebGL2）

**既知の残存事象**: macOS Chrome の **WebGPU** バックエンドのみ、本修正後も症状が解消しなかった。ただし Chrome Canary では解消していることを確認しており、Chrome Stable 側の WebGPU 実装の一時的な不具合である可能性が高い（本プロジェクトのコード側の問題ではないと判断）。将来 Chrome Stable の WebGPU 実装が追従すれば自動的に解消する見込み。この事象を理由に本 PR の修正を見送る／既定エンジン（`JPMAP_TERRAIN_DEFAULTS.engine = "webgpu"`）を変更することはしない（reverse-Z 自体は全環境で正しく機能する改善のため）。

## テスト

- `npm run lint`: pass
- `npm run typecheck`: pass
- `npm run test:unit`: pass（1308 tests）
- `npm run test:visuals`: pass（19/19、既存スナップショットとの差分なし）
- 上記実機での目視確認（Tester/ユーザー承認済み）

## 影響範囲

- `createBabylonEngine`（`src/lib/internal/engineFactory.ts`）は globe/geospatial バックエンドを含む全デモ共通の Engine 生成経路のため、reverse-Z は全デモに適用される。追加で flight / boids / artillery / avatar 等の主要デモを目視確認し、回帰がないことを確認済み。
- API・型の変更なし。

Closes #446