### PR TITLE
fix(scene): 3Dモデルデモ初回クリックの "Ray needs to be imported" を解消

### DIFF
--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -12,6 +12,12 @@
  * ズーム中は seat を一時停止し目標点を scene.pick 非依存で固定して実装。
  * URL 等価性はデモ（`demos/geospatial/index.ts`）側で実装。
  */
+// GeospatialCamera のポインタ操作（pan/zoom）は内部で scene.pick / createPickingRay を使い、これらは
+// Ray の副作用モジュールに依存する（未 import だと初回クリックで "Ray needs to be imported before ..."
+// が throw される）。他モジュールの初期化が Ray 依存 API をパッチ適用前に触る順序を避けるため、
+// 他の import より前でこの副作用を登録する。ライブラリ利用側（各デモ）が個別に import しなくても動く。
+import "@babylonjs/core/Culling/ray";
+
 import { Scene } from "@babylonjs/core/scene";
 import { Vector2, Vector3, Matrix } from "@babylonjs/core/Maths/math.vector";
 import { Color3, Color4 } from "@babylonjs/core/Maths/math.color";
@@ -32,11 +38,6 @@ import { CreateSphere } from "@babylonjs/core/Meshes/Builders/sphereBuilder";
 import type { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
 import { PickingInfo } from "@babylonjs/core/Collisions/pickingInfo";
-// GeospatialCamera のポインタ操作（pan/zoom）は内部で scene.pick / createPickingRay を使い、
-// これらは Ray の副作用モジュールに依存する（未 import だと初回クリックで "Ray needs to be
-// imported before ..." が throw される）。この副作用はグローブシーンの生成モジュールで一度
-// 読み込み、ライブラリ利用側（各デモ）が個別に import しなくても動くようにする。
-import "@babylonjs/core/Culling/ray";
 
 import { WORLD_TEXTURE_MAX_ZOOM, type MapType } from "../terrain/gsiTile";
 import { TERRAIN_CLICK_DRAG_THRESHOLD_PX, POLYGON_POINT_DRAG_THRESHOLD_PX } from "../lib/types";

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -32,6 +32,11 @@ import { CreateSphere } from "@babylonjs/core/Meshes/Builders/sphereBuilder";
 import type { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
 import { PickingInfo } from "@babylonjs/core/Collisions/pickingInfo";
+// GeospatialCamera のポインタ操作（pan/zoom）は内部で scene.pick / createPickingRay を使い、
+// これらは Ray の副作用モジュールに依存する（未 import だと初回クリックで "Ray needs to be
+// imported before ..." が throw される）。この副作用はグローブシーンの生成モジュールで一度
+// 読み込み、ライブラリ利用側（各デモ）が個別に import しなくても動くようにする。
+import "@babylonjs/core/Culling/ray";
 
 import { WORLD_TEXTURE_MAX_ZOOM, type MapType } from "../terrain/gsiTile";
 import { TERRAIN_CLICK_DRAG_THRESHOLD_PX, POLYGON_POINT_DRAG_THRESHOLD_PX } from "../lib/types";


### PR DESCRIPTION
## 概要

3Dモデルデモ（`model.html`）で最初に地図をクリックすると `Ray needs to be imported before as it contains a side-effect required by your code.` が throw される不具合を修正する。

## 原因

- `GeospatialCamera` のポインタ操作（pan/zoom）は内部で `scene.pick` / `createPickingRay` を使い、Ray の副作用モジュール `@babylonjs/core/Culling/ray` に依存する（未ロード時は `Scene.prototype.createPickingRay` の stub が上記メッセージを throw）。
- 従来は `@babylonjs/core/Cameras/geospatialCameraMovement` が Ray を transitive import して副作用を登録していたが、**babylon バージョン更新でこの transitive import に依存できなくなり**、Ray を明示 import しないデモ（model 等）で初回クリック時に throw するようになった。
- `distance` / `artillery` デモは各自 `Culling/ray` を import して回避済みだが、他デモ（model / avatar / avatar-controller / polygon / flight）は未対応だった。

## 対応

グローブシーン生成モジュール `src/scenes/globe.ts`（`GeospatialCamera` を使う本体）で `@babylonjs/core/Culling/ray` を**明示 side-effect import**。これにより:
- 利用側デモが個別に import しなくても動く（model 含む全デモが対応）。
- babylon 内部の transitive import 変化（実装詳細・tree-shaking で落ちうる）に依存しない恒久的な保証。

## 検証

- 実ブラウザ（Playwright headless で `model.html` 初回クリック、dev / 本番ビルド両方）で Ray エラーが出ないことを確認。
- 報告者環境でエラー解消を確認済み（babylon を前日に更新していたのが誘因）。
- `npm run typecheck` ✅ / `npm run lint` ✅

## 影響範囲

- `src/scenes/globe.ts` に副作用 import 1 行追加のみ。API/挙動の変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)