### PR TITLE
fix(terrain): グローブ極限視点のタイル被覆3件を修正（#465）

### DIFF
--- a/src/terrain/geo/globeLod.ts
+++ b/src/terrain/geo/globeLod.ts
@@ -412,7 +412,10 @@ export const selectGlobeRootTiles = (opts: GlobeRootSeedOptions): RootSeed[] => 
         // 可視域全体を被覆する。低〜中高度（未満）は従来どおり詳細＋品質下限を維持する。
         const highAlt = h >= HIGH_ALT_ZOOM_CAP_M;
         const texFloor = highAlt ? 0 : (textureQualityFloorZoom ?? 0);
-        const zCap = highAlt ? HIGH_ALT_MAX_ZOOM : minZoom;
+        // 上限は常に minZoom 以下に収める。minZoom < HIGH_ALT_MAX_ZOOM（URL/デモで minZoom を
+        // 小さく設定）でも seed zoom が minZoom を超えないようにする（超えると addAt の
+        // f=2**(minZoom-zoom) が負指数=f<1 になり不正なタイル座標変換になる, Copilotレビュー指摘）。
+        const zCap = highAlt ? Math.min(minZoom, HIGH_ALT_MAX_ZOOM) : minZoom;
         // 高高度では下限を 0 にして zStar/distCapZoom の距離累進（対数的粗化）を活かす。
         // floorZoom（rootZoomFloor 省略時は minZoom）を下限に残すと、それが zCap を上回るケース
         // （rootZoomFloor 未指定など）で下の Math.max が張り付き z=zCap(8) に平坦化して 8 未満へ

--- a/src/terrain/geo/globeLod.ts
+++ b/src/terrain/geo/globeLod.ts
@@ -413,11 +413,12 @@ export const selectGlobeRootTiles = (opts: GlobeRootSeedOptions): RootSeed[] => 
         const highAlt = h >= HIGH_ALT_ZOOM_CAP_M;
         const texFloor = highAlt ? 0 : (textureQualityFloorZoom ?? 0);
         const zCap = highAlt ? HIGH_ALT_MAX_ZOOM : minZoom;
