### PR TITLE
fix(terrain): Follow modeの前方タイル穴を viewForward で解消（#475）

### DIFF
--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -54,7 +54,7 @@ import {
     resolveRecalcCenterSource,
 } from "../terrain/geo/cameraMapping";
 import { createGlobeTileManager, type GlobeTileManager, type GlobeTileSyncStats } from "../terrain/geo/globeTileManager";
-import { viewForwardFromFrustumPlanes } from "../terrain/geo/globeLod";
+import { viewForwardFromFrustumPlanesToRef } from "../terrain/geo/globeLod";
 import type { FrustumPlane } from "../terrain/visibleTiles";
 import { createGlobeMarkerManager, type GlobeMarkerManager } from "../terrain/geo/globeMarkerManager";
 import {
@@ -1959,9 +1959,8 @@ export class GlobeScene {
             // 外部 frustum から実視線 forward を導出して LOD の前方到達距離補正に渡す。通常カメラ
             // （override なし）は center が真の注視点なので補正不要＝渡さない（後方互換）。
             let viewForward: Vector3 | undefined;
-            if (override) {
-                const f = viewForwardFromFrustumPlanes(override.planes);
-                if (f) viewForward = externalViewForward.copyFrom(f);
+            if (override && viewForwardFromFrustumPlanesToRef(override.planes, externalViewForward)) {
+                viewForward = externalViewForward;
             }
             const stats = tileManager.sync({
                 cameraEcef: override ? override.cameraEcef : computeCameraEcef(),

--- a/src/scenes/globe.ts
+++ b/src/scenes/globe.ts
@@ -54,6 +54,7 @@ import {
     resolveRecalcCenterSource,
 } from "../terrain/geo/cameraMapping";
 import { createGlobeTileManager, type GlobeTileManager, type GlobeTileSyncStats } from "../terrain/geo/globeTileManager";
+import { viewForwardFromFrustumPlanes } from "../terrain/geo/globeLod";
 import type { FrustumPlane } from "../terrain/visibleTiles";
 import { createGlobeMarkerManager, type GlobeMarkerManager } from "../terrain/geo/globeMarkerManager";
 import {
@@ -971,6 +972,9 @@ export class GlobeScene {
             normal: { x: 0, y: 0, z: 0 },
             d: 0,
         }));
+        // 外部 frustum（Follow mode）から導出する視線 forward の永続コピー先（毎フレームの
+        // Vector3 アロケーションを避ける。#475）。
+        const externalViewForward = new Vector3();
 
         /** GeospatialCamera の center/yaw/pitch/radius から真の ECEF 位置を復元する。 */
         const computeCameraEcef = (): Vector3 => {
@@ -1950,6 +1954,15 @@ export class GlobeScene {
 
         const syncTiles = (): void => {
             const override = externalFrustumOverride;
+            // Follow mode（外部 frustum）では center=機体直下地表・実カメラは水平前方視のため、
+            // center 由来の tilt では前方到達距離が過小になり地平線側が未種付けの穴になる（#475）。
+            // 外部 frustum から実視線 forward を導出して LOD の前方到達距離補正に渡す。通常カメラ
+            // （override なし）は center が真の注視点なので補正不要＝渡さない（後方互換）。
+            let viewForward: Vector3 | undefined;
+            if (override) {
+                const f = viewForwardFromFrustumPlanes(override.planes);
+                if (f) viewForward = externalViewForward.copyFrom(f);
+            }
             const stats = tileManager.sync({
                 cameraEcef: override ? override.cameraEcef : computeCameraEcef(),
                 centerEcef: camera.center,
@@ -1979,6 +1992,7 @@ export class GlobeScene {
                     return points;
                 })(),
                 textureQualityFloorZoom: GLOBE_SCENE_DEFAULTS.textureQualityFloorZoom,
+                viewForward,
             });
             if (options.onSyncStats) {
                 const geo = ecefToGeodetic(camera.center);

--- a/src/terrain/geo/globeLod.ts
+++ b/src/terrain/geo/globeLod.ts
@@ -275,15 +275,18 @@ const effectiveSseThreshold = (
  */
 /**
  * camera 相対（原点=cameraEcef、回転のみ・並進なし）の視錐台6平面から視線 forward（ECEF 向き
- * 単位ベクトル）を導出する。`FrustumPlane` の法線は内向き（`normal·p + d < 0` で外側,
+ * 単位ベクトル）を `ref` に書き込む。`FrustumPlane` の法線は内向き（`normal·p + d < 0` で外側,
  * `visibleTiles.ts` 規約）で、near/far は forward の逆向き同士＝相殺し、left/right・top/bottom は
  * lateral/vertical 成分が相殺し forward 成分のみ残るため、6平面法線の和は forward に比例する。
- * 平面インデックス順序に依存しない（順序非依存）。零和・非有限は `null`（呼び出し側でフォールバック）。
+ * 平面インデックス順序に依存しない（順序非依存）。導出できたら `true`、平面数≠6・零和・非有限は
+ * `false`（`ref` は未変更、呼び出し側でフォールバック）。毎フレーム呼ぶ経路（`globe.ts` syncTiles）が
+ * Vector3 を新規生成せず再利用できるよう ToRef 形にする。
  */
-export const viewForwardFromFrustumPlanes = (
+export const viewForwardFromFrustumPlanesToRef = (
     planes: readonly FrustumPlane[],
-): Vector3 | null => {
-    if (planes.length !== 6) return null;
+    ref: Vector3,
+): boolean => {
+    if (planes.length !== 6) return false;
     let sx = 0;
     let sy = 0;
     let sz = 0;
@@ -293,9 +296,21 @@ export const viewForwardFromFrustumPlanes = (
         sz += p.normal.z;
     }
     const lenSq = sx * sx + sy * sy + sz * sz;
-    if (!Number.isFinite(lenSq) || lenSq < 1e-12) return null;
+    if (!Number.isFinite(lenSq) || lenSq < 1e-12) return false;
     const inv = 1 / Math.sqrt(lenSq);
-    return new Vector3(sx * inv, sy * inv, sz * inv);
+    ref.set(sx * inv, sy * inv, sz * inv);
+    return true;
+};
+
+/**
+ * `viewForwardFromFrustumPlanesToRef` の Vector3 生成版（新規 Vector3 を返す。導出不能なら `null`）。
+ * 毎フレームでない呼び出し・テスト向け。ホットパスでは ToRef 版を使うこと。
+ */
+export const viewForwardFromFrustumPlanes = (
+    planes: readonly FrustumPlane[],
+): Vector3 | null => {
+    const out = new Vector3();
+    return viewForwardFromFrustumPlanesToRef(planes, out) ? out : null;
 };
 
 export const selectGlobeRootTiles = (opts: GlobeRootSeedOptions): RootSeed[] => {

--- a/src/terrain/geo/globeLod.ts
+++ b/src/terrain/geo/globeLod.ts
@@ -115,6 +115,12 @@ export interface GlobeLodOptions {
      * 省略時は無効（既存の `rootZoomFloor`/SSE のみで判定、後方互換）。
      */
     textureQualityFloorZoom?: number;
+    /**
+     * 実カメラ視線 forward（ECEF 向きベクトル）。前方 swath 到達距離を決める tilt をこの向きから
+     * 求める（`GlobeRootSeedOptions.viewForward` 参照）。`selectGlobeRootTiles` へそのまま転送する。
+     * 省略時は従来どおり camera→center から tilt を算出（後方互換）。
+     */
+    viewForward?: Vector3;
 }
 
 /** タイル中心の ECEF（基準標高 alt）を ref に書き込み、その緯度経度を返す。 */
@@ -187,6 +193,14 @@ export interface GlobeRootSeedOptions {
      * 負値（海面下）と NaN/Infinity は 0（海面）へ丸める。
      */
     referenceAltitude?: number;
+    /**
+     * 実カメラ視線 forward（ECEF 向きベクトル、camera 相対回転で導出可）。指定時、前方到達距離
+     * `forwardReach` を決める tilt（直下=-cameraEcef からの視線角）をこの向きから求める。
+     * Follow mode のように center（=機体直下地表）と実視線が乖離する経路で、center 由来の tilt が
+     * 過小算出され前方（地平線側）が未種付けになる問題（#475）を防ぐ。省略・零ベクトル・非有限は
+     * 従来どおり camera→center から tilt を算出（後方互換）。内部で正規化するため単位でなくてもよい。
+     */
+    viewForward?: Vector3;
 }
 
 /** カメラ↔地表点の弦距離の概算に使う WGS84 平均半径 [m]。 */
@@ -259,6 +273,31 @@ const effectiveSseThreshold = (
  * 帯の被覆過多や裏側は後段の地平線カリング・SSE・maxTiles 打ち切りで間引かれる。直下視
  * （nadir≒center で方向が定まらない）では nadir 中心の対称ボックスにフォールバックする。
  */
+/**
+ * camera 相対（原点=cameraEcef、回転のみ・並進なし）の視錐台6平面から視線 forward（ECEF 向き
+ * 単位ベクトル）を導出する。`FrustumPlane` の法線は内向き（`normal·p + d < 0` で外側,
+ * `visibleTiles.ts` 規約）で、near/far は forward の逆向き同士＝相殺し、left/right・top/bottom は
+ * lateral/vertical 成分が相殺し forward 成分のみ残るため、6平面法線の和は forward に比例する。
+ * 平面インデックス順序に依存しない（順序非依存）。零和・非有限は `null`（呼び出し側でフォールバック）。
+ */
+export const viewForwardFromFrustumPlanes = (
+    planes: readonly FrustumPlane[],
+): Vector3 | null => {
+    if (planes.length !== 6) return null;
+    let sx = 0;
+    let sy = 0;
+    let sz = 0;
+    for (const p of planes) {
+        sx += p.normal.x;
+        sy += p.normal.y;
+        sz += p.normal.z;
+    }
+    const lenSq = sx * sx + sy * sy + sz * sz;
+    if (!Number.isFinite(lenSq) || lenSq < 1e-12) return null;
+    const inv = 1 / Math.sqrt(lenSq);
+    return new Vector3(sx * inv, sy * inv, sz * inv);
+};
+
 export const selectGlobeRootTiles = (opts: GlobeRootSeedOptions): RootSeed[] => {
     const {
         cameraEcef,
@@ -474,10 +513,28 @@ export const selectGlobeRootTiles = (opts: GlobeRootSeedOptions): RootSeed[] => 
         Math.max(-1, Vector3.Dot(cameraEcef, centerEcef) / (camLen * centerEcef.length())),
     );
     const dirLenMeters = R * Math.acos(cosPsi);
-    const lookDir = centerEcef.subtract(cameraEcef); // camera→center（このあと未使用なので破棄可）
-    const tilt = Math.acos(
-        Math.min(1, Math.max(-1, -Vector3.Dot(lookDir, cameraEcef) / (lookDir.length() * camLen))),
-    );
+    const lookDir = centerEcef.subtract(cameraEcef); // camera→center
+    // tilt = 視線と直下（−cameraEcef）のなす角。Follow mode では実カメラが機体（高度あり）を見て
+    // ほぼ水平前方を向くのに center=機体直下地表のため、camera→center 由来の tilt が実際より小さく
+    // （下向き寄りに）算出され forwardReach が短縮、前方（地平線側）が未種付けになる（#475）。
+    // viewForward（実視線）が渡された場合はそれで tilt を求め、前方到達距離を実視線に一致させる。
+    // 零ベクトル・非有限は camera→center へフォールバック（後方互換）。
+    const vf = opts.viewForward;
+    const vfLenSq = vf ? vf.lengthSquared() : 0;
+    const tilt =
+        vf && Number.isFinite(vfLenSq) && vfLenSq > 1e-12
+            ? Math.acos(
+                  Math.min(
+                      1,
+                      Math.max(-1, -Vector3.Dot(vf, cameraEcef) / (Math.sqrt(vfLenSq) * camLen)),
+                  ),
+              )
+            : Math.acos(
+                  Math.min(
+                      1,
+                      Math.max(-1, -Vector3.Dot(lookDir, cameraEcef) / (lookDir.length() * camLen)),
+                  ),
+              );
 
     // nadir と center の root を最優先確保（各々の SSE 最適 zoom で）。budget=1 では nadir のみ。
     addAt(t0.x, t0.y, zoomForDist(chordDist(0)));
@@ -632,6 +689,7 @@ export const selectGlobeTiles = (opts: GlobeLodOptions): GlobeTile[] => {
         frustumPlanes,
         pinnedPoints,
         textureQualityFloorZoom,
+        viewForward,
     } = opts;
 
     if (maxZoom < minZoom) return [];
@@ -814,6 +872,7 @@ export const selectGlobeTiles = (opts: GlobeLodOptions): GlobeTile[] => {
         sseThreshold,
         textureQualityFloorZoom,
         referenceAltitude,
+        viewForward,
     });
     // root シードを traverse 開始点とする。日本被覆域外の root が minZoom(>WORLD_TEXTURE_MAX_ZOOM)
     // で生成されると、それ以上分割しなくても root タイル自体のテクスチャが存在せず(404)白く欠ける。

--- a/src/terrain/geo/globeTileManager.ts
+++ b/src/terrain/geo/globeTileManager.ts
@@ -204,6 +204,11 @@ export interface GlobeTileSyncParams {
      * `GlobeLodOptions.textureQualityFloorZoom` 参照）。省略時は無効。
      */
     textureQualityFloorZoom?: number;
+    /**
+     * 実カメラ視線 forward（ECEF 向きベクトル。`globeLod.ts` の `GlobeLodOptions.viewForward`
+     * 参照）。Follow mode で center と実視線が乖離する経路の前方到達距離補正に使う。省略時は無効。
+     */
+    viewForward?: Vector3;
 }
 
 /** 同期結果の統計。 */
@@ -1313,6 +1318,7 @@ export const createGlobeTileManager = (
             frustumPlanes: params.frustumPlanes,
             pinnedPoints: params.pinnedPoints,
             textureQualityFloorZoom: params.textureQualityFloorZoom,
+            viewForward: params.viewForward,
         });
         desiredKeys = new Set(tiles.map((t) => tileKey(t.zoom, t.x, t.y)));
         // 可視タイルの全祖先キー集合と最大 zoom を構築（カバー判定・zoom 階層判定に使う）。

--- a/tests/globeLod.unit.spec.ts
+++ b/tests/globeLod.unit.spec.ts
@@ -23,6 +23,7 @@ import {
     selectGlobeTiles,
     tileKey,
     viewForwardFromFrustumPlanes,
+    viewForwardFromFrustumPlanesToRef,
     type GlobeLodOptions,
 } from "../src/terrain/geo/globeLod";
 import { GLOBE_SCENE_DEFAULTS } from "../src/scenes/globe";
@@ -1132,6 +1133,22 @@ describe("viewForwardFromFrustumPlanes（#475）", () => {
             d: 0,
         }));
         expect(viewForwardFromFrustumPlanes(zero)).toBeNull();
+    });
+
+    it("ToRef 版は ref に書き込み true を返す／退化時は false で ref 未変更（アロケーション回避）", () => {
+        const eye = geodeticToEcef(CENTER_LAT, CENTER_LON, 3000);
+        const target = geodeticToEcef(CENTER_LAT + 0.05, CENTER_LON, 2000);
+        const planes = cameraRelativePlanes(eye, target, eye.clone().normalize());
+        const ref = new Vector3(1, 2, 3);
+        expect(viewForwardFromFrustumPlanesToRef(planes, ref)).toBe(true);
+        expect(ref.length()).toBeCloseTo(1, 6);
+        const trueFwd = target.subtract(eye).normalize();
+        expect(Vector3.Dot(ref, trueFwd)).toBeGreaterThan(0.999);
+
+        // 退化（平面数≠6）: false を返し、ref は元のまま（未変更）。
+        const sentinel = new Vector3(7, 8, 9);
+        expect(viewForwardFromFrustumPlanesToRef([], sentinel)).toBe(false);
+        expect(sentinel.equals(new Vector3(7, 8, 9))).toBe(true);
     });
 });
 

--- a/tests/globeLod.unit.spec.ts
+++ b/tests/globeLod.unit.spec.ts
@@ -9,16 +9,20 @@
  */
 
 import { describe, it, expect } from "@jest/globals";
-import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { Vector3, Matrix } from "@babylonjs/core/Maths/math.vector";
+import { Frustum } from "@babylonjs/core/Maths/math.frustum";
+import { Plane } from "@babylonjs/core/Maths/math.plane";
 import { ComputeLookAtFromYawPitchToRef } from "@babylonjs/core/Cameras/geospatialCamera";
 import { Wgs84Ellipsoid } from "@babylonjs/core/Maths/math.geospatial.functions";
 
 import { tileCenterLatLon, toTileXY } from "../src/terrain/gsiTile";
 import { geodeticToEcef, ecefToGeodetic } from "../src/terrain/geo/ecef";
+import { geographicTangentBasisToRef } from "../src/terrain/geo/cameraMapping";
 import {
     selectGlobeRootTiles,
     selectGlobeTiles,
     tileKey,
+    viewForwardFromFrustumPlanes,
     type GlobeLodOptions,
 } from "../src/terrain/geo/globeLod";
 import { GLOBE_SCENE_DEFAULTS } from "../src/scenes/globe";
@@ -1065,5 +1069,246 @@ describe("selectGlobeRootTiles", () => {
         );
         expect(seeds.length).toBeGreaterThan(0);
         for (const s of seeds) expect(s.zoom).toBeLessThanOrEqual(6);
+    });
+});
+
+describe("viewForwardFromFrustumPlanes（#475）", () => {
+    const V_FOV = 0.8;
+    const ASPECT = 1920 / 1080;
+
+    /**
+     * flight/index.ts と同一手順で camera 相対（原点=eye、回転のみ）の視錐台6平面を作る。
+     * FreeCamera は左手系（LookAtLH / PerspectiveFovLH）。view 行列の並進行を 0 にして
+     * projection と合成し、Frustum.GetPlanesToRef で平面を得る。
+     */
+    const cameraRelativePlanes = (
+        eye: Vector3,
+        target: Vector3,
+        up: Vector3,
+    ): FrustumPlane[] => {
+        const viewMat = Matrix.LookAtLH(eye, target, up);
+        viewMat.setRowFromFloats(3, 0, 0, 0, 1); // 並進を 0（camera 相対化）。
+        const projMat = Matrix.PerspectiveFovLH(V_FOV, ASPECT, 1, 400000);
+        const transform = Matrix.Identity();
+        viewMat.multiplyToRef(projMat, transform);
+        const raw: Plane[] = Array.from({ length: 6 }, () => new Plane(0, 0, 0, 0));
+        Frustum.GetPlanesToRef(transform, raw);
+        return raw.map((p) => ({
+            normal: { x: p.normal.x, y: p.normal.y, z: p.normal.z },
+            d: p.d,
+        }));
+    };
+
+    it("視錐台6平面から実視線 forward を復元する（真の forward と一致）", () => {
+        // 東京付近から北・やや下方を見るカメラ。真の forward = normalize(target - eye)。
+        const eye = geodeticToEcef(CENTER_LAT, CENTER_LON, 3000);
+        const target = geodeticToEcef(CENTER_LAT + 0.05, CENTER_LON, 2000);
+        const up = eye.clone().normalize();
+        const planes = cameraRelativePlanes(eye, target, up);
+        const fwd = viewForwardFromFrustumPlanes(planes);
+        expect(fwd).not.toBeNull();
+        const trueFwd = target.subtract(eye).normalize();
+        expect(Vector3.Dot(fwd as Vector3, trueFwd)).toBeGreaterThan(0.999);
+    });
+
+    it("戻り値は単位ベクトル", () => {
+        const eye = geodeticToEcef(CENTER_LAT, CENTER_LON, 5000);
+        const target = geodeticToEcef(CENTER_LAT + 0.1, CENTER_LON + 0.03, 0);
+        const planes = cameraRelativePlanes(eye, target, eye.clone().normalize());
+        const fwd = viewForwardFromFrustumPlanes(planes) as Vector3;
+        expect(fwd.length()).toBeCloseTo(1, 6);
+    });
+
+    it("平面数が6でなければ null", () => {
+        expect(viewForwardFromFrustumPlanes([])).toBeNull();
+        expect(
+            viewForwardFromFrustumPlanes([{ normal: { x: 1, y: 0, z: 0 }, d: 0 }]),
+        ).toBeNull();
+    });
+
+    it("法線和が零ベクトルなら null（退化）", () => {
+        const zero: FrustumPlane[] = Array.from({ length: 6 }, () => ({
+            normal: { x: 0, y: 0, z: 0 },
+            d: 0,
+        }));
+        expect(viewForwardFromFrustumPlanes(zero)).toBeNull();
+    });
+});
+
+describe("Follow mode 前方到達距離補正（viewForward, #475）", () => {
+    // Follow mode の幾何: 機体（高度 alt）の後方 radius・上方 height に追従カメラを置き、機体を見る。
+    // cameraEcef=追従カメラ位置、center=機体直下地表（本番の flight/index.ts が渡す値）。
+    // 追従カメラはほぼ水平前方を向くのに center=直下地表のため、center 由来 tilt では前方到達距離が
+    // 過小になり地平線側が未種付けの穴になる（#475）。frustum 由来 viewForward で解消する。
+    const V_FOV = 0.8;
+    const ASPECT = 1920 / 1080;
+    const R = 6371000;
+    const DEG = Math.PI / 180;
+
+    /** heading 北・rotationOffset 180（真後ろ）の追従カメラ eye/target/up を組む。 */
+    const followRig = (altM: number, radiusM: number, heightM: number) => {
+        const plane = geodeticToEcef(CENTER_LAT, CENTER_LON, altM);
+        const east = new Vector3();
+        const north = new Vector3();
+        geographicTangentBasisToRef(plane, east, north);
+        const up = plane.clone().normalize();
+        // rot=180° → sin=0, cos=-1 → 真北飛行の真後ろ（南）へ radius。
+        const eye = plane
+            .add(north.scale(-radiusM))
+            .add(up.scale(heightM));
+        return { eye, target: plane.clone(), up };
+    };
+
+    /** flight/index.ts と同手順の camera 相対視錐台平面。 */
+    const followPlanes = (eye: Vector3, target: Vector3, up: Vector3): FrustumPlane[] => {
+        const viewMat = Matrix.LookAtLH(eye, target, up);
+        viewMat.setRowFromFloats(3, 0, 0, 0, 1);
+        const projMat = Matrix.PerspectiveFovLH(V_FOV, ASPECT, 1, 400000);
+        const transform = Matrix.Identity();
+        viewMat.multiplyToRef(projMat, transform);
+        const raw: Plane[] = Array.from({ length: 6 }, () => new Plane(0, 0, 0, 0));
+        Frustum.GetPlanesToRef(transform, raw);
+        return raw.map((p) => ({
+            normal: { x: p.normal.x, y: p.normal.y, z: p.normal.z },
+            d: p.d,
+        }));
+    };
+
+    const followOpts = (
+        eye: Vector3,
+        planes: FrustumPlane[],
+        withViewForward: boolean,
+    ): GlobeLodOptions => {
+        const vf = withViewForward
+            ? (viewForwardFromFrustumPlanes(planes) ?? undefined)
+            : undefined;
+        return {
+            cameraEcef: eye,
+            centerLat: CENTER_LAT, // 本番: 機体直下地表点。
+            centerLon: CENTER_LON,
+            minZoom: GLOBE_SCENE_DEFAULTS.minZoom,
+            maxZoom: GLOBE_SCENE_DEFAULTS.maxZoom,
+            viewportHeight: 1080,
+            viewportWidth: 1920,
+            verticalFov: V_FOV,
+            sseThreshold: GLOBE_SCENE_DEFAULTS.sseThreshold,
+            maxTiles: GLOBE_SCENE_DEFAULTS.maxTiles,
+            rootSearchRadius: GLOBE_SCENE_DEFAULTS.rootSearchRadius,
+            maxRootTiles: GLOBE_SCENE_DEFAULTS.maxRootTiles,
+            horizonDotThreshold: GLOBE_SCENE_DEFAULTS.horizonDotThreshold,
+            referenceAltitude: 0,
+            rootZoomFloor: GLOBE_SCENE_DEFAULTS.rootZoomFloor,
+            frustumPlanes: planes,
+            textureQualityFloorZoom: GLOBE_SCENE_DEFAULTS.textureQualityFloorZoom,
+            viewForward: vf,
+        };
+    };
+
+    /** frustum 内の子午線サンプルで最遠被覆距離[km]と最初の穴[km]（無ければ-1）を返す。 */
+    const coverageNorth = (opts: GlobeLodOptions) => {
+        const tiles = selectGlobeTiles(opts);
+        const cam = opts.cameraEcef;
+        const inFrustum = (lat: number, lon: number): boolean => {
+            const p = geodeticToEcef(lat, lon, 0);
+            const rx = p.x - cam.x, ry = p.y - cam.y, rz = p.z - cam.z;
+            for (const pl of opts.frustumPlanes ?? []) {
+                if (pl.normal.x * rx + pl.normal.y * ry + pl.normal.z * rz + pl.d < 0) {
+                    return false;
+                }
+            }
+            return true;
+        };
+        const covered = (lat: number, lon: number): boolean =>
+            tiles.some((t) => {
+                const c = toTileXY(lat, lon, t.zoom);
+                return c.x === t.x && c.y === t.y;
+            });
+        const h = Math.max(0, ecefToGeodetic(cam).altMeters);
+        const horizonKm = (R * Math.acos(R / (R + h))) / 1000;
+        let lastCoveredKm = 0;
+        let firstHoleKm = -1;
+        for (let km = 0.5; km <= horizonKm; km += 0.5) {
+            const lat = CENTER_LAT + (km * 1000) / R / DEG; // 北（機体前方）。
+            if (!inFrustum(lat, CENTER_LON)) continue;
+            if (covered(lat, CENTER_LON)) lastCoveredKm = km;
+            else if (firstHoleKm < 0) firstHoleKm = km;
+        }
+        return { tiles, lastCoveredKm, firstHoleKm, horizonKm };
+    };
+
+    // 追従カメラを引き（radius 3000m・height 15m）水平線が見える構図。alt 2000 / 10000。
+    for (const altM of [2000, 10000]) {
+        it(`alt=${altM}m: viewForward 無しでは前方が地平線手前で穴、有りで地平線近くまで連続被覆`, () => {
+            const { eye, target, up } = followRig(altM, 3000, 15);
+            const planes = followPlanes(eye, target, up);
+
+            // 補正なし（現状=バグ）: frustum は地平線まで映すのに被覆が手前で頭打ち→穴が出る。
+            const base = coverageNorth(followOpts(eye, planes, false));
+            expect(base.firstHoleKm).toBeGreaterThan(0); // 穴がある。
+            expect(base.lastCoveredKm).toBeLessThan(base.horizonKm * 0.5);
+
+            // 補正あり（修正）: 前方が地平線の 7 割超まで連続被覆され、穴が消える。
+            const fixed = coverageNorth(followOpts(eye, planes, true));
+            expect(fixed.firstHoleKm).toBe(-1); // 穴なし。
+            expect(fixed.lastCoveredKm).toBeGreaterThan(fixed.horizonKm * 0.7);
+            // タイル数は maxTiles 予算内（暴発しない）。
+            expect(fixed.tiles.length).toBeLessThanOrEqual(GLOBE_SCENE_DEFAULTS.maxTiles);
+        });
+    }
+
+    it("viewForward=undefined は明示指定なしと同一結果（後方互換）", () => {
+        const { eye, target, up } = followRig(2000, 3000, 15);
+        const planes = followPlanes(eye, target, up);
+        const withUndef = selectGlobeTiles(followOpts(eye, planes, false));
+        const optsNoField = followOpts(eye, planes, false);
+        delete optsNoField.viewForward; // フィールド自体を消す。
+        const withoutField = selectGlobeTiles(optsNoField);
+        expect(withUndef).toEqual(withoutField);
+    });
+
+    it("viewForward=normalize(center−camera) は未指定と同一 seed（一致経路で挙動不変）", () => {
+        // ビューアのように視線が camera→center と一致する場合、viewForward を渡しても tilt は
+        // 同値に収束し seed 集合が変わらないこと（退行なしの担保）。
+        const cameraEcef = geodeticToEcef(CENTER_LAT - 0.5, CENTER_LON, 60000);
+        const centerEcef = geodeticToEcef(CENTER_LAT, CENTER_LON, 0);
+        const common = {
+            cameraEcef,
+            centerLat: CENTER_LAT,
+            centerLon: CENTER_LON,
+            minZoom: 11,
+            rootSearchRadius: 2,
+            maxRootTiles: 256,
+            viewportHeight: 1080,
+            viewportWidth: 1920,
+            verticalFov: V_FOV,
+            sseThreshold: GLOBE_SCENE_DEFAULTS.sseThreshold,
+            rootZoomFloor: 5,
+        } as const;
+        const seedsNoVf = selectGlobeRootTiles(common);
+        const seedsVf = selectGlobeRootTiles({
+            ...common,
+            viewForward: centerEcef.subtract(cameraEcef).normalize(),
+        });
+        expect(seedsVf).toEqual(seedsNoVf);
+    });
+
+    it("零ベクトル viewForward は camera→center 由来 tilt にフォールバック（例外なし）", () => {
+        const cameraEcef = geodeticToEcef(CENTER_LAT - 0.5, CENTER_LON, 60000);
+        const common = {
+            cameraEcef,
+            centerLat: CENTER_LAT,
+            centerLon: CENTER_LON,
+            minZoom: 11,
+            rootSearchRadius: 2,
+            maxRootTiles: 256,
+            viewportHeight: 1080,
+            viewportWidth: 1920,
+            verticalFov: V_FOV,
+            sseThreshold: GLOBE_SCENE_DEFAULTS.sseThreshold,
+            rootZoomFloor: 5,
+        } as const;
+        const seedsBase = selectGlobeRootTiles(common);
+        const seedsZero = selectGlobeRootTiles({ ...common, viewForward: new Vector3(0, 0, 0) });
+        expect(seedsZero).toEqual(seedsBase);
     });
 });


### PR DESCRIPTION
Closes #475

## 概要

フライトデモ Follow mode でカメラのチルトを寝かせ水平線が見える角度にすると、機体前方〜地平線側の中〜遠距離タイルが穴（暫定色/欠け）になる問題を修正する。

## 原因

Follow / 3D ビューア / 通常メインカメラは同一の `selectGlobeTiles`（`src/terrain/geo/globeLod.ts`）でタイルを選択する。root swath の前方到達距離（forwardReach）は `selectGlobeRootTiles` 内で `cameraEcef → centerEcef` から求めた視線の下向き角 `tilt` に依存して決まる。

Follow mode では追従カメラ（`FOLLOW_CAMERA_RADIUS=20m` / `HEIGHT_OFFSET=15m` と極小で、ほぼ機体位置）が機体（高度あり）を見て**ほぼ水平前方**を向くのに、LOD へ渡す center は機体**直下の地表点**（`flight/index.ts` の `pos.lat/pos.lon`）である。このため center 由来の `tilt` が実際より小さく（下向き寄りに）算出され、`forwardReach` が過小（実測で約39km）になり、frustum が地平線（高度2000mで約160km・10000mで約357km）まで映すのに遠方が未種付けのまま＝穴になる。3D ビューアは center が実注視点で `tilt` が実視線と一致するため発生しない（ユーザー報告「決定方法が違う」の正体）。

再現テストで数値確認済み: frustum カリングを外しても被覆は39kmで頭打ち（frustum は無罪、seed 自体は遠方まで生成）。center を実カメラが向く前方へ与えると被覆が地平線まで伸び穴が消えることを確認。

## 修正

- `GlobeLodOptions` / `GlobeRootSeedOptions` に optional `viewForward?: Vector3`（実カメラ視線 forward、ECEF 向き）を追加。指定時、`forwardReach` を決める `tilt` をこの向きから算出する。
- `viewForwardFromFrustumPlanes` を追加。camera 相対 frustum の6平面法線の和が forward に比例する（内向き法線で near/far は相殺、side 面の forward 成分が残る／平面順序非依存）性質を使い forward を導出。零和・非有限・平面数≠6 は `null`。
- `globe.ts` の `syncTiles` は外部 frustum（Follow）が有効なときのみ frustum から forward を導出して渡す。通常カメラ（override なし）は渡さない。
- `viewForward` 省略・零ベクトル・非有限は従来どおり `camera→center` から `tilt` を算出（**後方互換**）。

## 影響範囲

- 変更: `src/terrain/geo/globeLod.ts` / `src/terrain/geo/globeTileManager.ts` / `src/scenes/globe.ts`
- 挙動が変わるのは **Follow mode（外部 frustum）経路のみ**。3D ビューア・通常メインカメラは `viewForward` 未指定で従来と同一（退行なし）。API 破壊的変更なし（追加のみ・任意）。

## テスト

- `tests/globeLod.unit.spec.ts` に追加:
  - `viewForwardFromFrustumPlanes` の forward 復元（真の forward と `dot > 0.999`）・単位ベクトル・平面数≠6/零和で `null`
  - Follow 幾何の回帰: viewForward 無しで前方が地平線手前で穴あり、有りで地平線の7割超まで連続被覆・穴消滅・`maxTiles` 内
  - 後方互換: `viewForward` 未指定＝フィールドなしと同一結果、`normalize(center−camera)` は未指定と同一 seed、零ベクトルはフォールバック
- `npm run typecheck` / `npm run lint` / `npm run test:unit`（1336件）green
- `npm run test:visuals`（21件）退行なし（Follow mode は視覚 suite 対象外のため実アプリで目視確認済み）

## 目視確認（HITL）

- Follow mode でカメラを引き水平線を出す・高度を上げる・旋回中いずれも前方〜地平線側の穴が解消
- 機体の接地（seat）・直下 LOD は不変、通常メイン globe・3D ビューアも従来どおり

🤖 Generated with [Claude Code](https://claude.com/claude-code)
