### PR TITLE
docs(cleanup): Jestの痕跡を極力削除する (#490)

### DIFF
--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -11,13 +11,13 @@ model: sonnet
 ## Unit test 作成ルール
 
 ### フレームワーク・構成
-- Jest + ts-jest（ESM mode）
+- Vitest
 - 実行コマンド: `npm run test:unit`
-- 設定ファイル: `jest.config.js`（preset: `ts-jest/presets/default-esm`）
+- 設定ファイル: `vitest.config.ts`（`vite.config.ts` を継承）
 
 ### ファイル配置・命名
 - テストファイルは `tests/` ディレクトリに配置する
-- 命名規約（Jest/Unit）: `<対象モジュール名>.unit.spec.ts`（例: `tileCache.unit.spec.ts`）
+- 命名規約（Unit）: `<対象モジュール名>.unit.spec.ts`（例: `tileCache.unit.spec.ts`）
 - 命名規約（Playwright/E2E・Visual）: `<対象シナリオ>.spec.ts`（例: `atPathReload.spec.ts`）— `.unit.` を付けない
 - 対象ソースとテストファイルは 1:1 で対応させる
 
@@ -27,8 +27,9 @@ model: sonnet
 - 各 `it` は 1 つの振る舞いのみを検証する
 
 ### モックパターン
-- Babylon.js など外部依存は `jest.unstable_mockModule` でモックする
-- モックは各テストファイルのトップレベルで定義し、`await import(...)` で対象モジュールを動的インポートする
+- Babylon.js など外部依存は `vi.mock` でモックする
+- `vi.mock` はファイル先頭へ自動 hoist されるため、ファクトリが外部のトップレベル変数を参照しない場合は対象モジュールを通常の static import で読み込める
+- ファクトリがトップレベルの `const`/`let`（例: 呼び出し記録用の `vi.fn()`）を参照する場合は、`vi.mock` 自体は hoist されても参照先の初期化はされないため、対象モジュールはその変数を定義した後に `await import(...)` で動的に読み込む（先に静的 import すると TDZ エラーになる）
 - 純粋関数は直接 import してテストする（モック不要）
 
 ### テスト観点

--- a/.github/agents/40_tester.md
+++ b/.github/agents/40_tester.md
@@ -11,9 +11,9 @@ model: sonnet
 # Unit test 作成ルール
 
 ## フレームワーク・構成
-- Jest + ts-jest（ESM mode）
+- Vitest
 - 実行コマンド: `npm run test:unit`
-- 設定ファイル: `jest.config.js`（preset: `ts-jest/presets/default-esm`）
+- 設定ファイル: `vitest.config.ts`（`vite.config.ts` を継承）
 
 ## ファイル配置・命名
 - テストファイルは `tests/` ディレクトリに配置する
@@ -26,8 +26,9 @@ model: sonnet
 - 各 `it` は 1 つの振る舞いのみを検証する
 
 ## モックパターン
-- Babylon.js など外部依存は `jest.unstable_mockModule` でモックする
-- モックは各テストファイルのトップレベルで定義し、`await import(...)` で対象モジュールを動的インポートする
+- Babylon.js など外部依存は `vi.mock` でモックする
+- `vi.mock` はファイル先頭へ自動 hoist されるため、ファクトリが外部のトップレベル変数を参照しない場合は対象モジュールを通常の static import で読み込める
+- ファクトリがトップレベルの `const`/`let`（例: 呼び出し記録用の `vi.fn()`）を参照する場合は、`vi.mock` 自体は hoist されても参照先の初期化はされないため、対象モジュールはその変数を定義した後に `await import(...)` で動的に読み込む（先に静的 import すると TDZ エラーになる）
 - 純粋関数は直接 import してテストする（モック不要）
 
 ## テスト観点

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## 概要
 
 - 目的: 標高タイルを使った地形可視化の実装と検証
-- 技術スタック: TypeScript / Babylon.js / Vite（デモ）/ tsup（ライブラリ）/ Playwright / Jest
+- 技術スタック: TypeScript / Babylon.js / Vite（デモ）/ tsup（ライブラリ）/ Playwright / Vitest
 - バージョン: 0.2.1
 
 ## npm パッケージとしての利用
@@ -205,7 +205,7 @@ npm start
 | `npm run typecheck` | TypeScript 型チェック |
 | `npm run test:visuals` | Visual Regression Test 実行 |
 | `npm run test:visuals:update` | Visual テスト基準画像の強制更新（画面表示変更時のみ） |
-| `npm run test:unit` | ユニットテスト（Jest） |
+| `npm run test:unit` | ユニットテスト（Vitest） |
 
 ### デバッグ
 

--- a/src/demos/timelapse/clockOverlay.ts
+++ b/src/demos/timelapse/clockOverlay.ts
@@ -136,7 +136,7 @@ export interface ClockHandle {
 /**
  * 既存の `<svg>` 要素に時計盤と針を構築し、更新ハンドルを返す。
  * - 同じ要素に対して再マウントしないこと（再マウント時は `update` を使う）。
- * - DOM が無い環境（Vitest の jsdom 以外）では呼び出さない。
+ * - DOM が無い環境（SSR 等）では呼び出さない。
  */
 export const mountClock = (
     svg: SVGSVGElement,

--- a/src/demos/timelapse/clockOverlay.ts
+++ b/src/demos/timelapse/clockOverlay.ts
@@ -136,7 +136,7 @@ export interface ClockHandle {
 /**
  * 既存の `<svg>` 要素に時計盤と針を構築し、更新ハンドルを返す。
  * - 同じ要素に対して再マウントしないこと（再マウント時は `update` を使う）。
- * - DOM が無い環境（jest jsdom 以外）では呼び出さない。
+ * - DOM が無い環境（Vitest の jsdom 以外）では呼び出さない。
  */
 export const mountClock = (
     svg: SVGSVGElement,

--- a/src/demos/viewer/index.ts
+++ b/src/demos/viewer/index.ts
@@ -276,7 +276,7 @@ const start = async (): Promise<void> => {
     }
 };
 
-// テスト環境（jest）では副作用としてのデモ起動をスキップする。
+// テスト環境（Vitest jsdom 等）では副作用としてのデモ起動をスキップする。
 // jsdom 環境でも `#root` が無ければ `start()` 内で例外になるため、明示的にガードする。
 if (
     typeof document !== "undefined" &&

--- a/src/demos/viewer/index.ts
+++ b/src/demos/viewer/index.ts
@@ -276,7 +276,7 @@ const start = async (): Promise<void> => {
     }
 };
 
-// テスト環境（Vitest jsdom 等）では副作用としてのデモ起動をスキップする。
+// `#root` が無い環境（テスト環境等）では副作用としてのデモ起動をスキップする。
 // jsdom 環境でも `#root` が無ければ `start()` 内で例外になるため、明示的にガードする。
 if (
     typeof document !== "undefined" &&

--- a/src/terrain/elevationWorkerPool.ts
+++ b/src/terrain/elevationWorkerPool.ts
@@ -2,7 +2,7 @@
  * 標高計算用 Web Worker プール。
  *
  * - Worker をラウンドロビンで使い回し、メインスレッドの sync 処理を分散する
- * - Worker API が利用不能な環境（Jest / SSR / 古いブラウザ）では同期 fallback
+ * - Worker API が利用不能な環境（Vitest / SSR / 古いブラウザ）では同期 fallback
  * - Transferable な ArrayBuffer でメモリコピーを最小化
  *
  * tileManager の `applyElevationDataToMesh` がメインスレッドで実行していた

--- a/src/terrain/geo/cameraMapping.ts
+++ b/src/terrain/geo/cameraMapping.ts
@@ -10,7 +10,8 @@
  * - azimuth[deg] ⇄ yaw[rad]   （どちらも 0 = 北、+ = 東回り）
  * - tilt[deg]    ⇄ pitch[rad] （0 = 直下、90 = 水平。既存 UI の「地面からの傾き」と同義）
  *
- * 本モジュールは `GeospatialCamera` を直接 import しない（jest 環境を軽く保つ）。`yaw`/`pitch`
+ * 本モジュールは `GeospatialCamera` を直接 import しない（Babylon の実行時オブジェクトに
+ * 依存させず、DOM/WebGL 環境が無くても実行できる純関数として保つため）。`yaw`/`pitch`
  * から視線（lookAt）を組む処理は Babylon の `ComputeLookAtFromYawPitchToRef` を呼ぶ
  * 呼び出し側（`scenes/globe.ts`）が担い、本モジュールには算出済みのベクトルを渡す。
  */

--- a/src/terrain/geo/cameraMapping.ts
+++ b/src/terrain/geo/cameraMapping.ts
@@ -1,17 +1,17 @@
 /**
  * グローブカメラの UI/URL ⇄ `GeospatialCamera` マッピングと、
- * floating origin 下で `scene.pick` に依存しないパン（地表接線移動）・カメラ地形衝突の純関数群。
+ * floating origin 下で `scene.pick` に依存しないパン（地表接線移動）・カメラ地形衝突の関数群。
  *
  * 既存（平面版）の UI / URL 共有は `azimuth`(方位) / `tilt`(チルト) / `altitude`(高度) を用いる。
  * これを `GeospatialCamera` の `yaw` / `pitch` / `radius` / `center`(ECEF) と相互変換する。
- * PoC の純関数を本体共有モジュールへ昇格したもの。
+ * PoC の関数群を本体共有モジュールへ昇格したもの。
  *
  * 対応関係:
  * - azimuth[deg] ⇄ yaw[rad]   （どちらも 0 = 北、+ = 東回り）
  * - tilt[deg]    ⇄ pitch[rad] （0 = 直下、90 = 水平。既存 UI の「地面からの傾き」と同義）
  *
  * 本モジュールは `GeospatialCamera` を直接 import しない（Babylon の実行時オブジェクトに
- * 依存させず、DOM/WebGL 環境が無くても実行できる純関数として保つため）。`yaw`/`pitch`
+ * 依存させず、DOM/WebGL 環境が無くても実行できるようにするため）。`yaw`/`pitch`
  * から視線（lookAt）を組む処理は Babylon の `ComputeLookAtFromYawPitchToRef` を呼ぶ
  * 呼び出し側（`scenes/globe.ts`）が担い、本モジュールには算出済みのベクトルを渡す。
  */

--- a/src/terrain/geo/overlayPlacement.ts
+++ b/src/terrain/geo/overlayPlacement.ts
@@ -4,7 +4,8 @@
  * 平面版（`overlayCoords.ts`）は wx/wz と +Y up を前提とするが、グローブでは位置ごとに up
  * （地心方向）が変わる。本モジュールは「緯度経度＋標高 → ECEF 位置と地心 up」「カメラ距離に
  * 応じたスクリーン定スケール」「ドロップ線高さ」を ECEF ベースで提供する。平面オーバーレイ
- * とは独立（並行構築）で、`GeospatialCamera` を直接 import しない（jest 環境を軽く保つ）。
+ * とは独立（並行構築）で、`GeospatialCamera` を直接 import しない（Babylon の実行時
+ * オブジェクトに依存させず、DOM/WebGL 環境が無くても実行できる純関数として保つため）。
  */
 import { Vector3, Quaternion, Matrix } from "@babylonjs/core/Maths/math.vector";
 

--- a/src/terrain/geo/overlayPlacement.ts
+++ b/src/terrain/geo/overlayPlacement.ts
@@ -1,11 +1,11 @@
 /**
- * グローブオーバーレイの配置ユーティリティ（純関数）。
+ * グローブオーバーレイの配置ユーティリティ。
  *
  * 平面版（`overlayCoords.ts`）は wx/wz と +Y up を前提とするが、グローブでは位置ごとに up
  * （地心方向）が変わる。本モジュールは「緯度経度＋標高 → ECEF 位置と地心 up」「カメラ距離に
  * 応じたスクリーン定スケール」「ドロップ線高さ」を ECEF ベースで提供する。平面オーバーレイ
  * とは独立（並行構築）で、`GeospatialCamera` を直接 import しない（Babylon の実行時
- * オブジェクトに依存させず、DOM/WebGL 環境が無くても実行できる純関数として保つため）。
+ * オブジェクトに依存させず、DOM/WebGL 環境が無くても実行できるようにするため）。
  */
 import { Vector3, Quaternion, Matrix } from "@babylonjs/core/Maths/math.vector";
 

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -866,13 +866,13 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
      * Babylon のレンダーループ（VSync 同期）が必ず間に走るようにする。
      * テスト環境など rAF が無い場合は setTimeout(0) にフォールバック。
      */
-    // テスト環境（Jest）では rAF が setTimeout(16) に近い挙動になり、
+    // テスト環境（Vitest）では rAF が setTimeout(16) に近い挙動になり、
     // タイル数が多いと sync 完了までに 5s 以上かかってタイムアウトするため
     // 即時 resolve にして直列化のみ維持する。
     const isTestEnv =
         typeof process !== "undefined" &&
         typeof (process as { env?: Record<string, string | undefined> }).env !== "undefined" &&
-        (process as { env: Record<string, string | undefined> }).env.JEST_WORKER_ID !== undefined;
+        (process as { env: Record<string, string | undefined> }).env.VITEST !== undefined;
     // Babylon の onAfterRenderObservable に同期して、現在フレームの
      // 描画完了後にタイル sync を再開する。これにより
      // 「飛行機の位置反映 → render → タイル sync」の順番が保証され、

--- a/src/terrain/tileManager.ts
+++ b/src/terrain/tileManager.ts
@@ -872,7 +872,7 @@ export const createTileManager = (opts: TileManagerOptions): TileManager => {
     const isTestEnv =
         typeof process !== "undefined" &&
         typeof (process as { env?: Record<string, string | undefined> }).env !== "undefined" &&
-        (process as { env: Record<string, string | undefined> }).env.VITEST !== undefined;
+        (process as { env: Record<string, string | undefined> }).env.VITEST === "true";
     // Babylon の onAfterRenderObservable に同期して、現在フレームの
      // 描画完了後にタイル sync を再開する。これにより
      // 「飛行機の位置反映 → render → タイル sync」の順番が保証され、

--- a/tests/jpmapTerrain.unit.spec.ts
+++ b/tests/jpmapTerrain.unit.spec.ts
@@ -12,8 +12,10 @@
  * - dispose で canvas が除去されること
  *
  * Babylon.js Engine / Scene は jsdom で動かないためモックする。
- * `vi.mock` + 動的 import でモックを適用する
- * （Vitest 移行前の Jest ESM 実装の構造を維持）。
+ * `engineFactory` の `vi.mock` ファクトリはトップレベルの `createEngineMock` を
+ * 参照するため、対象モジュールは `vi.mock` 登録後（＝ここまでの const 初期化後）に
+ * 動的 import で読み込む。静的 import に変えると、ホイストされた `vi.mock` が
+ * 他の import 解決時に先走って実行され、`createEngineMock` の TDZ エラーになる。
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi, Mock } from "vitest";
@@ -1079,9 +1081,11 @@ vi.mock("../src/scenes/globeSceneController", () => {
     };
 });
 
-// vi.mock はファイル先頭へ自動 hoist されるため import 順を問わないが、
-// Jest からの移植構造を維持し、モック登録後に動的 import する。
+// `vi.mock` はファイル先頭へ自動 hoist されるが、上記ファクトリが参照する
+// `createEngineMock` はここまでの const 宣言で初期化されるため、
+// 対象モジュールはここで動的 import する。
 const { JpmapTerrain } = await import("../src/lib/jpmapTerrain");
+
 type UiTarget =
     | "compass"
     | "zoomButtons"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { mergeConfig, defineConfig } from "vitest/config";
 import baseConfig from "./vite.config";
 
 /**
- * Vitest 設定（Jest から移行）。
+ * Vitest 設定。
  *
  * `vite.config.ts` を `mergeConfig` で継承し、dev/build と同じ変換パイプライン
  * （TypeScript/ESM 変換・アセット解決）を単体テストでも利用する。
@@ -17,7 +17,7 @@ export default mergeConfig(
         test: {
             include: ["tests/**/*.unit.spec.ts"],
             // 既定値は node。`@vitest-environment jsdom` pragma を付与した
-            // ファイルのみ jsdom で実行する（Jest の `@jest-environment` 相当）。
+            // ファイルのみ jsdom で実行する。
             environment: "node",
             globals: false,
         },


### PR DESCRIPTION
## 概要

Vitest移行後もコード・ドキュメントに残っていたJest固有の記述・互換コードを、クリーンなVitestベースの実装/説明に置き換えました。

## 変更内容

- `README.md` / `.claude/agents/tester.md` / `.github/agents/40_tester.md`: Jest + ts-jest前提の記述をVitestベース（`vi.mock`等）に更新
- `vitest.config.ts`: 「Jestから移行」等の移行前提コメントを整理
- `src/terrain/geo/overlayPlacement.ts` / `cameraMapping.ts`: 「jest 環境を軽く保つ」というコメントを、本質的な設計理由（Babylon実行時オブジェクトへの非依存）に書き換え
- `src/demos/timelapse/clockOverlay.ts` / `src/demos/viewer/index.ts`: jest前提のコメントをVitest/jsdom前提の表現に統一
- `src/terrain/elevationWorkerPool.ts`: コメント中のJest表記をVitestに更新
- `src/terrain/tileManager.ts`: `isTestEnv`判定をJest専用の`JEST_WORKER_ID`からVitestが自動設定する`process.env.VITEST`に修正（Vitest移行後は機能していなかった判定ロジックの実質的なバグ修正）
- `tests/jpmapTerrain.unit.spec.ts`: 動的importが今も必要な理由（`vi.mock`ファクトリが参照する外部変数のTDZ回避）を明記し、「Jest互換のため」という誤った理由付けを是正

## 影響範囲

- ドキュメント（README, テスターエージェント定義）
- テスト設定・実装（vitest.config.ts, tileManager.ts, tests/jpmapTerrain.unit.spec.ts）
- terrain/geo系・demos系コメント

挙動の変更は`tileManager.ts`のテスト環境検出ロジックのみ（Vitest実行時に正しくtrueになるよう修正）。それ以外はコメント・ドキュメントのみの変更です。

## 検証

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test:unit` ✅（63 test files / 1352 tests all passed）

Closes #490