### PR TITLE
fix(terrain): terrainElevAt が gz<minZoom の遠方標高を返せない問題を距離ゲートで解消（#459）

### DIFF
--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -273,6 +273,12 @@ export const createGlobeTileManager = (
     opts: GlobeTileManagerOptions,
 ): GlobeTileManager => {
     const { scene, minZoom, geomMaxZoom, segments, snapEnabled } = opts;
+    // terrainElevAt の距離ゲート基準かつ buildReadyTiles の elevRelevantGeom 追加基準となる gz。
+    // これ未満の gz（遠景で minZoom を下回る距離適応タイル）だけを距離ゲートの対象にする。
+    // minZoom > geomMaxZoom（例: ?zoom=18）では最も細かい実タイルが gz=geomMaxZoom になるため、
+    // min(minZoom, geomMaxZoom) を基準にして geomMaxZoom を無条件採用する（seat-on-terrain 維持）。
+    // 両所で同じ基準を参照して条件のドリフトを防ぐ。
+    const gateBelowGz = Math.min(minZoom, geomMaxZoom);
     // 地図種別は実行時に切替可能。buildTile / buildBaseLayer のテクスチャ URL は
     // この可変値を参照するため、以降の新規タイルは切替後の mapType を使う。
     let currentMapType: MapType = opts.mapType;
@@ -459,16 +465,15 @@ export const createGlobeTileManager = (
 
     const terrainElevAt = (latDeg: number, lonDeg: number): number | null => {
         // 探索は geomMaxZoom（細）から粗へ下り、elevCache に実在する最も細かい gz を採用する。
-        // gz >= minZoom は従来どおり常に採用。gz < minZoom（遠景で距離適応 root zoom が minZoom を
-        // 下回ったタイル）は、buildReadyTiles が距離 <= ELEVATION_RELEVANT_MAX_DISTANCE_M と判定し
+        // gz >= gateBelowGz は従来どおり常に採用。gz < gateBelowGz（遠景で距離適応 root zoom が minZoom
+        // を下回ったタイル）は、buildReadyTiles が距離 <= ELEVATION_RELEVANT_MAX_DISTANCE_M と判定し
         // elevRelevantGeom に記録したものだけ採用する（#459: 東京駅→富士山 約100.5km/zoom=10 の
-        // ような近〜中距離で標高を返しつつ、全球視点の超粗タイルで誤った標高を返さない）。下限を 0 に
-        // しても elevCache/elevRelevantGeom に無い gz は skip されるだけ。
-        // 距離ゲートの基準 gz は min(minZoom, geomMaxZoom)。minZoom > geomMaxZoom（例: ?zoom=18）では
-        // 最も細かい実タイルが gz=geomMaxZoom(<minZoom) になるため、これを minZoom 未満としてゲート
-        // すると常に null になる。geomMaxZoom までは従来どおり無条件採用する（seat-on-terrain 維持）。
-        const gateBelowGz = Math.min(minZoom, geomMaxZoom);
-        for (let gz = geomMaxZoom; gz >= 0; gz--) {
+        // ような近〜中距離で標高を返しつつ、全球視点の超粗タイルで誤った標高を返さない）。
+        // 通常時（近景で elevRelevantGeom が空）は gz<gateBelowGz を探索しても必ず skip されるため、
+        // 下限を gateBelowGz に切り上げて毎フレーム呼び出しの無駄な toTileXY/tileKey を避ける。
+        // #459 の遠景タイルが登録されている間だけ 0 まで探索する。
+        const searchFloor = elevRelevantGeom.size > 0 ? 0 : gateBelowGz;
+        for (let gz = geomMaxZoom; gz >= searchFloor; gz--) {
             const { x, y } = toTileXY(latDeg, lonDeg, gz);
             const gk = tileKey(gz, x, y);
             if (gz < gateBelowGz && !elevRelevantGeom.has(gk)) continue;
@@ -1046,10 +1051,12 @@ export const createGlobeTileManager = (
             // 「標高が視覚的に無意味」として扱う。
             const isElevationRelevant =
                 t.zoom >= minZoom || t.distance <= ELEVATION_RELEVANT_MAX_DISTANCE_M;
-            // #459: gz<minZoom の距離適応タイルが「標高が意味を持つ」間だけ terrainElevAt の
+            // #459: gz<gateBelowGz の距離適応タイルが「標高が意味を持つ」間だけ terrainElevAt の
             // 採用対象に載せる。距離が離れて無意味化したら外す（terrainElevAt が全球視点の超粗
-            // タイル標高を返さないため）。gz>=minZoom は常に採用対象なので記録不要。
-            if (t.zoom < minZoom) {
+            // タイル標高を返さないため）。gz>=gateBelowGz は常に採用対象なので記録不要。判定基準を
+            // terrainElevAt の距離ゲートと同じ gateBelowGz に揃える（minZoom>geomMaxZoom で
+            // gz=geomMaxZoom を無駄に Set へ追加しない）。
+            if (gz < gateBelowGz) {
                 if (isElevationRelevant) elevRelevantGeom.add(gk);
                 else elevRelevantGeom.delete(gk);
             }

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -463,12 +463,15 @@ export const createGlobeTileManager = (
         // 下回ったタイル）は、buildReadyTiles が距離 <= ELEVATION_RELEVANT_MAX_DISTANCE_M と判定し
         // elevRelevantGeom に記録したものだけ採用する（#459: 東京駅→富士山 約100.5km/zoom=10 の
         // ような近〜中距離で標高を返しつつ、全球視点の超粗タイルで誤った標高を返さない）。下限を 0 に
-        // しても elevCache/elevRelevantGeom に無い gz は skip されるだけ。minZoom > geomMaxZoom
-        // （例: ?zoom=18）でもループは gz=geomMaxZoom で最低 1 回回る（seat-on-terrain 維持）。
+        // しても elevCache/elevRelevantGeom に無い gz は skip されるだけ。
+        // 距離ゲートの基準 gz は min(minZoom, geomMaxZoom)。minZoom > geomMaxZoom（例: ?zoom=18）では
+        // 最も細かい実タイルが gz=geomMaxZoom(<minZoom) になるため、これを minZoom 未満としてゲート
+        // すると常に null になる。geomMaxZoom までは従来どおり無条件採用する（seat-on-terrain 維持）。
+        const gateBelowGz = Math.min(minZoom, geomMaxZoom);
         for (let gz = geomMaxZoom; gz >= 0; gz--) {
             const { x, y } = toTileXY(latDeg, lonDeg, gz);
             const gk = tileKey(gz, x, y);
-            if (gz < minZoom && !elevRelevantGeom.has(gk)) continue;
+            if (gz < gateBelowGz && !elevRelevantGeom.has(gk)) continue;
             // 未解決 all-NaN（湖面・no-data）タイルは生 NaN を保持しており bilinear が 0m を返す。
             // これを採用すると湖上で centerElevation→0→referenceAltitude→0 と循環して暫定代表標高
             // まで 0m へ崩れる（湖中央 0m クレーターの一因）。未解決の間はこの zoom を飛ばし、
@@ -1376,11 +1379,16 @@ export const createGlobeTileManager = (
             if (!neededGeom.has(key)) {
                 elevCache.delete(key);
                 allNanGeom.delete(key);
-                elevRelevantGeom.delete(key);
                 coarseSeed.delete(key);
                 coarseSeedPending.delete(key);
                 coarseSeedDone.delete(key);
             }
+        }
+        // elevRelevantGeom は標高未ロード（elevCache 未登録）でも buildReadyTiles で追加され得るため、
+        // elevCache 起点の掃除では取りこぼす。可視タイル（neededGeom）を基準に直接 prune し、セッション
+        // 中の移動で Set が上限なく増え続けないようにする（#472 レビュー対応。loading/failedRetryAt と同型）。
+        for (const key of elevRelevantGeom) {
+            if (!neededGeom.has(key)) elevRelevantGeom.delete(key);
         }
         // 不要になった in-flight ロードを loading から外す。これにより、その後 resolve した
         // 結果は loadTile の then/catch ゲート（loading.has）で無視され、不要な geom が

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -301,6 +301,12 @@ export const createGlobeTileManager = (
     // 取得直後は隣接が未ロードでシードが無いため穴埋めできない。隣接の補間結果が揃い次第
     // `refineAllNaNTiles` で同 zoom 隣接からシードして反復補間する。解決したらこの集合から外す。
     const allNanGeom = new Set<string>();
+    // #459: gz<minZoom（遠景で距離適応 root zoom が minZoom を下回ったタイル）のうち、
+    // buildReadyTiles が「標高が視覚的に意味を持つ」（カメラ距離 <=
+    // ELEVATION_RELEVANT_MAX_DISTANCE_M）と判定した geom タイルキーの集合。terrainElevAt は
+    // gz<minZoom の標高を、この集合に載るものだけ採用する（全球視点の超粗タイルで誤った
+    // 標高を返さないための距離ゲート。距離が離れて無意味になれば buildReadyTiles で外す）。
+    const elevRelevantGeom = new Set<string>();
     // all-NaN タイルの粗ズーム祖先 DEM から得た代表標高（湖面標高近似）のキャッシュ。
     // 視界が全面水面で同 zoom に有効タイルが一切無い場合（大きな湖を z15 で接写等）、
     // 同 zoom 縫い合わせも視界内代表標高レスキューも効かない。粗ズーム祖先タイルは
@@ -452,13 +458,17 @@ export const createGlobeTileManager = (
     };
 
     const terrainElevAt = (latDeg: number, lonDeg: number): number | null => {
-        // 探索は geomMaxZoom から下る。minZoom > geomMaxZoom（例: ?zoom=18）でもループが
-        // 1 回は回るよう下限を min(minZoom, geomMaxZoom) とする（さもないと常に null を返し
-        // seat-on-terrain / referenceAltitude が機能しなくなる）。
-        const lowerGz = Math.min(minZoom, geomMaxZoom);
-        for (let gz = geomMaxZoom; gz >= lowerGz; gz--) {
+        // 探索は geomMaxZoom（細）から粗へ下り、elevCache に実在する最も細かい gz を採用する。
+        // gz >= minZoom は従来どおり常に採用。gz < minZoom（遠景で距離適応 root zoom が minZoom を
+        // 下回ったタイル）は、buildReadyTiles が距離 <= ELEVATION_RELEVANT_MAX_DISTANCE_M と判定し
+        // elevRelevantGeom に記録したものだけ採用する（#459: 東京駅→富士山 約100.5km/zoom=10 の
+        // ような近〜中距離で標高を返しつつ、全球視点の超粗タイルで誤った標高を返さない）。下限を 0 に
+        // しても elevCache/elevRelevantGeom に無い gz は skip されるだけ。minZoom > geomMaxZoom
+        // （例: ?zoom=18）でもループは gz=geomMaxZoom で最低 1 回回る（seat-on-terrain 維持）。
+        for (let gz = geomMaxZoom; gz >= 0; gz--) {
             const { x, y } = toTileXY(latDeg, lonDeg, gz);
             const gk = tileKey(gz, x, y);
+            if (gz < minZoom && !elevRelevantGeom.has(gk)) continue;
             // 未解決 all-NaN（湖面・no-data）タイルは生 NaN を保持しており bilinear が 0m を返す。
             // これを採用すると湖上で centerElevation→0→referenceAltitude→0 と循環して暫定代表標高
             // まで 0m へ崩れる（湖中央 0m クレーターの一因）。未解決の間はこの zoom を飛ばし、
@@ -1033,6 +1043,13 @@ export const createGlobeTileManager = (
             // 「標高が視覚的に無意味」として扱う。
             const isElevationRelevant =
                 t.zoom >= minZoom || t.distance <= ELEVATION_RELEVANT_MAX_DISTANCE_M;
+            // #459: gz<minZoom の距離適応タイルが「標高が意味を持つ」間だけ terrainElevAt の
+            // 採用対象に載せる。距離が離れて無意味化したら外す（terrainElevAt が全球視点の超粗
+            // タイル標高を返さないため）。gz>=minZoom は常に採用対象なので記録不要。
+            if (t.zoom < minZoom) {
+                if (isElevationRelevant) elevRelevantGeom.add(gk);
+                else elevRelevantGeom.delete(gk);
+            }
             // 実標高が未取得（ロード中 or 取得失敗でバックオフ中）の場合の暫定値（海面フラット 0m）。
             // ただしフラットで暫定建築するのは「取得失敗でバックオフ中(failedRetryAt)」または
             // 「標高が視覚的に無意味（isElevationRelevant=false）」に限る。それ以外（有意義な
@@ -1359,6 +1376,7 @@ export const createGlobeTileManager = (
             if (!neededGeom.has(key)) {
                 elevCache.delete(key);
                 allNanGeom.delete(key);
+                elevRelevantGeom.delete(key);
                 coarseSeed.delete(key);
                 coarseSeedPending.delete(key);
                 coarseSeedDone.delete(key);

--- a/tests/globeTileManager.unit.spec.ts
+++ b/tests/globeTileManager.unit.spec.ts
@@ -1135,6 +1135,70 @@ describe("createGlobeTileManager", () => {
         expect(elev).toBeNull();
     });
 
+    // ===== #459: gz<minZoom（遠景の距離適応タイル）の terrainElevAt 距離ゲート =====
+
+    /** minZoom=12 の manager（選択タイル zoom=10 は minZoom 未満になる）。 */
+    const makeFarViewManager = () =>
+        createGlobeTileManager({
+            scene: {} as never,
+            mapType: "std",
+            minZoom: 12,
+            geomMaxZoom: 15,
+            segments: 2,
+            snapEnabled: false,
+        });
+
+    it("gz<minZoom でも近距離(<=150km)でロード済みなら terrainElevAt が標高を返す（#459）", async () => {
+        // 東京駅→富士山 約100.5km 相当。distCapZoom で root zoom が minZoom(12) を下回り zoom=10 が
+        // 選ばれるが、実 DEM はロード完了している。旧実装は探索下限 min(minZoom,geomMaxZoom)=12 の
+        // ため gz=10 を探索できず常に null だった。修正後は距離ゲート付きで採用し標高を返す。
+        const mgr = makeFarViewManager();
+        loadElevationTile.mockImplementation(() =>
+            Promise.resolve(new Float32Array(256 * 256).fill(3000)),
+        );
+        selectedTiles = [tile(100, 100, 10, 100_500)]; // zoom=10 < minZoom=12, 100.5km <= 150km
+        mgr.sync(syncParams());
+        await flush(); // 実標高到着 → elevCache へ格納
+        mgr.sync(syncParams()); // buildReadyTiles が elevRelevantGeom へ登録
+
+        const elev = mgr.terrainElevAt(35, 139);
+        expect(elev).not.toBeNull();
+        expect(elev as number).toBeCloseTo(3000, 3);
+    });
+
+    it("gz<minZoom かつ遠距離(>150km)では terrainElevAt が null を返す（#459 の距離ゲート）", async () => {
+        // 全球視点相当の遠距離。DEM はロードされ elevCache に載るが、標高が視覚的に無意味な距離帯
+        // なので elevRelevantGeom に載らず、terrainElevAt は超粗タイルの誤った標高を返さない。
+        const mgr = makeFarViewManager();
+        loadElevationTile.mockImplementation(() =>
+            Promise.resolve(new Float32Array(256 * 256).fill(3000)),
+        );
+        selectedTiles = [tile(100, 100, 10, 200_000)]; // zoom=10 < minZoom=12, 200km > 150km
+        mgr.sync(syncParams());
+        await flush();
+        mgr.sync(syncParams());
+
+        expect(mgr.terrainElevAt(35, 139)).toBeNull();
+    });
+
+    it("近距離→遠距離へ移動すると terrainElevAt は再び null を返す（距離ゲートの解除, #459）", async () => {
+        // 一度近距離(<=150km)で採用対象になった gz<minZoom タイルが、カメラが離れて無意味化した
+        // 後は採用対象から外れること（elevRelevantGeom の削除経路）を検証する。
+        const mgr = makeFarViewManager();
+        loadElevationTile.mockImplementation(() =>
+            Promise.resolve(new Float32Array(256 * 256).fill(3000)),
+        );
+        selectedTiles = [tile(100, 100, 10, 100_500)]; // 近距離
+        mgr.sync(syncParams());
+        await flush();
+        mgr.sync(syncParams());
+        expect(mgr.terrainElevAt(35, 139)).not.toBeNull();
+
+        selectedTiles = [tile(100, 100, 10, 200_000)]; // 同一タイルが遠距離化
+        mgr.sync(syncParams());
+        expect(mgr.terrainElevAt(35, 139)).toBeNull();
+    });
+
     it("取得失敗(404)の湖面タイルを 0m でなく隣接タイルの接線標高で平坦建築する", async () => {
         const mgr = makeManager();
         // 中央 geom タイル(gx=100,gy=100)は全レイヤ 404（決定的未配信）かつ粗ズーム祖先も 404＝本栖湖 z15

--- a/tests/globeTileManager.unit.spec.ts
+++ b/tests/globeTileManager.unit.spec.ts
@@ -1199,6 +1199,32 @@ describe("createGlobeTileManager", () => {
         expect(mgr.terrainElevAt(35, 139)).toBeNull();
     });
 
+    it("minZoom > geomMaxZoom（?zoom=18 等）では gz=geomMaxZoom を距離ゲート無しで返す（#459 レビュー対応）", async () => {
+        // 最も細かい実タイルは gz=geomMaxZoom(15) で minZoom(18) 未満。これを一律 gz<minZoom として
+        // 距離ゲートで弾くと terrainElevAt が常に null になり seat-on-terrain が壊れる。ゲート基準を
+        // min(minZoom,geomMaxZoom) にして gz=geomMaxZoom は無条件採用する。遠距離(>150km)で
+        // elevRelevantGeom に載らないタイルでも返ることを確認する。
+        const mgr = createGlobeTileManager({
+            scene: {} as never,
+            mapType: "std",
+            minZoom: 18,
+            geomMaxZoom: 15,
+            segments: 2,
+            snapEnabled: false,
+        });
+        loadElevationTile.mockImplementation(() =>
+            Promise.resolve(new Float32Array(256 * 256).fill(1234)),
+        );
+        selectedTiles = [tile(100, 100, 15, 200_000)]; // gz=geomMaxZoom=15, 200km>150km（非 relevant）
+        mgr.sync(syncParams());
+        await flush();
+        mgr.sync(syncParams());
+
+        const elev = mgr.terrainElevAt(35, 139);
+        expect(elev).not.toBeNull();
+        expect(elev as number).toBeCloseTo(1234, 3);
+    });
+
     it("取得失敗(404)の湖面タイルを 0m でなく隣接タイルの接線標高で平坦建築する", async () => {
         const mgr = makeManager();
         // 中央 geom タイル(gx=100,gy=100)は全レイヤ 404（決定的未配信）かつ粗ズーム祖先も 404＝本栖湖 z15


### PR DESCRIPTION
## 概要

遠景で距離適応 root zoom が `minZoom` を下回るタイル（例: 東京駅→富士山 約100.5km / zoom=10）は、`elevCache` にロード済みでも `terrainElevAt` の探索下限 `Math.min(minZoom, geomMaxZoom)` により**常に `null`** を返していた（`buildReadyTiles` は #457 で距離考慮済みだが `terrainElevAt` が取り残されていた）。

Closes #459

## 対応方針

- `buildReadyTiles` が距離判定（`<= ELEVATION_RELEVANT_MAX_DISTANCE_M` = 150km）した `gz<minZoom` タイルの geomKey を `elevRelevantGeom: Set` に記録。
- `terrainElevAt` は探索下限を `0` まで下げつつ、`gz<minZoom` は `elevRelevantGeom` にあるものだけ採用。
- 全球視点の超粗タイルは >150km で除外され従来どおり `null`（誤標高・feature の早期 resolved 化を防止）。
- GC（sync）で `elevRelevantGeom` も掃除、距離が離れたら `buildReadyTiles` で除外。

### 検討した代替案（不採用）
- **距離引数を `terrainElevAt` に追加**: 公開 API（`sceneContract` / `jpmapTerrain` 経由で約40箇所）に波及し重い。かつ closure から距離も `rootZoomFloor`（sync パラメータ）も見えない。
- **固定 zoom 下限クランプ**: magic number で緯度により破綻、150km ポリシーに追従しない。

→ 公開 API のシグネチャは**不変**、150km ポリシーを再利用（二重管理なし）。

## 影響範囲

- 挙動: `gz<minZoom` かつ ≤150km で `terrainElevAt` が標高を返すようになる（seat-on-terrain / モデル接地 / クリック標高解決 等の遠方ケース）。>150km は従来どおり `null`。
- API/型: 変更なし。

## テスト

単体テスト3件追加（`tests/globeTileManager.unit.spec.ts`）:
- 近距離(≤150km)でロード済みなら標高を返す
- 遠距離(>150km)では `null`（距離ゲート）
- 近→遠でゲート解除され再び `null`

検証: `npm run typecheck` ✅ / `npm run lint` ✅ / `npm run test:unit` ✅（61 suites / 1315 tests）

🤖 Generated with [Claude Code](https://claude.com/claude-code)