### PR TITLE
docs(agents): model指定をエイリアス形式に変更 (#448)

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -1,7 +1,7 @@
 ---
 name: architect
 description: 最小差分で拡張可能な設計方針・インターフェース・移行計画を提示する。「設計して」「アーキテクチャを考えて」「API設計して」に対応。新規API/DB変更時は必ず使用。
-model: claude-opus-4-8
+model: opus
 ---
 # Architect Agent (Local)
 

--- a/.claude/agents/coder.md
+++ b/.claude/agents/coder.md
@@ -1,7 +1,7 @@
 ---
 name: coder
 description: 最小差分で実装し、対応する Unit test を作成してローカルで動作確認できる状態まで仕上げる。「実装して」「コードを書いて」「修正して」に対応。
-model: claude-opus-4-8
+model: opus
 ---
 # Coder Agent (Local)
 

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -1,7 +1,7 @@
 ---
 name: planner
 description: 要件をタスクへ分解し、Issue 作成とローカルで再現可能な作業手順を策定する。「タスク分解して」「Issue 作成して」「作業計画を立てて」に対応。
-model: claude-sonnet-4-6
+model: sonnet
 ---
 # Planner Agent (Local)
 

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: reviewer
 description: セキュリティ・品質・パフォーマンス・ベストプラクティスの4層レビューで再現性のある品質ゲートを提供する。「レビューして」「コードチェックして」「PR確認して」に対応。
-model: claude-sonnet-4-6
+model: sonnet
 ---
 # Reviewer Agent (Local)
 

--- a/.claude/agents/security.md
+++ b/.claude/agents/security.md
@@ -1,7 +1,7 @@
 ---
 name: security
 description: 安全性・権限・情報漏洩を点検し、危険操作を HITL で確実に停止させる。「セキュリティチェックして」「権限確認して」「機密情報リスクを確認して」に対応。外部連携/権限/機密変更時は必ず使用。
-model: claude-sonnet-4-6
+model: sonnet
 ---
 # Security Agent (Local)
 

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -1,7 +1,7 @@
 ---
 name: tester
 description: 壊れやすい境界と重要フローを優先して Unit test を追加し、3DCG は目視確認ゲートで妥当性を担保する。「テストを書いて」「テストを追加して」「テスト観点を洗い出して」に対応。
-model: claude-sonnet-4-6
+model: sonnet
 ---
 # Tester Agent (Local)
 

--- a/.github/agents/00_orchestrator.md
+++ b/.github/agents/00_orchestrator.md
@@ -4,7 +4,7 @@ description: 開発タスクを中央集権型で進行管理し、各専門役�
 role: orchestrator
 pattern: agents-as-tools
 version: 0.1
-model: claude-sonnet-4-6
+model: sonnet
 ---
 # 目的
 開発タスクを中央集権型（Orchestrator → 専門役割）で進め、ローカル環境で安全に完了させる。

--- a/.github/agents/10_planner.md
+++ b/.github/agents/10_planner.md
@@ -3,7 +3,7 @@ title: Planner Agent (Local)
 description: 要件をタスクへ分解し、Issue 作成とローカルで再現可能な作業手順の策定を担うプランナーエージェント。
 role: planner
 version: 0.1
-model: claude-sonnet-4-6
+model: sonnet
 ---
 # 目的
 要件をタスクに分解し、ローカルで再現可能な作業手順に落とす。

--- a/.github/agents/20_architect.md
+++ b/.github/agents/20_architect.md
@@ -3,7 +3,7 @@ title: Architect Agent (Local)
 description: 最小差分で拡張可能な設計方針・インターフェース・移行計画を提示する設計エージェント。
 role: architect
 version: 0.1
-model: claude-opus-4-8
+model: opus
 ---
 # 目的
 最小差分で拡張可能な設計を提示し、ローカル開発で安全に実装できるようにする。

--- a/.github/agents/30_coder.md
+++ b/.github/agents/30_coder.md
@@ -3,7 +3,7 @@ title: Coder Agent (Local)
 description: 最小差分で実装し、対応する Unit test を作成してローカルで動作確認できる状態まで仕上げる実装エージェント。
 role: coder
 version: 0.2
-model: claude-opus-4-8
+model: opus
 ---
 # 目的
 最小差分で実装し、ローカルで動作確認できる状態まで持っていく。

--- a/.github/agents/40_tester.md
+++ b/.github/agents/40_tester.md
@@ -3,7 +3,7 @@ title: Tester Agent (Local)
 description: 壊れやすい境界と重要フローを優先して Unit test を追加し、3DCG は目視確認ゲートで妥当性を担保するテストエージェント。
 role: tester
 version: 0.2
-model: claude-sonnet-4-6
+model: sonnet
 ---
 # 目的
 壊れやすい境界と重要フローを優先してテストを追加し、ローカルで実行可能にする。

--- a/.github/agents/50_reviewer.md
+++ b/.github/agents/50_reviewer.md
@@ -3,7 +3,7 @@ title: Reviewer Agent (Local)
 description: セキュリティ・品質・パフォーマンス・ベストプラクティスの4層レビューで再現性のある品質ゲートを提供するレビューエージェント。
 role: reviewer
 version: 0.2
-model: claude-sonnet-4-6
+model: sonnet
 ---
 # 目的
 ローカル運用でも再現性のある品質ゲートを提供する。

--- a/.github/agents/60_security.md
+++ b/.github/agents/60_security.md
@@ -3,7 +3,7 @@ title: Security Agent (Local)
 description: 安全性・権限・情報漏洩を点検し、危険操作を HITL で確実に停止させるセキュリティエージェント。
 role: security
 version: 0.1
-model: claude-sonnet-4-6
+model: sonnet
 ---
 # 目的
 安全性・権限・情報漏洩を点検し、危険操作は必ずHITLで止める。


### PR DESCRIPTION
## 概要
`.github/agents/*` / `.claude/agents/*` の `model:` 指定をバージョン固定文字列からエイリアス形式に変更し、常に最新バージョンが適用されるようにする。

- `model: claude-sonnet-4-6` → `model: sonnet`
- `model: claude-opus-4-8` → `model: opus`

## 変更ファイル
- `.github/agents/*.md` (7ファイル)
- `.claude/agents/*.md` (6ファイル)

## 影響範囲
frontmatterの `model:` 行のみ。コード・挙動への影響なし。

## テスト
- `npm run lint` 成功
- `npm run typecheck` 成功

Closes #448