### PR TITLE
fix(terrain): グローブ低高度・高チルトで地平線側タイル欠落を予算粗化統合で解消（#470）

### DIFF
--- a/src/terrain/geo/globeLod.ts
+++ b/src/terrain/geo/globeLod.ts
@@ -875,8 +875,90 @@ export const selectGlobeTiles = (opts: GlobeLodOptions): GlobeTile[] => {
               })
             : accepted;
 
-    dedup.sort((a, b) => a.distance - b.distance);
-    return dedup.slice(0, maxTiles);
+    // maxTiles 予算に収める。素朴に「距離昇順で slice」すると最遠（地平線側）のタイルから捨てられ、
+    // 高 DPI・低高度・高チルトで近景の細タイルが予算を食い切ると地平線側の被覆が丸ごと欠けて
+    // ベースレイヤ（青）が露出する（sseThreshold を下げるほどタイル総数が増えて予算超過が早まり、
+    // この症状が悪化する）。そこで削除ではなく「最遠の完全な 4 兄弟を親へ粗化統合」して枚数を
+    // 減らす。粗化は被覆を保ったままタイル数を 3 減らすため、地平線側の被覆を維持しつつ近景の
+    // 詳細を残せる（遠方から順に粗くする）。粗化しきれない（全タイルが floorZoom で兄弟統合の
+    // 余地がない）縮退ケースのみ、従来どおり距離昇順 slice で強制的に上限を満たす。
+    const budgeted = coarsenToBudget(
+        dedup,
+        maxTiles,
+        floorZoom,
+        cameraEcef,
+        referenceAltitude,
+        tileEcef,
+    );
+    budgeted.sort((a, b) => a.distance - b.distance);
+    return budgeted.length > maxTiles ? budgeted.slice(0, maxTiles) : budgeted;
+};
+
+/**
+ * quadtree カット `tiles`（重なりなしの完全被覆）を、被覆を保ったまま `maxTiles` 枚以内へ粗化する。
+ *
+ * 距離昇順 slice が最遠タイルを削除して地平線側にベースレイヤ露出の穴を空けるのを避けるため、
+ * 「最遠の、4 兄弟がすべて揃った」ノードを親（zoom-1）へ統合する操作を繰り返す。完全な 4 兄弟の
+ * みを統合するので重なり（祖先-子孫の二重被覆）は生じず、被覆は厳密に保たれ、1 回で枚数が 3 減る。
+ * `floorZoom` 未満へは粗化しない。完全な兄弟集合が尽きた時点で打ち切り、呼び出し側の距離昇順
+ * slice が縮退ケースの上限保証を担う（このとき初めて穴が生じ得るが、floorZoom が十分粗ければ
+ * 到達しない）。統合順は「最遠優先」で近景の詳細を温存する。
+ */
+const coarsenToBudget = (
+    tiles: GlobeTile[],
+    maxTiles: number,
+    floorZoom: number,
+    cameraEcef: Vector3,
+    referenceAltitude: number,
+    scratch: Vector3,
+): GlobeTile[] => {
+    if (tiles.length <= maxTiles) return tiles;
+    const byKey = new Map<string, GlobeTile>();
+    for (const t of tiles) byKey.set(tileKey(t.zoom, t.x, t.y), t);
+    // 統合は 1 回で高々 3 枚減り、各統合で zoom 総和が単調減少するため必ず停止する。ガードは保険。
+    let guard = tiles.length * 4 + 64;
+    while (byKey.size > maxTiles && guard-- > 0) {
+        // 4 兄弟がすべて揃い、親が floorZoom 以上になる、最も遠いノードを探す。
+        let bestDist = -1;
+        let bestZoom = -1;
+        let bestPx = 0;
+        let bestPy = 0;
+        for (const t of byKey.values()) {
+            const pz = t.zoom - 1;
+            if (pz < floorZoom) continue;
+            const px = t.x >> 1;
+            const py = t.y >> 1;
+            let complete = true;
+            for (let sy = 0; sy < 2 && complete; sy++) {
+                for (let sx = 0; sx < 2 && complete; sx++) {
+                    if (!byKey.has(tileKey(t.zoom, px * 2 + sx, py * 2 + sy))) complete = false;
+                }
+            }
+            if (!complete) continue;
+            if (t.distance > bestDist) {
+                bestDist = t.distance;
+                bestZoom = t.zoom;
+                bestPx = px;
+                bestPy = py;
+            }
+        }
+        if (bestZoom < 0) break; // 統合可能な完全兄弟集合なし（縮退）。
+        for (let sy = 0; sy < 2; sy++) {
+            for (let sx = 0; sx < 2; sx++) {
+                byKey.delete(tileKey(bestZoom, bestPx * 2 + sx, bestPy * 2 + sy));
+            }
+        }
+        const pz = bestZoom - 1;
+        const { lat } = tileCenterEcefToRef(pz, bestPx, bestPy, referenceAltitude, scratch);
+        byKey.set(tileKey(pz, bestPx, bestPy), {
+            zoom: pz,
+            x: bestPx,
+            y: bestPy,
+            tileSizeMeters: tileEdgeMeters(lat, pz),
+            distance: Vector3.Distance(cameraEcef, scratch),
+        });
+    }
+    return [...byKey.values()];
 };
 
 /** タイル一意キー（"z/x/y"）。 */

