### PR TITLE
fix(terrain): 近水平・長距離レイマーチングでの狭尾根貫通を修正 (#443)

### DIFF
--- a/src/terrain/geo/cameraMapping.ts
+++ b/src/terrain/geo/cameraMapping.ts
@@ -334,6 +334,13 @@ let farSubdivideCapWarned = false;
  * は第1段が手前で反転するため全域細分に入らず、コストを増やさない）。全域細分でも反転が見つから
  * なければ本当に地表が無い（平地・海面）ので、従来どおり標高 0 交点にフォールバックする。
  *
+ * 注意: 奥端が標高 0 面（`hasSeaLevelFar`）のとき、第1段の最終サンプル（t=tFar）は定義上つねに
+ * 「標高 0 面との交点」そのものであり、地形標高が 0（平地）ならレイ高度はそこで必ず 0 に収束する
+ * （隠れた尾根の有無と無関係に成立するトートロジー）。これを通常の「反転検出」として採用すると、
+ * 途中で尾根を見逃していても最終サンプルで必ず crossed 扱いになってしまい、全域細分（本来の対策）
+ * が発火しなくなる。そのため第1段では、hasSeaLevelFar かつ最終サンプルの場合に限り反転判定から
+ * 除外する（詳細は実装のコメント参照）。
+ *
  * 内部の ECEF↔測地変換（`ecefToGeodeticToRef`）は WGS84 の離心率で固定されているため、
  * `ellipsoidSemiMajor`/`ellipsoidSemiMinor` には WGS84 の値（`Wgs84Ellipsoid.semiMajorAxis`/
  * `semiMinorAxis`）を渡すこと。異なる楕円体を渡すと、半径ベースの交差判定と測地座標変換の
@@ -514,7 +521,15 @@ export const resolveTerrainClickElevationToRef = (
     let prevT = tNear;
     for (let i = 1; i <= steps; i++) {
         const t = tNear + ((tFar - tNear) * i) / steps;
-        if (heightAboveTerrainToRef(t) <= 0) {
+        // hasSeaLevelFar のとき、最終サンプル（t=tFar）は「標高0面との交点」そのものであり、
+        // 地形標高0（平地）なら定義上つねに heightAboveTerrain(tFar)≈0 になる（実測: WGS84の
+        // 実楕円体を渡すと厳密に 0）。これは隠れた尾根の有無と無関係なので「反転」として採用
+        // すると、途中で尾根を見逃していてもここで crossed=true になってしまい、後段の全域細分
+        // （下の else if 分岐）が発火しない＝隠れた尾根を貫通する（#443 のレビュー指摘）。そこで
+        // 最終サンプルかつ hasSeaLevelFar の場合だけは「反転」として採用せず、ループを反転なしの
+        // まま終える。
+        const isTautologicalSeaLevelEnd = i === steps && hasSeaLevelFar;
+        if (!isTautologicalSeaLevelEnd && heightAboveTerrainToRef(t) <= 0) {
             coarseLoT = prevT;
             coarseHiT = t;
             crossed = true;

--- a/src/terrain/geo/cameraMapping.ts
+++ b/src/terrain/geo/cameraMapping.ts
@@ -329,10 +329,14 @@ let farSubdivideCapWarned = false;
  * `stepDistanceM` より粗くなる。すると途中の幅の狭い尾根が第1段のサンプル格子の間隙に隠れて反転が
  * 検出されず（尾根の頂はどの粗サンプルにも入らずレイ高度の反転も局所ディップも第1段には現れない）、
  * レイはそのまま奥端の標高 0 面まで到達してしまう。この「第1段で反転せず、かつ奥端が標高 0 面
- * （海面）」のケースでは、手前区間の細分では尾根を見つけられないため、第2段の対象を探索区間全体に
- * 広げ、専用の上限 `SUBDIVIDE_MAX_STEPS_FAR` まで細かく刻み直して隠れた尾根を捕捉する（通常フレーム
- * は第1段が手前で反転するため全域細分に入らず、コストを増やさない）。全域細分でも反転が見つから
- * なければ本当に地表が無い（平地・海面）ので、従来どおり標高 0 交点にフォールバックする。
+ * （海面）であり、かつ `maxCoarseSteps` の頭打ちで実効ステップ幅が `stepDistanceM` より粗くなっている
+ * （`steps < idealSteps`）」ケースに限り、手前区間の細分では尾根を見つけられないため第2段の対象を
+ * 探索区間全体に広げ、専用の上限 `SUBDIVIDE_MAX_STEPS_FAR` まで細かく刻み直して隠れた尾根を捕捉する
+ * （通常フレームは第1段が手前で反転するか、頭打ちしておらずすでに `stepDistanceM` 相当の解像度で
+ * 走査済みのため全域細分に入らず、コストを増やさない）。全域細分でも反転が見つからなければ本当に
+ * 地表が無い（平地・海面）ので、従来どおり標高 0 交点にフォールバックする。頭打ちしていない場合
+ * （`steps === idealSteps`）は、第1段がすでに設計解像度で走査済みであり反転も見つからなかった＝
+ * 本当に地表が無いと判断できるため、全域再細分せず直接標高 0 交点にフォールバックする。
  *
  * 注意: 奥端が標高 0 面（`hasSeaLevelFar`）のとき、第1段の最終サンプル（t=tFar）は定義上つねに
  * 「標高 0 面との交点」そのものであり、地形標高が 0（平地）ならレイ高度はそこで必ず 0 に収束する
@@ -511,10 +515,10 @@ export const resolveTerrainClickElevationToRef = (
     // 応じてステップ数を動的に決めるが、上限 maxCoarseSteps で頭打ちにする（近水平視線で探索
     // 区間が数十kmに伸びると実効ステップ幅が stepDistanceM より粗くなり得る）。ここでは
     // 「符号反転が起きた手前区間」を第2段の細分対象として絞り込むだけで、精度は第2段が担保する。
-    const steps = Math.min(
-        Math.max(minCoarseSteps, Math.ceil((tFar - tNear) / stepDistanceM)),
-        maxCoarseSteps,
-    );
+    // idealSteps は頭打ち前の理想ステップ数（= 実効ステップ幅が stepDistanceM 相当に保てているか
+    // の判定にも使う。steps < idealSteps なら maxCoarseSteps で頭打ちして粗くなっている）。
+    const idealSteps = Math.max(1, Math.ceil((tFar - tNear) / stepDistanceM));
+    const steps = Math.min(Math.max(minCoarseSteps, idealSteps), maxCoarseSteps);
     let crossed = false;
     let coarseLoT = tNear; // 反転区間の手前端（直前の非反転サンプル）
     let coarseHiT = tFar; // 反転区間の奥端（初めて反転したサンプル）
@@ -543,22 +547,25 @@ export const resolveTerrainClickElevationToRef = (
         // 細分して反転区間を確定する。第1段で h(coarseHiT)<=0 を確認済みなので、この区間の
         // 細分は最終サンプルで必ず反転を捉える（subdivideForCrossing は true を返す）。
         subdivideForCrossing(coarseLoT, coarseHiT, SUBDIVIDE_MAX_STEPS);
-    } else if (hasSeaLevelFar) {
-        // 第1段は反転を検出しなかったが、奥端が標高0面（海面）に到達している。近水平・長距離の
-        // 探索では第1段が maxCoarseSteps で頭打ちして粗くなり、途中の狭い尾根を格子間隙で跨いで
-        // 見逃した可能性がある（見逃すとレイは奥の海面まで貫通し、遠方点が回転中心になる #443 の
-        // 不具合）。そこで探索区間全体を専用上限 SUBDIVIDE_MAX_STEPS_FAR まで細分し直し、隠れた
-        // 尾根（＝反転）を探す。反転が見つかればその区間を二分探索へ回し、見つからなければ本当に
-        // 地表が無い（平地・海面）ので従来どおり標高0交点にフォールバックする。
-        const span = tFar - tNear;
-        const idealSteps = Math.max(1, Math.ceil(span / stepDistanceM));
+    } else if (hasSeaLevelFar && steps < idealSteps) {
+        // 第1段は反転を検出しなかったが、奥端が標高0面（海面）に到達しており、かつ
+        // maxCoarseSteps で頭打ちして実効ステップ幅が stepDistanceM より粗くなっている
+        // （steps < idealSteps）。この場合のみ、途中の狭い尾根を格子間隙で跨いで見逃した
+        // 可能性がある（見逃すとレイは奥の海面まで貫通し、遠方点が回転中心になる #443 の不具合）。
+        // 頭打ちしていない（steps === idealSteps、通常の近距離・低速フレーム）場合は第1段が
+        // すでに stepDistanceM 相当の解像度で走査済みなので、全域再細分は不要かつ無駄なコスト
+        // 増になるため行わない（レビュー指摘）。
+        //
+        // 探索区間全体を専用上限 SUBDIVIDE_MAX_STEPS_FAR まで細分し直し、隠れた尾根（＝反転）を
+        // 探す。反転が見つかればその区間を二分探索へ回し、見つからなければ本当に地表が無い
+        // （平地・海面）ので従来どおり標高0交点にフォールバックする。
         if (idealSteps > SUBDIVIDE_MAX_STEPS_FAR && !farSubdivideCapWarned) {
             // 全域細分が上限で頭打ちし、実効ステップ幅が stepDistanceM より粗いままになる。
             // 想定より狭い尾根を再び見逃し得るため、パラメータ調整の観測点として一度だけ警告する
             // （恒常ログは避け、モジュールスコープのフラグで再発火を防ぐ）。
             farSubdivideCapWarned = true;
             console.warn(
-                `[cameraMapping] far subdivide capped (span=${span.toFixed(0)}m, ` +
+                `[cameraMapping] far subdivide capped (span=${(tFar - tNear).toFixed(0)}m, ` +
                     `cap=${SUBDIVIDE_MAX_STEPS_FAR}); narrow terrain may be missed`,
             );
         }
@@ -566,6 +573,11 @@ export const resolveTerrainClickElevationToRef = (
             // 隠れた尾根も無かった → 従来通り標高0交点にフォールバックする。
             return adopt(tFar);
         }
+    } else if (hasSeaLevelFar) {
+        // 第1段が頭打ちしておらず（steps === idealSteps）、すでに stepDistanceM 相当の解像度で
+        // 走査済み。反転が見つからなかった＝本当に地表が無い（平地・海面）ので、全域再細分せず
+        // 直接標高0交点にフォールバックする。
+        return adopt(tFar);
     } else {
         // 水平線よりわずかに上を見ている（標高0面には当たらない）ケースで地表（山）を検出
         // できなかった。外殻の奥交点は実際の地形と無関係などこか遠方の仮想点になり得るため、

--- a/src/terrain/geo/cameraMapping.ts
+++ b/src/terrain/geo/cameraMapping.ts
@@ -460,7 +460,7 @@ export const resolveTerrainClickElevationToRef = (
     }
     const tFar = hasSeaLevelFar ? seaLevelFarT : rtcOuterHits.t1;
 
-    // heightAboveTerrainToRef が直近に評価した地形標高（呼び出し元が「地形自体が海抜0か」を
+    // heightAboveTerrainToRef が直近に評価した地形標高（本関数内で「地形自体が海抜0か」を
     // 判定するために参照する。地表以下判定そのものには使わない）。
     let lastTerrainElevM = 0;
     const heightAboveTerrainToRef = (t: number): number => {

--- a/src/terrain/geo/cameraMapping.ts
+++ b/src/terrain/geo/cameraMapping.ts
@@ -301,9 +301,12 @@ const rtcOuterHits: EllipsoidHits = { t0: 0, t1: 0 };
 const rtcInnerHits: EllipsoidHits = { t0: 0, t1: 0 };
 // 探索中の各サンプル点の測地座標（呼び出し元の outGeo は採用確定時のみ書き込む）。
 const rtcGeo: Geodetic = { latDeg: 0, lonDeg: 0, altMeters: 0 };
+// 遠方海面ケースの全域細分が上限で頭打ちして実効ステップ幅が想定より粗いままになったことを
+// 一度だけ警告するためのガード（毎フレーム同じ警告を出さないための one-shot）。
+let farSubdivideCapWarned = false;
 
 /**
- * レイと地形表面（実標高データに基づく面）の交点を、レイに沿ったマーチング（粗い等分探索 +
+ * レイと地形表面（実標高データに基づく面）の交点を、レイに沿ったマーチング（二段階の粗探索 +
  * 二分探索での絞り込み）で求める（地形クリックピック・ズーム貫通対策）。
  *
  * 解析的な楕円体（クリック方向 1 点の標高だけで構成した定数面）との交差では、レイが経路上で
@@ -314,6 +317,22 @@ const rtcGeo: Geodetic = { latDeg: 0, lonDeg: 0, altMeters: 0 };
  * よりわずかに上を見ていて標高 0 面に当たらない（高い山の頂上だけが見えている）場合は「外殻
  * （maxTerrainElevM 面）の奥側交点」を使う。その場合に地表を検出できなければ、実際の地形と
  * 無関係な遠方の仮想点を返さないよう false を返す（詳細は本体コメント参照）。
+ *
+ * 粗探索は二段階で行う（two-tier coarse marching）。第1段は当たり付けのスキャンで、ステップ数を
+ * `[minCoarseSteps, maxCoarseSteps]` にクランプして tNear→tFar を進み、レイ高度が地形以下に
+ * なる（符号反転する）手前区間を第2段の細分対象として絞り込む。第2段はその区間だけを
+ * `stepDistanceM` 相当の細かさ（上限 `SUBDIVIDE_MAX_STEPS`）で再サンプリングして符号反転区間を
+ * 確定し、二分探索へ渡す。すなわち `maxCoarseSteps` は「第1段の当たり付けの計算量上限」を担い、
+ * 狭い尾根に対する検出精度は第2段の局所細分が担保する。
+ *
+ * 近水平視線では探索区間が数十 km に伸び、第1段が `maxCoarseSteps` で頭打ちして実効ステップ幅が
+ * `stepDistanceM` より粗くなる。すると途中の幅の狭い尾根が第1段のサンプル格子の間隙に隠れて反転が
+ * 検出されず（尾根の頂はどの粗サンプルにも入らずレイ高度の反転も局所ディップも第1段には現れない）、
+ * レイはそのまま奥端の標高 0 面まで到達してしまう。この「第1段で反転せず、かつ奥端が標高 0 面
+ * （海面）」のケースでは、手前区間の細分では尾根を見つけられないため、第2段の対象を探索区間全体に
+ * 広げ、専用の上限 `SUBDIVIDE_MAX_STEPS_FAR` まで細かく刻み直して隠れた尾根を捕捉する（通常フレーム
+ * は第1段が手前で反転するため全域細分に入らず、コストを増やさない）。全域細分でも反転が見つから
+ * なければ本当に地表が無い（平地・海面）ので、従来どおり標高 0 交点にフォールバックする。
  *
  * 内部の ECEF↔測地変換（`ecefToGeodeticToRef`）は WGS84 の離心率で固定されているため、
  * `ellipsoidSemiMajor`/`ellipsoidSemiMinor` には WGS84 の値（`Wgs84Ellipsoid.semiMajorAxis`/
@@ -449,29 +468,90 @@ export const resolveTerrainClickElevationToRef = (
         return adopt(tNear);
     }
 
-    // ステップ幅を stepDistanceM 相当に保つよう、探索距離に応じてステップ数を動的に決める。
+    // 第2段（局所細分）の再サンプリング数の上限。第1段で当たりを付けた狭い区間だけを
+    // stepDistanceM 相当の細かさで刻み直すためのローカル定数。ズーム毎フレーム呼び出しでの
+    // コスト増を避けるため控えめに取る（第1段 maxCoarseSteps + 第2段でも数百回程度に収める）。
+    const SUBDIVIDE_MAX_STEPS = 64;
+    // 第1段が反転を検出できず、かつ奥端が標高0面（hasSeaLevelFar）のケースで、探索区間全体を
+    // 細分し直すときの上限。近水平・長距離の探索では第1段が maxCoarseSteps で頭打ちして実効
+    // ステップ幅が広がり、途中の狭い尾根が粗サンプル格子の間隙に隠れる（尾根の頂はどの粗サンプル
+    // にも入らずレイ高度の反転も局所ディップも第1段には現れない）。このとき探索区間全体（数十km）を
+    // 細かく刻み直して隠れた尾根を捕捉するため、通常の上限より大きく取る（実効ステップ幅が想定
+    // 尾根幅より十分細かくなる目安。詳細は下の分岐コメント参照）。
+    const SUBDIVIDE_MAX_STEPS_FAR = 2048;
+
+    // 対象区間 [ta, tb] を stepDistanceM 相当（上限 cap）で細分し、最初の符号反転区間を
+    // [loT, hiT] に確定して true を返す局所探索。反転が無ければ false（loT/hiT は未確定）。
+    let loT = tNear;
+    let hiT = tFar;
+    const subdivideForCrossing = (ta: number, tb: number, cap: number): boolean => {
+        const subSpan = tb - ta;
+        const subSteps = Math.min(Math.max(1, Math.ceil(subSpan / stepDistanceM)), cap);
+        let subPrevT = ta;
+        for (let i = 1; i <= subSteps; i++) {
+            const t = ta + (subSpan * i) / subSteps;
+            if (heightAboveTerrainToRef(t) <= 0) {
+                loT = subPrevT;
+                hiT = t;
+                return true;
+            }
+            subPrevT = t;
+        }
+        return false;
+    };
+
+    // 第1段（粗スキャン / 当たり付け）: ステップ幅を stepDistanceM 相当に保つよう探索距離に
+    // 応じてステップ数を動的に決めるが、上限 maxCoarseSteps で頭打ちにする（近水平視線で探索
+    // 区間が数十kmに伸びると実効ステップ幅が stepDistanceM より粗くなり得る）。ここでは
+    // 「符号反転が起きた手前区間」を第2段の細分対象として絞り込むだけで、精度は第2段が担保する。
     const steps = Math.min(
         Math.max(minCoarseSteps, Math.ceil((tFar - tNear) / stepDistanceM)),
         maxCoarseSteps,
     );
-    let loT = tNear;
-    let hiT = tFar;
     let crossed = false;
+    let coarseLoT = tNear; // 反転区間の手前端（直前の非反転サンプル）
+    let coarseHiT = tFar; // 反転区間の奥端（初めて反転したサンプル）
+    let prevT = tNear;
     for (let i = 1; i <= steps; i++) {
         const t = tNear + ((tFar - tNear) * i) / steps;
         if (heightAboveTerrainToRef(t) <= 0) {
-            hiT = t;
+            coarseLoT = prevT;
+            coarseHiT = t;
             crossed = true;
             break;
         }
-        loT = t;
+        prevT = t;
     }
-    if (!crossed) {
-        if (hasSeaLevelFar) {
-            // 通常ケース（標高0面が奥端）: 地表が見つからないのは理論上ほぼ起きないはずだが、
-            // 保険として従来通り標高0交点にフォールバックする。
+
+    if (crossed) {
+        // 通常ケース: 反転した手前の狭区間 [coarseLoT, coarseHiT] だけを stepDistanceM 相当で
+        // 細分して反転区間を確定する。第1段で h(coarseHiT)<=0 を確認済みなので、この区間の
+        // 細分は最終サンプルで必ず反転を捉える（subdivideForCrossing は true を返す）。
+        subdivideForCrossing(coarseLoT, coarseHiT, SUBDIVIDE_MAX_STEPS);
+    } else if (hasSeaLevelFar) {
+        // 第1段は反転を検出しなかったが、奥端が標高0面（海面）に到達している。近水平・長距離の
+        // 探索では第1段が maxCoarseSteps で頭打ちして粗くなり、途中の狭い尾根を格子間隙で跨いで
+        // 見逃した可能性がある（見逃すとレイは奥の海面まで貫通し、遠方点が回転中心になる #443 の
+        // 不具合）。そこで探索区間全体を専用上限 SUBDIVIDE_MAX_STEPS_FAR まで細分し直し、隠れた
+        // 尾根（＝反転）を探す。反転が見つかればその区間を二分探索へ回し、見つからなければ本当に
+        // 地表が無い（平地・海面）ので従来どおり標高0交点にフォールバックする。
+        const span = tFar - tNear;
+        const idealSteps = Math.max(1, Math.ceil(span / stepDistanceM));
+        if (idealSteps > SUBDIVIDE_MAX_STEPS_FAR && !farSubdivideCapWarned) {
+            // 全域細分が上限で頭打ちし、実効ステップ幅が stepDistanceM より粗いままになる。
+            // 想定より狭い尾根を再び見逃し得るため、パラメータ調整の観測点として一度だけ警告する
+            // （恒常ログは避け、モジュールスコープのフラグで再発火を防ぐ）。
+            farSubdivideCapWarned = true;
+            console.warn(
+                `[cameraMapping] far subdivide capped (span=${span.toFixed(0)}m, ` +
+                    `cap=${SUBDIVIDE_MAX_STEPS_FAR}); narrow terrain may be missed`,
+            );
+        }
+        if (!subdivideForCrossing(tNear, tFar, SUBDIVIDE_MAX_STEPS_FAR)) {
+            // 隠れた尾根も無かった → 従来通り標高0交点にフォールバックする。
             return adopt(tFar);
         }
+    } else {
         // 水平線よりわずかに上を見ている（標高0面には当たらない）ケースで地表（山）を検出
         // できなかった。外殻の奥交点は実際の地形と無関係などこか遠方の仮想点になり得るため、
         // 採用せず false を返す（採用するとズームやセンター再計算が遠方点へ暴走する）。

--- a/src/terrain/geo/cameraMapping.ts
+++ b/src/terrain/geo/cameraMapping.ts
@@ -529,9 +529,8 @@ export const resolveTerrainClickElevationToRef = (
         // 地形標高0（平地）なら定義上つねに heightAboveTerrain(tFar)≈0 になる（実測: WGS84の
         // 実楕円体を渡すと厳密に 0）。これは隠れた尾根の有無と無関係なので「反転」として採用
         // すると、途中で尾根を見逃していてもここで crossed=true になってしまい、後段の全域細分
-        // （下の else if 分岐）が発火しない＝隠れた尾根を貫通する（#443 のレビュー指摘）。そこで
-        // 最終サンプルかつ hasSeaLevelFar の場合だけは「反転」として採用せず、ループを反転なしの
-        // まま終える。
+        // （下の else if 分岐）が発火しない＝隠れた尾根を貫通する。そこで最終サンプルかつ
+        // hasSeaLevelFar の場合だけは「反転」として採用せず、ループを反転なしのまま終える。
         const isTautologicalSeaLevelEnd = i === steps && hasSeaLevelFar;
         if (!isTautologicalSeaLevelEnd && heightAboveTerrainToRef(t) <= 0) {
             coarseLoT = prevT;
@@ -551,10 +550,10 @@ export const resolveTerrainClickElevationToRef = (
         // 第1段は反転を検出しなかったが、奥端が標高0面（海面）に到達しており、かつ
         // maxCoarseSteps で頭打ちして実効ステップ幅が stepDistanceM より粗くなっている
         // （steps < idealSteps）。この場合のみ、途中の狭い尾根を格子間隙で跨いで見逃した
-        // 可能性がある（見逃すとレイは奥の海面まで貫通し、遠方点が回転中心になる #443 の不具合）。
+        // 可能性がある（見逃すとレイは奥の海面まで貫通し、遠方点が回転中心になってしまう）。
         // 頭打ちしていない（steps === idealSteps、通常の近距離・低速フレーム）場合は第1段が
         // すでに stepDistanceM 相当の解像度で走査済みなので、全域再細分は不要かつ無駄なコスト
-        // 増になるため行わない（レビュー指摘）。
+        // 増になるため行わない。
         //
         // 探索区間全体を専用上限 SUBDIVIDE_MAX_STEPS_FAR まで細分し直し、隠れた尾根（＝反転）を
         // 探す。反転が見つかればその区間を二分探索へ回し、見つからなければ本当に地表が無い

--- a/src/terrain/geo/cameraMapping.ts
+++ b/src/terrain/geo/cameraMapping.ts
@@ -338,12 +338,13 @@ let farSubdivideCapWarned = false;
  * （`steps === idealSteps`）は、第1段がすでに設計解像度で走査済みであり反転も見つからなかった＝
  * 本当に地表が無いと判断できるため、全域再細分せず直接標高 0 交点にフォールバックする。
  *
- * 注意: 奥端が標高 0 面（`hasSeaLevelFar`）のとき、第1段の最終サンプル（t=tFar）は定義上つねに
- * 「標高 0 面との交点」そのものであり、地形標高が 0（平地）ならレイ高度はそこで必ず 0 に収束する
- * （隠れた尾根の有無と無関係に成立するトートロジー）。これを通常の「反転検出」として採用すると、
- * 途中で尾根を見逃していても最終サンプルで必ず crossed 扱いになってしまい、全域細分（本来の対策）
- * が発火しなくなる。そのため第1段では、hasSeaLevelFar かつ最終サンプルの場合に限り反転判定から
- * 除外する（詳細は実装のコメント参照）。
+ * 注意: 奥端が標高 0 面（`hasSeaLevelFar`）のとき、第1段の最終サンプル（t=tFar）でその地点の
+ * 地形標高が実際に 0（海面・未ロードのフォールバック含む）であれば、レイ高度は定義上つねにそこで
+ * 0 に収束する（隠れた尾根の有無と無関係に成立するトートロジー）。これを通常の「反転検出」として
+ * 採用すると、途中で尾根を見逃していても最終サンプルで必ず crossed 扱いになってしまい、全域細分
+ * （本来の対策）が発火しなくなる。そのため第1段では、hasSeaLevelFar かつ最終サンプルかつ地形標高が
+ * 実際に 0 の場合に限り反転判定から除外する（tFar 近傍の地形標高が 0 でない沿岸・低地等では、その
+ * 反転は本物の地表検出なので除外しない。詳細は実装のコメント参照）。
  *
  * 内部の ECEF↔測地変換（`ecefToGeodeticToRef`）は WGS84 の離心率で固定されているため、
  * `ellipsoidSemiMajor`/`ellipsoidSemiMinor` には WGS84 の値（`Wgs84Ellipsoid.semiMajorAxis`/
@@ -459,13 +460,17 @@ export const resolveTerrainClickElevationToRef = (
     }
     const tFar = hasSeaLevelFar ? seaLevelFarT : rtcOuterHits.t1;
 
+    // heightAboveTerrainToRef が直近に評価した地形標高（呼び出し元が「地形自体が海抜0か」を
+    // 判定するために参照する。地表以下判定そのものには使わない）。
+    let lastTerrainElevM = 0;
     const heightAboveTerrainToRef = (t: number): number => {
         // 探索中の一時計算は rtcGeo（内部スクラッチ）に書く。呼び出し元の outGeo は採用が
         // 確定した adopt() でのみ書き込む（失敗時に outGeo を変更しない契約を守るため）。
         rtcPoint.copyFrom(rtcUnitDir).scaleInPlace(t).addInPlace(origin);
         ecefToGeodeticToRef(rtcPoint, rtcGeo);
-        const elev = terrainElevAt(rtcGeo.latDeg, rtcGeo.lonDeg);
-        return rtcGeo.altMeters - (elev ?? 0);
+        const elev = terrainElevAt(rtcGeo.latDeg, rtcGeo.lonDeg) ?? 0;
+        lastTerrainElevM = elev;
+        return rtcGeo.altMeters - elev;
     };
     const adopt = (t: number): true => {
         rtcPoint.copyFrom(rtcUnitDir).scaleInPlace(t).addInPlace(origin);
@@ -525,14 +530,18 @@ export const resolveTerrainClickElevationToRef = (
     let prevT = tNear;
     for (let i = 1; i <= steps; i++) {
         const t = tNear + ((tFar - tNear) * i) / steps;
+        const h = heightAboveTerrainToRef(t);
         // hasSeaLevelFar のとき、最終サンプル（t=tFar）は「標高0面との交点」そのものであり、
-        // 地形標高0（平地）なら定義上つねに heightAboveTerrain(tFar)≈0 になる（実測: WGS84の
-        // 実楕円体を渡すと厳密に 0）。これは隠れた尾根の有無と無関係なので「反転」として採用
-        // すると、途中で尾根を見逃していてもここで crossed=true になってしまい、後段の全域細分
-        // （下の else if 分岐）が発火しない＝隠れた尾根を貫通する。そこで最終サンプルかつ
-        // hasSeaLevelFar の場合だけは「反転」として採用せず、ループを反転なしのまま終える。
-        const isTautologicalSeaLevelEnd = i === steps && hasSeaLevelFar;
-        if (!isTautologicalSeaLevelEnd && heightAboveTerrainToRef(t) <= 0) {
+        // その地点の地形標高が実際に0（海面・未ロードのフォールバック含む）なら定義上つねに
+        // heightAboveTerrain(tFar)≈0 になる（実測: WGS84の実楕円体を渡すと厳密に 0）。これは
+        // 隠れた尾根の有無と無関係なので「反転」として採用すると、途中で尾根を見逃していても
+        // ここで crossed=true になってしまい、後段の全域細分（下の else if 分岐）が発火しない
+        // ＝隠れた尾根を貫通する。そこで最終サンプルかつ hasSeaLevelFar かつ地形標高が実際に0の
+        // 場合だけは「反転」として採用せず、ループを反転なしのまま終える。tFar 近傍の地形標高が
+        // 0 でない（沿岸・低地等）場合は、そこでの反転は本物の地表検出なので通常どおり採用する。
+        const isTautologicalSeaLevelEnd =
+            i === steps && hasSeaLevelFar && Math.abs(lastTerrainElevM) < 1e-6;
+        if (!isTautologicalSeaLevelEnd && h <= 0) {
             coarseLoT = prevT;
             coarseHiT = t;
             crossed = true;

--- a/tests/geoCameraMapping.unit.spec.ts
+++ b/tests/geoCameraMapping.unit.spec.ts
@@ -450,52 +450,55 @@ describe("resolveTerrainClickElevationToRef", () => {
 
         // このテストの探索区間（約28km）は idealSteps が全域細分の上限を超えるため、
         // 実装側の one-shot 警告（narrow terrain may be missed）が発火する。想定内の警告
-        // でテストログを汚さないよう抑止する。
+        // でテストログを汚さないよう抑止する。expect失敗時もリークしないよう try/finally で
+        // 必ず restore する。
         const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            // 標高0面到達距離（tFar）を平地で1回解いて幾何を確定し、第1段の粗サンプル格子を再現する。
+            const flatHit = new Vector3();
+            const flatGeo = emptyGeo();
+            const gotFlat = resolveTerrainClickElevationToRef(
+                camOrigin, dir, A, B, () => 0, 5000, 5, 20, 300, 16, flatHit, flatGeo,
+            );
+            expect(gotFlat).toBe(true);
+            const tFar = flatHit.subtract(camOrigin).length(); // ≈ 28121m
+            expect(tFar).toBeGreaterThan(20000);
 
-        // 標高0面到達距離（tFar）を平地で1回解いて幾何を確定し、第1段の粗サンプル格子を再現する。
-        const flatHit = new Vector3();
-        const flatGeo = emptyGeo();
-        const gotFlat = resolveTerrainClickElevationToRef(
-            camOrigin, dir, A, B, () => 0, 5000, 5, 20, 300, 16, flatHit, flatGeo,
-        );
-        expect(gotFlat).toBe(true);
-        const tFar = flatHit.subtract(camOrigin).length(); // ≈ 28121m
-        expect(tFar).toBeGreaterThan(20000);
+            // 第1段の粗サンプル格子（steps=300 で頭打ち）を再現し、区間中央の格子間隙の緯度を求める。
+            const steps = 300; // ceil(28121/5)=5625 だが maxCoarseSteps=300 で頭打ち
+            const stepT = tFar / steps;
+            const iMid = Math.floor(steps / 2);
+            const unitDir = dir.clone();
+            const geodeticLatAt = (t: number): number =>
+                ecefToGeodetic(unitDir.scale(t).add(camOrigin)).latDeg;
+            const latSampleA = geodeticLatAt(stepT * iMid); // 尾根手前の粗サンプル
+            const latSampleB = geodeticLatAt(stepT * (iMid + 1)); // 尾根奥の粗サンプル
+            const gapLat = geodeticLatAt(stepT * iMid + stepT / 2); // 2サンプルの中間（格子間隙）
 
-        // 第1段の粗サンプル格子（steps=300 で頭打ち）を再現し、区間中央の格子間隙の緯度を求める。
-        const steps = 300; // ceil(28121/5)=5625 だが maxCoarseSteps=300 で頭打ち
-        const stepT = tFar / steps;
-        const iMid = Math.floor(steps / 2);
-        const unitDir = dir.clone();
-        const geodeticLatAt = (t: number): number =>
-            ecefToGeodetic(unitDir.scale(t).add(camOrigin)).latDeg;
-        const latSampleA = geodeticLatAt(stepT * iMid); // 尾根手前の粗サンプル
-        const latSampleB = geodeticLatAt(stepT * (iMid + 1)); // 尾根奥の粗サンプル
-        const gapLat = geodeticLatAt(stepT * iMid + stepT / 2); // 2サンプルの中間（格子間隙）
+            // 幅28m相当の尾根帯を格子間隙の緯度に中心を合わせて置く（両隣の粗サンプルは帯の外側）。
+            const halfBandDeg = 28 / (A * DEG2RAD) / 2;
+            expect(Math.abs(latSampleA - gapLat)).toBeGreaterThan(halfBandDeg); // 手前サンプルは帯外
+            expect(Math.abs(latSampleB - gapLat)).toBeGreaterThan(halfBandDeg); // 奥サンプルは帯外
+            const ridgeElevM = 300;
+            const terrainElevAt = (latDeg: number): number =>
+                latDeg > gapLat - halfBandDeg && latDeg < gapLat + halfBandDeg ? ridgeElevM : 0;
 
-        // 幅28m相当の尾根帯を格子間隙の緯度に中心を合わせて置く（両隣の粗サンプルは帯の外側）。
-        const halfBandDeg = 28 / (A * DEG2RAD) / 2;
-        expect(Math.abs(latSampleA - gapLat)).toBeGreaterThan(halfBandDeg); // 手前サンプルは帯外
-        expect(Math.abs(latSampleB - gapLat)).toBeGreaterThan(halfBandDeg); // 奥サンプルは帯外
-        const ridgeElevM = 300;
-        const terrainElevAt = (latDeg: number): number =>
-            latDeg > gapLat - halfBandDeg && latDeg < gapLat + halfBandDeg ? ridgeElevM : 0;
-
-        const outHit = new Vector3();
-        const geo = emptyGeo();
-        const hit = resolveTerrainClickElevationToRef(
-            camOrigin, dir, A, B, terrainElevAt, 5000, 5, 20, 300, 16, outHit, geo,
-        );
-        expect(hit).toBe(true);
-        // 尾根を貫通せず尾根近傍で止まること。標高は尾根相当（高さ300m付近まで持ち上がる）で、
-        // 平地(0m)ではない。着地距離は尾根位置（中央 ≈ tFar/2）付近で、遠方28km地点まで進んで
-        // いない（旧実装のバグ再現＝約28kmを明確に下回る）。
-        const hitDist = outHit.subtract(camOrigin).length();
-        expect(hitDist).toBeLessThan(tFar * 0.6); // 遠方海面(≈tFar)ではなく尾根手前〜尾根上
-        expect(geo.altMeters).toBeGreaterThan(100); // 平地(0m)ではなく尾根の標高に達している
-        expect(geo.altMeters).toBeLessThanOrEqual(ridgeElevM + 1);
-        warn.mockRestore();
+            const outHit = new Vector3();
+            const geo = emptyGeo();
+            const hit = resolveTerrainClickElevationToRef(
+                camOrigin, dir, A, B, terrainElevAt, 5000, 5, 20, 300, 16, outHit, geo,
+            );
+            expect(hit).toBe(true);
+            // 尾根を貫通せず尾根近傍で止まること。標高は尾根相当（高さ300m付近まで持ち上がる）で、
+            // 平地(0m)ではない。着地距離は尾根位置（中央 ≈ tFar/2）付近で、遠方28km地点まで進んで
+            // いない（旧実装のバグ再現＝約28kmを明確に下回る）。
+            const hitDist = outHit.subtract(camOrigin).length();
+            expect(hitDist).toBeLessThan(tFar * 0.6); // 遠方海面(≈tFar)ではなく尾根手前〜尾根上
+            expect(geo.altMeters).toBeGreaterThan(100); // 平地(0m)ではなく尾根の標高に達している
+            expect(geo.altMeters).toBeLessThanOrEqual(ridgeElevM + 1);
+        } finally {
+            warn.mockRestore();
+        }
     });
 
     it("奥端(tFar)近傍の地形標高が実際に0でない場合は最終サンプルの反転も見逃さない", () => {

--- a/tests/geoCameraMapping.unit.spec.ts
+++ b/tests/geoCameraMapping.unit.spec.ts
@@ -492,6 +492,48 @@ describe("resolveTerrainClickElevationToRef", () => {
         expect(geo.altMeters).toBeLessThanOrEqual(ridgeElevM + 1);
     });
 
+    it("奥端(tFar)近傍の地形標高が実際に0でない場合は最終サンプルの反転も見逃さない", () => {
+        // hasSeaLevelFar かつ最終サンプルの「反転」除外は、その地点の地形標高が実際に0（海面・
+        // 未ロードのフォールバック含む）の場合に限る必要がある。沿岸・低地等でtFar近傍の地形標高が
+        // 0でない場合、そこでの反転は本物の地表検出であり、除外すると地表を検出できず標高0交点
+        // （地表より低い位置）を誤って採用してしまう。
+        //
+        // maxCoarseSteps=200を固定し、idealSteps（後述）がこれを下回るようにして「頭打ちしていない
+        // 通常ケース」を作る（頭打ちしている場合は全域再細分が別途走り、この分岐の単体検証にならない）。
+        const dir = new Vector3(-1, 0, 0.3).normalize();
+        const flatHit = new Vector3();
+        const flatGeo = emptyGeo();
+        const gotFlat = resolveTerrainClickElevationToRef(
+            origin, dir, R, R, () => 0, 5000, 200, 200, 200, 16, flatHit, flatGeo,
+        );
+        expect(gotFlat).toBe(true);
+        const tFar = flatHit.subtract(origin).length();
+        const idealSteps = Math.ceil(tFar / 200);
+        expect(idealSteps).toBeLessThan(200); // 頭打ちしていないことの前提を確認
+
+        // 第1段最終区間 [t(steps-1), tFar] の中点より奥だけを標高10mにする。手前側の粗サンプル
+        // （i=steps-1 以前）は地形標高0のまま＝反転しない。最終サンプル（t=tFar）だけが
+        // heightAboveTerrain<=0になる状況を作る。
+        const steps = 200;
+        const stepT = tFar / steps;
+        const secondLastT = stepT * (steps - 1);
+        const geodeticLatAt = (t: number): number =>
+            ecefToGeodetic(dir.clone().scale(t).add(origin)).latDeg;
+        const midLat = (geodeticLatAt(secondLastT) + geodeticLatAt(tFar)) / 2;
+        const coastElevM = 10;
+        const terrainElevAt = (latDeg: number): number => (latDeg >= midLat ? coastElevM : 0);
+
+        const outHit = new Vector3();
+        const geo = emptyGeo();
+        const hit = resolveTerrainClickElevationToRef(
+            origin, dir, R, R, terrainElevAt, 5000, 200, 200, 200, 16, outHit, geo,
+        );
+        expect(hit).toBe(true);
+        // 標高0交点（地表より低い位置）ではなく、実際の地形標高付近で止まっていること。
+        expect(geo.altMeters).toBeGreaterThan(1);
+        expect(geo.altMeters).toBeLessThanOrEqual(coastElevM + 1);
+    });
+
     it("水平線よりわずかに上に高い山の頂上だけが見えるレイでも交点を検出する（貫通せずfalseも返さない）", () => {
         // カメラ高度50km。視線は「標高0楕円体の地平線角度」と「想定最大標高(5000m)楕円体の
         // 地平線角度」のちょうど中間を向く（Pythonで検算した角度）。この視線は標高0面には

--- a/tests/geoCameraMapping.unit.spec.ts
+++ b/tests/geoCameraMapping.unit.spec.ts
@@ -423,8 +423,8 @@ describe("resolveTerrainClickElevationToRef", () => {
         expect(geo.altMeters).toBeLessThan(100);
     });
 
-    it("近水平視線・長距離探索で第1段の粗格子間隙に隠れた狭い尾根を貫通しない（#443 実測条件）", () => {
-        // #443 実測再現: カメラ高度500m、下向き角0.02rad相当のほぼ水平視線。標高0面到達まで
+    it("近水平視線・長距離探索で第1段の粗格子間隙に隠れた狭い尾根を貫通しない（実測条件）", () => {
+        // 実測再現: カメラ高度500m、下向き角0.02rad相当のほぼ水平視線。標高0面到達まで
         // 約28km（探索区間が長大）。実運用定数（stepDistanceM=5, minCoarseSteps=20,
         // maxCoarseSteps=300）では第1段が300ステップで頭打ちし、実効ステップ幅が約93.6mまで
         // 劣化する。幅28m・高さ300mの尾根を探索区間中央付近の「隣り合う粗サンプルの間隙」に
@@ -439,7 +439,8 @@ describe("resolveTerrainClickElevationToRef", () => {
         // 正に残留し(このケースで緯度約-0.25°地点で約+0.4m)、粗探索の最終サンプルが
         // heightAboveTerrain<=0を満たさなくなる。これにより「反転なし→全域再細分」分岐に
         // 常に入ってしまい、「粗探索の最終サンプルがtFarそのものであるために反転扱いされる」
-        // という実運用WGS84での本来の不具合（#443の回帰条件そのもの）を再現できない。
+        // という実運用WGS84での本来の不具合（このテストが検証したい回帰条件そのもの）を
+        // 再現できない。
         const A = Wgs84Ellipsoid.semiMajorAxis;
         const B = Wgs84Ellipsoid.semiMinorAxis;
         const camAlt = 500;

--- a/tests/geoCameraMapping.unit.spec.ts
+++ b/tests/geoCameraMapping.unit.spec.ts
@@ -13,6 +13,7 @@ import { describe, it, expect } from "@jest/globals";
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 
 import { DEG2RAD, geodeticToEcef, ecefToGeodetic, type Geodetic } from "../src/terrain/geo/ecef";
+import { Wgs84Ellipsoid } from "@babylonjs/core/Maths/math.geospatial.functions";
 import {
     uiToYawPitch,
     yawPitchToUi,
@@ -432,8 +433,17 @@ describe("resolveTerrainClickElevationToRef", () => {
         // 約28km先の遠方点を採用していた（山を突き抜けた超遠方がカメラ回転中心になる不具合）。
         // 二段階探索では「第1段で反転せず奥端が標高0面」のケースで探索区間全体を細分し直し、
         // 隠れた尾根を捕捉して尾根手前で止まる。
+        //
+        // 楕円体はR,Rの球近似ではなく実運用どおりWGS84の実楕円体(a,b)を渡す。球近似だと、
+        // 標高0(平地)でも探索区間奥端(tFar)でのaltMetersがWGS84実楕円体との離心率差分だけ
+        // 正に残留し(このケースで緯度約-0.25°地点で約+0.4m)、粗探索の最終サンプルが
+        // heightAboveTerrain<=0を満たさなくなる。これにより「反転なし→全域再細分」分岐に
+        // 常に入ってしまい、「粗探索の最終サンプルがtFarそのものであるために反転扱いされる」
+        // という実運用WGS84での本来の不具合（PR#450レビュー指摘）を再現できない。
+        const A = Wgs84Ellipsoid.semiMajorAxis;
+        const B = Wgs84Ellipsoid.semiMinorAxis;
         const camAlt = 500;
-        const camOrigin = new Vector3(R + camAlt, 0, 0);
+        const camOrigin = new Vector3(A + camAlt, 0, 0);
         const downAngle = 0.02; // ローカル水平（+Z接線）からの下向き角[rad]
         const dir = new Vector3(-Math.sin(downAngle), 0, -Math.cos(downAngle)).normalize();
 
@@ -441,14 +451,14 @@ describe("resolveTerrainClickElevationToRef", () => {
         const flatHit = new Vector3();
         const flatGeo = emptyGeo();
         const gotFlat = resolveTerrainClickElevationToRef(
-            camOrigin, dir, R, R, () => 0, 5000, 5, 20, 300, 16, flatHit, flatGeo,
+            camOrigin, dir, A, B, () => 0, 5000, 5, 20, 300, 16, flatHit, flatGeo,
         );
         expect(gotFlat).toBe(true);
-        const tFar = flatHit.subtract(camOrigin).length(); // ≈ 28094m
+        const tFar = flatHit.subtract(camOrigin).length(); // ≈ 28121m
         expect(tFar).toBeGreaterThan(20000);
 
         // 第1段の粗サンプル格子（steps=300 で頭打ち）を再現し、区間中央の格子間隙の緯度を求める。
-        const steps = 300; // ceil(28094/5)=5619 だが maxCoarseSteps=300 で頭打ち
+        const steps = 300; // ceil(28121/5)=5625 だが maxCoarseSteps=300 で頭打ち
         const stepT = tFar / steps;
         const iMid = Math.floor(steps / 2);
         const unitDir = dir.clone();
@@ -459,7 +469,7 @@ describe("resolveTerrainClickElevationToRef", () => {
         const gapLat = geodeticLatAt(stepT * iMid + stepT / 2); // 2サンプルの中間（格子間隙）
 
         // 幅28m相当の尾根帯を格子間隙の緯度に中心を合わせて置く（両隣の粗サンプルは帯の外側）。
-        const halfBandDeg = 28 / (R * DEG2RAD) / 2;
+        const halfBandDeg = 28 / (A * DEG2RAD) / 2;
         expect(Math.abs(latSampleA - gapLat)).toBeGreaterThan(halfBandDeg); // 手前サンプルは帯外
         expect(Math.abs(latSampleB - gapLat)).toBeGreaterThan(halfBandDeg); // 奥サンプルは帯外
         const ridgeElevM = 300;
@@ -469,7 +479,7 @@ describe("resolveTerrainClickElevationToRef", () => {
         const outHit = new Vector3();
         const geo = emptyGeo();
         const hit = resolveTerrainClickElevationToRef(
-            camOrigin, dir, R, R, terrainElevAt, 5000, 5, 20, 300, 16, outHit, geo,
+            camOrigin, dir, A, B, terrainElevAt, 5000, 5, 20, 300, 16, outHit, geo,
         );
         expect(hit).toBe(true);
         // 尾根を貫通せず尾根近傍で止まること。標高は尾根相当（高さ300m付近まで持ち上がる）で、

--- a/tests/geoCameraMapping.unit.spec.ts
+++ b/tests/geoCameraMapping.unit.spec.ts
@@ -8,7 +8,7 @@
  * - clampRadiusForGroundClearance: 潜り込み補正・既クリアランス・水平視の発散回避
  */
 
-import { describe, it, expect } from "@jest/globals";
+import { describe, it, expect, jest } from "@jest/globals";
 
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { Wgs84Ellipsoid } from "@babylonjs/core/Maths/math.geospatial.functions";
@@ -448,6 +448,11 @@ describe("resolveTerrainClickElevationToRef", () => {
         const downAngle = 0.02; // ローカル水平（+Z接線）からの下向き角[rad]
         const dir = new Vector3(-Math.sin(downAngle), 0, -Math.cos(downAngle)).normalize();
 
+        // このテストの探索区間（約28km）は idealSteps が全域細分の上限を超えるため、
+        // 実装側の one-shot 警告（narrow terrain may be missed）が発火する。想定内の警告
+        // でテストログを汚さないよう抑止する。
+        const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+
         // 標高0面到達距離（tFar）を平地で1回解いて幾何を確定し、第1段の粗サンプル格子を再現する。
         const flatHit = new Vector3();
         const flatGeo = emptyGeo();
@@ -490,6 +495,7 @@ describe("resolveTerrainClickElevationToRef", () => {
         expect(hitDist).toBeLessThan(tFar * 0.6); // 遠方海面(≈tFar)ではなく尾根手前〜尾根上
         expect(geo.altMeters).toBeGreaterThan(100); // 平地(0m)ではなく尾根の標高に達している
         expect(geo.altMeters).toBeLessThanOrEqual(ridgeElevM + 1);
+        warn.mockRestore();
     });
 
     it("奥端(tFar)近傍の地形標高が実際に0でない場合は最終サンプルの反転も見逃さない", () => {

--- a/tests/geoCameraMapping.unit.spec.ts
+++ b/tests/geoCameraMapping.unit.spec.ts
@@ -439,7 +439,7 @@ describe("resolveTerrainClickElevationToRef", () => {
         // 正に残留し(このケースで緯度約-0.25°地点で約+0.4m)、粗探索の最終サンプルが
         // heightAboveTerrain<=0を満たさなくなる。これにより「反転なし→全域再細分」分岐に
         // 常に入ってしまい、「粗探索の最終サンプルがtFarそのものであるために反転扱いされる」
-        // という実運用WGS84での本来の不具合（PR#450レビュー指摘）を再現できない。
+        // という実運用WGS84での本来の不具合（#443の回帰条件そのもの）を再現できない。
         const A = Wgs84Ellipsoid.semiMajorAxis;
         const B = Wgs84Ellipsoid.semiMinorAxis;
         const camAlt = 500;

--- a/tests/geoCameraMapping.unit.spec.ts
+++ b/tests/geoCameraMapping.unit.spec.ts
@@ -11,9 +11,9 @@
 import { describe, it, expect } from "@jest/globals";
 
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { Wgs84Ellipsoid } from "@babylonjs/core/Maths/math.geospatial.functions";
 
 import { DEG2RAD, geodeticToEcef, ecefToGeodetic, type Geodetic } from "../src/terrain/geo/ecef";
-import { Wgs84Ellipsoid } from "@babylonjs/core/Maths/math.geospatial.functions";
 import {
     uiToYawPitch,
     yawPitchToUi,

--- a/tests/geoCameraMapping.unit.spec.ts
+++ b/tests/geoCameraMapping.unit.spec.ts
@@ -12,7 +12,7 @@ import { describe, it, expect } from "@jest/globals";
 
 import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 
-import { DEG2RAD, geodeticToEcef, type Geodetic } from "../src/terrain/geo/ecef";
+import { DEG2RAD, geodeticToEcef, ecefToGeodetic, type Geodetic } from "../src/terrain/geo/ecef";
 import {
     uiToYawPitch,
     yawPitchToUi,
@@ -403,7 +403,12 @@ describe("resolveTerrainClickElevationToRef", () => {
     });
 
     it("ステップ数を1に固定する（動的分割を無効化）と、幅の狭い尾根を見逃して貫通する", () => {
-        // 上と同じ狭い尾根だが、min=max=1 でステップ数を1に固定した比較用ケース。
+        // 上と同じ狭い尾根だが、min=max=1 かつ stepDistanceM=1,000,000m でステップ数を1に固定
+        // した比較用ケース。二段階探索では第2段の細分数も stepDistanceM に依存するため、
+        // stepDistanceM を探索区間より桁違いに大きくすると第2段（遠方海面ケースの全域細分を
+        // 含む）でも subSteps=ceil(区間/1,000,000)=1 に潰れ、尾根を跨いだまま見逃す。粗い設定
+        // では検出できないという回帰デモの意図を維持する（本来は stepDistanceM を地形解像度に
+        // 合わせて細かく渡すことで検出する）。
         const dir = new Vector3(-1, 0, 0.3).normalize();
         const terrainElevAt = (latDeg: number): number =>
             latDeg >= 0.02 && latDeg < 0.021 ? 3000 : 0;
@@ -415,6 +420,65 @@ describe("resolveTerrainClickElevationToRef", () => {
         expect(hit).toBe(true);
         // 尾根を検出できず、平地（標高0付近）に着地してしまう。
         expect(geo.altMeters).toBeLessThan(100);
+    });
+
+    it("近水平視線・長距離探索で第1段の粗格子間隙に隠れた狭い尾根を貫通しない（#443 実測条件）", () => {
+        // #443 実測再現: カメラ高度500m、下向き角0.02rad相当のほぼ水平視線。標高0面到達まで
+        // 約28km（探索区間が長大）。実運用定数（stepDistanceM=5, minCoarseSteps=20,
+        // maxCoarseSteps=300）では第1段が300ステップで頭打ちし、実効ステップ幅が約93.6mまで
+        // 劣化する。幅28m・高さ300mの尾根を探索区間中央付近の「隣り合う粗サンプルの間隙」に
+        // 置くと、粗探索はどの粗サンプルの緯度も尾根帯に入らず反転を検出できない。旧実装（単段
+        // 粗探索）では反転が一度も起きないまま奥端まで走破し、標高0面（海面）フォールバックで
+        // 約28km先の遠方点を採用していた（山を突き抜けた超遠方がカメラ回転中心になる不具合）。
+        // 二段階探索では「第1段で反転せず奥端が標高0面」のケースで探索区間全体を細分し直し、
+        // 隠れた尾根を捕捉して尾根手前で止まる。
+        const camAlt = 500;
+        const camOrigin = new Vector3(R + camAlt, 0, 0);
+        const downAngle = 0.02; // ローカル水平（+Z接線）からの下向き角[rad]
+        const dir = new Vector3(-Math.sin(downAngle), 0, -Math.cos(downAngle)).normalize();
+
+        // 標高0面到達距離（tFar）を平地で1回解いて幾何を確定し、第1段の粗サンプル格子を再現する。
+        const flatHit = new Vector3();
+        const flatGeo = emptyGeo();
+        const gotFlat = resolveTerrainClickElevationToRef(
+            camOrigin, dir, R, R, () => 0, 5000, 5, 20, 300, 16, flatHit, flatGeo,
+        );
+        expect(gotFlat).toBe(true);
+        const tFar = flatHit.subtract(camOrigin).length(); // ≈ 28094m
+        expect(tFar).toBeGreaterThan(20000);
+
+        // 第1段の粗サンプル格子（steps=300 で頭打ち）を再現し、区間中央の格子間隙の緯度を求める。
+        const steps = 300; // ceil(28094/5)=5619 だが maxCoarseSteps=300 で頭打ち
+        const stepT = tFar / steps;
+        const iMid = Math.floor(steps / 2);
+        const unitDir = dir.clone();
+        const geodeticLatAt = (t: number): number =>
+            ecefToGeodetic(unitDir.scale(t).add(camOrigin)).latDeg;
+        const latSampleA = geodeticLatAt(stepT * iMid); // 尾根手前の粗サンプル
+        const latSampleB = geodeticLatAt(stepT * (iMid + 1)); // 尾根奥の粗サンプル
+        const gapLat = geodeticLatAt(stepT * iMid + stepT / 2); // 2サンプルの中間（格子間隙）
+
+        // 幅28m相当の尾根帯を格子間隙の緯度に中心を合わせて置く（両隣の粗サンプルは帯の外側）。
+        const halfBandDeg = 28 / (R * DEG2RAD) / 2;
+        expect(Math.abs(latSampleA - gapLat)).toBeGreaterThan(halfBandDeg); // 手前サンプルは帯外
+        expect(Math.abs(latSampleB - gapLat)).toBeGreaterThan(halfBandDeg); // 奥サンプルは帯外
+        const ridgeElevM = 300;
+        const terrainElevAt = (latDeg: number): number =>
+            latDeg > gapLat - halfBandDeg && latDeg < gapLat + halfBandDeg ? ridgeElevM : 0;
+
+        const outHit = new Vector3();
+        const geo = emptyGeo();
+        const hit = resolveTerrainClickElevationToRef(
+            camOrigin, dir, R, R, terrainElevAt, 5000, 5, 20, 300, 16, outHit, geo,
+        );
+        expect(hit).toBe(true);
+        // 尾根を貫通せず尾根近傍で止まること。標高は尾根相当（高さ300m付近まで持ち上がる）で、
+        // 平地(0m)ではない。着地距離は尾根位置（中央 ≈ tFar/2）付近で、遠方28km地点まで進んで
+        // いない（旧実装のバグ再現＝約28kmを明確に下回る）。
+        const hitDist = outHit.subtract(camOrigin).length();
+        expect(hitDist).toBeLessThan(tFar * 0.6); // 遠方海面(≈tFar)ではなく尾根手前〜尾根上
+        expect(geo.altMeters).toBeGreaterThan(100); // 平地(0m)ではなく尾根の標高に達している
+        expect(geo.altMeters).toBeLessThanOrEqual(ridgeElevM + 1);
     });
 
     it("水平線よりわずかに上に高い山の頂上だけが見えるレイでも交点を検出する（貫通せずfalseも返さない）", () => {


### PR DESCRIPTION
## 概要
`resolveTerrainClickElevationToRef`（地形クリックピック・ズーム・パン/チルト回転中心再計算で共通利用）が、近水平視線かつ長距離探索時に狭い尾根を貫通して奥の遠方地表に誤着地する不具合を修正する。

## 原因
粗探索のステップ数は `clamp(探索区間長/stepDistanceM, minCoarseSteps, maxCoarseSteps)` で決まる。近水平視線では探索区間が数十km（実測28km）に伸び、`maxCoarseSteps=300` で頭打ちになるため実効ステップ幅が設計値5mから約94mまで劣化する。幅の狭い尾根（実測: 幅28m・高さ300m）が粗サンプル格子の間隙に収まると、レイ高度の反転が一度も検出されないまま奥端の標高0面（海面）まで到達し、その遠方点を地表交点として採用してしまう（#443本文のとおり、パン・チルトでカメラ回転中心が超遠方へ暴走する）。

## 修正内容
二段階粗探索を導入。
1. 第1段（当たり付け）: 従来どおり `maxCoarseSteps` を上限に粗く走査し、反転区間を検出。
2. 第2段（局所細分）: 反転を検出した手前区間、または「反転なし・奥端が標高0面」の場合は探索区間全体を、`stepDistanceM` 相当の細かさで再サンプリングし、隠れた尾根を捕捉する。

関数シグネチャ・呼び出し元（`src/scenes/globe.ts`）・既存定数は変更なし。通常フレーム（近距離・下向き視線で第1段が早期に反転検出）はコスト増なし。近水平・長距離フレームのみ追加コストが発生するが、最悪ケースでも呼び出し回数は数百〜2000回程度に収まる（ズーム毎フレーム呼び出しでも許容範囲）。

## 影響範囲
- `src/terrain/geo/cameraMapping.ts`: `resolveTerrainClickElevationToRef` 本体・JSDoc
- `tests/geoCameraMapping.unit.spec.ts`: #443実測条件の回帰テスト追加、既存「min=max=1で見逃す」デモテストのコメント更新（アルゴリズム変更に伴う正当な期待値維持の説明）
- 呼び出し元（地形クリックピック・ズームcenter再スナップ・パン/チルト回転中心再計算）の3箇所とも挙動改善のみで破壊的変更なし

## テスト
- `npm run test:unit`: 1309件 PASS
- `npm run lint` / `npm run typecheck`: PASS
- `npm run test:visuals`: PASS（既存ビジュアル回帰に影響なし）
- 実機目視確認: 山岳地帯（富士山付近）で近水平チルト・パン操作を実施し、カメラ回転中心が超遠方へ暴走しないことを確認済み

Closes #443