-        // floorZoom（rootZoomFloor 省略時は minZoom）が zCap を上回ると、下の Math.max が
-        // floorZoom で張り付き zStar/distCapZoom の距離累進が効かず z=zCap に平坦化する。
-        // 高高度では floorZoom も zCap まで下げ、対数的粗化を活かす（rootZoomFloor 指定有無で
-        // 挙動が変わらないようにする。本番は rootZoomFloor=2 のため元から効くが、公開 API 一貫性）。
-        const effFloorZoom = highAlt ? Math.min(floorZoom, zCap) : floorZoom;
+        // 高高度では下限を 0 にして zStar/distCapZoom の距離累進（対数的粗化）を活かす。
+        // floorZoom（rootZoomFloor 省略時は minZoom）を下限に残すと、それが zCap を上回るケース
+        // （rootZoomFloor 未指定など）で下の Math.max が張り付き z=zCap(8) に平坦化して 8 未満へ
+        // 粗化できず、rootZoomFloor 指定有無で挙動が変わってしまう。粗化の暴発は distCapZoom
+        // （タイル 1 辺 ≤ カメラ距離）が抑えるため 0 で安全（Copilotレビュー指摘）。
+        const effFloorZoom = highAlt ? 0 : floorZoom;
         return Math.min(
             zCap,
             Math.max(effFloorZoom, texFloor, Math.ceil(zStar), distCapZoom),

--- a/src/terrain/geo/globeLod.ts
+++ b/src/terrain/geo/globeLod.ts
@@ -178,6 +178,15 @@ export interface GlobeRootSeedOptions {
      * には適用しない。省略時は既存の `rootZoomFloor`/SSE のみで判定する（後方互換）。
      */
     textureQualityFloorZoom?: number;
+    /**
+     * 注視点(center)の地表標高[m]。前方到達距離を決める tilt を「camera→center 地表点」の
+     * 実ベクトルから求める際に使う。省略時 0（海面）だが、高標高地（富士山頂等）を注視点にすると
+     * seat-on-terrain でカメラが山頂相当高度へ持ち上がり、center を海面(0m)扱いすると camera→center
+     * が実際より急な下向きと誤算出され、tilt 過小→前方到達距離が極端に短縮→遠方（例: 50km 先）が
+     * 未種付けになる。center を実標高で評価すると正しい tilt になり遠方まで帯が伸びる（#465 続き）。
+     * 負値（海面下）と NaN/Infinity は 0（海面）へ丸める。
+     */
+    referenceAltitude?: number;
 }
 
 /** カメラ↔地表点の弦距離の概算に使う WGS84 平均半径 [m]。 */
@@ -200,6 +209,20 @@ const FORWARD_REACH_MARGIN = 1.25;
  * 約 1.0rad（≒57°, 高度 ≳1,000km）。これ未満（低〜中高度）は従来の帯で効率を維持する。
  */
 const GLOBAL_VIEW_EARTH_ANG_RADIUS = 1.0;
+
+/**
+ * この高度[m]以上では root zoom のテクスチャ品質下限（textureQualityFloorZoom）を外し、
+ * zoom を HIGH_ALT_MAX_ZOOM に頭打ちにする。高度が上がるほど可視域が広く（地図の文字も読めなく）
+ * なるため、詳細タイル（z9〜）を張るとタイル数が maxTiles を食い潰し可視域の外周が欠ける
+ * （高高度で「半分しか出ない」）。距離累進（zStar/distCapZoom）の対数的粗化に委ね、上限で
+ * 抑えることで少数の粗タイルで広域を被覆する。しきい値は「200km 以上は z8 以下で十分」という
+ * 実地の目視基準に合わせる。全球モード（GLOBAL_VIEW_EARTH_ANG_RADIUS, ≒1,200km 以上）は
+ * 別途 floorZoom で全球種付けするため、本キャップは 200km〜全球境界の帯モードに効く。
+ */
+const HIGH_ALT_ZOOM_CAP_M = 190_000;
+
+/** 高高度（HIGH_ALT_ZOOM_CAP_M 以上）での root zoom 上限。 */
+const HIGH_ALT_MAX_ZOOM = 8;
 
 /**
  * SSE しきい値の距離累進係数。実効しきい値を
@@ -249,6 +272,7 @@ export const selectGlobeRootTiles = (opts: GlobeRootSeedOptions): RootSeed[] => 
         verticalFov,
         sseThreshold,
         textureQualityFloorZoom,
+        referenceAltitude,
     } = opts;
     const margin = Math.max(0, rootSearchRadius);
     const budget = Math.max(1, maxRootTiles);
@@ -380,14 +404,23 @@ export const selectGlobeRootTiles = (opts: GlobeRootSeedOptions): RootSeed[] => 
             (edge0 * viewportHeight) / (eff * Math.max(1, d) * denom),
         );
         const distCapZoom = Math.ceil(Math.log2(edge0 / Math.max(1, d)));
+        // 高高度（HIGH_ALT_ZOOM_CAP_M 以上）では、テクスチャ品質下限
+        // （textureQualityFloorZoom）を外し、zoom 上限を HIGH_ALT_MAX_ZOOM に抑える。
+        // 高度が上がると可視域が広がり地図の文字も読めなくなるため、詳細（z9〜）を張ると
+        // タイル数が maxTiles を食い潰して可視域の外周が欠ける（半分しか出ない）。下限を外して
+        // zStar/distCapZoom の距離累進（対数的）に委ね、上限で頭打ちにすることで、少数の粗タイルで
+        // 可視域全体を被覆する。低〜中高度（未満）は従来どおり詳細＋品質下限を維持する。
+        const highAlt = h >= HIGH_ALT_ZOOM_CAP_M;
+        const texFloor = highAlt ? 0 : (textureQualityFloorZoom ?? 0);
+        const zCap = highAlt ? HIGH_ALT_MAX_ZOOM : minZoom;
+        // floorZoom（rootZoomFloor 省略時は minZoom）が zCap を上回ると、下の Math.max が
+        // floorZoom で張り付き zStar/distCapZoom の距離累進が効かず z=zCap に平坦化する。
+        // 高高度では floorZoom も zCap まで下げ、対数的粗化を活かす（rootZoomFloor 指定有無で
+        // 挙動が変わらないようにする。本番は rootZoomFloor=2 のため元から効くが、公開 API 一貫性）。
+        const effFloorZoom = highAlt ? Math.min(floorZoom, zCap) : floorZoom;
         return Math.min(
-            minZoom,
-            Math.max(
-                floorZoom,
-                textureQualityFloorZoom ?? 0,
-                Math.ceil(zStar),
-                distCapZoom,
-            ),
+            zCap,
+            Math.max(effFloorZoom, texFloor, Math.ceil(zStar), distCapZoom),
         );
     };
 
@@ -420,7 +453,17 @@ export const selectGlobeRootTiles = (opts: GlobeRootSeedOptions): RootSeed[] => 
     // nadir↔center の地表距離とチルトは、整数タイル座標（dirLen）由来だと丸め誤差で dFar が
     // 不正確になり特定高度で奥が欠けるため、実カメラ幾何（ベクトル）から正確に求める。
     // dirLenMeters = R·中心角(nadir↔center)。tilt = 視線(camera→center) と直下(−camera) のなす角。
-    const centerEcef = geodeticToEcefToRef(centerLat, centerLon, 0, new Vector3());
+    // 注視点の地表標高で center を評価する（tilt/前方到達距離の正確化）。負値（海面下）と
+    // NaN/Infinity は 0（海面）へ丸め、下流の cosPsi/acos への異常値伝播を防ぐ。
+    const centerAlt = Number.isFinite(referenceAltitude)
+        ? Math.max(0, referenceAltitude as number)
+        : 0;
+    const centerEcef = geodeticToEcefToRef(
+        centerLat,
+        centerLon,
+        centerAlt,
+        new Vector3(),
+    );
     const camLen = Math.max(1, cameraEcef.length());
     const cosPsi = Math.min(
         1,
@@ -609,6 +652,10 @@ export const selectGlobeTiles = (opts: GlobeLodOptions): GlobeTile[] => {
     // 揃える。地心距離−平均半径の近似だと緯度により数 km ズレ、root と traverse で実効 SSE しきい値が
     // 食い違って余計な分割・訪問が起き得るため（選択ごとに 1 回のみの呼び出しでコストは無視できる）。
     const camAlt = Math.max(1, ecefToGeodetic(cameraEcef).altMeters);
+    // 高高度では traverse の細分化上限も HIGH_ALT_MAX_ZOOM に抑える（root だけでなく quadtree 分割も
+    // 頭打ちにしないと、近 nadir で root(z8) が z9 へ再分割されて「200km 以上は z8 以下」を満たさない）。
+    const effectiveMaxZoom =
+        camAlt >= HIGH_ALT_ZOOM_CAP_M ? Math.min(maxZoom, HIGH_ALT_MAX_ZOOM) : maxZoom;
     // 可視地平線の中心角（acos(R/r), r=カメラ地心距離）。地平線カリングの「タイルサイズ考慮」救済に
     // 使う（高高度の全球被覆で粗タイルの可視縁を取りこぼさないため）。
     const capAngle = Math.acos(
@@ -722,10 +769,10 @@ export const selectGlobeTiles = (opts: GlobeLodOptions): GlobeTile[] => {
         // 交差判定は z>=WORLD_TEXTURE_MAX_ZOOM のノードに限定してコストを抑える。
         const effMaxZoom =
             zoom >= WORLD_TEXTURE_MAX_ZOOM &&
-            maxZoom > WORLD_TEXTURE_MAX_ZOOM &&
+            effectiveMaxZoom > WORLD_TEXTURE_MAX_ZOOM &&
             !tileIntersectsJapan(zoom, x, y)
                 ? WORLD_TEXTURE_MAX_ZOOM
-                : maxZoom;
+                : effectiveMaxZoom;
         const accept =
             zoom >= effMaxZoom ||
             ((tileSizeMeters * viewportHeight) /
@@ -762,6 +809,7 @@ export const selectGlobeTiles = (opts: GlobeLodOptions): GlobeTile[] => {
         verticalFov,
         sseThreshold,
         textureQualityFloorZoom,
+        referenceAltitude,
     });
     // root シードを traverse 開始点とする。日本被覆域外の root が minZoom(>WORLD_TEXTURE_MAX_ZOOM)
     // で生成されると、それ以上分割しなくても root タイル自体のテクスチャが存在せず(404)白く欠ける。
@@ -790,16 +838,20 @@ export const selectGlobeTiles = (opts: GlobeLodOptions): GlobeTile[] => {
     // 受容されるため中間ノードのカリング問題は生じない）。
     for (const key of pinnedRootKeys) {
         const [pz, px, py] = key.split("/").map(Number);
-        if (
+        // pinned は minZoom(z11) 固定で開始するが、開始ノードは effMaxZoom で即受容されるため、
+        // 高高度キャップ（effectiveMaxZoom）や域外 WORLD_TEXTURE_MAX_ZOOM 丸めを開始 zoom にも
+        // 適用しないと、キャップ下でも center の z11 タイル 1 枚が残ってしまう（#465 フォロー）。
+        const outOfJapan =
             pz > WORLD_TEXTURE_MAX_ZOOM &&
             maxZoom > WORLD_TEXTURE_MAX_ZOOM &&
-            !tileIntersectsJapan(pz, px, py)
-        ) {
-            const dz = pz - WORLD_TEXTURE_MAX_ZOOM;
-            traverse(WORLD_TEXTURE_MAX_ZOOM, px >> dz, py >> dz, true);
-        } else {
-            traverse(pz, px, py, true);
-        }
+            !tileIntersectsJapan(pz, px, py);
+        const startZoom = Math.min(
+            pz,
+            effectiveMaxZoom,
+            outOfJapan ? WORLD_TEXTURE_MAX_ZOOM : pz,
+        );
+        const dz = pz - startZoom;
+        traverse(startZoom, px >> dz, py >> dz, true);
     }
 
     // 正しい quadtree カットへ整える: 距離適応で root の zoom が位置ごとに変わるため、

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -91,6 +91,17 @@ const BASE_LAYER_OCEAN = new Color3(0.16, 0.26, 0.36);
 const BASE_LAYER_TEXTURE_TINT = new Color3(1, 1, 1);
 
 /**
+ * ベースレイヤに低ズーム世界地図テクスチャ（GSI std/photo の z2, 緑主体の世界地図スタイル）を
+ * 適用する最小カメラ高度[m]。これ未満（低〜中高度）は海色（BASE_LAYER_OCEAN）のままにする。
+ * 低高度・高チルトで地平線際を見ると、grazing で LOD メッシュが投影されない画素に常時表示の
+ * base が透け、緑の世界地図が日本詳細地図（白＋等高線）と混在して破綻する（#465）。base の
+ * 役割は「背景球（濃紺）の露出防止」の充填であり、低ズーム世界地図の絵を見せることは低〜中高度
+ * では不要（可視域は LOD が覆う）。高高度（全球表示）でのみ地図を適用する。しきい値は globeLod の
+ * 全球モード境界（`GLOBAL_VIEW_EARTH_ANG_RADIUS`≒高度 1,200km）に揃える。
+ */
+const BASE_MAP_MIN_ALT_M = 1_200_000;
+
+/**
  * 標高が視覚的に意味を持つとみなす、固定 minZoom 判定の代替として使うカメラ距離上限 [m]。
  * `globeLod` の SSE 距離累進（`SSE_FALLOFF_RATE`）により、低高度から遠方（例: 東京駅〜富士山
  * 間 ≈100km）を注視すると root zoom が minZoom を下回ることがあるが、この距離帯は実 DEM が
@@ -270,6 +281,15 @@ export const createGlobeTileManager = (
     // 常時表示の粗いベースレイヤのメッシュ（key="z/x/y"）。LOD の loaded とは別管理で
     // sync の選択/解放対象に含めず、マネージャ生存中ずっと保持する（新規回転インタイルの背景）。
     const baseLoaded = new Map<string, Mesh>();
+    // #465: base タイルのロード済みテクスチャ（key="z/x/y"）。高度に応じて地図適用/海色を
+    // 切り替えるため保持する。適用は wantBaseMap()（カメラ高度依存）で判定する。
+    const baseTex = new Map<string, Texture>();
+    // 直近カメラ高度[m]。初回 sync 前は Infinity（＝高高度扱いで従来どおり base 地図を適用）。
+    let lastCamAltMeters = Number.POSITIVE_INFINITY;
+    // 現在 base に地図テクスチャを適用中か（トグル差分検出用）。
+    let baseMapApplied = true;
+    /** カメラ高度に基づき base へ地図テクスチャを適用すべきか（未満は海色充填）。 */
+    const wantBaseMap = (): boolean => lastCamAltMeters >= BASE_MAP_MIN_ALT_M;
     // 各ロード済みタイルがどのクロスレベル coarse-edge 集合で建築されたかの署名。
     // LOD 再評価で隣接関係（同 zoom 隣接 ⇄ 粗タイル隣接）が変わると署名が変化し、
     // ジオメトリを再構築してスナップを更新する（境界の陰影シームを残さないため）。
@@ -1231,6 +1251,13 @@ export const createGlobeTileManager = (
         syncedAtLeastOnce = true;
         // 暫定代表標高の最終フォールバックとして referenceAltitude（カメラ中心地表標高）を保持。
         if (Number.isFinite(params.referenceAltitude)) lastReferenceAltitude = params.referenceAltitude;
+        // #465: カメラ高度で base の見た目（地図テクスチャ/海色）を切り替える。低〜中高度では
+        // 海色にして地平線際の緑（低ズーム世界地図）露出を防ぐ。境界をまたいだときのみ再適用する。
+        lastCamAltMeters = ecefToGeodetic(params.cameraEcef).altMeters;
+        if (wantBaseMap() !== baseMapApplied) {
+            baseMapApplied = wantBaseMap();
+            applyBaseAppearance();
+        }
         // root 探索はカメラの現在の注視点(center)を追従する（パン後もカメラ直下を選択）。
         const camGeo = ecefToGeodetic(params.centerEcef);
         const tiles = selectGlobeTiles({
@@ -1450,10 +1477,15 @@ export const createGlobeTileManager = (
                             tex.dispose();
                             return;
                         }
-                        mat.diffuseTexture = tex;
-                        // 暫定の海色ティントを解除（白に戻す）。さもないと diffuseTexture が乗算で
-                        // 暗く青くティントされ、地図画像が意図どおり発色しない。
-                        mat.diffuseColor = BASE_LAYER_TEXTURE_TINT;
+                        // #465: テクスチャは保持しつつ、適用は高度依存。低〜中高度では海色のまま
+                        // にして地平線際の緑（世界地図）露出を防ぐ。高高度でのみ地図を貼る。
+                        baseTex.set(k, tex);
+                        if (wantBaseMap()) {
+                            mat.diffuseTexture = tex;
+                            // 暫定の海色ティントを解除（白に戻す）。さもないと diffuseTexture が乗算で
+                            // 暗く青くティントされ、地図画像が意図どおり発色しない。
+                            mat.diffuseColor = BASE_LAYER_TEXTURE_TINT;
+                        }
                     },
                     // onError: 取得失敗時は Texture を破棄し、海色のまま背景として残す。
                     () => tex.dispose(),
@@ -1466,12 +1498,37 @@ export const createGlobeTileManager = (
         }
     };
 
+    /**
+     * #465: カメラ高度に応じて base レイヤの見た目を切り替える。高高度（全球表示）では
+     * 保持済みの地図テクスチャを適用し、低〜中高度では海色（BASE_LAYER_OCEAN）に戻す
+     * （地平線際で LOD が投影されない画素に緑の世界地図が透けるのを防ぐ）。
+     */
+    const applyBaseAppearance = (): void => {
+        const showMap = wantBaseMap();
+        for (const [k, mesh] of baseLoaded) {
+            const mat = mesh.material as StandardMaterial | null;
+            if (!mat) continue;
+            const tex = baseTex.get(k);
+            if (showMap && tex) {
+                mat.diffuseTexture = tex;
+                mat.diffuseColor = BASE_LAYER_TEXTURE_TINT;
+            } else {
+                mat.diffuseTexture = null;
+                mat.diffuseColor = BASE_LAYER_OCEAN;
+            }
+        }
+    };
+
     const dispose = (): void => {
         for (const mesh of loaded.values()) mesh.dispose(false, true);
         loaded.clear();
         // 常時表示ベースレイヤもテクスチャごと破棄する。
         for (const mesh of baseLoaded.values()) mesh.dispose(false, true);
         baseLoaded.clear();
+        // #465: 低〜中高度では base テクスチャは material に未アタッチ（diffuseTexture=null）で
+        // baseTex にのみ保持されるため、mesh.dispose では解放されない。明示的に破棄する。
+        for (const tex of baseTex.values()) tex.dispose();
+        baseTex.clear();
         // LOD 遷移中に残した pending タイルのタイマー解除＋メッシュ破棄。
         for (const pending of pendingRelease.values()) {
             clearTimeout(pending.timerId);
@@ -1539,9 +1596,23 @@ export const createGlobeTileManager = (
                     tex.dispose();
                     return;
                 }
+                if (isBase) {
+                    // #465: base はテクスチャを保持しつつ適用は高度依存。旧 base テクスチャを
+                    // 差し替え、高高度でのみ地図を貼る（低〜中高度は海色のまま）。
+                    const prev = baseTex.get(k);
+                    if (prev && prev !== tex) prev.dispose();
+                    baseTex.set(k, tex);
+                    if (wantBaseMap()) {
+                        mat.diffuseTexture = tex;
+                        mat.diffuseColor = BASE_LAYER_TEXTURE_TINT;
+                    } else {
+                        mat.diffuseTexture = null;
+                        mat.diffuseColor = BASE_LAYER_OCEAN;
+                    }
+                    return;
+                }
                 mat.diffuseTexture = tex;
-                if (isBase) mat.diffuseColor = BASE_LAYER_TEXTURE_TINT;
-                else markReady();
+                markReady();
                 // 新テクスチャ適用後に旧テクスチャを破棄（GPU リソースリーク防止）。
                 oldTex?.dispose();
             },

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -1606,10 +1606,11 @@ export const createGlobeTileManager = (
                     return;
                 }
                 if (isBase) {
-                    // #465: base はテクスチャを保持しつつ適用は高度依存。旧 base テクスチャを
-                    // 差し替え、高高度でのみ地図を貼る（低〜中高度は海色のまま）。
+                    // #465: base はテクスチャを保持しつつ適用は高度依存。高高度でのみ地図を貼る
+                    // （低〜中高度は海色のまま）。旧 base テクスチャの dispose は、新テクスチャ/null を
+                    // material へ適用した後に行う（表示中の旧テクスチャを外す前に破棄すると、一瞬
+                    // material が dispose 済み Texture を参照するのを避ける, Copilotレビュー指摘）。
                     const prev = baseTex.get(k);
-                    if (prev && prev !== tex) prev.dispose();
                     baseTex.set(k, tex);
                     if (wantBaseMap()) {
                         mat.diffuseTexture = tex;
@@ -1618,6 +1619,7 @@ export const createGlobeTileManager = (
                         mat.diffuseTexture = null;
                         mat.diffuseColor = BASE_LAYER_OCEAN;
                     }
+                    if (prev && prev !== tex) prev.dispose();
                     return;
                 }
                 mat.diffuseTexture = tex;

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -1522,12 +1522,21 @@ export const createGlobeTileManager = (
     const dispose = (): void => {
         for (const mesh of loaded.values()) mesh.dispose(false, true);
         loaded.clear();
-        // 常時表示ベースレイヤもテクスチャごと破棄する。
-        for (const mesh of baseLoaded.values()) mesh.dispose(false, true);
+        // 常時表示ベースレイヤもテクスチャごと破棄する。high-alt でアタッチ中の base テクスチャは
+        // mesh.dispose(false, true) が破棄するため、二重 dispose を避けるべく破棄対象を控える。
+        const disposedBaseTex = new Set<unknown>();
+        for (const mesh of baseLoaded.values()) {
+            const mat = mesh.material as StandardMaterial | null;
+            if (mat?.diffuseTexture) disposedBaseTex.add(mat.diffuseTexture);
+            mesh.dispose(false, true);
+        }
         baseLoaded.clear();
         // #465: 低〜中高度では base テクスチャは material に未アタッチ（diffuseTexture=null）で
-        // baseTex にのみ保持されるため、mesh.dispose では解放されない。明示的に破棄する。
-        for (const tex of baseTex.values()) tex.dispose();
+        // baseTex にのみ保持され mesh.dispose では解放されないため、ここで破棄する。ただし上で
+        // 既に破棄済み（アタッチ中だった）テクスチャは二重 dispose しない。
+        for (const tex of baseTex.values()) {
+            if (!disposedBaseTex.has(tex)) tex.dispose();
+        }
         baseTex.clear();
         // LOD 遷移中に残した pending タイルのタイマー解除＋メッシュ破棄。
         for (const pending of pendingRelease.values()) {

--- a/tests/globeLod.unit.spec.ts
+++ b/tests/globeLod.unit.spec.ts
@@ -110,6 +110,11 @@ describe("selectGlobeTiles", () => {
         expect(maxZ(a803)).toBeLessThan(maxZ(a200));
         // 低高度（190km 未満）は従来どおり詳細（z8 超）を維持する。
         expect(maxZ(low)).toBeGreaterThan(8);
+        // rootZoomFloor 未指定でも高高度の距離累進は同じ（floorZoom=minZoom で z8 に張り付かず、
+        // 遠方タイルは 8 未満へ粗化される）。
+        const a803NoFloor = selectGlobeTiles(baseOpts(803531, { maxZoom: 15 }));
+        for (const t of a803NoFloor) expect(t.zoom).toBeLessThanOrEqual(8);
+        expect(Math.min(...a803NoFloor.map((t) => t.zoom))).toBeLessThan(8);
     });
 
     it("maxTiles を超えない", () => {

--- a/tests/globeLod.unit.spec.ts
+++ b/tests/globeLod.unit.spec.ts
@@ -935,4 +935,17 @@ describe("selectGlobeRootTiles", () => {
         );
         expect(negative).toBe(flat);
     });
+
+    it("高高度キャップは minZoom も超えない（minZoom < z8 でも seed zoom ≤ minZoom, #465続き）", () => {
+        // minZoom=6（< HIGH_ALT_MAX_ZOOM=8）を高高度（300km）で使う。上限が z8 のままだと
+        // seed zoom が minZoom を超え、addAt の f=2**(minZoom-zoom) が負指数(f<1)になり得る。
+        const seeds = selectGlobeRootTiles(
+            baseRoot(geodeticToEcef(CENTER_LAT, CENTER_LON, 300000), {
+                minZoom: 6,
+                rootZoomFloor: 2,
+            }),
+        );
+        expect(seeds.length).toBeGreaterThan(0);
+        for (const s of seeds) expect(s.zoom).toBeLessThanOrEqual(6);
+    });
 });

--- a/tests/globeLod.unit.spec.ts
+++ b/tests/globeLod.unit.spec.ts
@@ -62,8 +62,11 @@ describe("selectGlobeTiles", () => {
     });
 
     it("minZoom===maxZoom では分割されず全タイルが root ズーム（中心を被覆）", () => {
+        // 高度は HIGH_ALT_ZOOM_CAP_M(190km) 未満にする。以上だと高高度 zoom キャップ(z8)が
+        // 効いて minZoom=maxZoom=11 でも z8 になり、本テストの「root ズームがそのまま出る」意図と
+        // ずれるため（キャップ自体は専用テストで検証）。
         const tiles = selectGlobeTiles(
-            baseOpts(200000, { minZoom: 11, maxZoom: 11, rootSearchRadius: 0 }),
+            baseOpts(60000, { minZoom: 11, maxZoom: 11, rootSearchRadius: 0 }),
         );
         // 分割上限 == root なので全タイル z11。視野フットプリント分の少数タイルで中心を覆う。
         expect(tiles.length).toBeGreaterThan(0);
@@ -87,6 +90,26 @@ describe("selectGlobeTiles", () => {
         const farMax = Math.max(...far.map((t) => t.zoom));
         const nearMax = Math.max(...near.map((t) => t.zoom));
         expect(nearMax).toBeGreaterThan(farMax);
+    });
+
+    it("高高度（190km以上）では root/タイル zoom を z8 以下に抑え、さらに高いほど粗くする（#465 フォロー: 無駄な高レベル・被覆欠けを防ぐ）", () => {
+        // 本番同様 rootZoomFloor を指定（globe.ts は常に 2 を渡す）。maxZoom=15 でも高高度キャップで
+        // z8 以下、かつ距離累進で高度が上がるほど粗くなる（対数的）。
+        const at = (alt: number) =>
+            selectGlobeTiles(baseOpts(alt, { maxZoom: 15, rootZoomFloor: 2 }));
+        const a200 = at(200000);
+        const a803 = at(803531);
+        const low = at(60000);
+        expect(a200.length).toBeGreaterThan(0);
+        // 200km 以上は全タイル z8 以下（地図の字が読めない高度では詳細不要）。
+        for (const t of a200) expect(t.zoom).toBeLessThanOrEqual(8);
+        for (const t of a803) expect(t.zoom).toBeLessThanOrEqual(8);
+        // 803km は 200km よりさらに粗い（floorZoom で張り付かず距離累進が効くこと）。
+        const maxZ = (ts: ReturnType<typeof selectGlobeTiles>) =>
+            Math.max(...ts.map((t) => t.zoom));
+        expect(maxZ(a803)).toBeLessThan(maxZ(a200));
+        // 低高度（190km 未満）は従来どおり詳細（z8 超）を維持する。
+        expect(maxZ(low)).toBeGreaterThan(8);
     });
 
     it("maxTiles を超えない", () => {
@@ -866,5 +889,45 @@ describe("selectGlobeRootTiles", () => {
             expect(s.y).toBeGreaterThanOrEqual(0);
             expect(s.y).toBeLessThan(n);
         }
+    });
+
+    it("高標高の注視点（富士山頂相当）でも前方到達距離が崩壊せず遠方まで種付けする（#465続き）", () => {
+        const DEG = Math.PI / 180;
+        const E = 3776; // 富士山頂標高。seat-on-terrain で注視点が山頂に載る状況を模す。
+        // グレージング視点（tilt70°）でカメラを山頂相当高度へ持ち上げて配置する。
+        const centerEcef = geodeticToEcef(CENTER_LAT, CENTER_LON, E);
+        const lookAt = new Vector3();
+        ComputeLookAtFromYawPitchToRef(20 * DEG, 70 * DEG, centerEcef, true, lookAt);
+        const cam = centerEcef.clone().subtract(lookAt.scale(7919));
+        const nadir = ecefToGeodetic(cam);
+        const reach = (seeds: { x: number; y: number; zoom: number }[]): number => {
+            let max = 0;
+            for (const s of seeds) {
+                const c = tileCenterLatLon(s.x, s.y, s.zoom);
+                const d = Math.hypot(c.lat - nadir.latDeg, c.lon - nadir.lonDeg);
+                if (d > max) max = d;
+            }
+            return max;
+        };
+        // 注視点を実標高で評価（正）→ tilt が水平寄りに正しく出て前方到達距離が伸びる。
+        const withElev = reach(
+            selectGlobeRootTiles(
+                baseRoot(cam, { referenceAltitude: E, rootZoomFloor: 2, maxRootTiles: 384 }),
+            ),
+        );
+        // 注視点を海面(0m)で評価（旧バグ）→ camera→center が急下向きと誤算出され tilt 過小→到達距離短縮。
+        const flat = reach(
+            selectGlobeRootTiles(
+                baseRoot(cam, { referenceAltitude: 0, rootZoomFloor: 2, maxRootTiles: 384 }),
+            ),
+        );
+        expect(withElev).toBeGreaterThan(flat * 1.5);
+        // 負値（海面下）は 0 へ丸め、referenceAltitude=0 と同一挙動（後方互換・異常値ガード）。
+        const negative = reach(
+            selectGlobeRootTiles(
+                baseRoot(cam, { referenceAltitude: -100, rootZoomFloor: 2, maxRootTiles: 384 }),
+            ),
+        );
+        expect(negative).toBe(flat);
     });
 });

--- a/tests/globeTileManager.unit.spec.ts
+++ b/tests/globeTileManager.unit.spec.ts
@@ -262,6 +262,85 @@ describe("createGlobeTileManager", () => {
         expect(mat0.diffuseColor).toEqual({ r: 1, g: 1, b: 1 });
     });
 
+    it("低〜中高度では base に地図テクスチャを適用せず海色のまま（#465 地平線際の緑露出防止）", () => {
+        MeshMock.mockClear();
+        MaterialMock.mockClear();
+        capturedTextures.length = 0;
+        const mgr = createGlobeTileManager({
+            scene: {} as never,
+            mapType: "std",
+            minZoom: 10,
+            geomMaxZoom: 15,
+            segments: 2,
+            snapEnabled: false,
+        });
+        const baseMat = MaterialMock.mock.results[0].value as {
+            diffuseColor: { r: number; g: number; b: number };
+            diffuseTexture: unknown;
+        };
+        // 低高度（60km < 1,200km しきい値）で sync → base は海色充填に切り替わる。
+        mgr.sync(syncParams());
+        // base テクスチャが到着しても、低高度では適用されず海色のまま（緑の世界地図を貼らない）。
+        capturedTextures[0].onLoad?.();
+        expect(baseMat.diffuseTexture).toBeNull();
+        expect(baseMat.diffuseColor.r).toBeLessThan(1);
+    });
+
+    it("高高度（全球表示）では base に地図テクスチャを適用する（#465）", () => {
+        MeshMock.mockClear();
+        MaterialMock.mockClear();
+        capturedTextures.length = 0;
+        const mgr = createGlobeTileManager({
+            scene: {} as never,
+            mapType: "std",
+            minZoom: 10,
+            geomMaxZoom: 15,
+            segments: 2,
+            snapEnabled: false,
+        });
+        const baseMat = MaterialMock.mock.results[0].value as {
+            diffuseColor: { r: number; g: number; b: number };
+            diffuseTexture: unknown;
+        };
+        // 高高度（3,000km ≥ 1,200km しきい値）で sync → base に地図を適用する。
+        const highCameraEcef = geodeticToEcef(35, 139, 3_000_000);
+        mgr.sync({ ...syncParams(), cameraEcef: highCameraEcef });
+        capturedTextures[0].onLoad?.();
+        expect(baseMat.diffuseTexture).not.toBeNull();
+        expect(baseMat.diffuseColor).toEqual({ r: 1, g: 1, b: 1 });
+    });
+
+    it("高度が全球境界を跨ぐと base の見た目を地図↔海色へ再適用する（#465 applyBaseAppearance）", () => {
+        MeshMock.mockClear();
+        MaterialMock.mockClear();
+        capturedTextures.length = 0;
+        const mgr = createGlobeTileManager({
+            scene: {} as never,
+            mapType: "std",
+            minZoom: 10,
+            geomMaxZoom: 15,
+            segments: 2,
+            snapEnabled: false,
+        });
+        const baseMat = MaterialMock.mock.results[0].value as {
+            diffuseColor: { r: number; g: number; b: number };
+            diffuseTexture: unknown;
+        };
+        const highCameraEcef = geodeticToEcef(35, 139, 3_000_000);
+        // 高高度で sync → base テクスチャ到着で地図適用。
+        mgr.sync({ ...syncParams(), cameraEcef: highCameraEcef });
+        capturedTextures[0].onLoad?.();
+        expect(baseMat.diffuseTexture).not.toBeNull();
+        // 低高度へ跨ぐと海色へ戻る（applyBaseAppearance）。
+        mgr.sync(syncParams());
+        expect(baseMat.diffuseTexture).toBeNull();
+        expect(baseMat.diffuseColor.r).toBeLessThan(1);
+        // 再び高高度へ跨ぐと地図が戻る（保持済み baseTex を再適用）。
+        mgr.sync({ ...syncParams(), cameraEcef: highCameraEcef });
+        expect(baseMat.diffuseTexture).not.toBeNull();
+        expect(baseMat.diffuseColor).toEqual({ r: 1, g: 1, b: 1 });
+    });
+
     it("dispose でベースレイヤ 16 枚もテクスチャごと破棄する", () => {
         MeshMock.mockClear();
         const mgr = createGlobeTileManager({


### PR DESCRIPTION
## 概要

低高度・高チルトや高高度・高標高注視点などの極限視点で、グローブLODのタイル被覆が破綻する3件を修正する。いずれも #463（視錐台カリング + `textureQualityFloorZoom`）のフォロー系。`selectGlobeTiles`/`selectGlobeRootTiles` の選択ロジックは #463 の視錐台カリング・root免除を維持し、後方互換（`referenceAltitude=0` / 低高度では従来と同一挙動）。

当初 #465 は「root帯シーディングの方位角依存ムラ」として起票されたが、精密な計測（footprint被覆はfrustum込みで100%・予算未飽和）と実ブラウザ描画での目視により、真因は**描画段・高度依存のタイル被覆**にあることが判明。関連する3件をまとめて修正する。

## 修正内容

### 1. 地平線際の緑z2ベースレイヤ露出（`globeTileManager.ts`）
低高度・高チルトで grazing な地平線際に LOD メッシュが投影されない画素へ、常時表示の base レイヤ（z2 世界地図＝緑主体スタイル）が透け、日本詳細地図（白+等高線）と混在破綻していた（#465 の主症状）。
- base の地図テクスチャ適用をカメラ高度でゲート（`BASE_MAP_MIN_ALT_M=1_200_000`）。低〜中高度は海色（`BASE_LAYER_OCEAN`）充填、高高度（全球表示）でのみ地図を適用。
- 高度境界跨ぎ時のみ `applyBaseAppearance()` で再適用。`dispose()` で `baseTex` の明示破棄も追加（低高度で material 未アタッチのテクスチャがリークするのを防止）。

### 2. 高高度で無駄な高レベル・被覆欠け（`globeLod.ts`）
約200km 以上で `textureQualityFloorZoom=9` が root zoom を z9 に張り付かせ、`maxTiles` を食い潰して可視域外周が欠ける（「半分しか出ない」）。
- 高高度（`HIGH_ALT_ZOOM_CAP_M=190_000` 以上）では品質下限を外し zoom 上限を `HIGH_ALT_MAX_ZOOM=8` に抑え、距離累進の対数的粗化に委ねて少数の粗タイルで広域を被覆。
- `selectGlobeTiles` の traverse 細分化上限・pinned root 開始 zoom も同キャップ。

### 3. 高標高注視点で前方到達距離が崩壊（`globeLod.ts`）
富士山頂等を注視点にすると seat-on-terrain でカメラが山頂高度へ持ち上がるが、前方到達距離を決める tilt を算出する際に注視点を海面(0m)固定で評価していたため tilt 過小 → 到達距離が極端に短縮（実測 412km→81km）→ 50km 先（東京方向等）が未種付けになっていた。
- `GlobeRootSeedOptions` に `referenceAltitude?` を追加し、`centerEcef` を注視点の実標高で評価（負値/NaN/Infinity は0へ丸め）。`selectGlobeTiles` → `selectGlobeRootTiles` に伝播。

## 影響範囲
- 画面: グローブバックエンド（`/viewer` の3Dモード）の低高度・高チルト／高高度／高標高注視点の遠景タイル被覆。平面（Web Mercator）バックエンドは対象外。
- API: `GlobeRootSeedOptions` に `referenceAltitude?` を追加（任意・省略時0で後方互換）。
- `referenceAltitude=0`・低高度では従来と完全に同一挙動。#335（全球モード効率）/#446（高チルト全面被覆）/#463（視錐台カリング・root免除）の既存テストはすべて通過。

## 検証
- 実ブラウザ描画（Playwright, 高DPI）で各シナリオの被覆改善・緑露出解消・遠方充填を目視確認。
- 回帰テスト追加（`globeLod.unit.spec.ts` / `globeTileManager.unit.spec.ts`）。
- `npm run lint` / `npm run typecheck` / `npm run test:unit`（1308）/ `npm run test:visuals`（22）すべて通過。

Closes #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)