--- a/tests/globeLod.unit.spec.ts
+++ b/tests/globeLod.unit.spec.ts
@@ -648,6 +648,124 @@ describe("selectGlobeTiles", () => {
         expect(hasForeground).toBe(true);
     });
 
+    describe("低高度・高チルト・高 DPI で地平線側の被覆が予算超過で欠けない（#470）", () => {
+        // 富士山頂付近をアップ（低高度・高チルト）にすると、近景の細タイルが maxTiles 予算を
+        // 食い切り、素朴な「距離昇順 slice」では最遠（地平線側）のタイルが丸ごと捨てられて青の
+        // ベースレイヤが露出した（sseThreshold=384 で顕在化。512 では総数が予算未満で露出しなかった）。
+        // 予算超過時は削除ではなく最遠の 4 兄弟を親へ粗化統合して被覆を保つ修正で、地平線側まで
+        // 連続被覆される（nadir から地平線までタイルが途切れず張られる不変条件）。再現 URL:
+        // @35.361947,138.729267,592,299.31,66.17（radius 592m, azimuth 299.31°, tilt 66.17°）。
+        const REPRO_LAT = 35.361947;
+        const REPRO_LON = 138.729267;
+        const DEG = Math.PI / 180;
+        const R = 6371000;
+
+        /** 注視点(REPRO 地点)標高 elev・radius・tilt・az から repro カメラ ECEF を組む。 */
+        const reproCamera = (elev: number, radius: number, tiltDeg: number, azDeg: number): Vector3 => {
+            const centerEcef = geodeticToEcef(REPRO_LAT, REPRO_LON, elev);
+            const lookAt = new Vector3();
+            ComputeLookAtFromYawPitchToRef(azDeg * DEG, tiltDeg * DEG, centerEcef, true, lookAt);
+            return centerEcef.clone().subtract(lookAt.scale(radius));
+        };
+
+        /** 緯度経度がいずれかの選択タイル（その zoom）に含まれるか。 */
+        const covered = (
+            tiles: ReturnType<typeof selectGlobeTiles>,
+            lat: number,
+            lon: number,
+        ): boolean =>
+            tiles.some((t) => {
+                const c = toTileXY(lat, lon, t.zoom);
+                return c.x === t.x && c.y === t.y;
+            });
+
+        /**
+         * nadir から視線方位 az の大円に沿って地表を刻み、被覆が始まってから最後に被覆された
+         * 地表距離[km] と、被覆開始後に最初に現れた穴の距離[km]（無ければ -1）を返す。
+         */
+        const coverageAlongView = (
+            opts: GlobeLodOptions,
+            azDeg: number,
+        ): { lastCoveredKm: number; firstGapKm: number; horizonKm: number } => {
+            const tiles = selectGlobeTiles(opts);
+            const nadir = ecefToGeodetic(opts.cameraEcef);
+            const h = Math.max(0, nadir.altMeters);
+            const horizonArc = R * Math.acos(R / (R + h));
+            const lat1 = nadir.latDeg * DEG;
+            const lon1 = nadir.lonDeg * DEG;
+            const theta = azDeg * DEG;
+            let lastCoveredKm = -1;
+            let firstGapKm = -1;
+            for (let arc = 0; arc <= horizonArc * 0.9; arc += 1000) {
+                const dlt = arc / R;
+                const lat2 = Math.asin(
+                    Math.sin(lat1) * Math.cos(dlt) + Math.cos(lat1) * Math.sin(dlt) * Math.cos(theta),
+                );
+                const lon2 =
+                    lon1 +
+                    Math.atan2(
+                        Math.sin(theta) * Math.sin(dlt) * Math.cos(lat1),
+                        Math.cos(dlt) - Math.sin(lat1) * Math.sin(lat2),
+                    );
+                if (covered(tiles, lat2 / DEG, lon2 / DEG)) lastCoveredKm = arc / 1000;
+                else if (firstGapKm < 0 && lastCoveredKm >= 0) firstGapKm = arc / 1000;
+            }
+            return { lastCoveredKm, firstGapKm, horizonKm: horizonArc / 1000 };
+        };
+
+        // 高標高の注視点（富士山頂相当 3776m）・radius 592m・tilt 66.17°・az 299.31°、
+        // 高 DPI 相当の高い viewportHeight（getRenderHeight はバックバッファ解像度 = DPR 倍）。
+        const elev = 3776;
+        const az = 299.31;
+        const reproOpts = (sse: number): GlobeLodOptions => {
+            const cameraEcef = reproCamera(elev, 592, 66.17, az);
+            const center = geodeticToEcef(REPRO_LAT, REPRO_LON, elev);
+            const cg = ecefToGeodetic(center);
+            return baseOpts(ecefToGeodetic(cameraEcef).altMeters, {
+                cameraEcef,
+                centerLat: cg.latDeg,
+                centerLon: cg.lonDeg,
+                minZoom: GLOBE_SCENE_DEFAULTS.minZoom,
+                maxZoom: GLOBE_SCENE_DEFAULTS.maxZoom,
+                viewportHeight: 1600,
+                viewportWidth: 2560,
+                sseThreshold: sse,
+                maxTiles: GLOBE_SCENE_DEFAULTS.maxTiles,
+                rootSearchRadius: GLOBE_SCENE_DEFAULTS.rootSearchRadius,
+                maxRootTiles: GLOBE_SCENE_DEFAULTS.maxRootTiles,
+                horizonDotThreshold: GLOBE_SCENE_DEFAULTS.horizonDotThreshold,
+                rootZoomFloor: GLOBE_SCENE_DEFAULTS.rootZoomFloor,
+                textureQualityFloorZoom: GLOBE_SCENE_DEFAULTS.textureQualityFloorZoom,
+                referenceAltitude: elev,
+            });
+        };
+
+        it("sseThreshold=384（本番値）で地平線側までベースレイヤ露出の穴がない", () => {
+            const opts = reproOpts(GLOBE_SCENE_DEFAULTS.sseThreshold);
+            const { lastCoveredKm, firstGapKm, horizonKm } = coverageAlongView(opts, az);
+            // 被覆開始後に穴がない（修正前は近景で予算を食い切り最遠が捨てられ数 km 先で穴あき）。
+            expect(firstGapKm).toBe(-1);
+            // 視線方向の地表が可視遠方（地平線の 7 割超）まで連続被覆される。
+            expect(lastCoveredKm).toBeGreaterThan(horizonKm * 0.7);
+        });
+
+        it("予算超過時も maxTiles を超えない（粗化統合で枚数を抑える）", () => {
+            const tiles = selectGlobeTiles(reproOpts(GLOBE_SCENE_DEFAULTS.sseThreshold));
+            expect(tiles.length).toBeLessThanOrEqual(GLOBE_SCENE_DEFAULTS.maxTiles);
+        });
+
+        it("粗化統合後も quadtree カットが崩れない（祖先-子孫の二重被覆がない）", () => {
+            const tiles = selectGlobeTiles(reproOpts(GLOBE_SCENE_DEFAULTS.sseThreshold));
+            const keys = new Set(tiles.map((t) => tileKey(t.zoom, t.x, t.y)));
+            for (const t of tiles) {
+                for (let z = t.zoom - 1; z >= GLOBE_SCENE_DEFAULTS.rootZoomFloor; z--) {
+                    const dz = t.zoom - z;
+                    expect(keys.has(tileKey(z, t.x >> dz, t.y >> dz))).toBe(false);
+                }
+            }
+        });
+    });
+
     describe("日本被覆域外のテクスチャ上限クランプ", () => {
         // 日本外（米ニューヨーク付近）。GSI テクスチャは z9 以上が存在しないため、
         // 近接カメラでも z8 までしか細分化されないこと。


### PR DESCRIPTION
## 概要

グローブ描画で低高度・高チルト視点にすると、遠方（地平線側）のタイルが欠けて青の base レイヤが露出する不具合を修正する。

Closes #470
関連: #456 #335 #465

再現URL: `http://localhost:8080/viewer/@35.361947,138.729267,592,299.31,66.17?mapType=standard&viewMode=3d`（高度592m, tilt66.17°）
目視で青 base 露出が解消することを確認済み。

## 真因

当初は `fFar`（前方到達マージン）が `sseThreshold` に結合していることを疑ったが、実測で反証（sse を変えても `fFar` は飽和して不変で no-op）。

真因は `selectGlobeTiles` 末尾の予算打ち切り `dedup.sort(距離昇順).slice(0, maxTiles)` が、予算超過時に**最遠（地平線側）タイルから削除**していたこと。

- sse=512 → タイル総数 < maxTiles(384) → 打ち切りなし → 地平線まで被覆。
- sse=384（#456 で変更）→ 総数 > 384 → 距離昇順 slice が最遠を削除 → 地平線側が欠落し base 露出。

高DPI・低高度・高チルトで近景の細タイルが予算を食い切ると顕在化する。「#456 以降に発生」「sse 依存」の観測と厳密に一致する。

## 修正

予算超過時の削除を、被覆保存型の粗化統合 `coarsenToBudget` に置き換えた。

- 最遠の「4 兄弟がすべて揃ったノード」を親（zoom-1）へ統合する操作を繰り返す。
- 完全な兄弟のみ統合するため祖先-子孫の二重被覆は生じず、被覆を厳密に保ったまま 1 回で枚数を 3 減らす。
- `floorZoom` 未満へは粗化しない。統合しきれない縮退ケースのみ従来の距離昇順 slice が上限を保証。
- `sseThreshold=384`（#456 の近中景高解像度化）は据え置き。実タイル選定ロジックには触れていないため #456 の改善に非干渉。

## 影響範囲

- `src/terrain/geo/globeLod.ts`: `selectGlobeTiles` の予算打ち切りロジックのみ変更（内部実装）。
- API・型変更なし。
- 予算内（通常視点・低DPI）は挙動不変。予算超過時のみ作用し、結果は常に maxTiles 以内。粗化は枚数を減らす方向のためタイル数増加はなし。

## テスト

- 再現URL相当（富士山頂・radius592・tilt66.17・az299.31・高DPI）で sse=384 でも地平線側に穴がないこと、maxTiles を超えないこと、quadtree カットが崩れないことを検証する回帰テスト 3 本を追加。
- 修正前に失敗・修正後に通過することを確認済み。
- `npm run test:unit` → 1312 passed。
- `npm run lint` / `npm run typecheck` → 成功。
- `npm run test:visuals` → 21 passed、globe 系ベースライン退行なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
