### PR TITLE
fix(terrain): 遠方タイルのメッシュ分割数を距離適応化し富士山級の起伏を保持（#460）

### DIFF
--- a/src/terrain/geo/globeMesh.ts
+++ b/src/terrain/geo/globeMesh.ts
@@ -30,6 +30,44 @@ const SKIRT_MIN_DEPTH = 150;
 const SKIRT_MAX_DEPTH = 1500;
 const SKIRT_DEPTH_RATIO = 0.05;
 
+/**
+ * 遠方（粗い zoom）タイルのメッシュ分割数を距離適応で増やす際の目標頂点間隔 [m]（#460）。
+ * メッシュは DEM(256px) を (segments+1) 頂点へサブサンプルするため、既定 segments=32 では遠方の
+ * 粗 zoom タイル（例: 東京→富士山 ≈100km で zoom=10, 1辺≈32km）が 1 頂点 ≈1km となり、富士山級の
+ * 急峻な独立峰が数頂点に潰れて稜線が失われる。1 辺実距離をこの目標で割った分割数へ引き上げ、
+ * ロード済み DEM 詳細（z10 で ≈125m/sample）を活かす。250m は zoom=10 タイルで 128 分割
+ * （≈250m/頂点＝zoom12 相当）となり富士山山頂部を約 12 頂点で表現できる実測閾値
+ * （計測: tests/farViewGeomResolution.unit.spec.ts）。
+ */
+export const ADAPTIVE_SEGMENTS_TARGET_M = 250;
+
+/**
+ * 距離適応で引き上げるメッシュ分割数の上限（遠方タイルの頂点数暴発を抑制, #460）。
+ * zoom=10（最粗の遠方タイル）で到達し、それ以上は DEM(256/tile) の情報量的にも過剰。
+ */
+export const ADAPTIVE_SEGMENTS_MAX = 128;
+
+/**
+ * タイルのメッシュ分割数を距離適応で決める（#460）。目標頂点間隔（`ADAPTIVE_SEGMENTS_TARGET_M`）
+ * からタイル 1 辺実距離で分割数を決め、`baseSegments` を下限、DEM 利用可能サンプル数
+ * （この描画タイルが覆う geom DEM 範囲 = 256 / 2^(displayZoom-geomZoom)）と `ADAPTIVE_SEGMENTS_MAX`
+ * を上限にクランプする。近景の細タイル（displayZoom>geomZoom, z16-18）は avail<=baseSegments と
+ * なり実質据え置き（ロード済み DEM の情報量を超えて細分せず、詳細を捏造しない）。
+ */
+export const adaptiveMeshSegments = (
+    tileSizeMeters: number,
+    displayZoom: number,
+    geomZoom: number,
+    baseSegments: number,
+): number => {
+    const availDemSamples = TILE_SIZE >> Math.max(0, displayZoom - geomZoom);
+    const target = Math.round(tileSizeMeters / ADAPTIVE_SEGMENTS_TARGET_M);
+    return Math.max(
+        baseSegments,
+        Math.min(target, availDemSamples, ADAPTIVE_SEGMENTS_MAX),
+    );
+};
+
 /** 生成された曲面タイルメッシュの頂点データ。 */
 export interface GlobeTileMeshData {
     /** アンカー相対の頂点座標（地表面 + スカート頂点）。 */

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -38,7 +38,11 @@ import { ecefToGeodetic } from "./ecef";
 import { latLonToPixel, totalPixelsForZoom } from "./mapping";
 import { selectGlobeTiles, tileKey, type GlobeTile } from "./globeLod";
 import { selectCoarseEdges, type CoarseEdge } from "./crossLevel";
-import { buildGlobeTileMeshData, type GlobeTileMeshData } from "./globeMesh";
+import {
+    buildGlobeTileMeshData,
+    adaptiveMeshSegments,
+    type GlobeTileMeshData,
+} from "./globeMesh";
 import { sampleElevBilinear } from "./elevSample";
 
 /** タイルマテリアルの鏡面反射（地形なので弱め）。 */
@@ -368,6 +372,7 @@ export const createGlobeTileManager = (
         const d = t.zoom - gz;
         return { gz, gx: t.x >> d, gy: t.y >> d };
     };
+
 
     /**
      * 粗ズーム親 DEM から geom タイル (gz,gx,gy) 領域を最近傍で TILE_SIZE 角に切り出す（globe 版）。
@@ -1043,6 +1048,8 @@ export const createGlobeTileManager = (
             const k = tileKey(t.zoom, t.x, t.y);
             const { gz, gx, gy } = geomCoordOf(t);
             const gk = tileKey(gz, gx, gy);
+            // 遠方の粗 zoom タイルは距離適応でメッシュ分割数を上げ、ロード済み DEM 詳細を活かす（#460）。
+            const segs = adaptiveMeshSegments(t.tileSizeMeters, t.zoom, gz, segments);
             const cachedElev = elevCache.get(gk);
             // 標高が視覚的に意味を持つか。固定 minZoom ではなく、カメラ距離も考慮する
             // （`ELEVATION_RELEVANT_MAX_DISTANCE_M` 参照）。`globeLod` の SSE 距離累進で root zoom
@@ -1174,7 +1181,7 @@ export const createGlobeTileManager = (
                     existing,
                     buildGlobeTileMeshData({
                         zoom: t.zoom, tx: t.x, ty: t.y,
-                        geomElev, geomZoom: gz, geomX: gx, geomY: gy, segments, edges,
+                        geomElev, geomZoom: gz, geomX: gx, geomY: gy, segments: segs, edges,
                     }),
                 );
                 builtEdgeSig.set(k, sig);
@@ -1189,7 +1196,7 @@ export const createGlobeTileManager = (
                 geomZoom: gz,
                 geomX: gx,
                 geomY: gy,
-                segments,
+                segments: segs,
                 edges,
             });
 

--- a/tests/farViewGeomResolution.unit.spec.ts
+++ b/tests/farViewGeomResolution.unit.spec.ts
@@ -1,0 +1,126 @@
+/**
+ * #460 遠方ジオメトリ解像度の回帰テスト。
+ *
+ * 東京駅（注視点/center）から富士山方向（カメラ→山頂 ≈100km）を望む実機視点
+ * （viewer.html `@35.680813,139.766423,345,254.18,81.79`）を faithful に再現し、
+ * `selectGlobeTiles` が富士山帯へ割り当てる実タイル zoom と、そこから `adaptiveMeshSegments`
+ * で決まるメッシュ実効解像度（1 頂点あたり地表距離）を検証する。
+ *
+ * 背景（#460）: 既定 segments=32 のままだと遠方の粗 zoom タイル（zoom≈10, 1辺≈32km）は
+ * 1 頂点 ≈1km となり富士山級の独立峰が数頂点に潰れて稜線が失われる。距離適応 segments により
+ * ロード済み DEM 詳細を活かし、遠方でも稜線相当の頂点密度を保つことを回帰として固定する。
+ *
+ * 注: 見た目（silhouette）の最終確認はビジュアル回帰 tests/elevationFarView.spec.ts で行う。
+ */
+import { describe, it, expect } from "@jest/globals";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { ComputeLookAtFromYawPitchToRef } from "@babylonjs/core/Cameras/geospatialCamera";
+
+import { geodeticToEcef } from "../src/terrain/geo/ecef";
+import { tileEdgeMeters } from "../src/terrain/gsiTile";
+import { selectGlobeTiles, type GlobeLodOptions } from "../src/terrain/geo/globeLod";
+import { adaptiveMeshSegments } from "../src/terrain/geo/globeMesh";
+import { GLOBE_SCENE_DEFAULTS } from "../src/scenes/globe";
+
+const DEG2RAD = Math.PI / 180;
+
+// 実機視点: GeospatialCamera 規約で @lat,lon=注視点(center), 第3項=radius[m], azimuth→yaw, tilt→pitch。
+const CENTER_LAT = 35.680813; // 東京駅（丸の内）
+const CENTER_LON = 139.766423;
+const RADIUS_M = 345;
+const YAW = 254.18 * DEG2RAD;
+const PITCH = Math.min(81.79, 89) * DEG2RAD; // globe.ts: min(tilt, MAX_TILT_DEG=89)
+const TOKYO_ELEV_M = 3;
+
+// 富士山山頂（GLOBE_SCENE_DEFAULTS と同一）。
+const FUJI_LAT = 35.3606;
+const FUJI_LON = 138.7274;
+const FUJI_SUMMIT_SPAN_M = 3000; // 山頂付近の急峻な稜線幅
+
+const BASE_SEGMENTS = GLOBE_SCENE_DEFAULTS.segments; // 32
+const GEOM_MAX_ZOOM = GLOBE_SCENE_DEFAULTS.geomMaxZoom; // 15
+
+/** GeospatialCamera と同一手順で cameraEcef を求める。 */
+function computeCameraEcef(centerEcef: Vector3): Vector3 {
+    const lookAt = new Vector3();
+    ComputeLookAtFromYawPitchToRef(YAW, PITCH, centerEcef, /*useRH*/ true, lookAt);
+    return centerEcef.subtract(lookAt.scale(RADIUS_M)); // center - lookAt * radius
+}
+
+describe("#460 farViewGeomResolution", () => {
+    const centerEcef = geodeticToEcef(CENTER_LAT, CENTER_LON, TOKYO_ELEV_M);
+    const cameraEcef = computeCameraEcef(centerEcef);
+
+    const opts: GlobeLodOptions = {
+        cameraEcef,
+        centerLat: CENTER_LAT,
+        centerLon: CENTER_LON,
+        minZoom: GLOBE_SCENE_DEFAULTS.minZoom, // 11
+        maxZoom: GLOBE_SCENE_DEFAULTS.maxZoom, // 18
+        viewportHeight: 1080,
+        viewportWidth: 1920,
+        verticalFov: 0.8,
+        sseThreshold: GLOBE_SCENE_DEFAULTS.sseThreshold, // 384
+        maxTiles: GLOBE_SCENE_DEFAULTS.maxTiles, // 384
+        rootSearchRadius: GLOBE_SCENE_DEFAULTS.rootSearchRadius,
+        maxRootTiles: GLOBE_SCENE_DEFAULTS.maxRootTiles,
+        horizonDotThreshold: GLOBE_SCENE_DEFAULTS.horizonDotThreshold,
+        referenceAltitude: TOKYO_ELEV_M,
+        rootZoomFloor: GLOBE_SCENE_DEFAULTS.rootZoomFloor,
+        textureQualityFloorZoom: GLOBE_SCENE_DEFAULTS.textureQualityFloorZoom,
+        // frustumPlanes は解像度（選択 zoom）に影響しないため省略（帯＋地平線カリングのみ）。
+    };
+
+    const tiles = selectGlobeTiles(opts);
+
+    it("カメラ→富士山山頂の距離が想定範囲（約100km）にある", () => {
+        const d = Vector3.Distance(cameraEcef, geodeticToEcef(FUJI_LAT, FUJI_LON, 3776));
+        expect(d).toBeGreaterThan(90_000);
+        expect(d).toBeLessThan(110_000);
+    });
+
+    it("遠方（富士山帯）は粗い zoom（<=10）が選ばれる（LOD の距離累進）", () => {
+        const minZ = Math.min(...tiles.map((t) => t.zoom));
+        // 距離累進 + distCapZoom により最粗 root は zoom=10 まで下がる。
+        expect(minZ).toBeLessThanOrEqual(10);
+        // 富士山帯（>=90km）に zoom<=10 のタイルが実在する。
+        const farCoarse = tiles.filter((t) => t.zoom <= 10 && t.distance >= 90_000);
+        expect(farCoarse.length).toBeGreaterThan(0);
+    });
+
+    it("距離適応 segments により遠方タイルの実効解像度が zoom12 相当（<=250m/頂点）に保たれる", () => {
+        // 富士山帯の最粗タイル群それぞれについて、adaptiveMeshSegments 適用後の 1 頂点あたり
+        // 地表距離が 250m 以下（=zoom12 相当）になり、既定 segments=32 の ~1km/頂点から改善する。
+        const farCoarse = tiles.filter((t) => t.zoom <= 10 && t.distance >= 90_000);
+        expect(farCoarse.length).toBeGreaterThan(0);
+        for (const t of farCoarse) {
+            const gz = Math.min(t.zoom, GEOM_MAX_ZOOM);
+            const segs = adaptiveMeshSegments(t.tileSizeMeters, t.zoom, gz, BASE_SEGMENTS);
+            const mPerVertex = t.tileSizeMeters / segs;
+            const baseMPerVertex = t.tileSizeMeters / BASE_SEGMENTS;
+
+            // 適応後は zoom12 相当（≈250m/頂点。緯度差で目標 250m を僅かに超える程度に収まる）。
+            expect(mPerVertex).toBeLessThanOrEqual(300);
+            // 既定 segments のままより明確に細かい（少なくとも 2 倍以上の頂点密度）。
+            expect(segs).toBeGreaterThanOrEqual(BASE_SEGMENTS * 2);
+            // 既定では ~1km/頂点だったことを確認（改善の前提）。
+            expect(baseMPerVertex).toBeGreaterThan(500);
+
+            // 富士山山頂急峻部（3km）を最低 10 頂点で表現できる（既定では約 3 頂点）。
+            expect(FUJI_SUMMIT_SPAN_M / mPerVertex).toBeGreaterThanOrEqual(10);
+        }
+    });
+
+    it("近景の細タイル（z16-18, geomZoom=15 共有）は既定 segments 据え置き", () => {
+        const near = tiles.filter((t) => t.zoom >= 16);
+        for (const t of near) {
+            const gz = Math.min(t.zoom, GEOM_MAX_ZOOM);
+            const segs = adaptiveMeshSegments(t.tileSizeMeters, t.zoom, gz, BASE_SEGMENTS);
+            // 覆う DEM サンプル数 = 256/2^(zoom-gz) <= 32 のため既定据え置き（詳細を捏造しない）。
+            expect(segs).toBe(BASE_SEGMENTS);
+        }
+        // 中景（z13-15）も 1 辺が小さく既定のまま（target<=base）であることの目安。
+        const midZ13 = tileEdgeMeters(FUJI_LAT, 13);
+        expect(adaptiveMeshSegments(midZ13, 13, 13, BASE_SEGMENTS)).toBe(BASE_SEGMENTS);
+    });
+});

--- a/tests/globeMesh.unit.spec.ts
+++ b/tests/globeMesh.unit.spec.ts
@@ -12,7 +12,11 @@ import { TILE_SIZE, NO_DATA_SENTINEL } from "../src/terrain/gsiTile";
 import { geodeticToEcef } from "../src/terrain/geo/ecef";
 import { pixelToLatLon, totalPixelsForZoom } from "../src/terrain/geo/mapping";
 import { sampleElevBilinear } from "../src/terrain/geo/elevSample";
-import { buildGlobeTileMeshData } from "../src/terrain/geo/globeMesh";
+import {
+    buildGlobeTileMeshData,
+    adaptiveMeshSegments,
+    ADAPTIVE_SEGMENTS_MAX,
+} from "../src/terrain/geo/globeMesh";
 
 describe("sampleElevBilinear", () => {
     it("定数ラスタは定数を返す", () => {
@@ -130,5 +134,56 @@ describe("buildGlobeTileMeshData", () => {
         const last = 8; // (row=2,col=2) のインデックス
         expect(data.uvs[last * 2]).toBeCloseTo(1, 9);
         expect(data.uvs[last * 2 + 1]).toBeCloseTo(0, 9);
+    });
+});
+
+describe("adaptiveMeshSegments (#460)", () => {
+    const BASE = 32; // GLOBE_SCENE_DEFAULTS.segments
+
+    // 富士緯度でのタイル1辺実距離[m]（計測値, tests/farViewGeomResolution.unit.spec.ts）。
+    const EDGE = {
+        z8: 127665,
+        z10: 31916,
+        z11: 15958,
+        z12: 7979,
+        z13: 3990,
+    } as const;
+
+    it("遠方 zoom=10 タイル（≈32km/辺）は 128 分割へ引き上げる（≈250m/頂点=zoom12相当）", () => {
+        // target = round(31916/250)=128, avail=256(gz==zoom), cap=128 → 128。
+        expect(adaptiveMeshSegments(EDGE.z10, 10, 10, BASE)).toBe(ADAPTIVE_SEGMENTS_MAX);
+        expect(ADAPTIVE_SEGMENTS_MAX).toBe(128);
+    });
+
+    it("zoom=11 タイル（≈16km/辺）は 64 分割へ引き上げる", () => {
+        expect(adaptiveMeshSegments(EDGE.z11, 11, 11, BASE)).toBe(64);
+    });
+
+    it("中〜近景 zoom>=12 は既定 segments のまま（target<=base）", () => {
+        expect(adaptiveMeshSegments(EDGE.z12, 12, 12, BASE)).toBe(BASE); // target=32
+        expect(adaptiveMeshSegments(EDGE.z13, 13, 13, BASE)).toBe(BASE); // target=16→floor 32
+    });
+
+    it("最粗の巨大タイル（zoom=8, ≈128km/辺）は上限 128 で頭打ち", () => {
+        // target=round(127665/250)=511 だが cap=128。
+        expect(adaptiveMeshSegments(EDGE.z8, 8, 8, BASE)).toBe(ADAPTIVE_SEGMENTS_MAX);
+    });
+
+    it("近景 z16-18（geomZoom=15 を共有）は DEM 利用可能サンプル数までに抑え既定据え置き", () => {
+        // 表示 z18/geom z15: 覆う DEM 範囲 = 256/2^3 = 32 サンプル。細分しても DEM 情報は増えない。
+        // 小さいタイル（1辺 ~150m）は target=1 でもあり、いずれにせよ base(32) 据え置き。
+        expect(adaptiveMeshSegments(150, 18, 15, BASE)).toBe(BASE);
+    });
+
+    it("DEM 利用可能サンプル数が base と cap の間なら avail でクランプする", () => {
+        // 合成ケース: displayZoom-geomZoom=2 → avail=256/4=64。target を avail 超へ設定しても
+        // 64 に制限される（ロード済み DEM 情報量を超えて詳細を捏造しない）。
+        expect(adaptiveMeshSegments(40000, 17, 15, BASE)).toBe(64);
+    });
+
+    it("結果は常に baseSegments 以上（近景の解像度を下げない）", () => {
+        for (const [edge, z] of [[EDGE.z10, 10], [EDGE.z13, 13], [150, 18]] as const) {
+            expect(adaptiveMeshSegments(edge, z, Math.min(z, 15), BASE)).toBeGreaterThanOrEqual(BASE);
+        }
     });
 });


### PR DESCRIPTION
## 概要

Issue #460「zoom=10相当のジオメトリ解像度では遠方（東京〜富士山級）の地形起伏をほぼ表現できない」の対応。

東京→富士山（約100km）等の遠景で選択される粗い zoom タイル（zoom≈10, 1辺≈32km）が、既定 `segments=32` のままでは 1頂点≈1km となり、DEM(256px, ≈125m/sample) の詳細を捨てて富士山級の独立峰が数頂点に潰れ平坦化していた。

## 定量根本原因（#459 修正後の現状で計測）

実 `selectGlobeTiles` + 実既定値で東京駅→富士山視点を faithful に再現して測定（計測スペック `tests/farViewGeomResolution.unit.spec.ts`）。

- 遠方（富士山帯 35–108km）は **zoom=10** が選択（1辺≈32km）。
- **2要因の複合**: ① LOD 距離累進で遠方が zoom=10 止まり、② `segments=32` が DEM(256) を約8倍粗くサブサンプル → **実効 997m/頂点**。
- 結果: 富士山 山頂急峻部(3km) が **約3頂点** ＝ ほぼ三角錐・稜線なしで平坦に見える。
- Issue 本文の「geomMaxZoom=10」は誤りで**実際は 15**（zoom=10 は LOD 由来）。#459（`terrainElevAt` の150km拡張）は標高クエリの話で描画メッシュ（`geomCoordOf`）とは無関係のため、平坦さは #459 では改善していなかった。
- 重要: **DEM 自体（125m/sample）はメッシュ（997m/頂点）より細かく、ロード済み詳細をメッシュが捨てていた。**

## 対応: 距離適応 segments

- `globeMesh.adaptiveMeshSegments(tileSizeMeters, displayZoom, geomZoom, baseSegments)` を新設・export。
  - 目標頂点間隔 `ADAPTIVE_SEGMENTS_TARGET_M=250` からタイル1辺実距離で分割数を決定。
  - `baseSegments`(=32) を下限、DEM 利用可能サンプル数 `256/2^(displayZoom-geomZoom)` と `ADAPTIVE_SEGMENTS_MAX=128` を上限にクランプ。
- `globeTileManager.buildReadyTiles` で per-tile に適用。
- 効果: 遠方のみ分割数を上げ（z10→128, z11→64、近景 z16-18 は据え置き）、**タイル追加ロード無し**で実効解像度を **997→250m/頂点（zoom12相当）**、富士山山頂を **3→約12頂点**へ改善。

## 影響範囲

- 描画（遠景メッシュの頂点密度）のみ。**API・型・既存挙動の変更なし**（cross-level snap / skirt / stitching は可変 segments 対応済み、near/近景は据え置き）。
- 頂点増は遠方の少数タイルに集中（+~280k頂点程度）。`maxTiles`（タイル数）予算は不変。

## 検証

- `npm run lint` / `npm run typecheck` 成功。
- `npm run test:unit` **1327 passed**（`adaptiveMeshSegments` 単体・東京→富士山 faithful 再現の回帰テストを追加）。
- `npm run test:visuals` **21 passed（視覚回帰なし）**。
- code-review（high）実施、実バグの指摘なし。

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)
