### PR TITLE
fix(avatar-controller): azimuth回転方向をviewer規約に整合（#462）

### DIFF
--- a/src/demos/avatar-controller/cameraControl.ts
+++ b/src/demos/avatar-controller/cameraControl.ts
@@ -5,9 +5,12 @@
  * チルト角（tilt）の変化量を計算する純粋関数群。
  *
  * 規約:
- * - 右スティック X 正 → 方位を時計回り（右回転）
+ * - 右スティック X 正 → 方位を時計回り（右回転）＝ azimuth 増加
  * - 右スティック Y 正（前入力）→ チルト減少（真上方向へ）
  * - 2D モード時は tilt 変化を 0 にする
+ *
+ * 方位角（azimuth）規約: viewer.azimuth（globe scene）に合わせ「北=0°・東回り正
+ * （時計回り正）」。GeospatialCamera yaw の "0 = north, π/2 = east" と一致。
  */
 
 import { applyDeadzone, type MoveVector } from "./movement";
@@ -26,7 +29,7 @@ export const TILT_MAX_DEG = 89;
 
 /** カメラ制御の計算結果 */
 export interface CameraControlResult {
-    /** 方位角の変化量（度）。本プロジェクト規約に従い、正=反時計回り */
+    /** 方位角の変化量（度）。viewer.azimuth 規約に従い、正=時計回り（東回り） */
     deltaAzimuth: number;
     /** チルト角の変化量（度）。正=水平方向へ */
     deltaTilt: number;
@@ -53,9 +56,9 @@ export const computeCameraControl = (
     const dz = applyDeadzone(stick);
 
     // 方位: vx 正 → 右回転（時計回り）
-    // 本プロジェクトの azimuth 規約は「北=0°・反時計回り正」なので、
-    // 右スティック右 = 時計回り = azimuth 減少。
-    const deltaAzimuth = dz.vx === 0 ? 0 : -dz.vx * AZIMUTH_SPEED_DPS * dtSec;
+    // viewer.azimuth 規約は「北=0°・東回り正（時計回り正）」なので、
+    // 右スティック右 = 時計回り = azimuth 増加。
+    const deltaAzimuth = dz.vx === 0 ? 0 : dz.vx * AZIMUTH_SPEED_DPS * dtSec;
 
     // チルト: 2D モード時は無効
     let deltaTilt = 0;

--- a/tests/cameraControl.unit.spec.ts
+++ b/tests/cameraControl.unit.spec.ts
@@ -15,25 +15,27 @@ import {
 
 describe("computeCameraControl", () => {
     describe("方位角（azimuth）制御", () => {
-        it("右スティック右入力で azimuth が減少する（時計回り）", () => {
+        // viewer.azimuth 規約は「北=0°・東回り正（時計回り正）」なので、
+        // 右スティック右（時計回り）= azimuth 増加、左（反時計回り）= azimuth 減少。
+        it("右スティック右入力で azimuth が増加する（時計回り）", () => {
             const result = computeCameraControl(
                 { vx: 1, vy: 0 },
                 1.0,
                 false,
                 45,
             );
-            expect(result.deltaAzimuth).toBeCloseTo(-AZIMUTH_SPEED_DPS, 1);
+            expect(result.deltaAzimuth).toBeCloseTo(AZIMUTH_SPEED_DPS, 1);
             expect(result.deltaTilt).toBe(0);
         });
 
-        it("右スティック左入力で azimuth が増加する（反時計回り）", () => {
+        it("右スティック左入力で azimuth が減少する（反時計回り）", () => {
             const result = computeCameraControl(
                 { vx: -1, vy: 0 },
                 1.0,
                 false,
                 45,
             );
-            expect(result.deltaAzimuth).toBeCloseTo(AZIMUTH_SPEED_DPS, 1);
+            expect(result.deltaAzimuth).toBeCloseTo(-AZIMUTH_SPEED_DPS, 1);
         });
 
         it("dtSec に比例して変化量が増える", () => {

--- a/tests/elevationFarView.spec.ts
+++ b/tests/elevationFarView.spec.ts
@@ -67,9 +67,8 @@ const CAMERA_LON = 138.992724;
 /**
  * カメラの向き [deg]（0=北, +=東回り、`GeospatialCamera.yaw` の規約 "0 = north,
  * π/2 = east" に準拠）。カメラ→富士山の測地線ベアリング（初期方位角）。
- * 注: `src/demos/avatar-controller/cameraControl.ts` のコメントは「反時計回り正」と
- * 記載しているが、`GeospatialCamera` 本体のドキュメント（および本テストでの実機確認）
- * とは逆であり、そちらのコメントが実態と食い違っている可能性がある（別課題、本PRの対象外）。
+ * 注: `src/demos/avatar-controller/cameraControl.ts` の azimuth 規約はこの「東回り正
+ * （時計回り正）」に統一済み（#462 で解消）。
  */
 const CAMERA_AZIMUTH_TO_FUJI = 285.76;
 


### PR DESCRIPTION
## 概要

avatar-controller デモの Game Controller 右スティックによるカメラ方位操作で、右に倒すと意図と逆方向（反時計回り）に回転していたバグを修正する。

## 原因

`viewer.azimuth`（globe scene）の規約は「北=0°・東回り正（時計回り正）」（`GeospatialCamera` yaw JSDoc "0 = north, π/2 = east"、`sceneContract.ts` / `globe.ts` / `cameraMapping.ts` と整合）。`index.ts` は `viewer.azimuth += deltaAzimuth` の単純加算のため、右スティック右（時計回りにしたい）は `deltaAzimuth` が正であるべき。

しかし `cameraControl.ts` は planar（`movement.ts` / ArcRotateCamera alpha 由来「反時計回り正」）の内部規約と混同し、`-dz.vx` として負にしていた。

## 修正内容

- `cameraControl.ts`: `deltaAzimuth` の符号を `-dz.vx` → `dz.vx` に修正。
- `cameraControl.ts`: コメント（冒頭規約 / 型定義 / 実装内）を「北=0°・東回り正（時計回り正）」に統一。
- `tests/cameraControl.unit.spec.ts`: 右=増加（時計回り）／左=減少（反時計回り）に期待値・テスト名を修正。
- `tests/elevationFarView.spec.ts`: 「別課題」注記を「#462 で解消」に更新。

## 触っていない箇所（別規約・正しい）

- `src/demos/avatar-controller/movement.ts`（planar「反時計回り正」内部規約）
- `tests/avatarController.unit.spec.ts`（`rotateByAzimuth` の別規約テスト）

## 検証

- `npm run test:unit`: 1337 passed
- `npm run lint` / `npm run typecheck`: 成功
- reviewer による Coding Rules 観点レビュー: 指摘なし
- 実機（ブラウザ + ゲームパッド）で右スティック右 = 時計回り（右回転）を目視確認済み

Closes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)